### PR TITLE
fix: TFLint v0.54.0 CLI parse error

### DIFF
--- a/ali/scripts/module_makefile
+++ b/ali/scripts/module_makefile
@@ -102,7 +102,7 @@ destroy: .terraform/modules/modules.json
 .PHONY: tflint
 tflint: .terraform/modules/modules.json
 	tflint --init
-	tflint --module --color --minimum-failure-severity=warning --recursive
+	tflint --call-module-type=all --color --minimum-failure-severity=warning --recursive
 
 .PHONY: link-test-infra-canary
 link-test-infra-canary: .terraform/modules/modules.json $(ALL_ZIPS)


### PR DESCRIPTION
Looks like TFLint v0.54.0 removed the --module option and now recommend using --call-module-type=all instead. This change adjusts that. Resolves the error below.

Failed to parse CLI options; --module option was removed in v0.54.0. Use --call-module-type=all instead