### PR TITLE
Update test-infra to v20240829-190428

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20240826-204017"
+  tag: "v20240829-190428"
   assets:
     - "runners.zip"
     - "webhook.zip"


### PR DESCRIPTION
This pulls in the change to allow runners to scale down to 0 when there is no jobs queued waiting for runners.

Issue: https://lf-pytorch.atlassian.net/browse/PC-33