### PR TITLE
fix: Use private subnet for K8s nodes

### DIFF
--- a/aws/391835788720/us-east-1/arc.tf
+++ b/aws/391835788720/us-east-1/arc.tf
@@ -11,7 +11,7 @@ module "arc_canary" {
     aws_vpc_suffix = each.key
     eks_cidr_blocks = local.external_k8s_cidr_ipv4
     environment = var.canary_environment
-    subnet_ids = each.value.public_subnets
+    subnet_ids = each.value.private_subnets
     vpc_id = each.value.vpc_id
 }
 
@@ -28,7 +28,7 @@ module "arc_vanguard" {
     aws_vpc_suffix = each.key
     eks_cidr_blocks = local.external_k8s_cidr_ipv4
     environment = var.vanguard_environment
-    subnet_ids = each.value.public_subnets
+    subnet_ids = each.value.private_subnets
     vpc_id = each.value.vpc_id
 }
 
@@ -45,6 +45,6 @@ module "arc_prod" {
     aws_vpc_suffix = each.key
     eks_cidr_blocks = local.external_k8s_cidr_ipv4
     environment = var.prod_environment
-    subnet_ids = each.value.public_subnets
+    subnet_ids = each.value.private_subnets
     vpc_id = each.value.vpc_id
 }

--- a/aws/391835788720/us-east-1/vpc.tf
+++ b/aws/391835788720/us-east-1/vpc.tf
@@ -12,7 +12,7 @@ module "runners_vpc" {
   create_private_hosted_zone            = false
   environment                           = "${var.prod_environment}-${each.value}"
   project                               = var.prod_environment
-  public_subnet_map_public_ip_on_launch = true
+  public_subnet_map_public_ip_on_launch = false
 }
 
 module "runners_canary_vpc" {
@@ -29,5 +29,5 @@ module "runners_canary_vpc" {
   create_private_hosted_zone            = false
   environment                           = "${var.canary_environment}-${each.value}"
   project                               = var.canary_environment
-  public_subnet_map_public_ip_on_launch = true
+  public_subnet_map_public_ip_on_launch = false
 }


### PR DESCRIPTION
The Kubernetes nodes do not need to be reachable via the Internet so should be launched in the private subnets for security.

Also disable auto-public IP assignment for resources in the public subnet. Resources that actually need public facing IP address should explicitly request it rather than relying on auto-assignment.

This resolves #56.

Issue: #56