### PR TITLE
Bump container hooks to v0.8.8 and harden smoke tests

### DIFF
--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -60,7 +60,7 @@ Every Karpenter NodePool applies this startup taint via the `startupTaints` fiel
 Runner pods include an init container that polls for a file on the host filesystem before the runner container can start. This file is placed by a DaemonSet.
 
 **DaemonSet**: `runner-hooks-warmer` (`modules/arc-runners/kubernetes/hooks-warmer.yaml`)
-- Downloads patched `runner-container-hooks` v0.8.3 from GitHub releases
+- Downloads patched `runner-container-hooks` v0.8.8 from GitHub releases
 - Extracts to `/mnt/runner-container-hooks/dist/` on host NVMe
 - Validates `dist/index.js` exists after extraction
 - Writes version marker for idempotency

--- a/osdc/integration-tests/load-test/scripts/python/workflow_generator.py
+++ b/osdc/integration-tests/load-test/scripts/python/workflow_generator.py
@@ -8,7 +8,7 @@ from distribution import RunnerAllocation
 
 # Container images
 CPU_CONTAINER = "ghcr.io/actions/actions-runner:latest"
-GPU_CONTAINER = "nvidia/cuda:12.6.3-runtime-ubuntu22.04"
+GPU_CONTAINER = "ghcr.io/actions/actions-runner:latest"
 
 # GitHub Actions matrix max entries
 MAX_MATRIX_SIZE = 256

--- a/osdc/integration-tests/workflows/build-image.yaml
+++ b/osdc/integration-tests/workflows/build-image.yaml
@@ -22,10 +22,17 @@ jobs:
     # The arch input selects which BuildKit endpoint to connect to.
     runs-on: ${{ inputs.runner_label }}
     container:
-      image: moby/buildkit:v0.29.0
-      # Run as root to use buildctl
-      options: --privileged
+      image: ghcr.io/actions/actions-runner:latest
     steps:
+      - name: Install buildctl
+        run: |
+          BUILDKIT_VERSION="v0.29.0"
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+            | tar xz --strip-components=1 -C "$HOME/.local/bin" bin/buildctl
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/buildctl" --version
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1387,7 +1387,7 @@ jobs:
   test-gpu-t4:
     runs-on: {{PREFIX}}l-x86iavx512-29-115-t4
     container:
-      image: nvidia/cuda:12.6.3-base-ubuntu22.04
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Verify GPU
         run: |
@@ -1434,7 +1434,7 @@ jobs:
   test-gpu-t4-multi:
     runs-on: {{PREFIX}}l-x86iavx512-45-172-t4-4
     container:
-      image: nvidia/cuda:12.6.3-base-ubuntu22.04
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Verify multi-GPU
         run: |
@@ -1471,7 +1471,7 @@ jobs:
   test-gpu-b200-2:
     runs-on: {{PREFIX}}a.linux.b200.2
     container:
-      image: nvidia/cuda:12.6.3-base-ubuntu22.04
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Verify B200 multi-GPU
         run: |

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -4,7 +4,7 @@
 #
 # Fix: find -exec stat {} \; -> find -exec stat {} + (10-100x faster)
 # Fix: exit code propagation — OOM-killed processes now correctly report failure
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.5
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.8
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -91,7 +91,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.7"
+              HOOKS_VERSION="0.8.8"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -91,7 +91,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.5"
+              HOOKS_VERSION="0.8.7"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -148,7 +148,7 @@ template:
             value: /home/runner/hook-extensions/job-pod.yaml
           # Use OSDC wrapper that validates env vars and surfaces errors
           # clearly, then delegates to patched hooks from DaemonSet.
-          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.4
+          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.8
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS
             value: /home/runner/hook-extensions/wrapper.js
           # Allow more time for workflow pods to come online during demand surges.

