### PR TITLE
Update terraform module to same version used by Meta prod

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250604-154741"
+  tag: "v20250716-153909"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Includes a bunch of reliability fixes from:

* https://github.com/pytorch/test-infra/pull/6934
* https://github.com/pytorch/test-infra/pull/6885
* https://github.com/pytorch/test-infra/pull/6933
* https://github.com/pytorch/test-infra/pull/6932