### PR TITLE
ci: Setup Nvidia GPUS in ARC Runner

### DIFF
--- a/modules/arc/Makefile
+++ b/modules/arc/Makefile
@@ -25,6 +25,7 @@ KARPENTER_VERSION = v0.32.1
 DOCKER_REGISTRY_NAMESPACE = docker-registry
 DOCKER_REGISTRY_INTERNAL_NAME = pytorch-internal
 DOCKER_REGISTRY_TLS_SECRET_NAME := $(DOCKER_REGISTRY_INTERNAL_NAME)-tls
+NVIDIA_NAMESPACE = nvidia-device-plugin
 
 .latest-arc-runner-pytorch:
 	[ "$$PUSH_PACKAGE_DOCKER_GITHUB_TOKEN" != "" ] || (echo "PUSH_PACKAGE_DOCKER_GITHUB_TOKEN not set"; exit 1)
@@ -103,6 +104,7 @@ update-kubectl: do-update-kubectl add-eksctl-identity-mappings
 .PHONY: helm-repo-update
 helm-repo-update: update-kubectl
 	helm repo add docker-registry-mirror https://t83714.github.io/docker-registry-mirror
+	helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
 	helm repo add twuni https://helm.twun.io
 	helm repo update
 
@@ -312,3 +314,11 @@ k8s-runner-scaler: .latest-arc-runner-pytorch .latest-arc-dind-pytorch
 			$(ADDITIONAL_VALUES) \
 		--root-classes nodeConfig runnerConfig \
 		--label-property runnerLabel
+
+.PHONY: setup-nvidia-device-plugin
+setup-nvidia-device-plugin: helm-repo-update
+	helm upgrade --install nvdp nvdp/nvidia-device-plugin \
+		--namespace $(NVIDIA_NAMESPACE) \
+		--create-namespace \
+		--values runnerscaleset/nvidia-device-plugin-values.yaml
+		--wait

--- a/modules/arc/runnerscaleset/dind-rootless-values.yaml
+++ b/modules/arc/runnerscaleset/dind-rootless-values.yaml
@@ -55,9 +55,11 @@ template:
         limits:
           cpu: $(CPU)
           memory: $(MEMORY)
+          $(NVIDIA_GPU)
         requests:
           cpu: $(CPU)
           memory: $(MEMORY)
+          $(NVIDIA_GPU)
       env:
         - name: DOCKER_HOST
           value: unix:///run/docker/docker.sock

--- a/modules/arc/runnerscaleset/nvidia-device-plugin-values.yaml
+++ b/modules/arc/runnerscaleset/nvidia-device-plugin-values.yaml
@@ -1,0 +1,122 @@
+# Plugin configuration
+# Only one of "name" or "map" should ever be set for a given deployment.
+# Use "name" to point to an external ConfigMap with a list of configurations.
+# Use "map" to build an integrated ConfigMap from a set of configurations as
+# part of this helm chart. An example of setting "map" might be:
+# config:
+#   map:
+#     default: |-
+#       version: v1
+#       flags:
+#         migStrategy: none
+#     mig-single: |-
+#       version: v1
+#       flags:
+#         migStrategy: single
+#     mig-mixed: |-
+#       version: v1
+#       flags:
+#         migStrategy: mixed
+config:
+  # ConfigMap name if pulling from an external ConfigMap
+  name: ""
+  # Set of named configs to build an integrated ConfigMap from
+  map: {}
+  # Default config name within the ConfigMap
+  default: ""
+  # List of fallback strategies to attempt if no config is selected and no default is provided
+  fallbackStrategies: ["named" , "single"]
+
+legacyDaemonsetAPI: null
+compatWithCPUManager: null
+migStrategy: null
+failOnInitError: null
+deviceListStrategy: null
+deviceIDStrategy: null
+nvidiaDriverRoot: null
+gdsEnabled: null
+mofedEnabled: null
+
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+selectorLabelsOverride: {}
+
+allowDefaultNamespace: false
+
+imagePullSecrets: []
+image:
+  repository: nvcr.io/nvidia/k8s-device-plugin
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+updateStrategy:
+  type: RollingUpdate
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+resources: {}
+nodeSelector: {}
+affinity: {}
+tolerations:
+  # This toleration is deprecated. Kept here for backward compatibility
+  # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: "arcRunnerNodeType-compute-amd64-nvidia-v100"
+    operator: "Exists"
+
+# Mark this pod as a critical add-on; when enabled, the critical add-on
+# scheduler reserves resources for critical add-on pods so that they can
+# be rescheduled after a failure.
+# See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+priorityClassName: "system-node-critical"
+
+runtimeClassName: null
+
+# Subcharts
+nfd:
+  nameOverride: node-feature-discovery
+  enableNodeFeatureApi: false
+  master:
+    extraLabelNs:
+      - nvidia.com
+    serviceAccount:
+      name: node-feature-discovery
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+  worker:
+    tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
+    - key: "nvidia.com/gpu"
+      operator: "Equal"
+      value: "present"
+      effect: "NoSchedule"
+    - key: "arcRunnerNodeType-compute-amd64-nvidia-v100"
+      operator: "Exists"
+    config:
+      sources:
+        pci:
+          deviceClassWhitelist:
+          - "02"
+          - "0200"
+          - "0207"
+          - "0300"
+          - "0302"
+          deviceLabelFields:
+          - vendor
+gfd:
+  enabled: true
+  nameOverride: gpu-feature-discovery
+  namespaceOverride: ""

