### PR TITLE
Use custom windows AMI

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
@@ -62,7 +62,7 @@ module "autoscaler-lambda-canary" {
   secretsmanager_secrets_id = data.aws_secretsmanager_secret_version.app_creds.secret_id
 
   # TODO This won't work, we need to copy the windows AMI to this account
-  ami_owners_windows = ["amazon"]
+  ami_owners_windows = ["391835788720"]
   ami_filter_windows = {
     name = var.ami_filter_windows
   }

--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -69,8 +69,7 @@ module "autoscaler-lambda" {
   encrypt_secrets           = false
   secretsmanager_secrets_id = data.aws_secretsmanager_secret_version.app_creds.secret_id
 
-  # TODO This won't work, we need to copy the windows AMI to this account
-  ami_owners_windows = ["amazon"]
+  ami_owners_windows = ["391835788720"]
   ami_filter_windows = {
     name = var.ami_filter_windows
   }

--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -44,5 +44,5 @@ variable "ami_filter_linux" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows_Server-2022-English-Full-Base-2024.04.10"]
+  default     = ["Windows 2019 GHA CI - 20240618170857"]
 }


### PR DESCRIPTION
This is a stopgap step to get windows builds started so that we can debug issues along the way.

The AMI should work in theory, but there are still permissions issues to fix before windows builds can work properly.   