### PR TITLE
Increase minimum runner time to 1 hr

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
@@ -50,7 +50,7 @@ module "autoscaler-lambda-canary" {
   runner_binaries_syncer_lambda_zip = abspath("../../../assets/lambdas-download-canary/runner-binaries-syncer.zip")
   runners_lambda_zip                = abspath("../../../assets/lambdas-download-canary/runners.zip")
   enable_organization_runners       = false
-  minimum_running_time_in_minutes   = 10
+  minimum_running_time_in_minutes   = 60
   runner_extra_labels               = "pytorch.runners"
   runners_scale_down_lambda_timeout = 600
   runners_scale_up_lambda_timeout         = 600

--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -55,7 +55,7 @@ module "autoscaler-lambda" {
   runner_binaries_syncer_lambda_zip = abspath("../../../assets/lambdas-download/runner-binaries-syncer.zip")
   runners_lambda_zip                = abspath("../../../assets/lambdas-download/runners.zip")
   enable_organization_runners       = false
-  minimum_running_time_in_minutes   = 10
+  minimum_running_time_in_minutes   = 60
   runner_extra_labels               = "pytorch.runners"
   runners_scale_down_lambda_timeout = 600
   runners_scale_up_lambda_timeout         = 600


### PR DESCRIPTION
Increase the runner minimum runtime to 1 hour to increase the chance that it will be reused by queued jobs.