### PR TITLE
Add gharts RDS instance and IRSA role to 01_infra

### DIFF
--- a/arc/aws/391835788720/us-east-1/01_infra/gharts-rds.tf
+++ b/arc/aws/391835788720/us-east-1/01_infra/gharts-rds.tf
@@ -1,0 +1,120 @@
+/*
+ * RDS PostgreSQL instance for gharts (GitHub Actions Runner Token Service).
+ *
+ * Placed in the private subnets of the cluster VPC. Access is restricted to
+ * within the VPC CIDR so only pods running on the cluster can connect.
+ *
+ * Authentication uses IAM RDS auth — no static password is required.
+ * The gharts service account is bound to an IAM role (IRSA) that carries the
+ * rds-db:connect permission.
+ */
+
+# Subnet group covering all private subnets in the VPC
+resource "aws_db_subnet_group" "gharts" {
+  name       = "${var.arc_dev_environment}-gharts"
+  subnet_ids = module.arc_runners_vpc.private_subnets
+
+  tags = {
+    Environment = var.arc_dev_environment
+    Project     = var.arc_dev_environment
+  }
+}
+
+# Allow inbound PostgreSQL from within the VPC (EKS nodes and pods)
+resource "aws_security_group" "gharts_rds" {
+  name        = "${var.arc_dev_environment}-gharts-rds"
+  description = "Allow PostgreSQL access from EKS nodes"
+  vpc_id      = module.arc_runners_vpc.vpc_id
+
+  ingress {
+    description = "PostgreSQL from VPC"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [module.arc_runners_vpc.vpc_cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.arc_dev_environment
+    Project     = var.arc_dev_environment
+  }
+}
+
+resource "aws_db_instance" "gharts" {
+  identifier        = "${var.arc_dev_environment}-gharts"
+  engine            = "postgres"
+  engine_version    = "16"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp2"
+  storage_encrypted = true
+
+  db_name  = "gharts"
+  username = "gharts"
+
+  # IAM authentication — no static password needed
+  iam_database_authentication_enabled = true
+  manage_master_user_password         = true
+
+  db_subnet_group_name   = aws_db_subnet_group.gharts.name
+  vpc_security_group_ids = [aws_security_group.gharts_rds.id]
+
+  # Dev instance — no Multi-AZ, no automated backups needed
+  multi_az                = false
+  backup_retention_period = 0
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  tags = {
+    Environment = var.arc_dev_environment
+    Project     = var.arc_dev_environment
+  }
+}
+
+# IAM policy granting rds-db:connect for the gharts DB user
+resource "aws_iam_policy" "gharts_rds_connect" {
+  name = "${var.arc_dev_environment}-gharts-rds-connect"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "rds-db:connect"
+      Resource = "arn:aws:rds-db:${local.aws_region}:${local.aws_account_id}:dbuser:${aws_db_instance.gharts.resource_id}/gharts"
+    }]
+  })
+}
+
+# IAM role for the gharts service account (IRSA)
+resource "aws_iam_role" "gharts" {
+  name = "${var.arc_dev_environment}-gharts"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = module.pytorch_arc_dev_eks.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${replace(module.pytorch_arc_dev_eks.cluster_oidc_issuer_url, "https://", "")}:aud" = "sts.amazonaws.com"
+          "${replace(module.pytorch_arc_dev_eks.cluster_oidc_issuer_url, "https://", "")}:sub" = "system:serviceaccount:gharts:gharts"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "gharts_rds_connect" {
+  policy_arn = aws_iam_policy.gharts_rds_connect.arn
+  role       = aws_iam_role.gharts.name
+}

--- a/arc/aws/391835788720/us-east-1/01_infra/outputs.tf
+++ b/arc/aws/391835788720/us-east-1/01_infra/outputs.tf
@@ -34,3 +34,13 @@ output "vpc_id" {
   description = "The ID of the cluster vpc"
   value       = module.arc_runners_vpc.vpc_id
 }
+
+output "gharts_rds_host" {
+  description = "RDS hostname for the gharts PostgreSQL instance"
+  value       = aws_db_instance.gharts.address
+}
+
+output "gharts_irsa_role_arn" {
+  description = "IAM role ARN for the gharts service account (IRSA)"
+  value       = aws_iam_role.gharts.arn
+}

