### PR TITLE
Add Network for MultiCloud ARC

### DIFF
--- a/arc/aws/391835788720/us-east-1/locals.tf
+++ b/arc/aws/391835788720/us-east-1/locals.tf
@@ -1,2 +1,7 @@
 locals {
+    availability_zones_loc = ["a", "b", "c", "d", "e", "f"]
+    availability_zones        = [
+        for loc in local.availability_zones_loc :
+        "${local.aws_region}${loc}"
+    ]
 }

--- a/arc/aws/391835788720/us-east-1/main.tf
+++ b/arc/aws/391835788720/us-east-1/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/random"
     }
     aws    = {
-      version = ">= 6.0"
+      version = ">= 5.95, < 6.0"
       source  = "hashicorp/aws"
     }
   }

--- a/arc/aws/391835788720/us-east-1/variables.tf
+++ b/arc/aws/391835788720/us-east-1/variables.tf
@@ -1,0 +1,5 @@
+variable "arc_prod_environment" {
+  description = "production environment prefix"
+  type        = string
+  default     = "lf-arc-prod"
+}

--- a/arc/aws/391835788720/us-east-1/vpc.tf
+++ b/arc/aws/391835788720/us-east-1/vpc.tf
@@ -1,0 +1,17 @@
+module "arc_runners_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.21"
+
+  name = var.arc_prod_environment
+  cidr = "10.0.0.0/16"
+
+  azs                     = local.availability_zones
+  private_subnets         = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  public_subnets          = ["10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20"]
+  map_public_ip_on_launch = false
+
+  tags = {
+    Environment         = var.arc_prod_environment
+    Project             = var.arc_prod_environment
+  }
+}


### PR DESCRIPTION
This adds the networking components necessary for us to deploy an EKS cluster.

Relates to pytorch-fdn/multicloud-ci-infra#17.