### PR TITLE
fix: DIND runner exec script path

### DIFF
--- a/modules/arc/runnerscaleset/dind-values.yaml
+++ b/modules/arc/runnerscaleset/dind-values.yaml
@@ -10,4 +10,4 @@ template:
     containers:
       - name: runner
         image: ghcr.io/pytorch/arc-runner-pytorch:$(LATESTRUNNERIMG)
-        command: [ "/actions-runner/run.sh" ]
+        command: [ "/home/runner/run.sh" ]


### PR DESCRIPTION
The script path for the executable for the runner is incorrect and causes the DIND runner to fail to initialize.