### PR TITLE
Add the AWS LB controller

### DIFF
--- a/arc/aws/391835788720/us-east-1/01_infra/outputs.tf
+++ b/arc/aws/391835788720/us-east-1/01_infra/outputs.tf
@@ -19,3 +19,18 @@ output "cluster_id" {
   description = "EKS cluster ID"
   value         = module.pytorch_arc_dev_eks.cluster_id
 }
+
+output "oidc_provider_arn" {
+  description = "ARN of the cluster OIDC provider"
+  value         = module.pytorch_arc_dev_eks.oidc_provider_arn
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "URL of the OIDC Issuer"
+  value         = module.pytorch_arc_dev_eks.cluster_oidc_issuer_url
+}
+
+output "vpc_id" {
+  description = "The ID of the cluster vpc"
+  value       = module.arc_runners_vpc.vpc_id
+}

--- a/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/k8s_infra.tf
@@ -1,26 +1,87 @@
 # This file includes basic k8s infrastructure managed via helm
 # Other k8s services must depend on resources defined here
 
+# Policy copied from https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.13.3/docs/install/iam_policy.json
+resource "aws_iam_policy" "aws_load_balancer_controller" {
+  name   = "AWSLoadBalancerControllerIAMPolicy-${local.cluster_name}"
+  policy = file("${path.module}/resources/aws-load-balancer-controller-policy.json")
+}
+
+# Role that allows the load balancer controller SA to benefit from the policy
+# See https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html
+# "aws-load-balancer-controller" is the name of service account provisioned by the helm chart
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name = "AWSLoadBalancerControllerRole-${local.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = local.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+          "${local.oidc_provider}:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
+        }
+      }
+    }]
+  })
+}
+
+# Connect the role to the policy
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
+  role       = aws_iam_role.aws_load_balancer_controller.name
+}
+
+# Deploy the AWS LB Controller
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.13.4"
+  namespace  = "kube-system"
+
+  values = [
+    templatefile("${path.module}/values/aws-load-balancer-controller.yaml.tftpl", {
+        cluster_name = local.cluster_name
+        vpc_id       = local.vpc_id
+        role_arn     = aws_iam_role.aws_load_balancer_controller.arn
+    })
+  ]
+
+  depends_on = [aws_iam_role_policy_attachment.aws_load_balancer_controller]
+}
+
+
+# Only install after the AWS LB controller is up and running
+# The nginx service is of type LB, and this helm deployment waits until
+# a public IP is assigned to the service
 resource "helm_release" "ingress_nginx" {
   name             = "ingress-nginx"
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
   namespace        = "ingress-nginx"
-  version          = "4.13.1"
+  version          = "4.13.2"
   create_namespace = true
 
   # Load values from dedicated file
   values = [
     file("${path.module}/values/ingress-nginx.yaml")
   ]
+
+  depends_on = [ helm_release.aws_load_balancer_controller ]
 }
 
 resource "helm_release" "cert_manager" {
   name             = "cert-manager"
-  repository       = "https://charts.jetstack.io"
+  repository       = "oci://quay.io/jetstack/charts"
   chart            = "cert-manager"
   namespace        = "cert-manager"
-  version          = "v1.13.2"
+  version          = "v1.18.2"
   create_namespace = true
 
   values = [
@@ -28,21 +89,41 @@ resource "helm_release" "cert_manager" {
   ]
 }
 
-resource "kubernetes_manifest" "letsencrypt_prod" {
-  manifest = yamldecode(templatefile("${path.module}/resources/clusterissuer.yaml.tftpl", {
-    cert_manager_email  = var.cert_manager_email
-    letsencrypt_issuer = var.letsencrypt_issuer
-  }))
+/*
+ * kubernetes_manifest has a limitation when it comes to CRDs and CRs.
+ * kubernetes_manifest fails planning a CR if the corresponding CRD is not on
+ * the cluster yet. The kubectl_manifest solves this, but unfortunately
+ * the kubectl provider is not maintained anymore.
+ *
+ * Deploying the ClusterIssuer using ArgoCD direcly would not be ideal as
+ * it would postpone having a fully functional ingress to later on in the
+ * infrastructure deployment.
+ *
+ * Short of deploying the CRD manually on the cluster, the only option left
+ * is to install the ClusterIssuer via kubectl, which doesn't provide
+ * much validation at terraform level, but it prevents the apply-time issue
+ */
 
-  depends_on = [helm_release.cert_manager]
+resource "null_resource" "letsencrypt_prod" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws eks update-kubeconfig --region ${local.aws_region} --name ${local.cluster_name}
+      cat <<'EOF' | kubectl apply -f -
+${templatefile("${path.module}/resources/clusterissuer.yaml.tftpl", {
+  letsencrypt_issuer = var.letsencrypt_issuer
+})}
+EOF
+    EOT
+  }
 }
 
 
 # This gives a single depends_on target for all other apps installed on k8s
 resource "null_resource" "k8s_infra_ready" {
   depends_on = [
+    helm_release.aws_load_balancer_controller,
     helm_release.ingress_nginx,
     helm_release.cert_manager,
-    kubernetes_manifest.letsencrypt_prod,
+    null_resource.letsencrypt_prod,
   ]
 }

