### PR TITLE
hotfix: Update to v20240626-135621 ALI module

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20240625-155400"
+  tag: "v20240626-135621"
   assets:
     - "runners.zip"
     - "webhook.zip"


### PR DESCRIPTION
This is a hotfix for the currently broken EC2 instances failing to become GitHub runners.