### PR TITLE
One RSS per namespace. Add role/binding for secrets

### DIFF
--- a/arc/aws/391835788720/us-east-1/03_argocd/runner-set-lf-aws.tf
+++ b/arc/aws/391835788720/us-east-1/03_argocd/runner-set-lf-aws.tf
@@ -7,7 +7,6 @@ module "argocd-runner-scale-set" {
   token         = local.argocd_ready ? local.argocd_terraform_sa_token : null
   organization  = "lf"
   cluster       = "in-cluster"
-  namespace     = "lf-aws"
   provider_path = "argocd/aws/391835788720/us-east-1"
   git_revision  = var.git_revision
 }

--- a/arc/modules/argocd-runner-scale-set/variables.tf
+++ b/arc/modules/argocd-runner-scale-set/variables.tf
@@ -14,12 +14,6 @@ variable "organization" {
     default     = "lf"
 }
 
-variable "namespace" {
-    description = "The namespace for in the format <org>-<cloud>"
-    type        = string
-    default     = "lf-aws"
-}
-
 variable "cluster" {
     description = "The name of the cluster as defined in ArgoCD"
     type        = string
@@ -49,4 +43,16 @@ variable "aws_secret_key_name" {
     description = "The name of the AWS SM secret with private key"
     type        = string
     default     = "pytorch-arc-github-app-private-key"
+}
+
+variable "arc_controller_sa" {
+    description = "Service account used by the ARC controller"
+    type        = string
+    default     = "arc-gha-rs-controller"
+}
+
+variable "arc_controller_sa_namespace" {
+    description = "Namespace where the service account used by the ARC controller is defined"
+    type        = string
+    default     = "arc-system"
 }

--- a/argocd/aws/391835788720/us-east-1/in-cluster/ubuntu-22-amd64-2c-4g/values.yaml
+++ b/argocd/aws/391835788720/us-east-1/in-cluster/ubuntu-22-amd64-2c-4g/values.yaml
@@ -11,9 +11,10 @@ maxRunners: 2
 ## calculated as a sum of minRunners and the number of jobs assigned to the scale set.
 minRunners: 0
 
-runnerGroup: "linux-amd64-2c-4g"
+# Using the default runner group for now
+# runnerGroup: "ubuntu-amd64-2c-4g"
 
-runnerScaleSetName: "lf-aws-linux-20250911-amd64-2c-4g"
+runnerScaleSetName: "lf-aws-ubuntu-22-amd64-2c-4g"
 
 template:
   spec:
@@ -21,8 +22,3 @@ template:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest
         command: ["/home/runner/run.sh"]
-
-# Service account of the controller
-controllerServiceAccount:
-  name: "arc-gha-rs-controller"
-  namespace: "arc-systems"


### PR DESCRIPTION
Change the ApplicationSet module so that each RunnerScaleSet is executed in its own namespace.
Add a role to get read access to secrets and a rolebinding in each namespace.
Also update the RSS name to reflect the OS/version of the runner container image, rather than the containing VM.
