### PR TITLE
Revert "Minor fix to clean up any existing swapfile"

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20241216-213021"
+  tag: "v20241216-184119"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Reverts pytorch/ci-infra#316 (I made a mistake in the change to be fixed by https://github.com/pytorch/test-infra/pull/6068, but let's revert this first)