### PR TITLE
Grant runners write access to S3 ossci-benchmarks bucket

### DIFF
--- a/ali/aws/391835788720/us-east-1/iam_policies.tf
+++ b/ali/aws/391835788720/us-east-1/iam_policies.tf
@@ -208,6 +208,12 @@ resource "aws_iam_policy" "allow_s3_sccache_access_on_gha_runners" {
             "Resource": [
                 "arn:aws:s3:::ossci-windows/*"
             ]
+        },
+        {
+            "Sid": "AllObjectActionsOssciBenchmarks",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::ossci-benchmarks/*"]
         }
     ]
 }


### PR DESCRIPTION
TSIA, this grants the runner the permission to upload benchmark results to this bucket.  Once there, the results will be propagated to ClickHouse.

The other PR on pytorch-gha-infra https://github.com/pytorch-labs/pytorch-gha-infra/pull/533.  I assume that I need to have this one to grant the permission to LF runners, plz correct me if that's not the case.