### PR TITLE
Enable reading TD assets

### DIFF
--- a/ali/aws/391835788720/us-east-1/iam_policies.tf
+++ b/ali/aws/391835788720/us-east-1/iam_policies.tf
@@ -157,7 +157,8 @@ resource "aws_iam_policy" "allow_s3_sccache_access_on_gha_runners" {
                 "s3:ListBucket*"
             ],
             "Resource": [
-                "arn:aws:s3:::target-determinator-assets/*"
+                "arn:aws:s3:::target-determinator-assets/*",
+                "arn:aws:s3:::target-determinator-assets"
             ]
         }
     ]


### PR DESCRIPTION
Ensure the 'llm-retrieval' job can access the required S3 bucket, specifically the "Fetch CodeLlama Checkpoint" step

Fixes https://github.com/pytorch/ci-infra/issues/213

Verified in https://github.com/pytorch/pytorch/actions/runs/9325243673?pr=127579