### PR TITLE
Increase node-compactor memory limits

### DIFF
--- a/osdc/base/node-compactor/kubernetes/deployment.yaml
+++ b/osdc/base/node-compactor/kubernetes/deployment.yaml
@@ -58,10 +58,10 @@ spec:
           resources:
             requests:
               cpu: "50m"
-              memory: "128Mi"
+              memory: "2Gi"
             limits:
               cpu: "200m"
-              memory: "256Mi"
+              memory: "4Gi"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
- Raise memory request from 128Mi to 2Gi
- Raise memory limit from 256Mi to 4Gi

The node-compactor Python controller manages node tainting and capacity reservations across all Karpenter-managed NodePools. The previous 128Mi/256Mi allocation was insufficient — the controller likely OOM-killed under load when tracking many nodes. Bumping to 2Gi/4Gi gives headroom for large cluster state in memory.