### PR TITLE
Added ECR access to pytorch_ci_artifacts_access policy

### DIFF
--- a/aws/391835788720/us-east-1/ci-artifacts.tf
+++ b/aws/391835788720/us-east-1/ci-artifacts.tf
@@ -50,7 +50,7 @@ resource "aws_ecr_repository" "pytorch-ci-repo" {
   image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
-    scan_on_push = true
+    scan_on_push = false
   }
 }
 
@@ -80,7 +80,7 @@ resource "aws_iam_policy" "pytorch_ci_artifacts_access" {
         "ecr:BatchGetImage"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ecr:us-east-1:***:repository/pytorch/*"
+      "Resource": "arn:aws:ecr:us-east-1:***:repository/${aws_ecr_repository.pytorch-ci-repo.name}/*"
     }
   ]
 }


### PR DESCRIPTION
To be able to push and pull a built Docker image, the workflow need to have access to the ECR. Currently [there is no access](https://github.com/pytorch/pytorch/actions/runs/8188189895/job/22390315447?pr=119544#step:6:114) and we run long "Calculate Docker Image" step every time.