### PR TITLE
DRAFT: Deploy ARC using Helm

### DIFF
--- a/arc-helm/arc-controller.tf
+++ b/arc-helm/arc-controller.tf
@@ -1,0 +1,7 @@
+resource "helm_release" "arc" {
+  name       = "arc"
+  namespace = kubernetes_namespace.arc_systems.metadata.0.name
+
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts/"
+  chart      = "gha-runner-scale-set-controller"
+}

--- a/arc-helm/arc-namespace.tf
+++ b/arc-helm/arc-namespace.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_namespace" "arc_systems" {
+  metadata {
+    name = "arc-systems"
+  }
+}
+
+resource "kubernetes_namespace" "arc_runners" {
+  metadata {
+    name = "arc-runners"
+  }
+}

--- a/arc-helm/arc-runner-dind-rootless-values.yaml
+++ b/arc-helm/arc-runner-dind-rootless-values.yaml
@@ -1,0 +1,98 @@
+## githubConfigUrl is the GitHub url for where you want to configure runners
+## ex: https://github.com/myorg/myrepo or https://github.com/myorg
+githubConfigUrl: "https://github.com/pytorch/test-infra"
+
+## githubConfigSecret is the k8s secrets to use when auth with GitHub API.
+## You can choose to use GitHub App or a PAT token
+githubConfigSecret:
+  ### GitHub Apps Configuration
+  ## NOTE: IDs MUST be strings, use quotes
+  github_app_id: "ID"
+  github_app_installation_id: "INSTALL_ID"
+  github_app_private_key: "PRIVATE_KEY"
+## maxRunners is the max number of runners the autoscaling runner set will scale up to.
+maxRunners: 2
+
+## minRunners is the min number of idle runners. The target number of runners created will be
+## calculated as a sum of minRunners and the number of jobs assigned to the scale set.
+minRunners: 1
+
+# Not needed for dind-rootless
+# containerMode:
+#   type: "dind"  ## type can be set to dind or kubernetes
+
+template:
+  spec:
+    initContainers:
+    - name: init-dind-externals
+      image: ghcr.io/actions/actions-runner:latest
+      command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+      volumeMounts:
+        - name: dind-externals
+          mountPath: /home/runner/tmpDir
+    - name: init-dind-rootless
+      image: docker:dind-rootless
+      command:
+        - sh
+        - -c
+        - |
+          set -x
+          cp -a /etc/. /dind-etc/
+          echo 'runner:x:1001:1001:runner:/home/runner:/bin/ash' >> /dind-etc/passwd
+          echo 'runner:x:1001:' >> /dind-etc/group
+          echo 'runner:100000:65536' >> /dind-etc/subgid
+          echo 'runner:100000:65536' >>  /dind-etc/subuid
+          chmod 755 /dind-etc;
+          chmod u=rwx,g=rx+s,o=rx /dind-home
+          chown 1001:1001 /dind-home
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - mountPath: /dind-etc
+          name: dind-etc
+        - mountPath: /dind-home
+          name: dind-home
+    containers:
+    - name: runner
+      image: ghcr.io/actions/actions-runner:latest
+      command: ["/home/runner/run.sh"]
+      env:
+        - name: DOCKER_HOST
+          value: unix:///run/docker/docker.sock
+      volumeMounts:
+        - name: work
+          mountPath: /home/runner/_work
+        - name: dind-sock
+          mountPath: /run/docker
+          readOnly: true
+    - name: dind
+      image: docker:dind-rootless
+      args:
+        - dockerd
+        - --host=unix:///run/docker/docker.sock
+      securityContext:
+        privileged: true
+        runAsUser: 1001
+        runAsGroup: 1001
+      volumeMounts:
+        - name: work
+          mountPath: /home/runner/_work
+        - name: dind-sock
+          mountPath: /run/docker
+        - name: dind-externals
+          mountPath: /home/runner/externals
+        - name: dind-etc
+          mountPath: /etc
+        - name: dind-home
+          mountPath: /home/runner
+    volumes:
+    - name: work
+      emptyDir: {}
+    - name: dind-externals
+      emptyDir: {}
+    - name: dind-sock
+      emptyDir: {}
+    - name: dind-etc
+      emptyDir: {}
+    - name: dind-home
+      emptyDir: {}

--- a/arc-helm/arc-runner-dind-rootless.tf
+++ b/arc-helm/arc-runner-dind-rootless.tf
@@ -1,0 +1,13 @@
+resource "helm_release" "arc_runner_dind_rootless" {
+  depends_on = [helm_release.arc]
+
+  name       = "arc-runner-dind-rootless"
+  namespace = kubernetes_namespace.arc_runners.metadata.0.name
+
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts/"
+  chart      = "gha-runner-scale-set"
+
+  values = [
+    "${file("arc-runner-dind-rootless-values.yaml")}"
+  ]
+}

