### PR TITLE
Grant access to s3://ossci-windows

### DIFF
--- a/ali/aws/391835788720/us-east-1/iam_policies.tf
+++ b/ali/aws/391835788720/us-east-1/iam_policies.tf
@@ -197,6 +197,17 @@ resource "aws_iam_policy" "allow_s3_sccache_access_on_gha_runners" {
                 "arn:aws:s3:::target-determinator-assets/*",
                 "arn:aws:s3:::target-determinator-assets"
             ]
+        },
+        {
+            "Sid": "ReadListOssciWindowsAssets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:ListBucket*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::ossci-windows/*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Grants the runners permission to access the s3://ossci-windows bucket, which they require for windows builds to succeed

Pairs with https://github.com/pytorch-labs/pytorch-gha-infra/pull/418, which grants the Linux Foundation AWS account to read this bucket in the first place.

Testing: 

Applied changes to canary and validated that build gets past the stage where it would previously fail due to lack of access to this s3 bucket: https://github.com/pytorch/pytorch-canary/actions/runs/9604036738/job/26490580560?pr=224

Without this change, the build step [would fail in seconds](https://github.com/pytorch/pytorch-canary/actions/runs/9604036738/job/26490115788?pr=224)