--- a/arc/aws/391835788720/us-east-1/02_helm/outputs.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/outputs.tf
@@ -22,6 +22,11 @@ output "cluster_info" {
   }
 }
 
+# ArgoCD is available through a public endpoint, but we use the internal endpoint
+# for the ArgoCD terraform provider. The public endpoint depends on the cert-manager
+# ClusterIssuer that is only provisioned in the next layer (see comments there), which
+# means that terraform cannot assume that the public endpoint is up and running at the
+# time when ArgoCD applications are deployed.
 output "argocd_endpoint" {
   description = "ArgoCD Endpoint"
   value = "http://${data.kubernetes_service.argocd_server.metadata[0].name}.${helm_release.argocd.namespace}.svc.cluster.local"

--- a/arc/aws/391835788720/us-east-1/02_helm/resources/aws-load-balancer-controller-policy.json
+++ b/arc/aws/391835788720/us-east-1/02_helm/resources/aws-load-balancer-controller-policy.json
@@ -1,0 +1,251 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/arc/aws/391835788720/us-east-1/02_helm/resources/clusterissuer.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/resources/clusterissuer.yaml.tftpl
@@ -4,7 +4,6 @@ metadata:
   name: ${letsencrypt_issuer}
 spec:
   acme:
-    email: ${cert_manager_email}
     privateKeySecretRef:
       name: ${letsencrypt_issuer}
     server: https://acme-v02.api.letsencrypt.org/directory

--- a/arc/aws/391835788720/us-east-1/02_helm/values/aws-load-balancer-controller.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/aws-load-balancer-controller.yaml.tftpl
@@ -1,0 +1,6 @@
+clusterName: ${cluster_name}
+vpcId: ${vpc_id}
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ${role_arn}

--- a/arc/aws/391835788720/us-east-1/02_helm/values/ingress-nginx.yaml
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/ingress-nginx.yaml
@@ -1,4 +1,15 @@
 controller:
+  service:
+    type: "LoadBalancer"  # Default value
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-name: apps-ingress
+      service.beta.kubernetes.io/aws-load-balancer-type: external
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /healthz
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: 10254
+
   # Terminate the SSL connection on the services
   # This providers enhanced security and simplifies configuration for ArgoCD
   # See https://argo-cd.readthedocs.io/en/latest/operator-manual/ingress/#option-1-ssl-passthrough

--- a/arc/aws/391835788720/us-east-1/02_helm/variables.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/variables.tf
@@ -10,20 +10,14 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
-variable "cert_manager_email" {
+variable "argocd_ingress_host" {
   type        = string
-  description = "Email to be used for the cert-manager cluster issuer"
-  default     = "hostmaster+pytorch-ci-argocd@linuxfoundation.org"
+  description = "Public ArgoCD endpoint"
+  default     = "argocd.pytorch.org"
 }
 
 variable "letsencrypt_issuer" {
   type        = string
   description = "Name of the cert-manager cluster issuer"
   default     = "letsencrypt-prod"
-}
-
-variable "argocd_ingress_host" {
-  type        = string
-  description = "Public ArgoCD endpoint"
-  default     = "argocd.pytorch.org"
 }


### PR DESCRIPTION
Add the resource required provision the AWS LB controller. This controller requires a special policy/role to provision an AWS network load balancer on the fly when an Ingress of the right class is created.

This PR adapts previous resources as well to work with the AWS LB and fixes an issue with the ClusterIssuer by moving its provisioning to helm layer to address a limitation of the kubernetes_manifest terraform module.