### PR TITLE
Add runnerscalesets for dind dind-rootless and kubernetes

### DIFF
--- a/modules/arc/Makefile
+++ b/modules/arc/Makefile
@@ -145,7 +145,7 @@ setup-karpenter-autoscaler: install-karpenter
 		--label-property nodeType
 
 .PHONY: k8s-runner-scaler
-k8s-runner-scaler: #install-arc
+k8s-runner-scaler: install-arc
 	[ "$(CLUSTER_CONFIG_FILE)" != "" ] || (echo "CLUSTER_CONFIG_FILE not set"; exit 1)
 	[ "$(EKS_CLUSTER_NAME)" != "" ] || (echo "EKS_CLUSTER_NAME not set"; exit 1)
 	[ "$(EKS_ENVIRONMENT)" != "" ] || (echo "EKS_ENVIRONMENT not set"; exit 1)
@@ -158,7 +158,7 @@ k8s-runner-scaler: #install-arc
 		--github-app-id $(GHA_ID) \
 		--github-app-installation-id $(GHA_INST_ID) \
 		--github-app-key "$$$(GHA_PRIVATE_KEY_VAR)" \
-		--template-name k8s/runnerscaleset-dind-values.yaml \
+		--template-name k8s/runnerscaleset-values.yaml \
 		--namespace $(RUNNERS_NAMESPACE) \
 		--arc-runner-config-files $(ARC_CFG_FILE_FOLDER)/ARC_NODE_CONFIG.yaml $(ARC_CFG_FILE_FOLDER)/ARC_RUNNER_CONFIG.yaml \
 		--helm-pkg-state-file $(HELM_PKG_STATE_FILE) \
@@ -174,46 +174,3 @@ k8s-runner-scaler: #install-arc
 			$(ADDITIONAL_VALUES) \
 		--root-classes nodeConfig runnerConfig \
 		--label-property runnerLabel \
-		--container-mode dind
-	../../venv/bin/python ../../scripts/helm_upgrade_runner_templates.py \
-		--github-app-id $(GHA_ID) \
-		--github-app-installation-id $(GHA_INST_ID) \
-		--github-app-key "$$$(GHA_PRIVATE_KEY_VAR)" \
-		--template-name k8s/runnerscaleset-dind-rootless-values.yaml \
-		--namespace $(RUNNERS_NAMESPACE) \
-		--arc-runner-config-files $(ARC_CFG_FILE_FOLDER)/ARC_NODE_CONFIG.yaml $(ARC_CFG_FILE_FOLDER)/ARC_RUNNER_CONFIG.yaml \
-		--helm-pkg-state-file $(HELM_PKG_STATE_FILE) \
-		--runner-scope $(RUNNERSCOPE) \
-		--additional-values \
-			eksclustername=$(EKS_CLUSTER_NAME) \
-			environment=$(EKS_ENVIRONMENT) \
-			karpenternoderole=$(KARPENTERNODEROLE) \
-			karpentersgids='$(KARPENTERSGIDS)' \
-			karpentersubnetids='$(KARPENTERSUBNETIDS)' \
-			project=gh-ci-$(EKS_ENVIRONMENT)-arc \
-			projecttag=$(PROJECTTAG) \
-			$(ADDITIONAL_VALUES) \
-		--root-classes nodeConfig runnerConfig \
-		--label-property runnerLabel \
-		--container-mode dind-rootless
-	../../venv/bin/python ../../scripts/helm_upgrade_runner_templates.py \
-		--github-app-id $(GHA_ID) \
-		--github-app-installation-id $(GHA_INST_ID) \
-		--github-app-key "$$$(GHA_PRIVATE_KEY_VAR)" \
-		--template-name k8s/runnerscaleset-kubernetes-values.yaml \
-		--namespace $(RUNNERS_NAMESPACE) \
-		--arc-runner-config-files $(ARC_CFG_FILE_FOLDER)/ARC_NODE_CONFIG.yaml $(ARC_CFG_FILE_FOLDER)/ARC_RUNNER_CONFIG.yaml \
-		--helm-pkg-state-file $(HELM_PKG_STATE_FILE) \
-		--runner-scope $(RUNNERSCOPE) \
-		--additional-values \
-			eksclustername=$(EKS_CLUSTER_NAME) \
-			environment=$(EKS_ENVIRONMENT) \
-			karpenternoderole=$(KARPENTERNODEROLE) \
-			karpentersgids='$(KARPENTERSGIDS)' \
-			karpentersubnetids='$(KARPENTERSUBNETIDS)' \
-			project=gh-ci-$(EKS_ENVIRONMENT)-arc \
-			projecttag=$(PROJECTTAG) \
-			$(ADDITIONAL_VALUES) \
-		--root-classes nodeConfig runnerConfig \
-		--label-property runnerLabel \
-		--container-mode kubernetes

