### PR TITLE
Config the ephemeral runners for pytorch/pytorch

### DIFF
--- a/argocd/aws/391835788720/us-east-1/in-cluster/lf-aws/linux-20250911-amd64-2c-4g/values.yaml
+++ b/argocd/aws/391835788720/us-east-1/in-cluster/lf-aws/linux-20250911-amd64-2c-4g/values.yaml
@@ -1,5 +1,5 @@
-# ci-infra repo only for now
-githubConfigUrl: https://github.com/pytorch/ci-infra
+# pytorch repo only
+githubConfigUrl: https://github.com/pytorch/pytorch
 
 ## githubConfigSecret is provisioned by terraform on the k8s cluster/namespace
 githubConfigSecret: github-config # checkov:skip=CKV_SECRET_6:Secret name reference, not actual secret


### PR DESCRIPTION
Configure the test RunnerScaleSet for the pytorch/pytorch git repo only.