--- a/osdc/modules/logging/tests/smoke/test_logging.py
+++ b/osdc/modules/logging/tests/smoke/test_logging.py
@@ -20,6 +20,7 @@ from helpers import (
     fetch_grafana_cloud_credentials,
     filter_pods,
     find_helm_release,
+    get_all_node_names,
     get_recently_stable_node_names,
     get_unstable_node_names,
     loki_read_url,
@@ -154,15 +155,23 @@ class TestAlloyLogging:
 
         assert len(pods) > 0, f"No alloy-logging pods found (after {READY_RETRIES} retries)"
 
+        known_node_names = get_all_node_names(nodes)
         unstable_names = get_unstable_node_names(nodes)
         recently_stable_names = get_recently_stable_node_names(nodes)
+        disappeared = 0
         not_running = [
             p["metadata"]["name"]
             for p in pods
             if p["status"].get("phase") != "Running"
+            and p["spec"].get("nodeName") in known_node_names  # skip pods on disappeared nodes
             and p["spec"].get("nodeName") not in unstable_names
             and not (p["status"].get("phase") == "Pending" and p["spec"].get("nodeName") in recently_stable_names)
         ]
+        disappeared = sum(
+            1
+            for p in pods
+            if p["status"].get("phase") != "Running" and p["spec"].get("nodeName") not in known_node_names
+        )
 
         if not not_running:
             return
@@ -173,15 +182,22 @@ class TestAlloyLogging:
             fresh_pods = run_kubectl(["get", "pods", "-A"])
             fresh_nodes = run_kubectl(["get", "nodes"])
             pods = filter_pods(fresh_pods, namespace=logging_ns, labels=alloy_labels)
+            known_node_names = get_all_node_names(fresh_nodes)
             unstable_names = get_unstable_node_names(fresh_nodes)
             recently_stable_names = get_recently_stable_node_names(fresh_nodes)
             not_running = [
                 p["metadata"]["name"]
                 for p in pods
                 if p["status"].get("phase") != "Running"
+                and p["spec"].get("nodeName") in known_node_names
                 and p["spec"].get("nodeName") not in unstable_names
                 and not (p["status"].get("phase") == "Pending" and p["spec"].get("nodeName") in recently_stable_names)
             ]
+            disappeared = sum(
+                1
+                for p in pods
+                if p["status"].get("phase") != "Running" and p["spec"].get("nodeName") not in known_node_names
+            )
             if not not_running:
                 return
 
@@ -189,6 +205,7 @@ class TestAlloyLogging:
             f"Alloy pods not Running on stable nodes: {not_running} "
             f"({len(unstable_names)} unstable nodes excluded, "
             f"{len(recently_stable_names)} recently-stable nodes with Pending pods tolerated, "
+            f"{disappeared} pods on disappeared nodes excluded, "
             f"after {READY_RETRIES} retries)"
         )
 

--- a/osdc/tests/smoke/helpers.py
+++ b/osdc/tests/smoke/helpers.py
@@ -191,9 +191,11 @@ def _parse_k8s_timestamp(ts: str) -> float:
 
 
 def _is_node_unstable(node: dict, min_node_age: int = MIN_NODE_AGE_SECONDS) -> bool:
-    """Check if a single node is unstable (new, NotReady, or being deleted)."""
+    """Check if a single node is unstable (new, NotReady, cordoned, or being deleted)."""
     meta = node.get("metadata", {})
     if meta.get("deletionTimestamp"):
+        return True
+    if node.get("spec", {}).get("unschedulable"):
         return True
     conditions = {c["type"]: c["status"] for c in node.get("status", {}).get("conditions", [])}
     if conditions.get("Ready") != "True":
@@ -207,10 +209,11 @@ def _is_node_unstable(node: dict, min_node_age: int = MIN_NODE_AGE_SECONDS) -> b
 
 
 def _count_unstable_nodes(all_nodes: dict, min_node_age: int = MIN_NODE_AGE_SECONDS) -> int:
-    """Count nodes that are new, NotReady, or being deleted.
+    """Count nodes that are new, NotReady, cordoned, or being deleted.
 
     A node is "unstable" if any of:
     - It has a deletionTimestamp (being deleted)
+    - It is cordoned (spec.unschedulable is true)
     - Its Ready condition is not True
     - It was created less than min_node_age seconds ago
     """
@@ -220,6 +223,11 @@ def _count_unstable_nodes(all_nodes: dict, min_node_age: int = MIN_NODE_AGE_SECO
 def get_unstable_node_names(all_nodes: dict, min_node_age: int = MIN_NODE_AGE_SECONDS) -> set[str]:
     """Return names of nodes that are new, NotReady, or being deleted."""
     return {node["metadata"]["name"] for node in all_nodes.get("items", []) if _is_node_unstable(node, min_node_age=min_node_age)}
+
+
+def get_all_node_names(all_nodes: dict) -> set[str]:
+    """Return names of all nodes currently known to the API server."""
+    return {node["metadata"]["name"] for node in all_nodes.get("items", [])}
 
 
 def get_recently_stable_node_names(
@@ -278,7 +286,7 @@ def assert_daemonset_healthy(
     """Assert DaemonSet is healthy, tolerating mismatches from node churn.
 
     Passes if desired == ready, OR if the mismatch is fully explained by
-    nodes that are new (< min_node_age seconds), NotReady, or being deleted.
+    nodes that are new (< min_node_age seconds), NotReady, cordoned, or being deleted.
 
     This is resilient to concurrent node churn (compactor e2e, Karpenter
     autoscaling, spot interruptions, node recycling).


### PR DESCRIPTION
**Impact:** CI runners, integration tests, smoke tests
**Risk:** High

See https://github.com/jeanschmidt/runner-container-hooks/pull/1 for details on what v0.8.7 introduces.

## What
Bumps the patched runner-container-hooks from v0.8.5 to v0.8.7 (from jeanschmidt/runner-container-hooks fork), standardizes all integration test containers on `ghcr.io/actions/actions-runner:latest`, and hardens smoke tests against node churn edge cases.

