### PR TITLE
Revert "Set min-available runners to 0"

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -67,7 +67,7 @@ module "autoscaler-lambda" {
   scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
-  min_available_runners                   = 0
+  min_available_runners                   = 2
   retry_scale_up_chron_hud_query_url      = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D"
 
   encrypt_secrets           = false


### PR DESCRIPTION
Reverts pytorch/ci-infra#350