### PR TITLE
Add annotation for karpenter to not disrupt arc

### DIFF
--- a/modules/arc/runnerscaleset/dind-rootless-values.yaml
+++ b/modules/arc/runnerscaleset/dind-rootless-values.yaml
@@ -1,4 +1,7 @@
 template:
+  metadata:
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
   spec:
     tolerations:
       - key: "arcRunnerNodeType-$(NODETYPE)"


### PR DESCRIPTION
Relates to #94.

Add the karpenter `karpenter.sh/do-not-disrupt: "true"` annotation to mark ARC Runner pods as undisruptable so that Karpenter does not try to consolidate these pods.

Ref: https://karpenter.sh/docs/concepts/disruption/#pod-eviction