### PR TITLE
Set min-available runners to 0

### DIFF
--- a/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
+++ b/ali/aws/391835788720/us-east-1/autoscaler-lambda.tf
@@ -67,7 +67,7 @@ module "autoscaler-lambda" {
   scale_config_org                        = "pytorch"
   scale_config_repo                       = "test-infra"
   scale_config_repo_path                  = ".github/lf-scale-config.yml"
-  min_available_runners                   = 2
+  min_available_runners                   = 0
   retry_scale_up_chron_hud_query_url      = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D"
 
   encrypt_secrets           = false


### PR DESCRIPTION
Re-attempt now that issues causing the revert
f9df791e35c5dfc23d449ff6279dc04d4d665309 have been addressed.

Considering there is now a scale-up cron job that periodically checks Clickhouse if there are jobs that have been queued for a long time and automatically scales up new runners. We should be able to set min-available to 0 again.

The cron checks this Clickhouse URL

https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate?parameters=%5B%5D