--- a/arc/aws/391835788720/us-east-1/02_helm/gharts.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/gharts.tf
@@ -1,0 +1,97 @@
+/*
+ * Deploys the GitHub Actions Runner Token Service (gharts).
+ *
+ * gharts provides JIT runner token provisioning with OIDC-based authentication.
+ * It reuses the same GitHub App credentials as ARC.
+ *
+ * The database is an RDS PostgreSQL instance provisioned in 01_infra.
+ * Authentication uses IAM RDS auth via IRSA — no password secret is required.
+ * The gharts service account is annotated with the IAM role ARN from 01_infra.
+ *
+ * Chart source: oci://ghcr.io/afrittoli/gharts
+ */
+
+data "aws_secretsmanager_secret_version" "gharts_arc_github_app" {
+  secret_id = "pytorch-arc-github-app"
+}
+
+data "aws_secretsmanager_secret_version" "gharts_arc_github_app_private_key" {
+  secret_id = "pytorch-arc-github-app-private-key"
+}
+
+locals {
+  gharts_arc_config         = jsondecode(data.aws_secretsmanager_secret_version.gharts_arc_github_app.secret_string)
+  gharts_github_app_id      = local.gharts_arc_config["app-id"]
+  gharts_github_install_id  = local.gharts_arc_config["installation-id"]
+  gharts_github_private_key = data.aws_secretsmanager_secret_version.gharts_arc_github_app_private_key.secret_string
+  gharts_rds_host           = data.terraform_remote_state.runners[0].outputs.gharts_rds_host
+  gharts_irsa_role_arn      = data.terraform_remote_state.runners[0].outputs.gharts_irsa_role_arn
+  gharts_oidc_jwks_url      = var.gharts_oidc_jwks_url != "" ? var.gharts_oidc_jwks_url : "${var.gharts_oidc_issuer}/.well-known/jwks.json"
+}
+
+resource "kubernetes_namespace" "gharts" {
+  metadata {
+    name = var.gharts_namespace
+  }
+}
+
+# GitHub App private key — consumed by the Helm chart as gharts-github
+resource "kubernetes_secret" "gharts_github" {
+  metadata {
+    name      = "gharts-github"
+    namespace = kubernetes_namespace.gharts.metadata[0].name
+  }
+
+  data = {
+    "private-key.pem" = local.gharts_github_private_key
+  }
+
+  type = "Opaque"
+}
+
+# OIDC client ID — consumed by the Helm chart as gharts-oidc
+# Populated from AWS Secrets Manager once Auth0 details are available.
+resource "kubernetes_secret" "gharts_oidc" {
+  metadata {
+    name      = "gharts-oidc"
+    namespace = kubernetes_namespace.gharts.metadata[0].name
+  }
+
+  data = {
+    "oidc-client-id" = var.gharts_oidc_client_id
+  }
+
+  type = "Opaque"
+}
+
+resource "helm_release" "gharts" {
+  name       = "gharts"
+  repository = "oci://ghcr.io/afrittoli"
+  chart      = "gharts"
+  version    = var.gharts_chart_version
+  namespace  = kubernetes_namespace.gharts.metadata[0].name
+  wait       = true
+  timeout    = 300
+
+  values = [
+    templatefile("${path.module}/values/gharts.yaml.tftpl", {
+      ingress_host       = var.gharts_ingress_host
+      letsencrypt_issuer = var.letsencrypt_issuer
+      github_org         = var.gharts_github_org
+      github_app_id      = local.gharts_github_app_id
+      github_install_id  = local.gharts_github_install_id
+      oidc_issuer        = var.gharts_oidc_issuer
+      oidc_audience      = var.gharts_oidc_audience
+      oidc_jwks_url      = local.gharts_oidc_jwks_url
+      rds_host           = local.gharts_rds_host
+      irsa_role_arn      = local.gharts_irsa_role_arn
+      aws_region         = local.aws_region
+    })
+  ]
+
+  depends_on = [
+    kubernetes_secret.gharts_github,
+    kubernetes_secret.gharts_oidc,
+    null_resource.k8s_infra_ready,
+  ]
+}

