### PR TITLE
[Take 2] Update Terrafile to version used by Meta fleet

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250604-154741"
+  tag: "v20250716-153909"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Includes a bunch of reliability fixes from:

* https://github.com/pytorch/test-infra/pull/6934
* https://github.com/pytorch/test-infra/pull/6885
* https://github.com/pytorch/test-infra/pull/6933
* https://github.com/pytorch/test-infra/pull/6932

Previously had to revert these changes to mitigate https://github.com/pytorch/pytorch/issues/159290.  It turns out the expiration policy added by https://github.com/pytorch/test-infra/pull/6885 required a setting to be set on AWS to allow advanced SSM parameters ([docs](https://github.com/pytorch/test-infra/pull/6885)).  

That setting had been set on the Meta AWS account but not on the LF account, causing the outage.  It's now been set on the LF account, so this should be safe to redeploy