### PR TITLE
Setup NAT gateway for ARC private subnet

### DIFF
--- a/arc/aws/391835788720/us-east-1/vpc.tf
+++ b/arc/aws/391835788720/us-east-1/vpc.tf
@@ -8,6 +8,7 @@ module "arc_runners_vpc" {
   azs                     = local.availability_zones
   private_subnets         = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
   public_subnets          = ["10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20"]
+  enable_nat_gateway = true
   map_public_ip_on_launch = false
 
   tags = {


### PR DESCRIPTION
Allows nodes from EKS cluster to make outbound connections to the internet.