### PR TITLE
Deploy AMI Windows 2019 GHA CI - 20250211231335 to prod

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -50,5 +50,5 @@ variable "ami_filter_linux_arm64" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows 2019 GHA CI - 20241127165339"]
+  default     = ["Windows 2019 GHA CI - 20250211231335"]
 }


### PR DESCRIPTION
AMI Windows 2019 GHA CI - 20250211231335
AMI: ami-0ad04eca090b1e0ff

Based on build: https://github.com/pytorch/test-infra/actions/runs/13274353312/job/37060857180