### PR TITLE
bump test infra to v20241213-212009

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20241212-001105"
+  tag: "v20241213-212009"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Includes (AFAIK):

* https://github.com/pytorch/test-infra/commit/1577e6b8541089412294fa71554af1b89be19cfe