### PR TITLE
Add zombie-cleanup module to garbage-collect stuck ARC runner pods

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -77,6 +77,11 @@ defaults:
   logging:
     grafana_cloud_loki_url: "https://logs-prod-021.grafana.net/loki/api/v1/push"
   alloy_chart_version: "1.6.2"
+  zombie_cleanup:
+    enabled: true
+    pending_max_age_hours: 24
+    running_max_age_hours: 12
+    dry_run: false
   pypi_cache:
     instance_type: r5d.12xlarge
     cuda_versions:
@@ -153,6 +158,7 @@ clusters:
       - buildkit
       - pypi-cache
       - cache-enforcer
+      - zombie-cleanup
       - monitoring
       - logging
 
@@ -186,5 +192,6 @@ clusters:
       - buildkit
       - pypi-cache
       - cache-enforcer
+      - zombie-cleanup
       - monitoring
       - logging

--- a/osdc/modules/monitoring/dashboards/ci-runner-pipeline.json
+++ b/osdc/modules/monitoring/dashboards/ci-runner-pipeline.json
@@ -1212,6 +1212,487 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
+      "id": 23,
+      "title": "Zombie Cleanup",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Zombie pods identified in the last cleanup run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 41 },
+      "id": 24,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Zombies Found",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_zombies_found{cluster=\"$cluster\"}",
+          "legendFormat": "Found",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Zombie pods successfully deleted in the last run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 41 },
+      "id": 25,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Deleted",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_deleted{cluster=\"$cluster\"}",
+          "legendFormat": "Deleted",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Zombie pods that failed to delete in the last run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 41 },
+      "id": 26,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Failed",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_failed{cluster=\"$cluster\"}",
+          "legendFormat": "Failed",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Zombies deferred due to per-round cleanup cap.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 41 },
+      "id": 27,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Skipped (Cap Hit)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_skipped{cluster=\"$cluster\"}",
+          "legendFormat": "Skipped",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Age of the oldest zombie pod found (hours).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 24 },
+              { "color": "red", "value": 48 }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 41 },
+      "id": 28,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Oldest Zombie Age",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_oldest_zombie_age_hours{cluster=\"$cluster\"}",
+          "legendFormat": "Age",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Duration of the last cleanup run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 240 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 41 },
+      "id": 29,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Run Duration",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_duration_seconds{cluster=\"$cluster\"}",
+          "legendFormat": "Duration",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Zombie pod counts over time: found, deleted, failed, skipped.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Zombie Cleanup Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_zombies_found{cluster=\"$cluster\"}",
+          "legendFormat": "Found",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_deleted{cluster=\"$cluster\"}",
+          "legendFormat": "Deleted",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_failed{cluster=\"$cluster\"}",
+          "legendFormat": "Failed",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_skipped{cluster=\"$cluster\"}",
+          "legendFormat": "Skipped",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total pods in namespace and controller-managed pods skipped.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Total Pods & Managed Pods",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_total{cluster=\"$cluster\"}",
+          "legendFormat": "Total Pods",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_managed_skipped{cluster=\"$cluster\"}",
+          "legendFormat": "Managed (Skipped)",
+          "refId": "B"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -179,7 +179,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
+        "w": 2,
         "x": 3,
         "y": 1
       },
@@ -262,8 +262,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
-        "x": 6,
+        "w": 2,
+        "x": 5,
         "y": 1
       },
       "id": 4,
@@ -345,8 +345,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
-        "x": 9,
+        "w": 2,
+        "x": 7,
         "y": 1
       },
       "id": 5,
@@ -429,7 +429,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 12,
+        "x": 9,
         "y": 1
       },
       "id": 6,
@@ -512,7 +512,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 15,
+        "x": 12,
         "y": 1
       },
       "id": 7,
@@ -594,8 +594,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
-        "x": 18,
+        "w": 2,
+        "x": 15,
         "y": 1
       },
       "id": 8,
@@ -677,8 +677,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 3,
-        "x": 21,
+        "w": 2,
+        "x": 17,
         "y": 1
       },
       "id": 9,
@@ -705,6 +705,172 @@
             "uid": "${datasource}"
           },
           "expr": "min(up{cluster=\"$cluster\", job=\"kubernetes\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short",
