### PR TITLE
Bump test-infra version to v20240807-193314

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20240802-160133"
+  tag: "v20240807-193314"
   assets:
     - "runners.zip"
     - "webhook.zip"


### PR DESCRIPTION
Mostly includes this PR change: https://github.com/pytorch/test-infra/pull/5541