### PR TITLE
Revert "Grant access to upload torchci metrics"

### DIFF
--- a/modules/arc/roles.tf
+++ b/modules/arc/roles.tf
@@ -270,21 +270,6 @@ resource "aws_iam_policy" "karpenter_node_role_access_other_accounts_resouces_po
             "ec2:CreateTags"
         ],
         "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "dynamodb:GetItem",
-        "dynamodb:PutItem",
-        "dynamodb:UpdateItem",
-        "dynamodb:DeleteItem",
-        "dynamodb:Scan",
-        "dynamodb:Query",
-        "dynamodb:CreateTable",
-        "dynamodb:ListTables"
-      ],
-      "Resource": "arn:aws:dynamodb:*:308535385114:table/torchci-metrics",
-      "Sid": "AllowUploadingTorchciMetrics"
     }
   ]
 }


### PR DESCRIPTION
Reverts pytorch/ci-infra#120

Need to use a different method to grant access to dynamodb