### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/arc-backup-2024/scripts/deployment.py
+++ b/arc-backup-2024/scripts/deployment.py
@@ -442,7 +442,7 @@ def parse_args() -> argparse.Namespace:
     opts.add_argument(
         '--repo',
         help='Github repo to use for the deployment',
-        default=os.environ.get('GITHUB_REPOSITORY', 'pytorch-labs/pytorch-gha-infra').strip() or None,
+        default=os.environ.get('GITHUB_REPOSITORY', 'meta-pytorch/pytorch-gha-infra').strip() or None,
         type=str,
         required=False
     )


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:58:47.637013+00:00Z