### PR TITLE
Reduce min runners to 2

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -67,7 +67,7 @@ module "autoscaler-lambda" {
   scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
-  min_available_runners                   = 4
+  min_available_runners                   = 2
   retry_scale_up_chron_hud_query_url      = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D"
 
   encrypt_secrets           = false


### PR DESCRIPTION
It's been about 3 weeks now that we set min runners to 4. Things appear to be pretty stable during that time so lets bump it down further to 2.

Reference 2265996928585909f37ec6f8c1e86bd52e2318b4