### PR TITLE
Added resource limits to the runner template

### DIFF
--- a/modules/arc/runnerscaleset/dind-rootless-values.yaml
+++ b/modules/arc/runnerscaleset/dind-rootless-values.yaml
@@ -75,7 +75,7 @@ template:
         sizeLimit: 5Gi
     - name: dind-sock
       emptyDir:
-        sizeLimit: 10Gi
+        sizeLimit: 50Gi
     - name: dind-etc
       emptyDir:
         sizeLimit: 10Gi


### PR DESCRIPTION
Added resource limits to the runner template

<img width="638" alt="Screenshot 2024-03-06 at 13 47 57" src="https://github.com/pytorch/ci-infra/assets/3964975/48e1f2b4-8e2b-4f3d-ae2f-a3c5816cdcbb">

<img width="637" alt="Screenshot 2024-03-06 at 16 49 32" src="https://github.com/pytorch/ci-infra/assets/3964975/6f2668d9-d7d7-4703-9498-c28474410331">

