### PR TITLE
[ALI] upgrade linux AMI to use AL23 version 8

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -38,13 +38,13 @@ variable "aws_canary_vpc_suffixes" {
 variable "ami_filter_linux" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.7.*-kernel-6.1-x86_64"]
+  default     = ["al2023-ami-2023.8.*-kernel-6.1-x86_64"]
 }
 
 variable "ami_filter_linux_arm64" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.7.*-kernel-6.1-arm64"]
+  default     = ["al2023-ami-2023.8.*-kernel-6.1-arm64"]
 }
 
 variable "ami_filter_windows" {


### PR DESCRIPTION
V7 is not available anymore, so releases are going to fail.

Meta's infra migrated yesterday successfully, so seems a safe upgrade.