### PR TITLE
Login to docker.io in addition to ECR

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
@@ -89,6 +89,7 @@ module "autoscaler-lambda-canary" {
 
   runner_iam_role_managed_policy_arns = [
     aws_iam_policy.allow_ecr_on_gha_runners.arn,
+    aws_iam_policy.allow_secretmanager_docker_hub_token_on_gha_runners.arn,
     aws_iam_policy.allow_s3_sccache_access_on_gha_runners.arn,
     aws_iam_policy.allow_lambda_on_gha_runners.arn,
     aws_iam_policy.allow_torchci_metrics_on_gha_runners.arn

--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -93,6 +93,7 @@ module "autoscaler-lambda" {
 
   runner_iam_role_managed_policy_arns = [
     aws_iam_policy.allow_ecr_on_gha_runners.arn,
+    aws_iam_policy.allow_secretmanager_docker_hub_token_on_gha_runners.arn,
     aws_iam_policy.allow_s3_sccache_access_on_gha_runners.arn,
     aws_iam_policy.allow_lambda_on_gha_runners.arn,
     aws_iam_policy.allow_torchci_metrics_on_gha_runners.arn

--- a/ali/aws/391835788720/us-east-1/iam_policies.tf
+++ b/ali/aws/391835788720/us-east-1/iam_policies.tf
@@ -69,6 +69,23 @@ resource "aws_iam_policy" "allow_ecr_on_gha_runners" {
 EOT
 }
 
+resource "aws_iam_policy" "allow_secretmanager_docker_hub_token_on_gha_runners" {
+  name        = "${var.ali_prod_environment}_allow_secretmanager_docker_hub_token_on_gha_runners"
+  description = "Allows our GHA EC2 runners access to the read-only docker.io token"
+  policy      = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Action": [
+            "secretsmanager:GetSecretValue"
+        ],
+        "Resource": "arn:aws:secretsmanager:us-east-1:391835788720:secret:docker_hub_readonly_token-V74gSU"
+    }]
+}
+EOT
+}
+
 // ossci-compiler-cache-circleci-v2 = linux sccache
 // ossci-compiler-cache = windows sccache
 resource "aws_iam_policy" "allow_s3_sccache_access_on_gha_runners" {

--- a/ali/modules/ali_scripts/linux_post_install.sh
+++ b/ali/modules/ali_scripts/linux_post_install.sh
@@ -2,6 +2,10 @@
 
 set +e
 
+# Log in to docker.io, it's ok if this fails, we will just fallback to an anonymous user then.
+# This is to mitigate https://docs.docker.com/docker-hub/download-rate-limit/#rate-limit
+aws secretsmanager get-secret-value --secret-id docker_hub_readonly_token | jq --raw-output '.SecretString' | jq -r .docker_hub_readonly_token | docker login --username pytorchbot --password-stdin || true
+
 # Log in to our ECR instance
 if uname -a | grep 'amzn2023' > /dev/null ; then
     echo "New amazon linux"
@@ -11,3 +15,7 @@ else
     $(aws ecr get-login --no-include-email --region us-east-1)
 fi
 
+# copy the docker config from root to ec2-user, so both users can access the same registries
+mkdir -p /home/ec2-user/.docker
+cat </root/.docker/config.json >/home/ec2-user/.docker/config.json
+chown -R ec2-user:ec2-user /home/ec2-user/.docker 


### PR DESCRIPTION
This brings https://github.com/pytorch-labs/pytorch-gha-infra/pull/544 and https://github.com/pytorch-labs/pytorch-gha-infra/pull/547 to LF fleet.  @jeanschmidt has already created the secret there in `arn:aws:secretsmanager:us-east-1:391835788720:secret:docker_hub_readonly_token-V74gSU`