--- a/modules/arc/k8s/runnerscaleset-dind-rootless-values.yaml
+++ b/modules/arc/k8s/runnerscaleset-dind-rootless-values.yaml
@@ -1,30 +1,3 @@
-githubConfigUrl: "$(RUNNERSCOPE)"
-
-githubConfigSecret: "gha-arc-secret"
-
-maxRunners: $(MAXRUNNERS)
-
-minRunners: $(MINRUNNERS)
-
-runnerGroup: "$(RUNNERGROUP)"
-
-runnerScaleSetName: "$(RUNNERLABEL)"
-
-# Not needed for dind-rootless
-# containerMode:
-#   type: "dind"
-
-listenerTemplate:
-  spec:
-    containers:
-      - name: listener
-        securityContext:
-          runAsUser: 1000
-    tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: Exists
-        effect: NoSchedule
-
 template:
   spec:
     tolerations:

--- a/modules/arc/k8s/runnerscaleset-dind-values.yaml
+++ b/modules/arc/k8s/runnerscaleset-dind-values.yaml
@@ -1,28 +1,5 @@
-githubConfigUrl: "$(RUNNERSCOPE)"
-
-githubConfigSecret: "gha-arc-secret"
-
-maxRunners: $(MAXRUNNERS)
-
-minRunners: $(MINRUNNERS)
-
-runnerGroup: "$(RUNNERGROUP)"
-
-runnerScaleSetName: "$(RUNNERLABEL)"
-
 containerMode:
   type: "dind"
-
-listenerTemplate:
-  spec:
-    containers:
-      - name: listener
-        securityContext:
-          runAsUser: 1000
-    tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: Exists
-        effect: NoSchedule
 
 template:
   spec:

--- a/modules/arc/k8s/runnerscaleset-kubernetes-values.yaml
+++ b/modules/arc/k8s/runnerscaleset-kubernetes-values.yaml
@@ -1,15 +1,3 @@
-githubConfigUrl: "$(RUNNERSCOPE)"
-
-githubConfigSecret: "gha-arc-secret"
-
-maxRunners: $(MAXRUNNERS)
-
-minRunners: $(MINRUNNERS)
-
-runnerGroup: "$(RUNNERGROUP)"
-
-runnerScaleSetName: "$(RUNNERLABEL)"
-
 containerMode:
   type: "kubernetes"
   kubernetesModeWorkVolumeClaim:
@@ -20,17 +8,6 @@ containerMode:
         storage: 1Gi
   kubernetesModeServiceAccount:
     annotations:
-
-listenerTemplate:
-  spec:
-    containers:
-      - name: listener
-        securityContext:
-          runAsUser: 1000
-    tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: Exists
-        effect: NoSchedule
 
 template:
   spec:

--- a/modules/arc/k8s/runnerscaleset-values.yaml
+++ b/modules/arc/k8s/runnerscaleset-values.yaml
@@ -1,0 +1,24 @@
+githubConfigUrl: "$(RUNNERSCOPE)"
+
+githubConfigSecret: "gha-arc-secret"
+
+maxRunners: $(MAXRUNNERS)
+
+minRunners: $(MINRUNNERS)
+
+runnerGroup: "$(RUNNERGROUP)"
+
+runnerScaleSetName: "$(RUNNERLABEL)"
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        securityContext:
+          runAsUser: 1000
+    tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: Exists
+        effect: NoSchedule
+
+$(DOCKERMODETEMPLATE)

