### PR TITLE
Bump hashicorp/aws provider from ~> 5.0 to ~> 6.23 for EKS module

### DIFF
--- a/osdc/modules/eks/terraform/backend.tf
+++ b/osdc/modules/eks/terraform/backend.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.23"
     }
   }
 

--- a/osdc/modules/eks/terraform/modules/eks/main.tf
+++ b/osdc/modules/eks/terraform/modules/eks/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.23"
     }
     null = {
       source  = "hashicorp/null"

--- a/osdc/modules/eks/terraform/modules/harbor/main.tf
+++ b/osdc/modules/eks/terraform/modules/harbor/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.23"
     }
   }
 }

--- a/osdc/modules/eks/terraform/modules/vpc/main.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.23"
     }
   }
 }


### PR DESCRIPTION
The control_plane_scaling_config block (needed for EKS provisioned control plane in #450) was added in hashicorp/aws v6.23.0. The v5.x constraint would cause tofu plan to fail with an unsupported block error. Bumps all four EKS terraform roots (backend, eks, vpc, harbor).

Basically, allowing https://github.com/pytorch/ci-infra/pull/450 to be deployed via tofu