### PR TITLE
Revert "Update AMI Windows 2019 GHA CI - 20250825191007"

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -50,5 +50,5 @@ variable "ami_filter_linux_arm64" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows 2019 GHA CI - 20250825191007"]
+  default     = ["Windows 2019 GHA CI - 20250813205303"]
 }


### PR DESCRIPTION
Reverts pytorch/ci-infra#357
Started seeing an issue with windows workers - hence roll back
https://github.com/pytorch/pytorch/actions/runs/17245964606/job/48935538476