### PR TITLE
Snapshot container hooks to emptyDir volume for per-pod isolation

### DIFF
--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -119,10 +119,11 @@ template:
           - /bin/sh
           - -c
           - |
+            set -e
             TIMEOUT=300
             ELAPSED=0
-            echo "Waiting for patched hooks at /opt/runner-hooks/dist/index.js..."
-            while [ ! -f /opt/runner-hooks/dist/index.js ]; do
+            echo "Waiting for patched hooks at /mnt/host-hooks/dist/index.js..."
+            while [ ! -f /mnt/host-hooks/dist/index.js ]; do
               if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                 echo "ERROR: Timed out waiting for patched hooks after ${TIMEOUT}s"
                 exit 1
@@ -130,11 +131,28 @@ template:
               sleep 10
               ELAPSED=$((ELAPSED + 10))
             done
-            echo "Patched hooks found."
+
+            # Snapshot: copy hooks from hostPath to emptyDir
+            cp -a /mnt/host-hooks/dist/ /opt/runner-hooks/dist/
+            if [ -f /mnt/host-hooks/.version ]; then
+              cp /mnt/host-hooks/.version /opt/runner-hooks/.version
+            fi
+
+            # Verify the snapshot
+            if [ ! -f /opt/runner-hooks/dist/index.js ]; then
+              echo "ERROR: Snapshot failed — index.js missing after copy"
+              exit 1
+            fi
+
+            VERSION=$(cat /opt/runner-hooks/.version 2>/dev/null || echo "unknown")
+            SIZE=$(wc -c < /opt/runner-hooks/dist/index.js)
+            echo "Hooks v${VERSION} snapshot complete (${SIZE} bytes)."
         volumeMounts:
           - name: patched-hooks
-            mountPath: /opt/runner-hooks
+            mountPath: /mnt/host-hooks
             readOnly: true
+          - name: hooks-snapshot
+            mountPath: /opt/runner-hooks
 
     containers:
       - name: runner
@@ -196,7 +214,7 @@ template:
         volumeMounts:
           - name: hook-extensions
             mountPath: /home/runner/hook-extensions
-          - name: patched-hooks
+          - name: hooks-snapshot
             mountPath: /opt/runner-hooks
             readOnly: true
 
@@ -205,6 +223,9 @@ template:
         hostPath:
           path: /mnt/runner-container-hooks
           type: DirectoryOrCreate
+      - name: hooks-snapshot
+        emptyDir:
+          sizeLimit: 50Mi
       - name: hook-extensions
         configMap:
           name: arc-runner-hook-{{RUNNER_NAME_NORMALIZED}}


### PR DESCRIPTION
**Impact:** All ARC runner pods across all clusters (upstream and consumer)
**Risk:** low

## What
Runner pods now snapshot the `runner-container-hooks` binary from the host into a per-pod emptyDir volume at startup, instead of reading directly from the shared hostPath during job execution.

## Why
The `runner-hooks-warmer` DaemonSet and runner pods share a mutable hostPath volume at `/mnt/runner-container-hooks`. When the DaemonSet downloads a new hooks version, every runner pod on that node immediately sees the new binary. Since each hook command (`prepare_job`, `run_script_step`, `cleanup_job`) spawns a separate Node.js process that reads `index.js` from disk, a mid-job update causes different hooks code to execute for different steps of the same job — producing state-schema mismatches (e.g., `http://undefined:undefined/exec` from RPC server deployment mismatches between `prepare_job` and subsequent steps).

## How
- Introduced a `hooks-snapshot` emptyDir volume (50Mi limit) that acts as a per-pod immutable copy of the hooks binary
- The init container (`wait-for-hooks`) still polls the hostPath for readiness, then copies the entire `dist/` directory and `.version` marker into the emptyDir via `cp -a`
- The runner container's volume mount switches from `patched-hooks` (hostPath) to `hooks-snapshot` (emptyDir), keeping the same mount path (`/opt/runner-hooks`) so `wrapper.js` requires zero changes
- Added `set -e` to the init container script and a post-copy verification step to fail fast on snapshot errors

## Changes
- **Init container (`wait-for-hooks`)**:
  - Added `set -e` for strict error handling
  - hostPath now mounted at `/mnt/host-hooks` (read-only source) instead of `/opt/runner-hooks`
  - emptyDir mounted at `/opt/runner-hooks` (write destination)
  - After polling, copies `dist/` and `.version` from hostPath to emptyDir
  - Verifies `index.js` exists in the snapshot; exits non-zero on failure
  - Logs snapshotted version and file size for debuggability
- **Runner container**: volume mount changed from `patched-hooks` to `hooks-snapshot` (same mount path)
- **Volumes**: added `hooks-snapshot` emptyDir with 50Mi sizeLimit

## Notes
- No changes to `wrapper.js`, `hooks-warmer.yaml`, `deploy.sh`, or the job pod template — the decoupling is entirely on the runner pod side
- Disk cost is ~17 MB per runner pod on NVMe instance storage; copy latency is <100ms
- The `patched-hooks` hostPath volume is retained — the init container still reads from it
- Existing runner pods continue using the hostPath until they finish their current job and are replaced by ARC

