### PR TITLE
CI: Disallow usage of AWS AdministratorAccess policy

### DIFF
--- a/ali/aws/391835788720/us-east-1/iam_policies.tf
+++ b/ali/aws/391835788720/us-east-1/iam_policies.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "ossci_gha_terraform" {
 
 resource "aws_iam_role_policy_attachment" "ossci_gha_terraform_admin" {
   role       = aws_iam_role.ossci_gha_terraform.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
 // Taken from https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html


### PR DESCRIPTION
Disallow IAM roles, users, and groups from using the AWS AdministratorAccess policy.

The PowerUserAccess policy provides almost full access to all AWS services and resources without adding the risk of accidental privilege escalation or misconfigurations related to access controls.