### PR TITLE
Several fixes to the ApplicationSet for ARC RunnerScaleSets

### DIFF
--- a/.github/workflows/arc-deploy-prod.yml
+++ b/.github/workflows/arc-deploy-prod.yml
@@ -40,3 +40,4 @@ jobs:
         AWS_DEFAULT_REGION: us-east-1
         GITHUB_TOKEN: ${{ secrets.LIST_PYTORCH_RUNNERS_GITHUB_TOKEN }}
         TERRAFORM_EXTRAS: -auto-approve -lock-timeout=15m
+        TF_VAR_git_revision: ${{ github.ref_name }}

--- a/arc/aws/391835788720/us-east-1/03_argocd/runner-set-lf-aws.tf
+++ b/arc/aws/391835788720/us-east-1/03_argocd/runner-set-lf-aws.tf
@@ -6,8 +6,8 @@ module "argocd-runner-scale-set" {
   server_addr   = local.argocd_ready ? local.argocd_endpoint : null
   token         = local.argocd_ready ? local.argocd_terraform_sa_token : null
   organization  = "lf"
-  cluster       = "local"
+  cluster       = "in-cluster"
   namespace     = "lf-aws"
-  provider_path = " argocd/aws/391835788720/us-east-1"
+  provider_path = "argocd/aws/391835788720/us-east-1"
   git_revision  = var.git_revision
 }

--- a/arc/modules/argocd-runner-scale-set/variables.tf
+++ b/arc/modules/argocd-runner-scale-set/variables.tf
@@ -23,7 +23,7 @@ variable "namespace" {
 variable "cluster" {
     description = "The name of the cluster as defined in ArgoCD"
     type        = string
-    default     = "local"
+    default     = "in-cluster"
 }
 
 variable "provider_path" {

--- a/argocd/aws/391835788720/us-east-1/in-cluster/lf-aws/linux-20250911-amd64-2c-4g/values.yaml
+++ b/argocd/aws/391835788720/us-east-1/in-cluster/lf-aws/linux-20250911-amd64-2c-4g/values.yaml
@@ -21,3 +21,8 @@ template:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest
         command: ["/home/runner/run.sh"]
+
+# Service account of the controller
+controllerServiceAccount:
+  name: "arc-gha-rs-controller"
+  namespace: "arc-systems"


### PR DESCRIPTION
Several fixes:

* The provider_path for ARC runner scale sets included an unwanted leading space, causing path match to fail.
* Add `TF_VAR_git_revision` to the arc-deploy-prod job so that we can deploy from a PR including changes to the values for the RunnerScaleSet.
* Add a repository definition to the cluster, which is required for OCI based helm charts.
* Add enough permissions to the ArgoCD project to deploy all resources included in the helm chart.
* Add auto-sync to the applicationset template
* Change the local cluster name to `in-cluster` which is ArgoCD default

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>