### PR TITLE
Configure the k8s provider in the helm layer

### DIFF
--- a/arc/aws/391835788720/us-east-1/02_helm/main.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/main.tf
@@ -24,6 +24,23 @@ terraform {
   }
 }
 
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.runners[0].outputs.cluster_endpoint
+  cluster_ca_certificate  = base64decode(data.terraform_remote_state.runners[0].outputs.cluster_ca_certificate)
+  
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      data.terraform_remote_state.runners[0].outputs.cluster_name,
+    ]
+  }
+}
+
+
 provider "helm" {
   kubernetes {
     host                  = data.terraform_remote_state.runners[0].outputs.cluster_endpoint


### PR DESCRIPTION
The helm layer in the ARC infra uses the k8s service resources to fetch and verify the Argo service name.

Configure the k8s provider so that that may work.