### PR TITLE
Update test-infra version to improve scale-down logging 

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250327-194722"
+  tag: "v20250423-171917"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Update terrafile to include this PR, which improves logging during scale-downs
* https://github.com/pytorch/test-infra/pull/6557

Will also include other misc changes that have been made in the past month.  We should have some alerts that fire if the Meta & LF fleets stay out of sync with each other for too long...