### PR TITLE
Enable EKS provisioned control plane (4XL tier)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -115,6 +115,7 @@ clusters:
       base_node_max_unavailable_percentage: 100  # all-at-once for staging
       single_nat_gateway: true       # cost optimization for staging
       vpc_cidr: "10.0.0.0/16"
+      control_plane_scaling_tier: "tier-xl"  # validate provisioned control plane before production
     harbor:
       core_replicas: 1
       registry_replicas: 1
@@ -166,6 +167,15 @@ clusters:
         - ossci_gha_terraform
     base:
       vpc_cidr: "10.1.0.0/16"
+      # Provisioned control plane XL ($1.75/hr, ~$15K/yr).
+      # Analysis (2026-04-15, 7-day window) showed the standard tier constantly
+      # throttling POST-pods requests (~0.4 req/s of 429s, 0.36% of traffic,
+      # ~34K rejected requests/day).  Cluster peaks at 171 nodes / 4,220 pods
+      # with API rates up to 638 req/s.  XL provides 2,000 API concurrency
+      # seats (10x standard) and 167 pods/s scheduling — ample headroom.
+      # 4XL (8,000 seats, $5.1K/mo) was ruled out as overkill given the
+      # modest concurrency deficit.
+      control_plane_scaling_tier: "tier-xl"
     git_cache:
       central_replicas: 5
       central_cpu_request: "6"

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -115,7 +115,6 @@ clusters:
       base_node_max_unavailable_percentage: 100  # all-at-once for staging
       single_nat_gateway: true       # cost optimization for staging
       vpc_cidr: "10.0.0.0/16"
-      control_plane_scaling_tier: "tier-xl"  # validate provisioned control plane before production
     harbor:
       core_replicas: 1
       registry_replicas: 1
@@ -167,15 +166,7 @@ clusters:
         - ossci_gha_terraform
     base:
       vpc_cidr: "10.1.0.0/16"
-      # Provisioned control plane XL ($1.75/hr, ~$15K/yr).
-      # Analysis (2026-04-15, 7-day window) showed the standard tier constantly
-      # throttling POST-pods requests (~0.4 req/s of 429s, 0.36% of traffic,
-      # ~34K rejected requests/day).  Cluster peaks at 171 nodes / 4,220 pods
-      # with API rates up to 638 req/s.  XL provides 2,000 API concurrency
-      # seats (10x standard) and 167 pods/s scheduling — ample headroom.
-      # 4XL (8,000 seats, $5.1K/mo) was ruled out as overkill given the
-      # modest concurrency deficit.
-      control_plane_scaling_tier: "tier-xl"
+      control_plane_scaling_tier: "tier-4xl"
     git_cache:
       central_replicas: 5
       central_cpu_request: "6"

--- a/osdc/modules/eks/terraform/main.tf
+++ b/osdc/modules/eks/terraform/main.tf
@@ -78,8 +78,9 @@ module "eks" {
   base_node_max_unavailable_percentage = var.base_node_max_unavailable_percentage
   base_node_ami_version                = var.base_node_ami_version
 
-  authentication_mode      = var.authentication_mode
-  cluster_admin_role_names = var.cluster_admin_role_names
+  control_plane_scaling_tier = var.control_plane_scaling_tier
+  authentication_mode        = var.authentication_mode
+  cluster_admin_role_names   = var.cluster_admin_role_names
 
   tags = local.tags
 }

--- a/osdc/modules/eks/terraform/modules/eks/main.tf
+++ b/osdc/modules/eks/terraform/modules/eks/main.tf
@@ -93,6 +93,17 @@ resource "aws_eks_cluster" "this" {
     }
   }
 
+  # Provisioned control plane: pin dedicated API server capacity for predictable
+  # performance under load.  "standard" (the default) uses the shared control
+  # plane; any "tier-*" value opts into a provisioned tier with higher API
+  # concurrency, pod scheduling rate, and a 99.99 % SLA.
+  dynamic "control_plane_scaling_config" {
+    for_each = var.control_plane_scaling_tier != "standard" ? [var.control_plane_scaling_tier] : []
+    content {
+      tier = control_plane_scaling_config.value
+    }
+  }
+
   enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
   tags = merge(

--- a/osdc/modules/eks/terraform/modules/eks/variables.tf
+++ b/osdc/modules/eks/terraform/modules/eks/variables.tf
@@ -101,6 +101,17 @@ variable "cluster_admin_role_names" {
   default     = ""
 }
 
+variable "control_plane_scaling_tier" {
+  description = "EKS provisioned control plane scaling tier (standard, tier-xl, tier-2xl, tier-4xl, tier-8xl). Standard uses the default shared control plane. Provisioned tiers pin dedicated capacity with 99.99% SLA."
+  type        = string
+  default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "tier-xl", "tier-2xl", "tier-4xl", "tier-8xl"], var.control_plane_scaling_tier)
+    error_message = "control_plane_scaling_tier must be one of: standard, tier-xl, tier-2xl, tier-4xl, tier-8xl"
+  }
+}
+
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)