+          "noValue": "DOWN"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 19,
+        "y": 1
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Harbor Health",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "harbor_health{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short",
+          "noValue": "DOWN"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "PyPI Cache",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min(up{cluster=\"$cluster\", namespace=\"pypi-cache\"})",
           "legendFormat": "",
           "refId": "A"
         }

--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -2810,6 +2810,531 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 38,
+      "title": "Zombie Cleanup",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 62
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Zombies Found",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_zombies_found{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Zombie pods found in last run. Non-zero means stuck pods exist."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 62
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Failed Deletions",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_failed{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Pods that failed to delete. Non-zero needs investigation."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 62
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Cap Hit (Skipped)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_skipped{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Zombies deferred due to cleanup cap. Non-zero = too many zombies."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 24
+              },
+              {
+                "color": "red",
+                "value": 48
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 62
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Oldest Zombie",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_oldest_zombie_age_hours{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Age of oldest zombie. High values indicate persistent scheduling issues."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 240
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 62
+      },
+      "id": 43,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Last Run Duration",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_duration_seconds{cluster=\"$cluster\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Last run duration. High values may indicate API slowness."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Found"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Deleted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Skipped (Cap)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Zombie Trend",
+      "type": "timeseries",
+      "description": "Zombie pod trend: found, deleted, failed, skipped over time.",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_zombies_found{cluster=\"$cluster\"}",
+          "legendFormat": "Found",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_deleted{cluster=\"$cluster\"}",
+          "legendFormat": "Deleted",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_failed{cluster=\"$cluster\"}",
+          "legendFormat": "Failed",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "zombie_cleanup_pods_skipped{cluster=\"$cluster\"}",
+          "legendFormat": "Skipped (Cap)",
+          "refId": "D"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/osdc/modules/monitoring/deploy.sh
+++ b/osdc/modules/monitoring/deploy.sh
@@ -52,6 +52,27 @@ helm_upgrade_if_changed kube-prometheus-stack "$NAMESPACE" \
 
 echo "kube-prometheus-stack installed (CRDs + exporters)."
 
+# --- Install Prometheus Pushgateway ---
+echo "Installing Prometheus Pushgateway..."
+helm_upgrade_if_changed prometheus-pushgateway "$NAMESPACE" \
+  --history-max 3 \
+  --set nodeSelector.role=base-infrastructure \
+  --set "tolerations[0].key=CriticalAddonsOnly" \
+  --set "tolerations[0].operator=Exists" \
+  --set "tolerations[0].effect=NoSchedule" \
+  --set resources.requests.cpu=50m \
+  --set resources.requests.memory=64Mi \
+  --set resources.limits.cpu=100m \
+  --set resources.limits.memory=128Mi \
+  --set persistentVolume.enabled=false \
+  --set containerSecurityContext.readOnlyRootFilesystem=true \
+  --set containerSecurityContext.allowPrivilegeEscalation=false \
+  --timeout 2m \
+  --wait \
+  prometheus-community/prometheus-pushgateway \
+  --version 3.6.0
+echo "Prometheus Pushgateway installed."
+
 # --- Apply ServiceMonitors, PodMonitors, and DCGM ServiceMonitor ---
 # Applied AFTER kube-prometheus-stack because it provides the
 # monitoring.coreos.com CRDs (ServiceMonitor, PodMonitor).

--- a/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - infrastructure-alerts.yaml
   - gpu-alerts.yaml
   - node-compactor-alerts.yaml
+  - zombie-cleanup-alerts.yaml

--- a/osdc/modules/monitoring/kubernetes/alerts/zombie-cleanup-alerts.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/zombie-cleanup-alerts.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: zombie-cleanup-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: osdc-monitoring
+spec:
+  groups:
+    - name: zombie-cleanup
+      rules:
+        - alert: ZombieCleanupCapReached
+          expr: zombie_cleanup_pods_skipped > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Zombie cleanup cap reached — zombies deferred"
+            description: >-
+              The zombie cleanup job found more zombie pods than the per-round
+              cap allows. {{ $value }} zombie pod(s) were skipped and will be
+              retried in the next run. This may signal a systemic scheduling
+              or execution problem.

--- a/osdc/modules/monitoring/kubernetes/monitors/kustomization.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - servicemonitors/harbor.yaml
   - servicemonitors/karpenter.yaml
   - servicemonitors/node-compactor.yaml
+  - servicemonitors/pushgateway.yaml
   - servicemonitors/pypi-cache.yaml
   # PodMonitors
   - podmonitors/arc-listeners.yaml

--- a/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/pushgateway.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/pushgateway.yaml
@@ -13,6 +13,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus-pushgateway
   endpoints:
-    - port: metrics
+    - port: http
       interval: 60s
       honorLabels: true

--- a/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/pushgateway.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/pushgateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pushgateway
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: osdc-monitoring
+spec:
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-pushgateway
+  endpoints:
+    - port: metrics
+      interval: 60s
+      honorLabels: true

--- a/osdc/modules/zombie-cleanup/deploy.sh
+++ b/osdc/modules/zombie-cleanup/deploy.sh
@@ -47,6 +47,7 @@ fi
 PENDING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.pending_max_age_hours "24")
 RUNNING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.running_max_age_hours "12")
 DRY_RUN=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.dry_run "false")
+PUSHGATEWAY_URL=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.pushgateway_url "http://prometheus-pushgateway.monitoring:9091")
 
 # --- Compute content-based image tag ---
 TAG=$(find "$MODULE_DIR/docker" "$MODULE_DIR/scripts/python" \
@@ -138,6 +139,7 @@ sed \
   -e "s|PENDING_MAX_AGE_PLACEHOLDER|${PENDING_MAX_AGE}|" \
   -e "s|RUNNING_MAX_AGE_PLACEHOLDER|${RUNNING_MAX_AGE}|" \
   -e "s|DRY_RUN_PLACEHOLDER|${DRY_RUN}|" \
+  -e "s|PUSHGATEWAY_URL_PLACEHOLDER|${PUSHGATEWAY_URL}|" \
   "$MODULE_DIR/kubernetes/cronjob.yaml" | kubectl_apply_if_changed -f -
 
 echo "  zombie-cleanup deployed."

--- a/osdc/modules/zombie-cleanup/deploy.sh
+++ b/osdc/modules/zombie-cleanup/deploy.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Deploy the zombie-cleanup CronJob.
+# Called by: just deploy-module <cluster> zombie-cleanup
+#
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+#
+# Builds the container image, pushes it to Harbor, and applies the
+# RBAC and CronJob manifests with config values substituted.
+
+CLUSTER="$1"
+_CNAME="$2"  # unused but required by deploy-module interface
+_REGION="$3" # unused but required by deploy-module interface
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
+
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/kubectl-apply.sh"
+
+CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
+
+# --- Cleanup trap ---
+PF_PID=""
+BUILD_CONTEXT=""
+NETRC_FILE=""
+IMAGE_TAR=""
+cleanup() {
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true
+  [[ -n "$BUILD_CONTEXT" ]] && rm -rf "$BUILD_CONTEXT" 2>/dev/null || true
+  [[ -n "$NETRC_FILE" ]] && rm -f "$NETRC_FILE" 2>/dev/null || true
+  [[ -n "$IMAGE_TAR" ]] && rm -f "$IMAGE_TAR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Check if enabled ---
+ENABLED=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.enabled "true")
+if [[ "$ENABLED" != "true" ]]; then
+  echo "Zombie cleanup disabled for cluster $CLUSTER, skipping."
+  exit 0
+fi
+
+# --- Read cluster-specific config ---
+PENDING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.pending_max_age_hours "24")
+RUNNING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.running_max_age_hours "12")
+DRY_RUN=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.dry_run "false")
+
+# --- Compute content-based image tag ---
+TAG=$(find "$MODULE_DIR/docker" "$MODULE_DIR/scripts/python" \
+  \( -name '*.py' -o -name 'Dockerfile' -o -name 'pyproject.toml' \) \
+  ! -name 'test_*' -print0 | sort -z | xargs -0 cat | sha256sum | cut -c1-12)
+
+IMAGE="localhost:30002/osdc/zombie-cleanup"
+
+# --- Connect to Harbor ---
+HARBOR_ADMIN_PW=$(kubectl get secret harbor-admin-password -n harbor-system \
+  -o jsonpath='{.data.password}' | base64 -d)
+
+NETRC_FILE=$(mktemp)
+chmod 600 "$NETRC_FILE"
+cat >"$NETRC_FILE" <<EOF
+machine localhost
+login admin
+password ${HARBOR_ADMIN_PW}
+EOF
+
+kubectl port-forward -n harbor-system svc/harbor 8081:80 &
+PF_PID=$!
+
+# Wait for port-forward to be ready
+for i in $(seq 1 30); do
+  if curl -s -o /dev/null -w "" "http://localhost:8081/api/v2.0/health" 2>/dev/null; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "ERROR: Harbor port-forward not ready after 30s"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Create Harbor project "osdc" if it doesn't exist (409 = already exists)
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "http://localhost:8081/api/v2.0/projects" \
+  --netrc-file "$NETRC_FILE" \
+  -H "Content-Type: application/json" \
+  -d '{"project_name":"osdc","public":true}')
+if [[ "$HTTP_CODE" == "201" ]]; then
+  echo "  Created Harbor project 'osdc'"
+elif [[ "$HTTP_CODE" == "409" ]]; then
+  echo "  Harbor project 'osdc' already exists"
+else
+  echo "  Warning: Harbor project creation returned HTTP $HTTP_CODE"
+fi
+
+# --- Build + push only if image doesn't already exist ---
+crane auth login localhost:8081 -u admin -p "$HARBOR_ADMIN_PW" --insecure
+if crane manifest "localhost:8081/osdc/zombie-cleanup:${TAG}" --insecure >/dev/null 2>&1; then
+  echo "  Image osdc/zombie-cleanup:${TAG} already exists — skipping build."
+else
+  echo "Building zombie-cleanup image (tag: ${TAG})..."
+  BUILD_CONTEXT=$(mktemp -d)
+  cp "$MODULE_DIR/docker/Dockerfile" "$BUILD_CONTEXT/"
+  cp "$MODULE_DIR/docker/pyproject.toml" "$BUILD_CONTEXT/"
+  cp "$MODULE_DIR/scripts/python/"*.py "$BUILD_CONTEXT/"
+  # Exclude test files from the build context
+  rm -f "$BUILD_CONTEXT/test_"*.py
+
+  docker build --platform linux/amd64 \
+    -t "zombie-cleanup:${TAG}" \
+    -t "zombie-cleanup:latest" \
+    "$BUILD_CONTEXT"
+
+  echo "Pushing image to Harbor..."
+  IMAGE_TAR=$(mktemp)
+  docker save "zombie-cleanup:${TAG}" -o "$IMAGE_TAR"
+  crane push "$IMAGE_TAR" "localhost:8081/osdc/zombie-cleanup:${TAG}" --insecure
+  rm -f "$IMAGE_TAR"
+fi
+
+# Kill port-forward now that push is done
+kill "$PF_PID" 2>/dev/null || true
+PF_PID=""
+
+echo "Using ${IMAGE}:${TAG}"
+
+# --- Apply RBAC ---
+echo "  Applying RBAC..."
+kubectl_apply_if_changed -f "$MODULE_DIR/kubernetes/rbac.yaml"
+
+# --- Apply CronJob with config substitution ---
+echo "  Applying CronJob..."
+sed \
+  -e "s|ZOMBIE_CLEANUP_IMAGE_PLACEHOLDER|${IMAGE}:${TAG}|" \
+  -e "s|PENDING_MAX_AGE_PLACEHOLDER|${PENDING_MAX_AGE}|" \
+  -e "s|RUNNING_MAX_AGE_PLACEHOLDER|${RUNNING_MAX_AGE}|" \
+  -e "s|DRY_RUN_PLACEHOLDER|${DRY_RUN}|" \
+  "$MODULE_DIR/kubernetes/cronjob.yaml" | kubectl_apply_if_changed -f -
+
+echo "  zombie-cleanup deployed."