--- a/scripts/helm_upgrade_runner_templates.py
+++ b/scripts/helm_upgrade_runner_templates.py
@@ -257,6 +257,10 @@ def main() -> None:
     for runner_config in get_merged_arc_runner_config(options.arc_runner_config_files, options.root_classes):
         label = runner_config[options.label_property]
 
+        additional_values['NVIDIA_GPU'] = ''  # Unset if no GPU configuration in runner config
+        if 'nvidiaGpus' in runner_config:
+            additional_values['NVIDIA_GPU'] = f'nvidia.com/gpu: {runner_config["nvidiaGpus"]}'
+
         additional_values['RUNNERARCH'] = [
             l['values'][0]
             for l in runner_config['requirements'] if l['key'] == 'kubernetes.io/arch'

--- a/scripts/module_makefile
+++ b/scripts/module_makefile
@@ -182,7 +182,7 @@ arc-canary: inventory/eks/canary_cluster_name inventory/eks/canary_cluster_confi
 				PROJECTTAG=gi-ci-canary \
 				REGION=$(REGION) \
 				RUNNERSCOPE=pytorch-canary \
-				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler k8s-runner-scaler delete-stale-resources || exit 1 ; \
+				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler setup-nvidia-device-plugin k8s-runner-scaler delete-stale-resources || exit 1 ; \
 		done
 
 .PHONY: install-docker-registry-canary
@@ -255,7 +255,7 @@ k8s-runner-scaler-canary: inventory/eks/canary_cluster_name inventory/eks/canary
 				PROJECTTAG=gi-ci-canary \
 				REGION=$(REGION) \
 				RUNNERSCOPE=pytorch-canary \
-				clean-k8s-rds-state k8s-runner-scaler delete-stale-helm-pkgs || exit 1 ; \
+				clean-k8s-rds-state setup-nvidia-device-plugin k8s-runner-scaler delete-stale-helm-pkgs || exit 1 ; \
 		done
 
 # Vanguard
@@ -282,7 +282,7 @@ arc-vanguard: inventory/eks/vanguard_cluster_name inventory/eks/vanguard_cluster
 				MINRUNNERS=30 \
 				MAXRUNNERS=30 \
 				REGION=$(REGION) \
-				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler k8s-runner-scaler delete-stale-resources || exit 1 ; \
+				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler setup-nvidia-device-plugin k8s-runner-scaler delete-stale-resources || exit 1 ; \
 		done
 
 .PHONY: arc-vanguard-off
@@ -330,7 +330,7 @@ arc-prod: inventory/eks/prod_cluster_name inventory/eks/prod_cluster_config $(PR
 				ARC_CFG_FILE_FOLDER=$(PROHOME)/aws/$(ACCOUNT)/$(REGION) \
 				RUNNERSCOPE=pytorch-org \
 				REGION=$(REGION) \
-				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler k8s-runner-scaler delete-stale-resources || exit 1 ; \
+				clean-k8s-rds-state install-arc install-karpenter install-docker-registry setup-karpenter-autoscaler setup-nvidia-device-plugin k8s-runner-scaler delete-stale-resources || exit 1 ; \
 		done
 
 .PHONY: eks-use-cluster


### PR DESCRIPTION
This iteration fixes the quoting issue.

from f'nvidia.com/gpu: {runner_config['nvidiaGpus']}'
to   f'nvidia.com/gpu: {runner_config["nvidiaGpus"]}'

Which should resolve the error we saw when trying to deploy with CI.

  File "/home/runner/work/ci-infra/ci-infra/modules/arc/../../scripts/helm_upgrade_runner_templates.py", line 262
1204
    additional_values['NVIDIA_GPU'] = f'nvidia.com/gpu: {runner_config['nvidiaGpus']}'
1205
                                                                        ^^^^^^^^^^
1206
SyntaxError: f-string: unmatched '['