### PR TITLE
Retrieve the ArgoCD oauth secrets from AWS SM

### DIFF
--- a/.github/workflows/arc-deploy-prod.yml
+++ b/.github/workflows/arc-deploy-prod.yml
@@ -40,5 +40,3 @@ jobs:
         AWS_DEFAULT_REGION: us-east-1
         GITHUB_TOKEN: ${{ secrets.LIST_PYTORCH_RUNNERS_GITHUB_TOKEN }}
         TERRAFORM_EXTRAS: -auto-approve -lock-timeout=15m
-        TF_VAR_argocd_dex_github_client_id: ${{ secrets.ARGOCD_GITHUB_CLIENT_ID }}
-        TF_VAR_argocd_dex_github_client_secret: ${{ secrets.ARGOCD_GITHUB_CLIENT_SECRET }}

--- a/.github/workflows/arc-on-pr.yml
+++ b/.github/workflows/arc-on-pr.yml
@@ -49,9 +49,6 @@ jobs:
       shell: bash
       working-directory: arc
       run: make tflint
-      env:
-        TF_VAR_argocd_dex_github_client_id: ${{ secrets.ARGOCD_GITHUB_CLIENT_ID }}
-        TF_VAR_argocd_dex_github_client_secret: ${{ secrets.ARGOCD_GITHUB_CLIENT_SECRET }}
 
     - name: Make plan
       shell: bash
@@ -59,5 +56,3 @@ jobs:
       run: make plan
       env:
         TERRAFORM_EXTRAS: -lock-timeout=15m
-        TF_VAR_argocd_dex_github_client_id: ${{ secrets.ARGOCD_GITHUB_CLIENT_ID }}
-        TF_VAR_argocd_dex_github_client_secret: ${{ secrets.ARGOCD_GITHUB_CLIENT_SECRET }}

--- a/arc/aws/391835788720/us-east-1/02_helm/values/argocd.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/argocd.yaml.tftpl
@@ -7,6 +7,9 @@ configs:
     server.url: https://${ingress_host}
 
   cm:
+    # No local admin user. Authn/authz managed via Dex/RBAC
+    admin.enabled: "false"
+
     # Dex configuration for GitHub SSO
     dex.config: |
       connectors:

--- a/arc/aws/391835788720/us-east-1/02_helm/variables.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/variables.tf
@@ -33,13 +33,3 @@ variable "argocd_dex_github_team" {
     description = "GitHub team with readonly access to ArgoCD"
     default     = "multicloud-wg"
 }
-
-variable "argocd_dex_github_client_id" {
-    type        = string
-    description = "GitHub OAuth App Client Id ArgoCD Dex"
-}
-
-variable "argocd_dex_github_client_secret" {
-    type        = string
-    description = "GitHub OAuth App Client Secret ArgoCD Dex"
-}


### PR DESCRIPTION
Instead of relying on env variables and GitHub secrets, fetch the ArgoCD oauth app details from AWS secret manager.