## Why
The container hooks v0.8.7 release includes fixes from [jeanschmidt/runner-container-hooks#1](https://github.com/jeanschmidt/runner-container-hooks/pull/1). Smoke tests were flaking when pods remained scheduled on nodes that had already been terminated (disappeared from the API server) or on cordoned nodes.

## How
- Switched all test containers to actions-runner image — GPU tests rely on host-level NVIDIA drivers exposed into the container, not on CUDA libraries in the container image
- Added "disappeared node" tracking in smoke tests — pods referencing nodes no longer in the API server are excluded from failure counts rather than causing false positives
- Added cordoned node (`spec.unschedulable`) detection to the unstable node classifier

## Changes

**Container hooks bump:**
- `hooks-warmer.yaml`: `HOOKS_VERSION` 0.8.5 → 0.8.7

**Integration test container standardization:**
- `build-image.yaml`: Replaced privileged `moby/buildkit:v0.29.0` container with non-privileged `actions-runner:latest` + runtime `buildctl` install step
- `integration-test.yaml.tpl`: GPU test jobs (`test-gpu-t4`, `test-gpu-t4-multi`, `test-gpu-b200-2`) switched from `nvidia/cuda:12.6.3-base-ubuntu22.04` to `actions-runner:latest`
- `workflow_generator.py`: `GPU_CONTAINER` constant changed from `nvidia/cuda:12.6.3-runtime-ubuntu22.04` to `actions-runner:latest`

**Smoke test hardening:**
- `helpers.py`: `_is_node_unstable()` now treats cordoned nodes (`spec.unschedulable`) as unstable; new `get_all_node_names()` helper
- `test_logging.py`: `test_alloy_pods_running` now excludes pods on "disappeared" nodes (node no longer in API server) from failure assertions; reports count in error messages

## Testing
```
$  just integration-test arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
17:36:04 [INFO] Integration test for cluster: arc-staging (pytorch-arc-staging)
17:36:04 [INFO]   Runner prefix: 'c-mt-'
17:36:04 [INFO]   B200 enabled: False
17:36:04 [INFO]   Release runners: True
17:36:04 [INFO]   Cache enforcer: True
17:36:04 [INFO]   PyPI cache slugs: cpu cu126 cu128 cu130
17:36:04 [INFO]   Smoke tests: skip
17:36:04 [INFO]   Compactor tests: skip
17:36:04 [INFO]   Branch: osdc-integration-test-arc-staging
17:36:04 [INFO] Phase 0: Cleaning up stale PRs...
17:36:09 [INFO] Phase 1: Checking for active runner pods (arc-staging only)...
17:36:16 [INFO]   No runner pods active. Skipping pool clear.
17:36:16 [INFO]   Canary repo already cloned at /Users/jschmidt/meta/ciforge/osdc/upstream/osdc/.scratch/pytorch-canary, fetching...
17:36:17 [INFO] Phase 2: Preparing PR...
17:36:33 [INFO]   PR #411 created: https://github.com/pytorch/pytorch-canary/pull/411
17:36:33 [INFO] Phase 3: Running parallel validation...
17:36:33 [INFO] Phase 4: Waiting for PR workflow runs (timeout: 50 min, buffer: 10 min)...
17:36:33 [INFO]   Filtering to runs created after 2026-04-11T00:36:17.795084+00:00
17:36:40 [INFO]   Run: OSDC Integration Test — https://github.com/pytorch/pytorch-canary/actions/runs/24270460678
17:36:40 [INFO]   1/1 runs still in progress...
17:37:13 [INFO]   1/1 runs still in progress...
17:37:45 [INFO]   1/1 runs still in progress...
17:38:18 [INFO]   1/1 runs still in progress...
17:38:52 [INFO]   1/1 runs still in progress...
17:39:24 [INFO]   1/1 runs still in progress...
17:40:00 [INFO]   1/1 runs still in progress...
17:40:31 [INFO]   1/1 runs still in progress...
17:41:05 [INFO]   1/1 runs still in progress...
17:41:40 [INFO]   1/1 runs still in progress...
17:42:13 [INFO]   1/1 runs still in progress...
17:42:49 [INFO]   All 1 run(s) completed.


============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-04-11 00:42 UTC

  PR Workflow Jobs:
    ✓ test-gpu-t4                    success
    ✓ test-pypi-cache-defaults       success
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-git-cache                 success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-cpu-x86-amx               success
    ✓ test-cpu-arm64                 success
    ✓ test-cpu-x86-avx512            success
    ✓ test-cache-enforcer            success
    ✓ test-release-arm64             success
    ✓ test-gpu-t4-multi              success
    ✓ test-harbor                    success
    ✓ build-amd64 / build            success
    ✓ build-arm64 / build            success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================

17:42:53 [INFO] Phase 5: Closing PR #411...
17:42:56 [INFO] Total integration test time: 6m52s
```