### PR TITLE
Update gharts to v0.0.4

### DIFF
--- a/arc/aws/391835788720/us-east-1/02_helm/variables.tf
+++ b/arc/aws/391835788720/us-east-1/02_helm/variables.tf
@@ -45,7 +45,7 @@ variable "argocd_sa_terraform" {
 variable "gharts_chart_version" {
   type        = string
   description = "gharts Helm chart version"
-  default     = "0.0.3"
+  default     = "0.0.4"
 }
 
 variable "gharts_namespace" {


### PR DESCRIPTION
The latest version of the helm charts includes various security fixes, the fix to the default image names as some extra cleanup.

https://github.com/afrittoli/gha-runner-token-service/releases/tag/v0.0.4