### PR TITLE
Update AMI pinning  to al2023-ami-2023.6.*

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -38,13 +38,13 @@ variable "aws_canary_vpc_suffixes" {
 variable "ami_filter_linux" {
   description = "AMI for linux"
   type        = list
-  default     = ["amzn2-ami-hvm-2.0.20240306.2-x86_64-ebs"]
+  default     = ["al2023-ami-2023.6.202*-kernel-6.1-x86_64"]
 }
 
 variable "ami_filter_linux_arm64" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.5.202*-kernel-6.1-arm64"]
+  default     = ["al2023-ami-2023.6.202*-kernel-6.1-arm64"]
 }
 
 variable "ami_filter_windows" {


### PR DESCRIPTION
update the AMI pinning so it reflects what is already on `pytorch-labs/pytorch-gha-infra` and is on all variants of `scale-config.yml` 