### PR TITLE
Reduce minimum runners to 4

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -67,7 +67,7 @@ module "autoscaler-lambda" {
   scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
-  min_available_runners                   = 6
+  min_available_runners                   = 4
   retry_scale_up_chron_hud_query_url      = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D"
 
   encrypt_secrets           = false


### PR DESCRIPTION
Back in September we increased this from 0 to 6 to mitigate issues for runner types that were not frequently used where the Autoscaler dropped scale-up requests resulting in no runners being available for jobs. At time we were also testing LF runners at 95% - 100% load balance which is no longer the case.

Let's reduce the min_available_runners again to try to reduce idle costs on the account. Lets try 4 for now and reduce it further if no issues reported.