### PR TITLE
Switch to OpenTofu

### DIFF
--- a/.github/workflows/ali-deploy-canary.yml
+++ b/.github/workflows/ali-deploy-canary.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: opentofu/setup-opentofu@v1
       with:
         terraform_version: 1.5.7
         terraform_wrapper: false

--- a/.github/workflows/ali-deploy-prod.yml
+++ b/.github/workflows/ali-deploy-prod.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: opentofu/setup-opentofu@v1
       with:
         terraform_version: 1.5.7
         terraform_wrapper: false

--- a/.github/workflows/ali-on-pr.yml
+++ b/.github/workflows/ali-on-pr.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: opentofu/setup-opentofu@v1
       with:
         terraform_version: 1.5.7
         terraform_wrapper: false

--- a/ali/Makefile
+++ b/ali/Makefile
@@ -21,7 +21,7 @@ tflint:
 	cd modules ; for module in ./*/ ; do \
 		pushd $$module ; \
 		echo "==== START TFLINT: modules/$$module ============================================" ; \
-		terraform init && tflint --init && tflint --module --color --minimum-failure-severity=warning --recursive ; \
+		tofu init && tflint --init && tflint --module --color --minimum-failure-severity=warning --recursive ; \
 		echo "==== END TFLINT: modules/$$module ============================================" ; \
 		popd ; \
 	done

--- a/ali/scripts/module_makefile
+++ b/ali/scripts/module_makefile
@@ -26,7 +26,7 @@ $(PROHOME)/tf-modules/VERSIONS: $(PROHOME)/venv/bin/pip $(PROHOME)/Terrafile
 terrafile: $(PROHOME)/tf-modules/VERSIONS
 
 .terraform/modules/modules.json: $(PROHOME)/tf-modules/VERSIONS backend.tf
-	terraform init
+	tofu init
 
 .PHONY: init
 init: .terraform/modules/modules.json
@@ -59,9 +59,9 @@ backend.tf: backend-state.tf
 
 backend-state.tf: dyn_locals.tf external_k8s_cidr_ipv4.tf
 	sed "s/#AWS_REGION/$(REGION)/g" <$(PROHOME)/modules/backend-file/backend-state.tf >backend-state.tf
-	terraform get -update
-	terraform init -backend=false
-	terraform plan -input=false -out=backend.plan -detailed-exitcode -target=module.backend-state -lock-timeout=15m ; \
+	tofu get -update
+	tofu init -backend=false
+	tofu plan -input=false -out=backend.plan -detailed-exitcode -target=module.backend-state -lock-timeout=15m ; \
 		ext_code=$$? ; \
 		if [ $$ext_code -eq 2 ] ; then \
 			if [ "$$GITHUB_ACTIONS" != "true" ] ; then \
@@ -80,19 +80,19 @@ backend-state.tf: dyn_locals.tf external_k8s_cidr_ipv4.tf
 
 .PHONY: plan
 plan: .terraform/modules/modules.json
-	terraform plan $(TERRAFORM_EXTRAS)
+	tofu plan $(TERRAFORM_EXTRAS)
 
 .PHONY: plan-canary
 plan-canary: .terraform/modules/modules.json
-	terraform plan -target module.autoscaler-lambda-canary $(TERRAFORM_EXTRAS)
+	tofu plan -target module.autoscaler-lambda-canary $(TERRAFORM_EXTRAS)
 
 .PHONY: apply
 apply: .terraform/modules/modules.json
-	terraform apply ${TERRAFORM_EXTRAS}
+	tofu apply ${TERRAFORM_EXTRAS}
 
 .PHONY: apply-canary
 apply-canary: .terraform/modules/modules.json
-	terraform apply -target module.autoscaler-lambda-canary ${TERRAFORM_EXTRAS}
+	tofu apply -target module.autoscaler-lambda-canary ${TERRAFORM_EXTRAS}
 
 .PHONY: destroy
 destroy: .terraform/modules/modules.json


### PR DESCRIPTION
It seems Homebrew is no longer providing new versions of Terraform so switch to OpenTofu which appears to be a drop in replacement.

Ref: https://formulae.brew.sh/formula/terraform