### PR TITLE
ci: Scale down green node group to minimum 1 node

### DIFF
--- a/modules/arc/eks.tf
+++ b/modules/arc/eks.tf
@@ -54,9 +54,9 @@ module "eks" {
 
   eks_managed_node_groups = {
     green = {
-      min_size     = 4
+      min_size     = 1
       max_size     = 20
-      desired_size = 4
+      desired_size = 1
 
       taints = [
         {


### PR DESCRIPTION
Currently the "green" node group is configured to require 4 nodes with a max of 20. We are likely overprovisioning that nodegroup since the services we run in there aren't all that resource intensive. Let's set the minimum to 1 and allow to to auto-scale and adjust on it's own.

This closes #78.

Issue: #78