### PR TITLE
Drop cert-manager from terraform for ARC

### DIFF
--- a/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
@@ -15,26 +15,11 @@ resource "helm_release" "ingress_nginx" {
   ]
 }
 
-resource "helm_release" "cert_manager" {
-  name             = "cert-manager"
-  repository       = "https://charts.jetstack.io"
-  chart            = "cert-manager"
-  namespace        = "cert-manager"
-  version          = "v1.13.2"
-  create_namespace = true
-
-  values = [
-    file("${path.module}/values/cert-manager.yaml")
-  ]
-}
-
 resource "kubernetes_manifest" "letsencrypt_prod" {
   manifest = yamldecode(templatefile("${path.module}/resources/clusterissuer.yaml.tftpl", {
     cert_manager_email  = var.cert_manager_email
     letsencrypt_issuer = var.letsencrypt_issuer
   }))
-
-  depends_on = [helm_release.cert_manager]
 }
 
 
@@ -42,7 +27,6 @@ resource "kubernetes_manifest" "letsencrypt_prod" {
 resource "null_resource" "k8s_infra_ready" {
   depends_on = [
     helm_release.ingress_nginx,
-    helm_release.cert_manager,
     kubernetes_manifest.letsencrypt_prod,
   ]
 }

--- a/arc/aws/391835788720/us-east-1/02_helm/values/cert-manager.yaml
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/cert-manager.yaml
@@ -1,2 +1,0 @@
-# Install CRDs with the chart
-installCRDs: true


### PR DESCRIPTION
cert-manager is preinstalled on the ARC eks cluster, managed by AWS, so no need to re-install it separately via terraform.