## Testing
```
 $  just integration-test arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
17:19:52 [INFO] Integration test for cluster: arc-staging (pytorch-arc-staging)
17:19:52 [INFO]   Runner prefix: 'c-mt-'
17:19:52 [INFO]   B200 enabled: False
17:19:52 [INFO]   Release runners: True
17:19:52 [INFO]   Cache enforcer: True
17:19:52 [INFO]   PyPI cache slugs: cpu cu126 cu128 cu130
17:19:52 [INFO]   Smoke tests: skip
17:19:52 [INFO]   Compactor tests: skip
17:19:52 [INFO]   Branch: osdc-integration-test-arc-staging
17:19:52 [INFO] Phase 0: Cleaning up stale PRs...
17:19:53 [INFO] Phase 1: Checking for active runner pods (arc-staging only)...
17:19:54 [INFO]   No runner pods active. Skipping pool clear.
17:19:54 [INFO]   Canary repo already cloned at /Users/jschmidt/meta/ciforge/osdc/upstream/osdc/.scratch/pytorch-canary, fetching...
17:19:55 [INFO] Phase 2: Preparing PR...
17:20:01 [INFO]   PR #420 created: https://github.com/pytorch/pytorch-canary/pull/420
17:20:01 [INFO] Phase 3: Running parallel validation...
17:20:01 [INFO] Phase 4: Waiting for PR workflow runs (timeout: 50 min, buffer: 10 min)...
17:20:01 [INFO]   Filtering to runs created after 2026-04-15T00:19:55.703454+00:00
17:20:02 [INFO]   No runs found yet, waiting...
17:20:33 [INFO]   Run: OSDC Integration Test — https://github.com/pytorch/pytorch-canary/actions/runs/24429683157
17:20:33 [INFO]   1/1 runs still in progress...
17:21:04 [INFO]   1/1 runs still in progress...
17:21:36 [INFO]   1/1 runs still in progress...
17:22:07 [INFO]   1/1 runs still in progress...
17:22:38 [INFO]   1/1 runs still in progress...
17:23:09 [INFO]   1/1 runs still in progress...
17:23:41 [INFO]   1/1 runs still in progress...
17:24:12 [INFO]   1/1 runs still in progress...
17:24:43 [INFO]   1/1 runs still in progress...
17:25:14 [INFO]   1/1 runs still in progress...
17:25:45 [INFO]   1/1 runs still in progress...
17:26:16 [INFO]   All 1 run(s) completed.


============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-04-15 00:26 UTC

  PR Workflow Jobs:
    ✓ test-gpu-t4                    success
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-cpu-x86-avx512            success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-pypi-cache-defaults       success
    ✓ test-gpu-t4-multi              success
    ✓ test-cpu-x86-amx               success
    ✓ test-git-cache                 success
    ✓ test-cpu-arm64                 success
    ✓ test-release-arm64             success
    ✓ test-cache-enforcer            success
    ✓ build-amd64 / build            success
    ✓ build-arm64 / build            success
    ✓ test-harbor                    success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================

17:26:18 [INFO] Phase 5: Closing PR #420...
17:26:20 [INFO] Total integration test time: 6m28s
```
```
$  just smoke arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
Running smoke tests for cluster: arc-staging
Test directories:
  - base/helm/harbor/tests/smoke
  - base/kubernetes/git-cache/tests/smoke
  - base/kubernetes/image-cache-janitor/tests/smoke
  - base/kubernetes/tests/smoke
  - base/node-compactor/tests/smoke
  - modules/eks/tests/smoke
  - modules/karpenter/tests/smoke
  - modules/arc/tests/smoke
  - modules/nodepools/tests/smoke
  - modules/arc-runners/tests/smoke
  - modules/buildkit/tests/smoke
  - modules/pypi-cache/tests/smoke
  - modules/cache-enforcer/tests/smoke
  - modules/monitoring/tests/smoke
  - modules/logging/tests/smoke

=========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ciforge/osdc/upstream/osdc
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0
16 workers [195 items]
................................................................................................................................... [ 67%]
.....................s..........................................                                                                    [100%]
========================================================= short test summary info =========================================================
SKIPPED [1] modules/monitoring/tests/smoke/test_monitoring.py:173: No dcgm-exporter pods found (no GPU nodes)
===================================================== 194 passed, 1 skipped in 35.33s =====================================================
```
```
$  just test-janitor arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
warning: `VIRTUAL_ENV=/Users/jschmidt/meta/ciforge/osdc/upstream/osdc/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
=========================================================== test session starts ===========================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ciforge/osdc/upstream/osdc
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 5 items

test_e2e.py .....                                                                    [100%]

=============================== 5 passed in 61.24s (0:01:01) ===============================

Janitor e2e tests completed in 1m3s
```