### PR TITLE
Limit cpu usage on docker-in-docker containers

### DIFF
--- a/modules/arc/runnerscaleset/dind-rootless-values.yaml
+++ b/modules/arc/runnerscaleset/dind-rootless-values.yaml
@@ -84,7 +84,9 @@ template:
         limits:
           cpu: $(CPU)
           memory: $(MEMORY)
-          $(NVIDIA_GPU)
+        requests: # Set some tiny request. The actual usage will be bould be the limits value
+          cpu: 0.1
+          memory: 10Mi
       securityContext:
         privileged: true
         runAsUser: 1000


### PR DESCRIPTION
Addresses https://github.com/pytorch/ci-infra/issues/94

When the release container launches a container, that container runs in the dind (docker-in-docker) host container running on the node.

Adding resource limits on CPU, Memory, and GPU usage to the dind container so that containers executed inside it don't take over the entire node.

This approach should be okay, since when the runner launches a container it just waits until the container exits, so the runner won't be using CPU at the same time as the docker container. However, it would still be holding onto some memory, and it would be ideal if we could instead declare a limit at the pod level instead of specifying per-container limits.