### PR TITLE
Create release CI for main

### DIFF
--- a/.github/workflows/ali-deploy-canary.yml
+++ b/.github/workflows/ali-deploy-canary.yml
@@ -1,0 +1,42 @@
+name: Terraform Apply / Runners / Canary - ALI
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "terraform-make-apply"
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  release:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v3
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.5.7
+        terraform_wrapper: false
+
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v1.7.0
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.PY_FOUNDATION_AWS_ACC_ID }}:role/${{ secrets.PY_FOUNDATION_AWS_DEPLOY_ROLE }}
+        aws-region: us-east-1
+
+    - name: Terraform Apply
+      working-directory: runners
+      shell: bash
+      run: make apply-canary
+      env:
+        AWS_DEFAULT_REGION: us-east-1
+        GITHUB_TOKEN: ${{ secrets.LIST_PYTORCH_RUNNERS_GITHUB_TOKEN }}
+        TERRAFORM_EXTRAS: -auto-approve -lock-timeout=15m

--- a/.github/workflows/ali-deploy-prod.yml
+++ b/.github/workflows/ali-deploy-prod.yml
@@ -1,0 +1,42 @@
+name: Terraform Apply / Runners / Production - ALI
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "terraform-make-apply"
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  release:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v3
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.5.7
+        terraform_wrapper: false
+
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v1.7.0
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.PY_FOUNDATION_AWS_ACC_ID }}:role/${{ secrets.PY_FOUNDATION_AWS_DEPLOY_ROLE }}
+        aws-region: us-east-1
+
+    - name: Terraform Apply
+      working-directory: runners
+      shell: bash
+      run: make apply
+      env:
+        AWS_DEFAULT_REGION: us-east-1
+        GITHUB_TOKEN: ${{ secrets.LIST_PYTORCH_RUNNERS_GITHUB_TOKEN }}
+        TERRAFORM_EXTRAS: -auto-approve -lock-timeout=15m

--- a/ali/Makefile
+++ b/ali/Makefile
@@ -51,6 +51,20 @@ plan:
 		popd ; \
 	done
 
+.PHONY: plan-canary
+plan-canary:
+	cd aws ; for account in ./*/ ; do \
+		pushd $$account ; \
+		for region in ./*/ ; do \
+			pushd $$region ; \
+			echo "==== START make plan: aws/$$account/$$region ============================================" ; \
+			$(MAKE) plan-canary || exit 1 ; \
+			echo "==== END make plan: aws/$$account/$$region ============================================" ; \
+			popd ; \
+		done ; \
+		popd ; \
+	done
+
 .PHONY: apply
 apply:
 	cd aws ; for account in ./*/ ; do \
@@ -59,6 +73,20 @@ apply:
 			pushd $$region ; \
 			echo "==== START make apply: aws/$$account/$$region ============================================" ; \
 			$(MAKE) apply || exit 1 ; \
+			echo "==== END make apply: aws/$$account/$$region ============================================" ; \
+			popd ; \
+		done ; \
+		popd ; \
+	done
+
+.PHONY: apply-canary
+apply-canary:
+	cd aws ; for account in ./*/ ; do \
+		pushd $$account ; \
+		for region in ./*/ ; do \
+			pushd $$region ; \
+			echo "==== START make apply: aws/$$account/$$region ============================================" ; \
+			$(MAKE) apply-canary || exit 1 ; \
 			echo "==== END make apply: aws/$$account/$$region ============================================" ; \
 			popd ; \
 		done ; \


### PR DESCRIPTION
This adapts the deployment script from /arc/scripts/deployment.py for use with ALI. This creates a action that opens a release PR which automatically deploys the release to canary and if successful allows us to comment PROCEED_TO_PRODUCTION to deploy to production. If successful the comment CLEANUP_DEPLOYMENT will merge the PR and close it out.

This closes #206 and closes #205.