### PR TITLE
Release v20250310-124810

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250204-163312"
+  tag: "v20250310-124810"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
This release version includes the reuse of ephemeral instances capabilities implemented recently in test-infra.

Its been validated for a week in Meta's infra now. So it is time to update LF infra with those changes that proven to be effective and stable.