### PR TITLE
Remove Canary label from cant_have_issues_labels

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
@@ -55,7 +55,7 @@ module "autoscaler-lambda-canary" {
   runners_scale_up_sqs_max_retry          = 1
   runners_scale_up_sqs_message_ret_s      = 7200
   scale_down_schedule_expression          = "cron(*/15 * * * ? *)"
-  cant_have_issues_labels                 = ["Use Canary Lambdas"]
+  cant_have_issues_labels                 = []
   scale_config_repo_path                  = ".github/lf-canary-scale-config.yml"
 
   encrypt_secrets           = false


### PR DESCRIPTION
I believe this label is meant only for the prod instance to prevent it from picking up jobs meant for Canary. Let's remove it so that Canary is able to scale it's runners.

Issue: #228