### PR TITLE
Use latest windows AMI

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -44,5 +44,5 @@ variable "ami_filter_linux" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows 2019 GHA CI - 20240618170857"]
+  default     = ["Windows 2019 GHA CI - 20240627160742"]
 }


### PR DESCRIPTION
The AMI had already been validated using a slightly older code.  This new AMI is now built from the same code that's currently used by pytorch/pytorch runners

Testing: Deployed the latest AMI to canary and ran these jobs using them. The one failing triton test seems unrelated to runner infra. It's a missing import, most likely a stale canary artifact.
https://github.com/pytorch/pytorch-canary/actions/runs/9604925867/job/26956456227?pr=224 