### PR TITLE
Use --quiet flag for checkov

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Install Checkov
         run: pip install checkov
       - name: Run Checkov
-        run: checkov -d .
+        run: checkov --quiet -d .


### PR DESCRIPTION
Rather than print all checks including those that pass. Use --quiet to only display failed checks in output to cut down on noise.