### PR TITLE
Use version that outputs more runner metadata to GHA logs

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20240718-180515"
+  tag: "v20240719-185908"
   assets:
     - "runners.zip"
     - "webhook.zip"


### PR DESCRIPTION
Pulling in the changes made here:
- https://github.com/pytorch/test-infra/pull/5485