### PR TITLE
Do not disable CKV_AWS_28 completely

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -17,7 +17,6 @@ skip-check:
   - CKV_AWS_145
   - CKV_AWS_144
   - CKV2_AWS_16
-  - CKV_AWS_28
 
 # Configure Checkov's log level (useful for debugging)
 # log-level: DEBUG  # Available options: DEBUG, INFO, WARN, ERROR

--- a/modules/backend-state/dynamo.tf
+++ b/modules/backend-state/dynamo.tf
@@ -1,4 +1,5 @@
 resource "aws_dynamodb_table" "terraform_state_lock" {
+  #checkov:skip=CKV_AWS_28:ALI uses this as a cache and does not need backup
   count =  data.external.terraform_state_bucket_exists.result.exists == "true" ? 0 : 1
   name           = "${var.dynamo_table_name}-${var.project}-${var.environment}"
   read_capacity  = 1


### PR DESCRIPTION
This check is generally useful as a reminder to setup backups. However the DynamoDB used by ALI is only a cache so does not need to be backed up in this case. This change re-enables the check however disables it for this specific instance.