--- a/arc/aws/391835788720/us-east-1/02_helm/values/gharts.yaml.tftpl
+++ b/arc/aws/391835788720/us-east-1/02_helm/values/gharts.yaml.tftpl
@@ -1,0 +1,77 @@
+# Replica counts — reduced for dev cluster
+replicaCount:
+  backend: 1
+  frontend: 1
+
+# Disable autoscaling for dev
+backend:
+  autoscaling:
+    enabled: false
+
+frontend:
+  autoscaling:
+    enabled: false
+
+# ─── OIDC ─────────────────────────────────────────────────────────────────────
+oidc:
+  enabled: true
+  issuer: "${oidc_issuer}"
+  audience: "${oidc_audience}"
+  jwksUrl: "${oidc_jwks_url}"
+  clientIdSecret: "gharts-oidc"
+  clientIdSecretKey: "oidc-client-id"
+
+# ─── GitHub App ────────────────────────────────────────────────────────────────
+github:
+  organization: "${github_org}"
+  appId: "${github_app_id}"
+  installationId: "${github_install_id}"
+  privateKeySecret: "gharts-github"
+  privateKeySecretKey: "private-key.pem"
+
+# ─── Database — RDS via IAM authentication ────────────────────────────────────
+postgresql:
+  enabled: false
+
+database:
+  host: "${rds_host}"
+  port: 5432
+  name: gharts
+  username: gharts
+  sslMode: require
+  poolRecycle: 900  # keep below IAM token expiry of 15 minutes
+  iamAuth:
+    enabled: true
+    region: "${aws_region}"
+
+# ─── Service account — IRSA annotation for RDS IAM auth ──────────────────────
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "${irsa_role_arn}"
+
+# ─── Application config ────────────────────────────────────────────────────────
+config:
+  logLevel: "INFO"
+
+# ─── Ingress ──────────────────────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "${letsencrypt_issuer}"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  hosts:
+    - host: ${ingress_host}
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: gharts-tls
+      hosts:
+        - ${ingress_host}
+
+# ─── PodDisruptionBudget — disable for single-replica dev ─────────────────────
+podDisruptionBudget:
+  enabled: false

--- a/arc/aws/391835788720/us-east-1/02_helm/variables.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/variables.tf
@@ -39,3 +39,53 @@ variable "argocd_sa_terraform" {
   description = "Name of the ArgoCD service account for terraform"
   default     = "terraform-sa"
 }
+
+# ─── gharts variables ──────────────────────────────────────────────────────────
+
+variable "gharts_chart_version" {
+  type        = string
+  description = "gharts Helm chart version"
+  default     = "0.0.3"
+}
+
+variable "gharts_namespace" {
+  type        = string
+  description = "Namespace for gharts installation"
+  default     = "gharts"
+}
+
+variable "gharts_ingress_host" {
+  type        = string
+  description = "Public gharts endpoint"
+  default     = "gharts.pytorch.org"
+}
+
+variable "gharts_github_org" {
+  type        = string
+  description = "GitHub organization managed by gharts"
+  default     = "pytorch"
+}
+
+variable "gharts_oidc_issuer" {
+  type        = string
+  description = "OIDC issuer URL"
+  default     = "https://sso.linuxfoundation.org"
+}
+
+variable "gharts_oidc_audience" {
+  type        = string
+  description = "OIDC audience expected in tokens"
+  default     = "gharts"
+}
+
+variable "gharts_oidc_jwks_url" {
+  type        = string
+  description = "JWKS endpoint for OIDC token validation; defaults to <issuer>/.well-known/jwks.json"
+  default     = ""
+}
+
+variable "gharts_oidc_client_id" {
+  type        = string
+  description = "OIDC SPA client ID"
+  default     = "gFWBLBdbhBPCdkLF82qcRWlFUGMI8icP"
+}


### PR DESCRIPTION
Provisions the AWS infrastructure required by the gharts service on the arc dev cluster.

## This PR
- RDS db.t3.micro PostgreSQL instance with IAM authentication enabled
- Security group allowing PostgreSQL access from within the VPC
- DB subnet group covering private subnets
- IAM role and rds-db:connect policy for IRSA
- Outputs: `gharts_rds_host`, `gharts_irsa_role_arn` (consumed by 02_helm)

## Stack Overview
1. **PR #??? (this PR)**: 01_infra — RDS instance and IRSA role ← MERGE FIRST
2. **PR #404**: 02_helm — gharts Helm release (depends on this PR)

## Review Guidance
Changes are isolated to `01_infra/gharts-rds.tf` and `01_infra/outputs.tf`.