### PR TITLE
CI: Add security-scan workflow to run code scans

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,23 @@
+# .checkov.yml - Configuration file for Checkov
+
+# Path configurations
+skip-path:
+  - arc
+  - '.github/workflows/arc*'
+
+# Skip INFO and other unresolvable checks
+skip-check:
+  - CKV2_AWS_61
+  - CKV_AWS_274
+  - CKV_AWS_355
+  - CKV_AWS_290
+  - CKV_AWS_119
+  - CKV2_AWS_62
+  - CKV_AWS_18
+  - CKV_AWS_145
+  - CKV_AWS_144
+  - CKV2_AWS_16
+  - CKV_AWS_28
+
+# Configure Checkov's log level (useful for debugging)
+# log-level: DEBUG  # Available options: DEBUG, INFO, WARN, ERROR

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,43 @@
+# CodeQL and Checkov scans for ci-infra
+#
+name: "Security Scan"
+
+permissions: read-all
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 12 * * 6'  # Runs every Saturday at 12:00 PM
+
+jobs:
+  Analyze-Python:
+    name: Analyze Python code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - name: Run CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        continue-on-error: true
+
+  Analyze-IaC:
+    name: Analyze Infra as Code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Checkov
+        run: pip install checkov
+      - name: Run Checkov
+        run: checkov -d .


### PR DESCRIPTION
Runs every Saturday at 12:00 PM
- Runs CodeQL to analyze application source code (Python)
- Runs Checkov to analyze infrastructure as code (IaC)

Might need to be expanded after the repo becomes public