### PR TITLE
Update link-test-infra-canary to use make

### DIFF
--- a/ali/scripts/module_makefile
+++ b/ali/scripts/module_makefile
@@ -111,7 +111,9 @@ link-test-infra-canary: .terraform/modules/modules.json $(ALL_ZIPS)
 	rm -rf ../../../lambdas-download-canary/*
 	rm -rf ../../../lambdas-download/*
 	cd ../../../tf-modules && ln -s $(TEST_INFRA_DIR)/terraform-aws-github-runner/
-	cd ../../../tf-modules/terraform-aws-github-runner/modules/runners/lambdas/runners && rm -rf dist && rm -rf runners.zip && yarn install && yarn dist
-	cd ../../../tf-modules/terraform-aws-github-runner/modules/webhook/lambdas/webhook && rm -rf dist && rm -rf webhook.zip && yarn install && yarn dist
+	cd ../../../tf-modules/terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer && make clean && make dist
+	cd ../../../tf-modules/terraform-aws-github-runner/modules/runners/lambdas/runners && make clean && make dist
+	cd ../../../tf-modules/terraform-aws-github-runner/modules/webhook/lambdas/webhook && make clean && make dist
+	cp ../../../tf-modules/terraform-aws-github-runner/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/runner-binaries-syncer.zip  ../../../assets/lambdas-download-canary/runner-binaries-syncer.zip
 	cp ../../../tf-modules/terraform-aws-github-runner/modules/runners/lambdas/runners/runners.zip  ../../../assets/lambdas-download-canary/runners.zip
 	cp ../../../tf-modules/terraform-aws-github-runner/modules/webhook/lambdas/webhook/webhook.zip  ../../../assets/lambdas-download-canary/webhook.zip


### PR DESCRIPTION
Update the link-test-infra-canary to use the Makefiles added to test-infra. Also adds support for runner-binaries-syncer that was previously missing.

Depends-On: pytorch/test-infra#5695
Issue: #274