### PR TITLE
Have a minimum number of runners always available for every variant 

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -65,7 +65,7 @@ module "autoscaler-lambda" {
   scale_down_schedule_expression          = "cron(*/15 * * * ? *)"
   cant_have_issues_labels                 = ["Use Canary Lambdas"]
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
-  min_available_runners                   = 4
+  min_available_runners                   = 6
 
   encrypt_secrets           = false
   secretsmanager_secrets_id = data.aws_secretsmanager_secret_version.app_creds.secret_id


### PR DESCRIPTION
By setting a minimum runner count that will always be kept instantiated (even if they're idle) we can mitigate the effect of dropped scale-up requests.

This change will be reverted once a more permanent solution is implemented.