### PR TITLE
ci: Set "green" nodegroup min size to 2

### DIFF
--- a/modules/arc/eks.tf
+++ b/modules/arc/eks.tf
@@ -54,9 +54,9 @@ module "eks" {
 
   eks_managed_node_groups = {
     green = {
-      min_size     = 1
+      min_size     = 2
       max_size     = 20
-      desired_size = 1
+      desired_size = 2
 
       taints = [
         {


### PR DESCRIPTION
It seems Karpenter has an anti-node affinity requiring that both its instances run on different nodes. This is not possible when minimum node is only 1. Bump to 2 to allow Karpenter to run properly.