--- a/arc-helm/arc-runner-dind-values.yaml
+++ b/arc-helm/arc-runner-dind-values.yaml
@@ -1,0 +1,22 @@
+## githubConfigUrl is the GitHub url for where you want to configure runners
+## ex: https://github.com/myorg/myrepo or https://github.com/myorg
+githubConfigUrl: "https://github.com/pytorch/test-infra"
+
+## githubConfigSecret is the k8s secrets to use when auth with GitHub API.
+## You can choose to use GitHub App or a PAT token
+githubConfigSecret:
+  ### GitHub Apps Configuration
+  ## NOTE: IDs MUST be strings, use quotes
+  github_app_id: "ID"
+  github_app_installation_id: "INSTALL_ID"
+  github_app_private_key: "PRIVATE_KEY"
+
+## maxRunners is the max number of runners the autoscaling runner set will scale up to.
+maxRunners: 2
+
+## minRunners is the min number of idle runners. The target number of runners created will be
+## calculated as a sum of minRunners and the number of jobs assigned to the scale set.
+minRunners: 1
+
+containerMode:
+  type: "dind"  ## type can be set to dind or kubernetes

--- a/arc-helm/arc-runner-dind.tf
+++ b/arc-helm/arc-runner-dind.tf
@@ -1,0 +1,13 @@
+resource "helm_release" "arc_runner_dind" {
+  depends_on = [helm_release.arc]
+
+  name       = "arc-runner-dind"
+  namespace = kubernetes_namespace.arc_runners.metadata.0.name
+
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts/"
+  chart      = "gha-runner-scale-set"
+
+  values = [
+    "${file("arc-runner-dind-values.yaml")}"
+  ]
+}

--- a/arc-helm/arc-runner-kubernetes-values.yaml
+++ b/arc-helm/arc-runner-kubernetes-values.yaml
@@ -1,0 +1,41 @@
+## githubConfigUrl is the GitHub url for where you want to configure runners
+## ex: https://github.com/myorg/myrepo or https://github.com/myorg
+githubConfigUrl: "https://github.com/pytorch/test-infra"
+
+## githubConfigSecret is the k8s secrets to use when auth with GitHub API.
+## You can choose to use GitHub App or a PAT token
+githubConfigSecret:
+  ### GitHub Apps Configuration
+  ## NOTE: IDs MUST be strings, use quotes
+  github_app_id: "ID"
+  github_app_installation_id: "INSTALL_ID"
+  github_app_private_key: "PRIVATE_KEY"
+
+## maxRunners is the max number of runners the autoscaling runner set will scale up to.
+maxRunners: 2
+
+## minRunners is the min number of idle runners. The target number of runners created will be
+## calculated as a sum of minRunners and the number of jobs assigned to the scale set.
+minRunners: 1
+
+containerMode:
+  type: "kubernetes"  ## type can be set to dind or kubernetes
+  kubernetesModeWorkVolumeClaim:
+    accessModes: ["ReadWriteOnce"]
+    # For local testing, use https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md to provide dynamic provision volume with storageClassName: openebs-hostpath
+    storageClassName: "dynamic-blob-storage"
+    resources:
+      requests:
+        storage: 1Gi
+  kubernetesModeServiceAccount:
+    annotations:
+
+template:
+  spec:
+    containers:
+    - name: runner
+      image: ghcr.io/actions/actions-runner:latest
+      command: ["/home/runner/run.sh"]
+      env:
+      - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+        value: "false"

--- a/arc-helm/arc-runner-kubernetes.tf
+++ b/arc-helm/arc-runner-kubernetes.tf
@@ -1,0 +1,13 @@
+resource "helm_release" "arc_runner_kubernetes" {
+  depends_on = [helm_release.arc]
+
+  name       = "arc-runner-kubernetes"
+  namespace = kubernetes_namespace.arc_runners.metadata.0.name
+
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts/"
+  chart      = "gha-runner-scale-set"
+
+  values = [
+    "${file("arc-runner-kubernetes-values.yaml")}"
+  ]
+}

--- a/arc-helm/providers.tf
+++ b/arc-helm/providers.tf
@@ -1,0 +1,10 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+  config_context = "pytorch"
+}
+
+provider "helm" {
+  kubernetes {
+  	config_path = "~/.kube/config"
+  }
+}


### PR DESCRIPTION
This deploys the official GitHub ARC Helm Charts.

This PR is only for reference and needs to be adjusted for ci-infra AWS.