### PR TITLE
Update cloud-account-access for LFID auth

### DIFF
--- a/cloud-account-access.md
+++ b/cloud-account-access.md
@@ -16,28 +16,13 @@ Infrastructure weekly meeting and are able to administer the account.
 Policy:
 
 * Administrator level permissions will be granted
-  (arn:aws:iam::aws:policy/AdministratorAccess).
+  (arn:aws:iam::aws:policy/PowerUserAccess).
 * Permissions automatically expire after 6 months if not renewed.
 * Permissions will be reviewed and extended on a quarterly cadence by existing
   pytorch-infra-admins with advisory of regular attendees of the weekly
   PyTorch CI Sync meeting or the PyTorch TAC.
 * pytorch-infra-admins should themselves be regular attendees of the weekly
   PyTorch CI Sync meeting.
-* MFA-Required policy will be configured on the permissions group.
-
-### Infra Contributor Level Access: pytorch-infra-contributors
-
-This permission level access is granted to those participating in the PyTorch
-Infrastructure that may need access to work on features that require access to
-AWS to develop.
-
-Policy:
-
-* Power User level permissions will be granted
-  (arn:aws:iam::aws:policy/PowerUserAccess).
-* Permissions automatically expire after 6 months if not renewed.
-* Permissions will be reviewed and extended on a quarterly cadence by
-  pytorch-infra-admins.
 * MFA-Required policy will be configured on the permissions group.
 
 ### Infra Advisory Level Access: pytorch-infra-advisors
@@ -62,12 +47,37 @@ this can be done via one of 2 methods:
 1. Request access at the weekly PyTorch CI Sync meeting.
 2. At the discretion of one of the existing pytorch-infra-admins.
 
-## Implementation
+LFID account access will be defined via Terraform configuration and is managed
+by LFIT staff in a private repo. Please contact a PyTorch LFIT staff member to
+request access for a new account.
 
-The implementation of the account access will be defined via Terraform
-configuration in the **access** directory of this repo.
+## Access AWS Console
 
-Automation will be put in place to automatically create a pull request to
-extend existing user access on a quarterly basis that need to be reviewed by
-the pytorch-infra-admins team to continue extended permissions for any active
-user accounts.
+To access AWS Console navigate to the login portal at
+https://lfstrategic.awsapps.com/start
+
+Enter your LFID authentication details and you should be directed back to AWS
+Console logged in.
+
+## Access AWS CLI
+
+To use the AWS CLI, SSO configuration needs to be setup. Start by running
+`aws configure sso` and answer the following questions:
+
+```
+SSO session name (Recommended): pytorch-ci
+SSO start URL [None]: https://lfstrategic.awsapps.com/start
+SSO region [None]: us-west-2
+
+# Leave the next one blank to accept the defaults.
+SSO registration scopes [sso:account:access]:
+# Web URL will open to authenticate you
+
+Default client Region [None]: us-east-1
+Profile name [AWSPowerUserAccess-391835788720]: pytorch-ci
+```
+
+Recommended: Export the AWS_PROFILE when using the CLI `export AWS_PROFILE=pytorch-ci`
+
+Once configured you will be able to use the AWS CLI with access tokens. If your
+access token requires a refresh. Simply run `aws sso login`.


### PR DESCRIPTION
We are now using IAM Identity Center for authentication into PyTorch AWS Account. This updates the instructions on how to access PyTorch AWS using the LFID login portal for AWS.

Update the pytorch-infra-admins role to use PowerUserAccess as it is effectively administrator access minus the ability to manage users / groups. LFIT staff will handle account access moving forward as it hooks into LFID SSO so needs a different level of account access to manage.

Also remove the pytorch-infra-contributor access role. We currently do not have any members of this group and this group should be more restricted than is defined. PowerUserAccess essentially grants admin privileges minus the ability to manage users / groups.