--- a/scripts/helm_upgrade_runner_templates.py
+++ b/scripts/helm_upgrade_runner_templates.py
@@ -41,10 +41,14 @@ def parse_args() -> argparse.Namespace:
         required=True,
     )
     parser.add_argument(
-        "--container-mode",
-        help="Set the ARC Runner container mode: dind, dind-rootless, kubernetes",
+        "--docker-mode-template-rel",
+        help="template to use for docker mode",
         type=str,
-        required=True,
+        default=",".join([
+            "dind", "k8s/runnerscaleset-dind-values.yaml",
+            "dind-rootless", "k8s/runnerscaleset-dind-rootless-values.yaml",
+            "k8s", "k8s/runnerscaleset-kubernetes-values.yaml",
+        ]),
     )
     parser.add_argument(
         "--root-classes",
@@ -236,7 +240,6 @@ def main() -> None:
     gh = get_gh_client(options)
     pytorch_org = gh.get_organization('pytorch')
     runner_groups = {rg.name: rg for rg in gh_get_runner_groups(pytorch_org)}
-    container_mode = options.container_mode
 
     additional_values = {
         value.split('=')[0].upper(): value.split('=')[1]
@@ -246,9 +249,7 @@ def main() -> None:
     additional_values['RUNNERSCOPE'] = {
         'pytorch-org': 'https://github.com/pytorch',
         'pytorch-canary': 'https://github.com/pytorch',
-        # 'pytorch-canary': 'https://github.com/pytorch/pytorch-canary',
         'pytorch-repo': 'https://github.com/pytorch',
-        # 'pytorch-repo': 'https://github.com/pytorch/pytorch',
     }[options.runner_scope]
 
     if len(options.root_classes) != len(options.arc_runner_config_files):
@@ -256,10 +257,6 @@ def main() -> None:
 
     for runner_config in get_merged_arc_runner_config(options.arc_runner_config_files, options.root_classes):
         label = runner_config[options.label_property]
-
-        # Adjust label for multiple container mode runner scale set deployments
-        label = f'{label}-{container_mode}'
-        runner_config[options.label_property] = label
 
         additional_values['RUNNERARCH'] = [
             l['values'][0]
@@ -274,9 +271,24 @@ def main() -> None:
         if additional_values['ENVIRONMENT'] == 'canary':
             additional_values['ENVRUNNERLABEL'] += '.canary'
         l = additional_values['ENVRUNNERLABEL']
+
+        # Please note that the prefix for RUNNERGROUP is very important as it is used
+        # as the refenence for witch runner groups to clean up when there is no matching
+        # configs
         additional_values['RUNNERGROUP'] = f'arc-lf-{l}'
 
+        # Please note that the prefix for install_name is very important as it is used
+        # as the refenence for witch installations to clean up when there is no matching
+        # configs
         install_name = f'rssi-{label}'
+
+        template_mode_rel_it = iter(options.docker_mode_template_rel.split(','))
+        template_mode_rel_dict = dict(zip(template_mode_rel_it, template_mode_rel_it))
+
+        additional_values['DOCKERMODETEMPLATE'] = get_template(
+            template_mode_rel_dict[runner_config['containerMode']],
+            runner_config | additional_values
+        )
         to_apply = get_template(options.template_name, runner_config | additional_values)
         add_to_helm_pkg_state(options.helm_pkg_state_file, install_name, options.namespace)
 
@@ -287,7 +299,7 @@ def main() -> None:
             '--values',
             '-',
         ]
-        print(f"helm upgrade for rssi-{label}: {' '.join(cmd)}")
+        print(f"helm upgrade for {install_name}: {' '.join(cmd)}")
 
         if options.dry_run:
             print("------------------------------------- compiled template -------------------------------------")
@@ -303,12 +315,13 @@ def main() -> None:
                 'pytorch-canary': [398371105],
                 'pytorch-repo': [65600975],
             }[options.runner_scope]
-            if additional_values['RUNNERGROUP'] not in runner_groups:
-                gh_create_runner_group(pytorch_org, additional_values['RUNNERGROUP'], runner_scope, selected_repository_ids)
             if subprocess.run(cmd, input=to_apply, capture_output=False, text=True).returncode != 0:
                 print("------------------------------------- compiled template -------------------------------------")
                 print(to_apply)
                 raise Exception(f"Kubectl failed for {label}")
+            if additional_values['RUNNERGROUP'] not in runner_groups:
+                print(f"Creating runner group {additional_values['RUNNERGROUP']}")
+                gh_create_runner_group(pytorch_org, additional_values['RUNNERGROUP'], runner_scope, selected_repository_ids)
 
 
 if __name__ == "__main__":

--- a/scripts/module_makefile
+++ b/scripts/module_makefile
@@ -39,6 +39,8 @@ init: .terraform/modules/modules.json
 clean:
 	$(RM) -r .terraform
 	$(RM) .terraform.lock.hcl
+	$(RM) ARC_NODE_CONFIG.yaml
+	$(RM) ARC_RUNNER_CONFIG.yaml
 	$(RM) backend-state.tf
 	$(RM) backend.plan
 	$(RM) backend.tf


### PR DESCRIPTION
Add RunnerScaleSets for deploying container modes:

- dind
- dind-rootless
- kubernetes

This appends a suffix with each of those node names at the end of the runner label to differentiate the runners.