--- a/osdc/modules/eks/terraform/variables.tf
+++ b/osdc/modules/eks/terraform/variables.tf
@@ -53,6 +53,12 @@ variable "eks_version" {
   default     = "1.35"
 }
 
+variable "control_plane_scaling_tier" {
+  description = "EKS provisioned control plane scaling tier"
+  type        = string
+  default     = "standard"
+}
+
 variable "authentication_mode" {
   description = "EKS cluster authentication mode (API, API_AND_CONFIG_MAP, or CONFIG_MAP)"
   type        = string

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -62,6 +62,9 @@ def tfvars(cluster_id, cluster_cfg, defaults):
         "base_node_max_unavailable_percentage": base.get("base_node_max_unavailable_percentage", 33),
         "base_node_ami_version": base.get("base_node_ami_version", defaults.get("base_node_ami_version", "v*")),
         "eks_version": base.get("eks_version", defaults.get("eks_version", "1.35")),
+        "control_plane_scaling_tier": base.get(
+            "control_plane_scaling_tier", defaults.get("control_plane_scaling_tier", "standard")
+        ),
     }
     # Optional fields — only emit if explicitly set
     access_config = cluster_cfg.get("access_config") or base.get("access_config") or {}

--- a/osdc/scripts/test_cluster_config.py
+++ b/osdc/scripts/test_cluster_config.py
@@ -166,6 +166,7 @@ class TestTfvars:
         assert '-var="base_node_max_unavailable_percentage=33"' in out
         assert '-var="base_node_ami_version=v*"' in out
         assert '-var="eks_version=1.35"' in out
+        assert '-var="control_plane_scaling_tier=standard"' in out
 
     def test_cluster_overrides(self, capsys):
         cluster_cfg = {
@@ -179,6 +180,7 @@ class TestTfvars:
                 "base_node_max_unavailable_percentage": 50,
                 "base_node_ami_version": "v20260318",
                 "eks_version": "1.36",
+                "control_plane_scaling_tier": "tier-xl",
             },
         }
         defaults = {
@@ -195,6 +197,18 @@ class TestTfvars:
         assert '-var="base_node_max_unavailable_percentage=50"' in out
         assert '-var="base_node_ami_version=v20260318"' in out
         assert '-var="eks_version=1.36"' in out
+        assert '-var="control_plane_scaling_tier=tier-xl"' in out
+
+    def test_control_plane_scaling_tier_from_defaults(self, capsys):
+        """Tier set in defaults should propagate when cluster has no override."""
+        cluster_cfg = {
+            "cluster_name": "c",
+            "region": "r",
+        }
+        defaults = {"control_plane_scaling_tier": "tier-2xl"}
+        cluster_config.tfvars("c", cluster_cfg, defaults)
+        out = capsys.readouterr().out.strip()
+        assert '-var="control_plane_scaling_tier=tier-2xl"' in out
 
     def test_bool_formatting(self, capsys):
         """single_nat_gateway bool should be lowercased."""


### PR DESCRIPTION
The standard EKS control plane is constantly throttling the production cluster.  Analysis of 7-day Mimir metrics (2026-04-15) showed:

- POST pods requests throttled at ~0.4 req/s (0.36% of traffic, ~34K rejected requests/day) — 429s present in 100% of samples
- Peak API rate: 638 req/s (p99: 478, p95: 321, avg: 130)
- Cluster scale: up to 171 nodes / 4,220 pods / 223 node creations/hr

The provisioned tier provides:

```
┌───────────────────────┬────────────────┬──────────────────────────────────────┐
│        Metric         │ XL             │              4XL (new)               │
├───────────────────────┼────────────────┼──────────────────────────────────────┤
│ Hourly cost           │ ~$1.65–1.75/hr │ ~$6.90/hr                            │
├───────────────────────┼────────────────┼──────────────────────────────────────┤
│ Annual cost           │ ~$15K/yr       │ ~$60K/yr                             │
├───────────────────────┼────────────────┼──────────────────────────────────────┤
│ API concurrency seats │ 1,700–2,000    │ 6,800–8,000 (depends on EKS version) │
├───────────────────────┼────────────────┼──────────────────────────────────────┤
│ Pod scheduling rate   │ 167 pods/s     │ 400 pods/s                           │
├───────────────────────┼────────────────┼──────────────────────────────────────┤
│ SLA                   │ 99.99%         │ 99.99%                               │
└───────────────────────┴────────────────┴──────────────────────────────────────┘
```

Implementation wires a new `control_plane_scaling_tier` variable from clusters.yaml through cluster-config.py and the tofu module chain. Uses a dynamic block so clusters on "standard" (the default) emit no control_plane_scaling_config block, keeping existing behavior unchanged.

### Q

This currently updates both staging and production. Do we need this for staging? A: No, we don't need it for staging

### Deployment plan

1. tofu plan on staging — confirm it shows only ~ update in-place on aws_eks_cluster.this with the control_plane_scaling_config addition. No other resources should change.
2. tofu apply on staging — watch the ScalingTierConfigUpdate complete (several minutes).
3. Verify staging — confirm API server is responsive, pods are scheduling normally.
4. Repeat for production.