### PR TITLE
Bump terraform-aws-github-runner to match Meta fleet

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20250716-153909"
+  tag: "v20250814-220933"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
Key change being pulled in is:
- https://github.com/pytorch/test-infra/pull/7004

That allows AMI experiments to be run via runner determinator even on custom AMIs (which is what we use for Windows)