### PR TITLE
Use a wildcard to filter the ARM64 AMI

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -44,7 +44,7 @@ variable "ami_filter_linux" {
 variable "ami_filter_linux_arm64" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.5.20240701.0-kernel-6.1-arm64"]
+  default     = ["al2023-ami-2023.5.202*-kernel-6.1-arm64"]
 }
 
 variable "ami_filter_windows" {


### PR DESCRIPTION
It seems like the specific filter we were using for ARM64 AMI now results in no results. Adjust the filter to use a wildcard for a section of the version string so that we can pick up a newer AMI.