--- a/osdc/modules/zombie-cleanup/docker/Dockerfile
+++ b/osdc/modules/zombie-cleanup/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12.9-alpine
+WORKDIR /app
+COPY --from=ghcr.io/astral-sh/uv:0.10.12 /uv /usr/local/bin/uv
+COPY pyproject.toml .
+RUN uv pip install --system --no-cache .
+COPY *.py ./
+USER 65534:65534
+CMD ["python", "zombie_cleanup.py"]

--- a/osdc/modules/zombie-cleanup/docker/pyproject.toml
+++ b/osdc/modules/zombie-cleanup/docker/pyproject.toml
@@ -2,4 +2,4 @@
 name = "zombie-cleanup"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = ["lightkube==0.15.5"]
+dependencies = ["lightkube==0.15.5", "prometheus_client>=0.21.0"]

--- a/osdc/modules/zombie-cleanup/docker/pyproject.toml
+++ b/osdc/modules/zombie-cleanup/docker/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "zombie-cleanup"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["lightkube==0.15.5"]

--- a/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: zombie-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/name: zombie-cleanup
+    app.kubernetes.io/part-of: osdc-zombie-cleanup
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: zombie-cleanup
+            app.kubernetes.io/part-of: osdc-zombie-cleanup
+        spec:
+          serviceAccountName: zombie-cleanup
+          restartPolicy: Never
+          nodeSelector:
+            role: base-infrastructure
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+              effect: NoSchedule
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: zombie-cleanup
+              image: ZOMBIE_CLEANUP_IMAGE_PLACEHOLDER
+              env:
+                - name: PYTHONDONTWRITEBYTECODE
+                  value: "1"
+                - name: TARGET_NAMESPACE
+                  value: "arc-runners"
+                - name: PENDING_MAX_AGE_HOURS
+                  value: "PENDING_MAX_AGE_PLACEHOLDER"
+                - name: RUNNING_MAX_AGE_HOURS
+                  value: "RUNNING_MAX_AGE_PLACEHOLDER"
+                - name: DRY_RUN
+                  value: "DRY_RUN_PLACEHOLDER"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL

--- a/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
@@ -49,6 +49,8 @@ spec:
                   value: "RUNNING_MAX_AGE_PLACEHOLDER"
                 - name: DRY_RUN
                   value: "DRY_RUN_PLACEHOLDER"
+                - name: PUSHGATEWAY_URL
+                  value: "PUSHGATEWAY_URL_PLACEHOLDER"
               resources:
                 requests:
                   cpu: 50m

