### PR TITLE
Add cert-manager and ingress-nginx to ARC

### DIFF
--- a/arc/aws/391835788720/us-east-1/02_helm/argocd.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/argocd.tf
@@ -10,8 +10,13 @@ resource "helm_release" "argocd" {
 
   values = [
     # Nothing to pass to the template for now
-    templatefile("${path.module}/values/argocd.yaml.tftpl", {})
+    templatefile("${path.module}/values/argocd.yaml.tftpl", {
+      ingress_host       = var.argocd_ingress_host,
+      letsencrypt_issuer = var.letsencrypt_issuer,
+    })
   ]
+
+  depends_on = [null_resource.k8s_infra_ready]
 }
 
 # Verify that the service exists with expected name and namespace

--- a/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
@@ -1,0 +1,48 @@
+# This file includes basic k8s infrastructure managed via helm
+# Other k8s services must depend on resources defined here
+
+resource "helm_release" "ingress_nginx" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  namespace        = "ingress-nginx"
+  version          = "4.13.1"
+  create_namespace = true
+
+  # Load values from dedicated file
+  values = [
+    file("${path.module}/values/ingress-nginx.yaml")
+  ]
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  namespace        = "cert-manager"
+  version          = "v1.13.2"
+  create_namespace = true
+
+  values = [
+    file("${path.module}/values/cert-manager.yaml")
+  ]
+}
+
+resource "kubernetes_manifest" "letsencrypt_prod" {
+  manifest = yamldecode(templatefile("${path.module}/resources/clusterissuer.yaml.tftpl", {
+    cert_manager_email  = var.cert_manager_email
+    letsencrypt_issuer = var.letsencrypt_issuer
+  }))
+
+  depends_on = [helm_release.cert_manager]
+}
+
+
+# This gives a single depends_on target for all other apps installed on k8s
+resource "null_resource" "k8s_infra_ready" {
+  depends_on = [
+    helm_release.ingress_nginx,
+    helm_release.cert_manager,
+    kubernetes_manifest.letsencrypt_prod,
+  ]
+}

--- a/arc/aws/391835788720/us-east-1/02_helm/main.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/main.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.10"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 

--- a/arc/aws/391835788720/us-east-1/02_helm/resources/clusterissuer.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/resources/clusterissuer.yaml.tftpl
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${letsencrypt_issuer}
+spec:
+  acme:
+    email: ${cert_manager_email}
+    privateKeySecretRef:
+      name: ${letsencrypt_issuer}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+          ingressTemplate:
+            metadata:
+              annotations:
+                nginx.ingress.kubernetes.io/ssl-passthrough: "false"

--- a/arc/aws/391835788720/us-east-1/02_helm/values/argocd.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/argocd.yaml.tftpl
@@ -1,20 +1,27 @@
 # This is a very simple setup of ArgoCD
-# No HA, no Ingress, no TLS, no Dex (for OIDC)
+# No HA, no Dex (for OIDC)
 # The admin password is generated and stored in a secret in the cluster
 
-# The domain is only set when exposing ArgoCD through an ingress
-# See https://artifacthub.io/packages/helm/argo/argo-cd#aws-application-load-balancer
-
-# global:
-#   domain: __ingress_host__
+global:
+  domain: ${ingress_host}
 
 configs:
   params:
-    server.insecure: true
+    server.insecure: false
 
 server:
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: ${letsencrypt_issuer}
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/app-root: /login
+    tls: 
+    - hosts:
+      - ${ingress_host}
+      secretName: ingress-argocd-server-tls
 
 controller:
   resources:

--- a/arc/aws/391835788720/us-east-1/02_helm/values/cert-manager.yaml
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/cert-manager.yaml
@@ -1,0 +1,2 @@
+# Install CRDs with the chart
+installCRDs: true

--- a/arc/aws/391835788720/us-east-1/02_helm/values/ingress-nginx.yaml
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/ingress-nginx.yaml
@@ -1,0 +1,6 @@
+controller:
+  # Terminate the SSL connection on the services
+  # This providers enhanced security and simplifies configuration for ArgoCD
+  # See https://argo-cd.readthedocs.io/en/latest/operator-manual/ingress/#option-1-ssl-passthrough
+  extraArgs:
+    enable-ssl-passthrough: true

--- a/arc/aws/391835788720/us-east-1/02_helm/variables.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/variables.tf
@@ -9,3 +9,21 @@ variable "argocd_namespace" {
   type        = string
   default     = "argocd"
 }
+
+variable "cert_manager_email" {
+  type        = string
+  description = "Email to be used for the cert-manager cluster issuer"
+  default     = "hostmaster+pytorch-ci-argocd@linuxfoundation.org"
+}
+
+variable "letsencrypt_issuer" {
+  type        = string
+  description = "Name of the cert-manager cluster issuer"
+  default     = "letsencrypt-prod"
+}
+
+variable "argocd_ingress_host" {
+  type        = string
+  description = "Public ArgoCD endpoint"
+  default     = "argocd.pytorch.org"
+}


### PR DESCRIPTION
Add cert-manager to the k8s cluster used for ARC.
Add a ClusterIssuer. The email address required for that is pulled from a GitHub secret called CERT_MANAGER_EMAIL that needs to be created. GitHub workflows have been updated accordingly.

Add ingress-nginx to the k8s cluster used for ARC. This ingress works nicely with cert-manager, ArgoCD and the AWS LB infra.

Configure ArgoCD to use an ingress with the domain name argocd.pytorch.org, annotated for cert-manager and nginx. ArgoCD prefers SSL passthrough, because it transports HTTPs and grpc on the same port. Using SSL passthrough also enhances security as the traffic stays encrypted within the cluster as well.

Using SSL passthrough is a bit of an headache for the HTTP01 challenge. Adding a dedicated ingress template to the cluster issuer should solve that be creating a dedicated route in the ingress backed by the challenge pod and with SSL pass-through disabled.

The DNS name needs to be provisioned manually, so the ingress won't have a valid certificate initially, since Let's Encrypt challange will fail. Once the DNS record is provisioned, the certificate will be created.

Order of execution (after the PR is reviewed):
- merge this PR
- check the public IP address associated with the new ingress
- provision the DNS record
- verify that the certificate is provisioned correctly