### PR TITLE
Setup pre-commit to run tflint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.88.4
+  hooks:
+    - id: terraform_tflint
+      args:
+        - --args=--module
+        - --args=--color
+        - --args=--minimum-failure-severity=warning
+        - --args=--recursive

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 
 .PHONY: tflint
 tflint:
-	cd modules/arc && terraform init && tflint --init && tflint --module --color --minimum-failure-severity=warning --recursive
+	cd modules/arc && terraform init && tflint --init && pre-commit run --all-files
 	cd aws ; for account in ./*/ ; do \
 		pushd $$account ; \
 		for region in ./*/ ; do \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Optional, but this lets you run terraform lint locally via `make tflint`
 
 1. Install Terraform. Instructions: https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
 2. Install tflint Instructions: https://github.com/terraform-linters/tflint
+3. Install pre-commit. Instructions: https://pre-commit.com/index.html#install
+
+   Then run `pre-commit --install` in repo to install the git hooks to
+   automatically run when `git commit` is called.
 
 ## Deploy
 Once the above setup steps are complete you can run make as follows:


### PR DESCRIPTION
This adds a .pre-commit-config.yaml file to enable pre-commit hooks to automatically run tflint in the repo when `git commit` is called.