### PR TITLE
Allow test-infra repo to use packer role

### DIFF
--- a/ali/aws/391835788720/us-east-1/gha_roles.tf
+++ b/ali/aws/391835788720/us-east-1/gha_roles.tf
@@ -77,7 +77,8 @@ resource "aws_iam_role" "gha-packer-role" {
           StringLike = {
             "token.actions.githubusercontent.com:sub" = [
               "repo:pytorch/pytorch:environment:packer-build-env",
-              "repo:pytorch/pytorch-canary:environment:packer-build-env"
+              "repo:pytorch/pytorch-canary:environment:packer-build-env",
+              "repo:pytorch/test-infra:environment:packer-build-env"
             ]
           }
         }


### PR DESCRIPTION
Allow the pytorch/test-infra repo to be able to use the packer role.

Issue: pytorch/test-infra#5992