### PR TITLE
Bump test-infra version to v20250317-134413

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250310-124810"
+  tag: "v20250317-134413"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"

--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda-canary.tf
@@ -59,6 +59,7 @@ module "autoscaler-lambda-canary" {
   runners_scale_up_sqs_message_ret_s      = 7200
   scale_down_schedule_expression          = "cron(*/15 * * * ? *)"
   cant_have_issues_labels                 = []
+  scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-canary-scale-config.yml"
   min_available_runners                   = 0

--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -64,9 +64,11 @@ module "autoscaler-lambda" {
   runners_scale_up_sqs_message_ret_s      = 7200
   scale_down_schedule_expression          = "cron(*/15 * * * ? *)"
   cant_have_issues_labels                 = ["Use Canary Lambdas"]
+  scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
   min_available_runners                   = 6
+  retry_scale_up_chron_hud_query_url      = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D"
 
   encrypt_secrets           = false
   secretsmanager_secrets_id = data.aws_secretsmanager_secret_version.app_creds.secret_id


### PR DESCRIPTION
# Releases test-infra to version v20250317-134413

It mostly includes the new lambda `scaleUpChron`: https://github.com/pytorch/test-infra/pull/6390