### PR TITLE
Update Linux AMI filter

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -38,13 +38,13 @@ variable "aws_canary_vpc_suffixes" {
 variable "ami_filter_linux" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.6.202*-kernel-6.1-x86_64"]
+  default     = ["al2023-ami-2023.*-kernel-6.1-x86_64"]
 }
 
 variable "ami_filter_linux_arm64" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.6.202*-kernel-6.1-arm64"]
+  default     = ["al2023-ami-2023.*-kernel-6.1-arm64"]
 }
 
 variable "ami_filter_windows" {


### PR DESCRIPTION
The filter for "2023.6.202*" is no longer returning a match. Looks like AWS has moved to 2023.7 for this AMI. Make the search more broad so that hopefully we don't keep running into this issue when AWS removes older images.