### PR TITLE
Set resource limits for dind container

### DIFF
--- a/modules/arc/runnerscaleset/dind-rootless-values.yaml
+++ b/modules/arc/runnerscaleset/dind-rootless-values.yaml
@@ -80,6 +80,10 @@ template:
       args:
         - dockerd
         - --host=unix:///run/docker/docker.sock
+      resources:
+        limits:
+          cpu: $(CPU)
+          memory: $(MEMORY)
       securityContext:
         privileged: true
         runAsUser: 1000


### PR DESCRIPTION
Relates to pytorch/pytorch#124727

This sets the cpu/memory resource limits to apply the same limit as the runner container to ensure that the dind container does not exceed the limits we set.