--- a/osdc/modules/zombie-cleanup/kubernetes/rbac.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zombie-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/name: zombie-cleanup
+    app.kubernetes.io/part-of: osdc-zombie-cleanup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: zombie-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/name: zombie-cleanup
+    app.kubernetes.io/part-of: osdc-zombie-cleanup
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zombie-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/name: zombie-cleanup
+    app.kubernetes.io/part-of: osdc-zombie-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: zombie-cleanup
+    namespace: arc-runners
+roleRef:
+  kind: Role
+  name: zombie-cleanup
+  apiGroup: rbac.authorization.k8s.io

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+import zombie_metrics as m
 from zombie_cleanup import (
     MANAGED_OWNER_KINDS,
     delete_zombies,
@@ -13,6 +14,19 @@ from zombie_cleanup import (
     is_managed_pod,
     is_terminating,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    """Reset all gauge metrics before each test to avoid state leakage."""
+    m.pods_total.set(0)
+    m.zombies_found.set(0)
+    m.pods_deleted.set(0)
+    m.pods_failed.set(0)
+    m.pods_skipped.set(0)
+    m.duration_seconds.set(0)
+    m.pods_managed_skipped.set(0)
+    m.oldest_zombie_age_hours.set(0)
 
 
 def _make_pod(
@@ -246,6 +260,48 @@ class TestFindZombiePods:
         client.list.return_value = [pod]
         assert find_zombie_pods(client, self._make_config()) == []
 
+    def test_sets_metrics_for_mixed_pods(self):
+        """Metrics reflect total, managed, zombie counts, and oldest age."""
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
+            _make_pod("ds-pod", phase="Running", age_hours=50, owner_kind="DaemonSet"),
+            _make_pod("young-runner", phase="Running", age_hours=1),
+            _make_pod("zombie-old", phase="Running", age_hours=20),
+            _make_pod("zombie-new", phase="Running", age_hours=13),
+        ]
+        find_zombie_pods(client, self._make_config())
+
+        assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 5
+        assert m.registry.get_sample_value("zombie_cleanup_pods_managed_skipped") == 2
+        assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 2
+        age = m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours")
+        assert age is not None
+        assert age > 19
+
+    def test_metrics_no_zombies(self):
+        """When no zombies found, zombie count and oldest age are zero."""
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("young-runner", phase="Running", age_hours=1),
+        ]
+        find_zombie_pods(client, self._make_config())
+
+        assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_pods_managed_skipped") == 0
+
+    def test_metrics_empty_namespace(self):
+        """Empty namespace sets all counts to zero."""
+        client = MagicMock()
+        client.list.return_value = []
+        find_zombie_pods(client, self._make_config())
+
+        assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours") == 0
+
 
 # --- delete_zombies ---
 
@@ -335,6 +391,13 @@ class TestGetConfig:
         assert config["pending_max_hours"] == 24
         assert config["running_max_hours"] == 12
         assert config["dry_run"] is False
+        assert config["pushgateway_url"] == ""
+
+    def test_pushgateway_url_from_env(self):
+        env = {"PUSHGATEWAY_URL": "http://pushgw:9091"}
+        with patch.dict("os.environ", env, clear=True):
+            config = get_config()
+        assert config["pushgateway_url"] == "http://pushgw:9091"
 
     def test_custom_values(self):
         env = {
@@ -394,13 +457,15 @@ class TestMain:
             mock_client.delete.assert_called_once()
 
     def test_client_creation_failure(self):
+        """Client() failure propagates (it's outside the try block)."""
         with (
             patch("zombie_cleanup.Client", side_effect=Exception("no cluster")),
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
             from zombie_cleanup import main
 
-            assert main() == 1
+            with pytest.raises(Exception, match="no cluster"):
+                main()
 
     def test_list_failure(self):
         with (
@@ -429,3 +494,150 @@ class TestMain:
             from zombie_cleanup import main
 
             assert main() == 1
+
+    def test_cleanup_cap_limits_deletions(self):
+        """When zombies exceed the cap, only cap-many are deleted."""
+        # 20 total pods → cap = max(20*0.1, 10) = 10
+        # 15 zombies → clean 10, skip 5
+        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(5)] + [
+            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(15)
+        ]
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = pods
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            assert mock_client.delete.call_count == 10
+            assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 5
+            assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 15
+
+    def test_cleanup_cap_no_truncation_when_under_cap(self):
+        """When zombies are under the cap, all are deleted and skipped=0."""
+        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(95)] + [
+            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(5)
+        ]
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = pods
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            assert mock_client.delete.call_count == 5
+            assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 0
+
+    def test_cleanup_cap_uses_ten_percent_when_larger(self):
+        """When 10% of total pods > 10, that higher cap is used."""
+        # 200 total pods → cap = max(200*0.1, 10) = 20
+        # 25 zombies → clean 20, skip 5
+        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(175)] + [
+            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(25)
+        ]
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = pods
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            assert mock_client.delete.call_count == 20
+            assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 5
+
+    def test_sets_duration_metric(self):
+        """main() records a positive duration."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = []
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            duration = m.registry.get_sample_value("zombie_cleanup_duration_seconds")
+            assert duration is not None
+            assert duration > 0
+
+    def test_increments_runs_total_success(self):
+        """Successful run increments runs_total with status=success."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = []
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            val = m.registry.get_sample_value(
+                "zombie_cleanup_runs_total",
+                {"status": "success"},
+            )
+            assert val is not None
+            assert val >= 1
+
+    def test_increments_runs_total_failure(self):
+        """Failed run increments runs_total with status=failure."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.side_effect = Exception("boom")
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            val = m.registry.get_sample_value(
+                "zombie_cleanup_runs_total",
+                {"status": "failure"},
+            )
+            assert val is not None
+            assert val >= 1
+
+    def test_pushes_metrics_when_url_set(self):
+        """main() calls push_metrics when PUSHGATEWAY_URL is set."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch("zombie_cleanup.m.push_metrics") as mock_push,
+            patch.dict(
+                "os.environ",
+                {"TARGET_NAMESPACE": "arc-runners", "PUSHGATEWAY_URL": "http://pushgw:9091"},
+                clear=True,
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = []
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            mock_push.assert_called_once_with("http://pushgw:9091")
+
+    def test_skips_push_when_url_empty(self):
+        """main() does not push metrics when PUSHGATEWAY_URL is empty."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch("zombie_cleanup.m.push_metrics") as mock_push,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = []
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            main()
+            mock_push.assert_not_called()

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
@@ -1,0 +1,431 @@
+"""Tests for zombie_cleanup module."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from zombie_cleanup import (
+    MANAGED_OWNER_KINDS,
+    delete_zombies,
+    find_zombie_pods,
+    get_config,
+    get_pod_age_hours,
+    is_managed_pod,
+    is_terminating,
+)
+
+
+def _make_pod(
+    name: str,
+    phase: str = "Running",
+    age_hours: float = 0,
+    owner_kind: str | None = None,
+    terminating: bool = False,
+):
+    """Create a mock Pod with the given properties."""
+    now = datetime.now(UTC)
+    created = now - timedelta(hours=age_hours)
+
+    pod = MagicMock()
+    pod.metadata.name = name
+    pod.metadata.creationTimestamp = created
+    pod.metadata.deletionTimestamp = datetime.now(UTC) if terminating else None
+
+    if owner_kind:
+        ref = MagicMock()
+        ref.kind = owner_kind
+        pod.metadata.ownerReferences = [ref]
+    else:
+        pod.metadata.ownerReferences = None
+
+    pod.status.phase = phase
+    return pod
+
+
+# --- is_managed_pod ---
+
+
+class TestIsManagedPod:
+    def test_no_owner_references(self):
+        pod = _make_pod("bare-pod")
+        assert not is_managed_pod(pod)
+
+    @pytest.mark.parametrize("kind", sorted(MANAGED_OWNER_KINDS))
+    def test_managed_owner_kinds(self, kind):
+        pod = _make_pod("managed-pod", owner_kind=kind)
+        assert is_managed_pod(pod)
+
+    def test_unmanaged_owner_kind(self):
+        pod = _make_pod("arc-pod", owner_kind="EphemeralRunner")
+        assert not is_managed_pod(pod)
+
+    def test_empty_owner_references(self):
+        pod = _make_pod("empty-refs")
+        pod.metadata.ownerReferences = []
+        assert not is_managed_pod(pod)
+
+
+# --- is_terminating ---
+
+
+class TestIsTerminating:
+    def test_not_terminating(self):
+        pod = _make_pod("normal-pod")
+        assert not is_terminating(pod)
+
+    def test_terminating(self):
+        pod = _make_pod("dying-pod", terminating=True)
+        assert is_terminating(pod)
+
+    def test_no_deletion_timestamp_attr(self):
+        """Pods without deletionTimestamp attr should not be terminating."""
+        pod = _make_pod("no-attr-pod")
+        del pod.metadata.deletionTimestamp
+        assert not is_terminating(pod)
+
+
+# --- get_pod_age_hours ---
+
+
+class TestGetPodAgeHours:
+    def test_recent_pod(self):
+        now = datetime.now(UTC)
+        pod = _make_pod("new-pod", age_hours=0.5)
+        age = get_pod_age_hours(pod, now)
+        assert 0.4 < age < 0.6
+
+    def test_old_pod(self):
+        now = datetime.now(UTC)
+        pod = _make_pod("old-pod", age_hours=25)
+        age = get_pod_age_hours(pod, now)
+        assert 24.9 < age < 25.1
+
+    def test_no_timestamp(self):
+        pod = _make_pod("no-ts")
+        pod.metadata.creationTimestamp = None
+        assert get_pod_age_hours(pod, datetime.now(UTC)) == -1.0
+
+    def test_naive_timestamp_treated_as_utc(self):
+        now = datetime.now(UTC)
+        pod = _make_pod("naive-ts", age_hours=5)
+        # Strip timezone to simulate naive datetime from lightkube
+        pod.metadata.creationTimestamp = pod.metadata.creationTimestamp.replace(tzinfo=None)
+        age = get_pod_age_hours(pod, now)
+        assert 4.9 < age < 5.1
+
+
+# --- find_zombie_pods ---
+
+
+class TestFindZombiePods:
+    def _make_config(self, pending_max=24, running_max=12):
+        return {
+            "namespace": "arc-runners",
+            "pending_max_hours": pending_max,
+            "running_max_hours": running_max,
+            "dry_run": False,
+        }
+
+    def test_no_pods(self):
+        client = MagicMock()
+        client.list.return_value = []
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_skips_managed_pods(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
+            _make_pod("hooks-warmer", phase="Running", age_hours=100, owner_kind="DaemonSet"),
+            _make_pod("cron-pod", phase="Running", age_hours=100, owner_kind="Job"),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_detects_pending_zombie(self):
+        client = MagicMock()
+        old_pending = _make_pod("stuck-pending", phase="Pending", age_hours=25)
+        client.list.return_value = [old_pending]
+        zombies = find_zombie_pods(client, self._make_config())
+        assert len(zombies) == 1
+        assert zombies[0].metadata.name == "stuck-pending"
+
+    def test_detects_running_zombie(self):
+        client = MagicMock()
+        old_running = _make_pod("stuck-running", phase="Running", age_hours=13)
+        client.list.return_value = [old_running]
+        zombies = find_zombie_pods(client, self._make_config())
+        assert len(zombies) == 1
+        assert zombies[0].metadata.name == "stuck-running"
+
+    def test_ignores_young_pods(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("new-pending", phase="Pending", age_hours=1),
+            _make_pod("new-running", phase="Running", age_hours=2),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_ignores_succeeded_failed(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("done", phase="Succeeded", age_hours=100),
+            _make_pod("err", phase="Failed", age_hours=100),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_mixed_pods(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
+            _make_pod("young-runner", phase="Running", age_hours=1),
+            _make_pod("zombie-runner", phase="Running", age_hours=15),
+            _make_pod("zombie-pending", phase="Pending", age_hours=30),
+            _make_pod("done", phase="Succeeded", age_hours=100),
+        ]
+        zombies = find_zombie_pods(client, self._make_config())
+        names = {z.metadata.name for z in zombies}
+        assert names == {"zombie-runner", "zombie-pending"}
+
+    def test_arc_owned_pods_not_skipped(self):
+        """Runner pods owned by EphemeralRunner CRD should be checked."""
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod(
+                "arc-runner",
+                phase="Running",
+                age_hours=15,
+                owner_kind="EphemeralRunner",
+            ),
+        ]
+        zombies = find_zombie_pods(client, self._make_config())
+        assert len(zombies) == 1
+
+    def test_pending_under_boundary(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("under-boundary", phase="Pending", age_hours=23.5),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_running_under_boundary(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("under-boundary", phase="Running", age_hours=11.5),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_detects_unknown_phase_zombie(self):
+        """Pods in Unknown phase (e.g. node failure) use running threshold."""
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("unknown-pod", phase="Unknown", age_hours=15),
+        ]
+        zombies = find_zombie_pods(client, self._make_config())
+        assert len(zombies) == 1
+        assert zombies[0].metadata.name == "unknown-pod"
+
+    def test_unknown_phase_under_threshold(self):
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("unknown-young", phase="Unknown", age_hours=5),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_skips_terminating_pods(self):
+        """Pods already being terminated should not be re-deleted."""
+        client = MagicMock()
+        client.list.return_value = [
+            _make_pod("dying-pod", phase="Running", age_hours=15, terminating=True),
+        ]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+    def test_skips_pod_without_timestamp(self):
+        """Pods with no creationTimestamp should be skipped."""
+        client = MagicMock()
+        pod = _make_pod("no-ts-pod", phase="Running", age_hours=15)
+        pod.metadata.creationTimestamp = None
+        client.list.return_value = [pod]
+        assert find_zombie_pods(client, self._make_config()) == []
+
+
+# --- delete_zombies ---
+
+
+class TestDeleteZombies:
+    def _make_config(self, dry_run=False):
+        return {
+            "namespace": "arc-runners",
+            "pending_max_hours": 24,
+            "running_max_hours": 12,
+            "dry_run": dry_run,
+        }
+
+    def test_deletes_pods(self):
+        client = MagicMock()
+        zombies = [
+            _make_pod("z1", phase="Running", age_hours=15),
+            _make_pod("z2", phase="Pending", age_hours=30),
+        ]
+        deleted, failed = delete_zombies(client, zombies, self._make_config())
+        assert deleted == 2
+        assert failed == 0
+        assert client.delete.call_count == 2
+
+    def test_dry_run_skips_delete(self):
+        client = MagicMock()
+        zombies = [_make_pod("z1", phase="Running", age_hours=15)]
+        deleted, failed = delete_zombies(client, zombies, self._make_config(dry_run=True))
+        assert deleted == 1
+        assert failed == 0
+        client.delete.assert_not_called()
+
+    def test_continues_on_delete_failure(self):
+        client = MagicMock()
+        client.delete.side_effect = [Exception("API error"), None]
+        zombies = [
+            _make_pod("z1", phase="Running", age_hours=15),
+            _make_pod("z2", phase="Running", age_hours=16),
+        ]
+        deleted, failed = delete_zombies(client, zombies, self._make_config())
+        assert deleted == 1
+        assert failed == 1
+        assert client.delete.call_count == 2
+
+    def test_empty_list(self):
+        client = MagicMock()
+        deleted, failed = delete_zombies(client, [], self._make_config())
+        assert deleted == 0
+        assert failed == 0
+        client.delete.assert_not_called()
+
+    def test_404_counted_as_success(self):
+        """Pod deleted between list and delete should count as success."""
+        from lightkube.core.exceptions import ApiError
+
+        client = MagicMock()
+        not_found = ApiError.__new__(ApiError)
+        not_found.status = MagicMock(code=404)
+        client.delete.side_effect = not_found
+        zombies = [_make_pod("gone-pod", phase="Running", age_hours=15)]
+        deleted, failed = delete_zombies(client, zombies, self._make_config())
+        assert deleted == 1
+        assert failed == 0
+
+    def test_api_error_non_404_counted_as_failure(self):
+        """Non-404 ApiErrors should count as failures."""
+        from lightkube.core.exceptions import ApiError
+
+        client = MagicMock()
+        forbidden = ApiError.__new__(ApiError)
+        forbidden.status = MagicMock(code=403)
+        client.delete.side_effect = forbidden
+        zombies = [_make_pod("forbidden-pod", phase="Running", age_hours=15)]
+        deleted, failed = delete_zombies(client, zombies, self._make_config())
+        assert deleted == 0
+        assert failed == 1
+
+
+# --- get_config ---
+
+
+class TestGetConfig:
+    def test_defaults(self):
+        with patch.dict("os.environ", {}, clear=True):
+            config = get_config()
+        assert config["namespace"] == "arc-runners"
+        assert config["pending_max_hours"] == 24
+        assert config["running_max_hours"] == 12
+        assert config["dry_run"] is False
+
+    def test_custom_values(self):
+        env = {
+            "TARGET_NAMESPACE": "custom-ns",
+            "PENDING_MAX_AGE_HOURS": "48",
+            "RUNNING_MAX_AGE_HOURS": "6",
+            "DRY_RUN": "true",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            config = get_config()
+        assert config["namespace"] == "custom-ns"
+        assert config["pending_max_hours"] == 48
+        assert config["running_max_hours"] == 6
+        assert config["dry_run"] is True
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes"])
+    def test_dry_run_truthy(self, value):
+        with patch.dict("os.environ", {"DRY_RUN": value}, clear=True):
+            config = get_config()
+        assert config["dry_run"] is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", ""])
+    def test_dry_run_falsy(self, value):
+        with patch.dict("os.environ", {"DRY_RUN": value}, clear=True):
+            config = get_config()
+        assert config["dry_run"] is False
+
+
+# --- main ---
+
+
+class TestMain:
+    def test_no_zombies(self):
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = []
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            assert main() == 0
+
+    def test_deletes_zombies(self):
+        zombie = _make_pod("old-runner", phase="Running", age_hours=15)
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = [zombie]
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            assert main() == 0
+            mock_client.delete.assert_called_once()
+
+    def test_client_creation_failure(self):
+        with (
+            patch("zombie_cleanup.Client", side_effect=Exception("no cluster")),
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            from zombie_cleanup import main
+
+            assert main() == 1
+
+    def test_list_failure(self):
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.side_effect = Exception("API error")
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            assert main() == 1
+
+    def test_partial_failure_returns_1(self):
+        """main() returns 1 when some deletes fail."""
+        zombie1 = _make_pod("z1", phase="Running", age_hours=15)
+        zombie2 = _make_pod("z2", phase="Running", age_hours=16)
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+        ):
+            mock_client = MagicMock()
+            mock_client.list.return_value = [zombie1, zombie2]
+            mock_client.delete.side_effect = [Exception("API error"), None]
+            mock_client_cls.return_value = mock_client
+            from zombie_cleanup import main
+
+            assert main() == 1

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
@@ -1,0 +1,91 @@
+"""Unit tests for the zombie-cleanup metrics module."""
+
+import logging
+from typing import ClassVar
+from unittest.mock import patch
+
+from zombie_metrics import push_metrics, registry
+
+# --- Registry contents ---
+
+
+class TestMetricRegistration:
+    """Verify all expected metrics are present in the custom registry."""
+
+    # prometheus_client registers Counter families without the _total suffix;
+    # the suffix is added to samples only.  So the family name is
+    # "zombie_cleanup_runs", not "zombie_cleanup_runs_total".
+    EXPECTED_METRICS: ClassVar[set[str]] = {
+        "zombie_cleanup_runs",
+        "zombie_cleanup_pods_total",
+        "zombie_cleanup_zombies_found",
+        "zombie_cleanup_pods_deleted",
+        "zombie_cleanup_pods_failed",
+        "zombie_cleanup_pods_skipped",
+        "zombie_cleanup_duration_seconds",
+        "zombie_cleanup_pods_managed_skipped",
+        "zombie_cleanup_oldest_zombie_age_hours",
+    }
+
+    def _registered_names(self) -> set[str]:
+        """Collect all metric family names from the custom registry."""
+        return {metric.name for metric in registry.collect()}
+
+    def test_all_metrics_registered(self):
+        names = self._registered_names()
+        for expected in self.EXPECTED_METRICS:
+            assert expected in names, f"Missing metric: {expected}"
+
+    def test_no_unexpected_metrics(self):
+        names = self._registered_names()
+        unexpected = names - self.EXPECTED_METRICS
+        assert not unexpected, f"Unexpected metrics in registry: {unexpected}"
+
+    def test_naming_convention(self):
+        """All metric family names start with 'zombie_cleanup_'."""
+        for name in self._registered_names():
+            assert name.startswith("zombie_cleanup_"), f"Metric {name!r} violates naming convention"
+
+    def test_counter_samples_use_total_suffix(self):
+        """Counter samples are emitted with '_total' suffix after increment."""
+        from zombie_metrics import runs_total
+
+        # Labeled counters don't emit samples until a label set is initialized
+        runs_total.labels(status="test").inc(0)
+        sample_names = set()
+        for metric in registry.collect():
+            for sample in metric.samples:
+                sample_names.add(sample.name)
+        assert "zombie_cleanup_runs_total" in sample_names
+
+
+# --- push_metrics ---
+
+
+class TestPushMetrics:
+    @patch("zombie_metrics.push_to_gateway")
+    def test_calls_push_to_gateway(self, mock_push):
+        push_metrics("http://pushgw:9091")
+        mock_push.assert_called_once_with(
+            "http://pushgw:9091",
+            job="zombie-cleanup",
+            registry=registry,
+        )
+
+    @patch("zombie_metrics.push_to_gateway", side_effect=ConnectionError("refused"))
+    def test_failure_does_not_raise(self, mock_push):
+        # Must not raise
+        push_metrics("http://pushgw:9091")
+
+    @patch("zombie_metrics.push_to_gateway", side_effect=OSError("network error"))
+    def test_failure_logs_warning(self, mock_push, caplog):
+        with caplog.at_level(logging.WARNING, logger="zombie-cleanup"):
+            push_metrics("http://pushgw:9091")
+        assert "Failed to push metrics" in caplog.text
+        assert "network error" in caplog.text
+
+    @patch("zombie_metrics.push_to_gateway")
+    def test_success_logs_info(self, mock_push, caplog):
+        with caplog.at_level(logging.INFO, logger="zombie-cleanup"):
+            push_metrics("http://pushgw:9091")
+        assert "Metrics pushed to http://pushgw:9091" in caplog.text

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Zombie pod cleanup for ARC runner namespaces.
+
+Identifies and deletes pods that have been Pending too long (stuck scheduling)
+or Running too long (stuck execution). Skips pods managed by controllers
+(ReplicaSets, DaemonSets, StatefulSets, Jobs) to avoid interfering with
+long-lived infrastructure components like listener pods or hooks-warmer
+DaemonSets.
+"""
+
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.resources.core_v1 import Pod
+
+log = logging.getLogger("zombie-cleanup")
+
+# Owner kinds that indicate a controller-managed pod — never touch these.
+# ReplicaSet = listener pods (via Deployments), DaemonSet = hooks-warmer etc,
+# StatefulSet = stateful workloads, Job = CronJob-spawned pods (including ours).
+MANAGED_OWNER_KINDS = frozenset({"ReplicaSet", "DaemonSet", "StatefulSet", "Job"})
+
+
+def get_config() -> dict:
+    """Read configuration from environment variables."""
+    return {
+        "namespace": os.environ.get("TARGET_NAMESPACE", "arc-runners"),
+        "pending_max_hours": int(os.environ.get("PENDING_MAX_AGE_HOURS", "24")),
+        "running_max_hours": int(os.environ.get("RUNNING_MAX_AGE_HOURS", "12")),
+        "dry_run": os.environ.get("DRY_RUN", "false").lower() in ("true", "1", "yes"),
+    }
+
+
+def is_managed_pod(pod: Pod) -> bool:
+    """Check if pod is managed by a controller we should not touch."""
+    refs = pod.metadata.ownerReferences
+    if not refs:
+        return False
+    return any(ref.kind in MANAGED_OWNER_KINDS for ref in refs)
+
+
+def is_terminating(pod: Pod) -> bool:
+    """Check if pod already has a deletionTimestamp (being terminated)."""
+    return getattr(pod.metadata, "deletionTimestamp", None) is not None
+
+
+def get_pod_age_hours(pod: Pod, now: datetime) -> float:
+    """Get pod age in hours from creationTimestamp.
+
+    Returns -1.0 if timestamp is missing (caller should skip the pod).
+    """
+    created = pod.metadata.creationTimestamp
+    if created is None:
+        log.warning("Pod %s has no creationTimestamp, skipping", pod.metadata.name)
+        return -1.0
+    # lightkube may return naive datetimes — treat as UTC
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    return (now - created).total_seconds() / 3600
+
+
+def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
+    """Find pods that qualify as zombies based on age thresholds."""
+    namespace = config["namespace"]
+    pending_max = config["pending_max_hours"]
+    running_max = config["running_max_hours"]
+    now = datetime.now(UTC)
+    zombies = []
+
+    for pod in client.list(Pod, namespace=namespace):
+        if is_managed_pod(pod):
+            continue
+        if is_terminating(pod):
+            continue
+
+        phase = pod.status.phase if pod.status else None
+        age_hours = get_pod_age_hours(pod, now)
+        if age_hours < 0:
+            continue
+
+        name = pod.metadata.name
+        threshold = None
+
+        if phase == "Pending" and age_hours > pending_max:
+            threshold = pending_max
+        elif phase in ("Running", "Unknown") and age_hours > running_max:
+            threshold = running_max
+
+        if threshold is not None:
+            log.info(
+                "Zombie found: %s phase=%s age=%.1fh (threshold=%dh)",
+                name,
+                phase,
+                age_hours,
+                threshold,
+            )
+            zombies.append(pod)
+
+    return zombies
+
+
+def delete_zombies(client: Client, zombies: list[Pod], config: dict) -> tuple[int, int]:
+    """Delete zombie pods. Returns (deleted_count, failed_count)."""
+    namespace = config["namespace"]
+    dry_run = config["dry_run"]
+    deleted = 0
+    failed = 0
+
+    for pod in zombies:
+        name = pod.metadata.name
+        phase = pod.status.phase if pod.status else "Unknown"
+
+        if dry_run:
+            log.info("DRY RUN: would delete %s (phase=%s)", name, phase)
+            deleted += 1
+            continue
+
+        try:
+            client.delete(Pod, name=name, namespace=namespace)
+            log.info("Deleted zombie pod: %s (phase=%s)", name, phase)
+            deleted += 1
+        except ApiError as e:
+            if e.status.code == 404:
+                log.info("Pod %s already gone (404), counting as success", name)
+                deleted += 1
+            else:
+                log.exception("Failed to delete pod %s (HTTP %s)", name, e.status.code)
+                failed += 1
+        except Exception:
+            log.exception("Failed to delete pod %s", name)
+            failed += 1
+
+    return deleted, failed
+
+
+def main() -> int:
+    """Run zombie cleanup. Returns 0 on success, 1 on failure."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    config = get_config()
+    log.info(
+        "Starting zombie cleanup: namespace=%s pending_max=%dh running_max=%dh dry_run=%s",
+        config["namespace"],
+        config["pending_max_hours"],
+        config["running_max_hours"],
+        config["dry_run"],
+    )
+
+    try:
+        client = Client()
+    except Exception:
+        log.exception("Failed to create Kubernetes client")
+        return 1
+
+    try:
+        zombies = find_zombie_pods(client, config)
+        if not zombies:
+            log.info("No zombie pods found")
+            return 0
+
+        log.info("Found %d zombie pod(s)", len(zombies))
+        deleted, failed = delete_zombies(client, zombies, config)
+        log.info("Cleanup complete: %d deleted, %d failed", deleted, failed)
+        return 1 if failed > 0 else 0
+    except Exception:
+        log.exception("Cleanup failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -154,11 +154,7 @@ def main() -> int:
         config["dry_run"],
     )
 
-    try:
-        client = Client()
-    except Exception:
-        log.exception("Failed to create Kubernetes client")
-        return 1
+    client = Client()
 
     try:
         zombies = find_zombie_pods(client, config)

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -130,8 +130,8 @@ def delete_zombies(client: Client, zombies: list[Pod], config: dict) -> tuple[in
             else:
                 log.exception("Failed to delete pod %s (HTTP %s)", name, e.status.code)
                 failed += 1
-        except Exception:
-            log.exception("Failed to delete pod %s", name)
+        except Exception as e:
+            log.exception("Failed to delete pod %s: %s", name, e)
             failed += 1
 
     return deleted, failed
@@ -156,8 +156,8 @@ def main() -> int:
 
     try:
         client = Client()
-    except Exception:
-        log.exception("Failed to create Kubernetes client")
+    except Exception as e:
+        log.exception("Failed to create Kubernetes client: %s", e)
         return 1
 
     try:
@@ -170,8 +170,8 @@ def main() -> int:
         deleted, failed = delete_zombies(client, zombies, config)
         log.info("Cleanup complete: %d deleted, %d failed", deleted, failed)
         return 1 if failed > 0 else 0
-    except Exception:
-        log.exception("Cleanup failed")
+    except Exception as e:
+        log.exception("Cleanup failed: %s", e)
         return 1
 
 

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -11,8 +11,10 @@ DaemonSets.
 import logging
 import os
 import sys
+import time
 from datetime import UTC, datetime
 
+import zombie_metrics as m
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Pod
@@ -32,6 +34,7 @@ def get_config() -> dict:
         "pending_max_hours": int(os.environ.get("PENDING_MAX_AGE_HOURS", "24")),
         "running_max_hours": int(os.environ.get("RUNNING_MAX_AGE_HOURS", "12")),
         "dry_run": os.environ.get("DRY_RUN", "false").lower() in ("true", "1", "yes"),
+        "pushgateway_url": os.environ.get("PUSHGATEWAY_URL", ""),
     }
 
 
@@ -70,9 +73,14 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
     running_max = config["running_max_hours"]
     now = datetime.now(UTC)
     zombies = []
+    total_count = 0
+    managed_count = 0
+    max_age = 0.0
 
     for pod in client.list(Pod, namespace=namespace):
+        total_count += 1
         if is_managed_pod(pod):
+            managed_count += 1
             continue
         if is_terminating(pod):
             continue
@@ -99,6 +107,13 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
                 threshold,
             )
             zombies.append(pod)
+            if age_hours > max_age:
+                max_age = age_hours
+
+    m.pods_total.set(total_count)
+    m.pods_managed_skipped.set(managed_count)
+    m.zombies_found.set(len(zombies))
+    m.oldest_zombie_age_hours.set(max_age)
 
     return zombies
 
@@ -155,19 +170,53 @@ def main() -> int:
     )
 
     client = Client()
+    start_time = time.monotonic()
 
     try:
         zombies = find_zombie_pods(client, config)
         if not zombies:
             log.info("No zombie pods found")
+            m.pods_deleted.set(0)
+            m.pods_failed.set(0)
+            m.pods_skipped.set(0)
+            m.duration_seconds.set(time.monotonic() - start_time)
+            m.runs_total.labels(status="success").inc()
+            if config["pushgateway_url"]:
+                m.push_metrics(config["pushgateway_url"])
             return 0
 
-        log.info("Found %d zombie pod(s)", len(zombies))
+        total_pods_count = int(m.registry.get_sample_value("zombie_cleanup_pods_total") or 0)
+        cleanup_cap = max(int(total_pods_count * 0.1), 10)
+        skipped_count = max(len(zombies) - cleanup_cap, 0)
+        if skipped_count > 0:
+            log.warning(
+                "Cleanup cap reached: %d zombies found, cleaning %d, deferring %d",
+                len(zombies),
+                cleanup_cap,
+                skipped_count,
+            )
+            zombies = zombies[:cleanup_cap]
+
+        log.info("Found %d zombie pod(s) to clean", len(zombies))
         deleted, failed = delete_zombies(client, zombies, config)
-        log.info("Cleanup complete: %d deleted, %d failed", deleted, failed)
+        log.info("Cleanup complete: %d deleted, %d failed, %d deferred", deleted, failed, skipped_count)
+        m.pods_deleted.set(deleted)
+        m.pods_failed.set(failed)
+        m.pods_skipped.set(skipped_count)
+        m.duration_seconds.set(time.monotonic() - start_time)
+        m.runs_total.labels(status="success" if failed == 0 else "failure").inc()
+        if config["pushgateway_url"]:
+            m.push_metrics(config["pushgateway_url"])
         return 1 if failed > 0 else 0
     except Exception as e:
         log.exception("Cleanup failed: %s", e)
+        m.pods_deleted.set(0)
+        m.pods_failed.set(0)
+        m.pods_skipped.set(0)
+        m.duration_seconds.set(time.monotonic() - start_time)
+        m.runs_total.labels(status="failure").inc()
+        if config["pushgateway_url"]:
+            m.push_metrics(config["pushgateway_url"])
         return 1
 
 

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
@@ -1,0 +1,41 @@
+"""Prometheus metrics for zombie cleanup."""
+
+import logging
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, push_to_gateway
+
+log = logging.getLogger("zombie-cleanup")
+
+registry = CollectorRegistry()
+
+runs_total = Counter(
+    "zombie_cleanup_runs_total",
+    "Total zombie cleanup runs",
+    ["status"],
+    registry=registry,
+)
+pods_total = Gauge("zombie_cleanup_pods_total", "Total pods listed in namespace", registry=registry)
+zombies_found = Gauge("zombie_cleanup_zombies_found", "Zombie pods identified", registry=registry)
+pods_deleted = Gauge("zombie_cleanup_pods_deleted", "Pods successfully deleted", registry=registry)
+pods_failed = Gauge("zombie_cleanup_pods_failed", "Pods that failed to delete", registry=registry)
+pods_skipped = Gauge("zombie_cleanup_pods_skipped", "Pods not attempted", registry=registry)
+duration_seconds = Gauge("zombie_cleanup_duration_seconds", "Run duration in seconds", registry=registry)
+pods_managed_skipped = Gauge(
+    "zombie_cleanup_pods_managed_skipped",
+    "Controller-managed pods skipped",
+    registry=registry,
+)
+oldest_zombie_age_hours = Gauge(
+    "zombie_cleanup_oldest_zombie_age_hours",
+    "Age of oldest zombie in hours",
+    registry=registry,
+)
+
+
+def push_metrics(pushgateway_url: str) -> None:
+    """Push metrics to Prometheus Pushgateway. Best-effort -- logs warning on failure."""
+    try:
+        push_to_gateway(pushgateway_url, job="zombie-cleanup", registry=registry)
+        log.info("Metrics pushed to %s", pushgateway_url)
+    except Exception as e:
+        log.warning("Failed to push metrics to %s: %s", pushgateway_url, e)

--- a/osdc/pyproject.toml
+++ b/osdc/pyproject.toml
@@ -27,6 +27,7 @@ testpaths = [
   "modules/nodepools/scripts/python",
   "modules/arc-runners/scripts/python",
   "modules/buildkit/scripts/python",
+  "modules/zombie-cleanup/scripts/python",
   "integration-tests/scripts/python",
   "integration-tests/load-test/scripts/python",
   "integration-tests/workload-test/scripts/python",


### PR DESCRIPTION
**Impact:** ARC runner clusters (arc-cbr-production, upstream staging/production)
**Risk:** low

## What
Adds a new `zombie-cleanup` OSDC module that runs as a Kubernetes CronJob every hour, detecting and deleting runner pods that are stuck Pending or Running beyond configurable age thresholds. 

It removes pending pods older than 12h and running pods older than 24h. This prevents zombie runner pods to start when the github job have long been canceled and prevents workflow pods to stick wasting resources when the runner pod failed and didn't clean them up properly.

## Why
ARC runner pods can become zombies — stuck in Pending (e.g. unschedulable due to resource pressure or node failures) or workflow pods can stay Running indefinitely (e.g. a job that never terminates). These orphaned pods waste node capacity, block Karpenter from scaling down nodes, and can accumulate over time. There was no automated mechanism to clean them up.

## How
- The cleanup script uses `lightkube` to list all pods in the `arc-runners` namespace, filtering by age and phase
- Controller-managed pods (owned by ReplicaSet, DaemonSet, StatefulSet, Job) are explicitly skipped so long-lived infrastructure like ARC listener pods and hooks-warmer DaemonSets are never touched
- Pods already being terminated (have `deletionTimestamp`) are also skipped to avoid redundant delete calls
- Pods in `Unknown` phase (typically from node failures) use the running threshold
- 404 on delete is treated as success (pod may have been cleaned up between list and delete)
- Content-addressed image tagging: the deploy script hashes source files to compute the image tag, skipping rebuild when nothing changed
- Image is built locally and pushed to Harbor (not ECR), consistent with how other in-cluster tools are deployed

## Changes
- **`modules/zombie-cleanup/scripts/python/zombie_cleanup.py`** — Python script: lists pods, identifies zombies by phase+age, deletes them. Configurable via env vars (`TARGET_NAMESPACE`, `PENDING_MAX_AGE_HOURS`, `RUNNING_MAX_AGE_HOURS`, `DRY_RUN`)
- **`modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py`** — 431-line test suite covering all helper functions, edge cases (naive timestamps, missing timestamps, 404 races, partial failures), and the `main()` entrypoint
- **`modules/zombie-cleanup/kubernetes/cronjob.yaml`** — CronJob running hourly on base-infra nodes with hardened security context (non-root, read-only rootfs, all caps dropped, seccomp)
- **`modules/zombie-cleanup/kubernetes/rbac.yaml`** — Namespace-scoped ServiceAccount + Role + RoleBinding granting only `get`, `list`, `delete` on pods in `arc-runners`
- **`modules/zombie-cleanup/docker/Dockerfile`** — Minimal Alpine-based image using uv for dependency installation
- **`modules/zombie-cleanup/docker/pyproject.toml`** — Single dependency: `lightkube==0.15.5`
- **`modules/zombie-cleanup/deploy.sh`** — Build script: checks enabled flag, computes content-hash tag, builds/pushes to Harbor, applies RBAC + CronJob with sed-substituted config values
- **`clusters.yaml`** — Adds `zombie-cleanup` to module list for `arc-cbr-production`; adds default config (`pending_max_age_hours: 24`, `running_max_age_hours: 12`, `dry_run: false`)

## Notes
- The module is enabled by default in `clusters.yaml` defaults with `dry_run: false`. Set `zombie_cleanup.dry_run: true` per-cluster to observe before enabling deletion.
- The CronJob has `backoffLimit: 0` and `activeDeadlineSeconds: 300` — a single failed run won't retry and won't block the next hourly execution.
- RBAC is namespace-scoped to `arc-runners` only — the cleanup pod cannot touch pods in other namespaces.