### PR TITLE
Document GitHub repo admin access

### DIFF
--- a/github-admin-permissions.md
+++ b/github-admin-permissions.md
@@ -1,0 +1,23 @@
+# GitHub Administrator Access
+
+This document outlines how the administrator permissions for the PyTorch 
+Foundation GitHub repos are managed.
+
+Currently this applies to the repos / orgs:
+
+* pytorch/ci-infra
+* pytorch/pytorch
+* pytorch-fdn
+
+Administration of these repos are managed by Linux Foundation staff with the
+following primary points of contact:
+
+* Jordan Conway <jconway@linuxfoundation.org>
+* Thanh Ha <thanh.ha@linuxfoundation.org>
+
+## Offboarding accounts
+
+Remove administrative permissions from the account from the following places:
+
+* The list of repos above
+* All [cloud access](cloud-account-access.md)


### PR DESCRIPTION
Document how the PyTorch Foundation admin permissions to GitHub repos are managed and who the points of contact for them are as well as steps to offboard accounts.