### PR TITLE
Update Windows AMI to AMI Windows 2019 GHA CI - 20260325213408

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -50,5 +50,5 @@ variable "ami_filter_linux_arm64" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows 2019 GHA CI - 20250825191007"]
+  default     = ["Windows 2019 GHA CI - 20260325213408"]
 }


### PR DESCRIPTION
Keeping it as draft for canary testing