### PR TITLE
fix: K8s container mode permission denied

### DIFF
--- a/modules/arc/k8s/runnerscaleset-kubernetes-values.yaml
+++ b/modules/arc/k8s/runnerscaleset-kubernetes-values.yaml
@@ -5,7 +5,7 @@ containerMode:
     storageClassName: "gp2"
     resources:
       requests:
-        storage: 1Gi
+        storage: 40Gi
   kubernetesModeServiceAccount:
     annotations:
 
@@ -15,6 +15,8 @@ template:
       - key: "arcRunnerNodeType-$(NODETYPE)"
         operator: Exists
         effect: NoSchedule
+    securityContext:
+      fsGroup: 123
     containers:
     - name: runner
       image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
This resolves the permission denied issue we are running into when container mode is set to "kubernetes". Also increase the storage request size to 40Gi as 1Gi originally is not nearly enough to clone the `pytorch/pytorch` repo.

Ref: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/troubleshooting-actions-runner-controller-errors#error-access-to-the-path-homerunner_work_tool-is-denied