### PR TITLE
Use recommended way to reference modules in other repos

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -8,7 +8,7 @@ resource "random_password" "webhook_secret" {
 }
 
 module "autoscaler-lambda" {
-  source = "../../../tf-modules/terraform-aws-github-runner"
+  source = "github.com/pytorch/test-infra//terraform-aws-github-runner"
 
   aws_region           = local.aws_region
   aws_region_instances = var.ali_aws_region


### PR DESCRIPTION
Readability improvement. This makes it way easier to understand where the module inquestio is actually coming from.  It goes doubly so for someone who might be trying to debug an issue and hasn't run make init yet