### PR TITLE
Add node-fleet abstraction to nodepool generation

### DIFF
--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -11,6 +11,11 @@ Writes: modules/nodepools/generated/*.yaml (one per definition)
 Each generated file contains a Karpenter NodePool + EC2NodeClass pair.
 CLUSTER_NAME_PLACEHOLDER is used everywhere a cluster name would go —
 deploy.sh does sed replacement at apply time with the actual cluster name.
+
+Supports three definition formats:
+  - ``nodepool:``  — Legacy single-instance format (one NodePool per file)
+  - ``fleet:``     — Fleet format (multiple instances share a fleet name)
+  - ``fleets:``    — Multi-fleet format (GPU families with several fleets per file)
 """
 
 import os
@@ -19,6 +24,15 @@ import sys
 from pathlib import Path
 
 import yaml
+
+# instance_specs lives in scripts/python/ at the repo root.  Add it to
+# sys.path so the import works both when run directly (deploy.sh) and
+# when run via pytest (pyproject.toml testpaths also adds it).
+_scripts_python = str(Path(__file__).resolve().parents[4] / "scripts" / "python")
+if _scripts_python not in sys.path:
+    sys.path.insert(0, _scripts_python)
+
+from instance_specs import INSTANCE_SPECS  # noqa: E402
 
 # ANSI colors
 GREEN = "\033[0;32m"
@@ -106,6 +120,10 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     is_gpu = nodepool_def.get("gpu", False)
     has_nvme = nodepool_def.get("has_nvme", False)
     user_data_script_path = nodepool_def.get("user_data_script")
+
+    # Fleet-specific fields (only present for fleet-format defs)
+    fleet_name = nodepool_def.get("fleet_name")
+    weight = nodepool_def.get("weight")
 
     # Per-def kubelet topology overrides (e.g. B200 needs single-numa-node/pod)
     topology_policy = nodepool_def.get("topology_manager_policy", "restricted")
@@ -203,6 +221,15 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     for label_key, label_value in extra_labels.items():
         extra_labels_yaml += f'        {label_key}: "{label_value}"\n'
 
+    # ----- Fleet-specific YAML blocks -----
+    weight_block = f"  weight: {weight}\n" if weight is not None else ""
+    fleet_label = f'        node-fleet: "{fleet_name}"\n' if fleet_name else ""
+    fleet_taint = (
+        (f'        - key: node-fleet\n          value: "{fleet_name}"\n          effect: NoSchedule\n')
+        if fleet_name
+        else ""
+    )
+
     # ----- Build YAML -----
     yaml_content = f"""# Karpenter NodePool + EC2NodeClass: {instance_type}
 # Auto-generated from defs/{name}.yaml — do not edit by hand.
@@ -215,6 +242,7 @@ metadata:
     osdc.io/module: {module_name}
 {compactor_label}\
 spec:
+{weight_block}\
   disruption:
     consolidationPolicy: {consolidation_policy}
     consolidateAfter: {consolidation_after}
@@ -226,6 +254,7 @@ spec:
       labels:
         workload-type: github-runner
         instance-type: "{instance_type}"
+{fleet_label}\
 {gpu_labels}\
 {extra_labels_yaml}\
     spec:
@@ -250,6 +279,7 @@ spec:
         name: {name}
 
       taints:
+{fleet_taint}\
         - key: instance-type
           value: "{instance_type}"
           effect: NoSchedule
@@ -329,6 +359,106 @@ spec:
     return yaml_content
 
 
+def _process_nodepool(nodepool_def, def_file, defs_dir, output_dir, module_name):
+    """Process a legacy ``nodepool:`` definition. Returns count of generated files."""
+    name = nodepool_def.get("name")
+    instance_type = nodepool_def.get("instance_type")
+
+    if not name or not instance_type:
+        raise ValueError(f"Invalid {def_file.name}: missing 'name' or 'instance_type'")
+
+    is_gpu = nodepool_def.get("gpu", False)
+    has_nvme = nodepool_def.get("has_nvme", False)
+    node_disk = _get_node_disk_size(nodepool_def)
+    log_info(
+        f"  {def_file.name}: {instance_type} ({'GPU' if is_gpu else 'CPU'}, "
+        f"{nodepool_def.get('arch', 'amd64')}, node_disk={node_disk}Gi{', NVMe' if has_nvme else ''})"
+    )
+
+    # Auto-derive fleet name for legacy defs so nodes get the node-fleet label/taint
+    family = instance_type.split(".")[0]
+    specs = INSTANCE_SPECS.get(instance_type, {})
+    node_gpus = specs.get("gpu", 0)
+    nodepool_def["fleet_name"] = f"{family}-{node_gpus}gpu" if node_gpus else family
+
+    content = generate_nodepool_yaml(nodepool_def, module_name, defs_dir)
+    out_path = output_dir / f"{name}.yaml"
+    out_path.write_text(content)
+    return 1
+
+
+def _build_fleet_nodepool_def(fleet_data, inst, name_suffix="", extra_labels=None):
+    """Build a nodepool_def dict from a fleet instance entry."""
+    instance_type = inst["type"]
+    name = instance_type.replace(".", "-")
+    if name_suffix:
+        name = f"{name}{name_suffix}"
+
+    nodepool_def = {
+        "name": name,
+        "instance_type": instance_type,
+        "arch": fleet_data["arch"],
+        "gpu": fleet_data.get("gpu", False),
+        "has_nvme": inst.get("has_nvme", False),
+        "node_disk_size": inst["node_disk_size"],
+        "baremetal": inst.get("baremetal", False),
+        # Fleet-specific fields
+        "fleet_name": fleet_data["name"],
+        "weight": inst["weight"],
+        # Per-instance overrides
+        "extra_labels": inst.get("extra_labels", {}),
+        "capacity_type": inst.get("capacity_type", "on-demand"),
+        "capacity_reservation_ids": inst.get("capacity_reservation_ids", []),
+    }
+
+    # Only set optional keys when explicitly provided — leaving them absent
+    # lets generate_nodepool_yaml() fall through to its own defaults.
+    for key in ("node_compactor", "topology_manager_policy", "topology_manager_scope", "user_data_script"):
+        val = inst.get(key)
+        if val is not None:
+            nodepool_def[key] = val
+
+    if extra_labels:
+        merged = dict(nodepool_def["extra_labels"])
+        merged.update(extra_labels)
+        nodepool_def["extra_labels"] = merged
+
+    return nodepool_def
+
+
+def _process_fleet(fleet_data, def_file, defs_dir, output_dir, module_name):
+    """Process a ``fleet:`` definition. Returns count of generated files."""
+    fleet_name = fleet_data["name"]
+    instances = fleet_data.get("instances", [])
+    release_instances = fleet_data.get("release", [])
+
+    log_info(f"  Fleet '{fleet_name}': {len(instances)} instance(s)")
+
+    generated = 0
+    for inst in instances:
+        nodepool_def = _build_fleet_nodepool_def(fleet_data, inst)
+        content = generate_nodepool_yaml(nodepool_def, module_name, defs_dir)
+        out_path = output_dir / f"{nodepool_def['name']}.yaml"
+        out_path.write_text(content)
+        generated += 1
+
+    if release_instances:
+        log_info(f"  Fleet '{fleet_name}': {len(release_instances)} release instance(s)")
+        for inst in release_instances:
+            nodepool_def = _build_fleet_nodepool_def(
+                fleet_data,
+                inst,
+                name_suffix="-release",
+                extra_labels={"osdc.io/runner-class": "release"},
+            )
+            content = generate_nodepool_yaml(nodepool_def, module_name, defs_dir)
+            out_path = output_dir / f"{nodepool_def['name']}.yaml"
+            out_path.write_text(content)
+            generated += 1
+
+    return generated
+
+
 def main():
     script_dir = Path(__file__).parent
     module_dir = script_dir.parent.parent
@@ -357,31 +487,23 @@ def main():
             with open(def_file) as f:
                 data = yaml.safe_load(f)
 
-            if not data or "nodepool" not in data:
-                log_error(f"Invalid {def_file.name}: missing 'nodepool' key")
+            if not data:
+                log_error(f"Invalid {def_file.name}: empty file")
                 skipped.append(def_file.name)
                 continue
 
-            nodepool_def = data["nodepool"]
-            name = nodepool_def.get("name")
-            instance_type = nodepool_def.get("instance_type")
-
-            if not name or not instance_type:
-                log_error(f"Invalid {def_file.name}: missing 'name' or 'instance_type'")
+            # Determine format: fleet, fleets, or legacy nodepool
+            if "fleet" in data:
+                generated += _process_fleet(data["fleet"], def_file, defs_dir, output_dir, module_name)
+            elif "fleets" in data:
+                for fleet_data in data["fleets"]:
+                    generated += _process_fleet(fleet_data, def_file, defs_dir, output_dir, module_name)
+            elif "nodepool" in data:
+                generated += _process_nodepool(data["nodepool"], def_file, defs_dir, output_dir, module_name)
+            else:
+                log_error(f"Invalid {def_file.name}: missing 'nodepool', 'fleet', or 'fleets' key")
                 skipped.append(def_file.name)
                 continue
-
-            is_gpu = nodepool_def.get("gpu", False)
-            has_nvme = nodepool_def.get("has_nvme", False)
-            node_disk = _get_node_disk_size(nodepool_def)
-            log_info(
-                f"  {def_file.name}: {instance_type} ({'GPU' if is_gpu else 'CPU'}, {nodepool_def.get('arch', 'amd64')}, node_disk={node_disk}Gi{', NVMe' if has_nvme else ''})"
-            )
-
-            content = generate_nodepool_yaml(nodepool_def, module_name, defs_dir)
-            out_path = output_dir / f"{name}.yaml"
-            out_path.write_text(content)
-            generated += 1
 
         except Exception as e:
             log_error(f"Failed to process {def_file.name}: {e}")

--- a/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 from generate_nodepools import (
+    _build_fleet_nodepool_def,
     _detect_arch,
     _get_node_disk_size,
     _read_user_data_script,
@@ -41,10 +42,52 @@ REAL_DEFS_DIR = Path(__file__).parent.parent.parent / "defs"
 
 
 def _load_real_def(filename: str) -> dict:
-    """Load a real def file from modules/nodepools/defs/."""
+    """Load a real def file from modules/nodepools/defs/.
+
+    For legacy ``nodepool:`` files, returns the nodepool dict directly.
+    For ``fleet:`` or ``fleets:`` files, returns the first expanded nodepool_def.
+    """
     with open(REAL_DEFS_DIR / filename) as f:
         data = yaml.safe_load(f)
-    return data["nodepool"]
+    if "nodepool" in data:
+        return data["nodepool"]
+    if "fleet" in data:
+        fleet = data["fleet"]
+        return _build_fleet_nodepool_def(fleet, fleet["instances"][0])
+    if "fleets" in data:
+        fleet = data["fleets"][0]
+        return _build_fleet_nodepool_def(fleet, fleet["instances"][0])
+    raise ValueError(f"Unknown format in {filename}")
+
+
+def _load_all_real_defs() -> list[dict]:
+    """Load all real def files, expanding fleets into individual nodepool_defs."""
+    result = []
+    for f in sorted(REAL_DEFS_DIR.glob("*.yaml")):
+        with open(f) as fh:
+            data = yaml.safe_load(fh)
+        if not data:
+            continue
+        if "nodepool" in data:
+            result.append(data["nodepool"])
+        elif "fleet" in data:
+            fleet = data["fleet"]
+            for inst in fleet.get("instances", []):
+                result.append(_build_fleet_nodepool_def(fleet, inst))
+            for inst in fleet.get("release", []):
+                result.append(
+                    _build_fleet_nodepool_def(
+                        fleet,
+                        inst,
+                        name_suffix="-release",
+                        extra_labels={"osdc.io/runner-class": "release"},
+                    )
+                )
+        elif "fleets" in data:
+            for fleet in data["fleets"]:
+                for inst in fleet.get("instances", []):
+                    result.append(_build_fleet_nodepool_def(fleet, inst))
+    return result
 
 
 # ============================================================================
@@ -524,18 +567,174 @@ class TestGenerateNodepoolYaml:
 
 
 # ============================================================================
+# Fleet-specific tests
+# ============================================================================
+
+
+class TestFleetNodepoolGeneration:
+    """Tests for fleet-format nodepool generation (weight, fleet label, fleet taint)."""
+
+    def _parse(self, text: str) -> list[dict]:
+        return parse_all_yaml(text)
+
+    def test_fleet_weight_in_spec(self):
+        nodepool_def = _make_nodepool_def(fleet_name="r7a", weight=100)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        assert np["spec"]["weight"] == 100
+
+    def test_no_weight_without_fleet(self):
+        nodepool_def = _make_nodepool_def()
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        assert "weight" not in np["spec"]
+
+    def test_fleet_label_present(self):
+        nodepool_def = _make_nodepool_def(fleet_name="r7a", weight=80)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        labels = np["spec"]["template"]["metadata"]["labels"]
+        assert labels.get("node-fleet") == "r7a"
+
+    def test_no_fleet_label_without_fleet(self):
+        nodepool_def = _make_nodepool_def()
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        labels = np["spec"]["template"]["metadata"]["labels"]
+        assert "node-fleet" not in labels
+
+    def test_fleet_taint_present(self):
+        nodepool_def = _make_nodepool_def(fleet_name="g5-1gpu", weight=100)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        taints = np["spec"]["template"]["spec"]["taints"]
+        fleet_taints = [t for t in taints if t["key"] == "node-fleet"]
+        assert len(fleet_taints) == 1
+        assert fleet_taints[0]["value"] == "g5-1gpu"
+        assert fleet_taints[0]["effect"] == "NoSchedule"
+
+    def test_fleet_taint_before_instance_taint(self):
+        nodepool_def = _make_nodepool_def(fleet_name="r7a", weight=100)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        taints = np["spec"]["template"]["spec"]["taints"]
+        taint_keys = [t["key"] for t in taints]
+        fleet_idx = taint_keys.index("node-fleet")
+        instance_idx = taint_keys.index("instance-type")
+        assert fleet_idx < instance_idx
+
+    def test_no_fleet_taint_without_fleet(self):
+        nodepool_def = _make_nodepool_def()
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        taints = np["spec"]["template"]["spec"]["taints"]
+        taint_keys = [t["key"] for t in taints]
+        assert "node-fleet" not in taint_keys
+
+    def test_instance_type_taint_still_present_with_fleet(self):
+        nodepool_def = _make_nodepool_def(fleet_name="r7a", weight=50)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        taints = np["spec"]["template"]["spec"]["taints"]
+        taint_keys = [t["key"] for t in taints]
+        assert "instance-type" in taint_keys
+
+    def test_fleet_gpu_has_all_taints(self):
+        """Fleet GPU nodepool has fleet taint + instance-type taint + GPU taint."""
+        nodepool_def = _make_nodepool_def(
+            fleet_name="g5-1gpu",
+            weight=100,
+            gpu=True,
+            instance_type="g5.8xlarge",
+            arch="amd64",
+        )
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        np = docs[0]
+        taints = np["spec"]["template"]["spec"]["taints"]
+        taint_keys = [t["key"] for t in taints]
+        assert "node-fleet" in taint_keys
+        assert "instance-type" in taint_keys
+        assert "nvidia.com/gpu" in taint_keys
+
+
+class TestBuildFleetNodepoolDef:
+    """Tests for _build_fleet_nodepool_def helper."""
+
+    def test_basic_construction(self):
+        fleet = {"name": "r7a", "arch": "amd64", "gpu": False}
+        inst = {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800}
+        result = _build_fleet_nodepool_def(fleet, inst)
+        assert result["name"] == "r7a-48xlarge"
+        assert result["instance_type"] == "r7a.48xlarge"
+        assert result["arch"] == "amd64"
+        assert result["gpu"] is False
+        assert result["fleet_name"] == "r7a"
+        assert result["weight"] == 100
+        assert result["node_disk_size"] == 4800
+
+    def test_release_suffix(self):
+        fleet = {"name": "r7a", "arch": "amd64", "gpu": False}
+        inst = {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800}
+        result = _build_fleet_nodepool_def(
+            fleet,
+            inst,
+            name_suffix="-release",
+            extra_labels={"osdc.io/runner-class": "release"},
+        )
+        assert result["name"] == "r7a-48xlarge-release"
+        assert result["extra_labels"]["osdc.io/runner-class"] == "release"
+
+    def test_gpu_fleet(self):
+        fleet = {"name": "g5-1gpu", "arch": "amd64", "gpu": True}
+        inst = {"type": "g5.8xlarge", "weight": 100, "node_disk_size": 600, "has_nvme": True}
+        result = _build_fleet_nodepool_def(fleet, inst)
+        assert result["gpu"] is True
+        assert result["has_nvme"] is True
+
+    def test_baremetal_flag(self):
+        fleet = {"name": "g4dn-8gpu", "arch": "amd64", "gpu": True}
+        inst = {"type": "g4dn.metal", "weight": 100, "node_disk_size": 600, "baremetal": True}
+        result = _build_fleet_nodepool_def(fleet, inst)
+        assert result["baremetal"] is True
+
+    def test_optional_fields_default_correctly(self):
+        fleet = {"name": "r7a", "arch": "amd64"}
+        inst = {"type": "r7a.8xlarge", "weight": 20, "node_disk_size": 800}
+        result = _build_fleet_nodepool_def(fleet, inst)
+        assert result["capacity_type"] == "on-demand"
+        assert result["capacity_reservation_ids"] == []
+        assert result["extra_labels"] == {}
+        # Optional keys with None defaults are omitted so generate_nodepool_yaml
+        # falls through to its own defaults (e.g. topology_manager_policy="restricted")
+        assert "topology_manager_policy" not in result
+        assert "topology_manager_scope" not in result
+        assert "user_data_script" not in result
+        assert "node_compactor" not in result
+
+
+# ============================================================================
 # Real def files — round-trip validation
 # ============================================================================
 
 
 class TestRealDefFiles:
-    """Round-trip tests using actual def files from modules/nodepools/defs/."""
+    """Round-trip tests using actual def files from modules/nodepools/defs/.
 
-    @pytest.fixture(params=sorted(REAL_DEFS_DIR.glob("*.yaml")), ids=lambda p: p.stem)
+    Supports both legacy ``nodepool:`` files and new ``fleet:``/``fleets:`` files.
+    """
+
+    @pytest.fixture(params=_load_all_real_defs(), ids=lambda d: d["name"])
     def real_def(self, request):
-        with open(request.param) as f:
-            data = yaml.safe_load(f)
-        return data["nodepool"]
+        return request.param
 
     def test_generates_valid_yaml(self, real_def):
         output = generate_nodepool_yaml(real_def, "nodepools", REAL_DEFS_DIR)
@@ -669,3 +868,146 @@ class TestMain:
         assert len(docs) == 2
         assert docs[0]["kind"] == "NodePool"
         assert docs[1]["kind"] == "EC2NodeClass"
+
+    def test_fleet_format_generates_multiple(self, tmp_path):
+        """A fleet file with 3 instances generates 3 output files."""
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        fleet_data = {
+            "fleet": {
+                "name": "r7a",
+                "arch": "amd64",
+                "gpu": False,
+                "instances": [
+                    {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800},
+                    {"type": "r7a.24xlarge", "weight": 80, "node_disk_size": 2400},
+                    {"type": "r7a.8xlarge", "weight": 20, "node_disk_size": 800},
+                ],
+            }
+        }
+        (defs_dir / "r7a.yaml").write_text(yaml.dump(fleet_data))
+        output_dir = tmp_path / "generated"
+
+        env = {
+            "NODEPOOLS_DEFS_DIR": str(defs_dir),
+            "NODEPOOLS_OUTPUT_DIR": str(output_dir),
+            "NODEPOOLS_MODULE_NAME": "test",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = main()
+
+        assert result == 0
+        generated = sorted(f.name for f in output_dir.glob("*.yaml"))
+        assert generated == ["r7a-24xlarge.yaml", "r7a-48xlarge.yaml", "r7a-8xlarge.yaml"]
+
+    def test_fleet_with_release_generates_extra(self, tmp_path):
+        """Fleet with release entries generates both regular and release outputs."""
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        fleet_data = {
+            "fleet": {
+                "name": "r7a",
+                "arch": "amd64",
+                "gpu": False,
+                "instances": [
+                    {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800},
+                ],
+                "release": [
+                    {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800},
+                ],
+            }
+        }
+        (defs_dir / "r7a.yaml").write_text(yaml.dump(fleet_data))
+        output_dir = tmp_path / "generated"
+
+        env = {
+            "NODEPOOLS_DEFS_DIR": str(defs_dir),
+            "NODEPOOLS_OUTPUT_DIR": str(output_dir),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = main()
+
+        assert result == 0
+        generated = sorted(f.name for f in output_dir.glob("*.yaml"))
+        assert generated == ["r7a-48xlarge-release.yaml", "r7a-48xlarge.yaml"]
+
+        # Verify release has the runner-class label
+        release_content = (output_dir / "r7a-48xlarge-release.yaml").read_text()
+        docs = parse_all_yaml(release_content)
+        labels = docs[0]["spec"]["template"]["metadata"]["labels"]
+        assert labels.get("osdc.io/runner-class") == "release"
+
+    def test_fleets_format_multi_fleet(self, tmp_path):
+        """A fleets file (multi-fleet) generates outputs for all fleets."""
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        fleet_data = {
+            "fleets": [
+                {
+                    "name": "g5-1gpu",
+                    "arch": "amd64",
+                    "gpu": True,
+                    "instances": [
+                        {"type": "g5.8xlarge", "weight": 100, "node_disk_size": 600, "has_nvme": True},
+                    ],
+                },
+                {
+                    "name": "g5-4gpu",
+                    "arch": "amd64",
+                    "gpu": True,
+                    "instances": [
+                        {"type": "g5.12xlarge", "weight": 100, "node_disk_size": 600, "has_nvme": True},
+                    ],
+                },
+            ]
+        }
+        (defs_dir / "g5.yaml").write_text(yaml.dump(fleet_data))
+        output_dir = tmp_path / "generated"
+
+        env = {
+            "NODEPOOLS_DEFS_DIR": str(defs_dir),
+            "NODEPOOLS_OUTPUT_DIR": str(output_dir),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = main()
+
+        assert result == 0
+        generated = sorted(f.name for f in output_dir.glob("*.yaml"))
+        assert generated == ["g5-12xlarge.yaml", "g5-8xlarge.yaml"]
+
+        # Verify fleet names are different
+        g5_8 = parse_all_yaml((output_dir / "g5-8xlarge.yaml").read_text())
+        g5_12 = parse_all_yaml((output_dir / "g5-12xlarge.yaml").read_text())
+        assert g5_8[0]["spec"]["template"]["metadata"]["labels"]["node-fleet"] == "g5-1gpu"
+        assert g5_12[0]["spec"]["template"]["metadata"]["labels"]["node-fleet"] == "g5-4gpu"
+
+    def test_mixed_nodepool_and_fleet(self, tmp_path):
+        """Legacy nodepool and fleet files can coexist in the same defs dir."""
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        (defs_dir / "legacy.yaml").write_text(
+            yaml.dump({"nodepool": _make_nodepool_def(name="legacy-pool", instance_type="m5.4xlarge")})
+        )
+        fleet_data = {
+            "fleet": {
+                "name": "r7a",
+                "arch": "amd64",
+                "gpu": False,
+                "instances": [
+                    {"type": "r7a.48xlarge", "weight": 100, "node_disk_size": 4800},
+                ],
+            }
+        }
+        (defs_dir / "r7a.yaml").write_text(yaml.dump(fleet_data))
+        output_dir = tmp_path / "generated"
+
+        env = {
+            "NODEPOOLS_DEFS_DIR": str(defs_dir),
+            "NODEPOOLS_OUTPUT_DIR": str(output_dir),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = main()
+
+        assert result == 0
+        generated = sorted(f.name for f in output_dir.glob("*.yaml"))
+        assert generated == ["legacy-pool.yaml", "r7a-48xlarge.yaml"]

--- a/osdc/modules/nodepools/tests/smoke/test_nodepools.py
+++ b/osdc/modules/nodepools/tests/smoke/test_nodepools.py
@@ -31,14 +31,51 @@ def _get_defs_dir(upstream_dir: Path) -> Path:
 
 
 def _load_all_defs(upstream_dir: Path) -> list[dict]:
-    """Load all nodepool definition YAML files and return the nodepool dicts."""
+    """Load all nodepool definition YAML files and return the nodepool dicts.
+
+    Supports three formats: ``nodepool:`` (legacy), ``fleet:`` (single fleet),
+    and ``fleets:`` (multi-fleet per file, e.g. GPU families).
+    """
     defs_dir = _get_defs_dir(upstream_dir)
     defs = []
     for f in sorted(defs_dir.glob("*.yaml")):
         data = yaml.safe_load(f.read_text())
-        if data and "nodepool" in data:
+        if not data:
+            continue
+        if "nodepool" in data:
             defs.append(data["nodepool"])
+        elif "fleet" in data:
+            defs.extend(_expand_fleet(data["fleet"]))
+        elif "fleets" in data:
+            for fleet_data in data["fleets"]:
+                defs.extend(_expand_fleet(fleet_data))
     return defs
+
+
+def _expand_fleet(fleet_data: dict) -> list[dict]:
+    """Expand a fleet definition into individual nodepool-like dicts for validation."""
+    result = []
+    for inst in fleet_data.get("instances", []):
+        result.append(
+            {
+                "name": inst["type"].replace(".", "-"),
+                "instance_type": inst["type"],
+                "arch": fleet_data["arch"],
+                "gpu": fleet_data.get("gpu", False),
+                "node_disk_size": inst["node_disk_size"],
+            }
+        )
+    for inst in fleet_data.get("release", []):
+        result.append(
+            {
+                "name": f"{inst['type'].replace('.', '-')}-release",
+                "instance_type": inst["type"],
+                "arch": fleet_data["arch"],
+                "gpu": fleet_data.get("gpu", False),
+                "node_disk_size": inst["node_disk_size"],
+            }
+        )
+    return result
 
 
 # ============================================================================


### PR DESCRIPTION

**Impact:** nodepool generation pipeline
**Risk:** medium — new generation paths, but no existing defs use them yet (pure capability addition)

## What
Extend `generate_nodepools.py` to support two new def formats — `fleet:` (single fleet, multiple instance sizes) and `fleets:` (multiple fleets, e.g. GPU families split by GPU count). Karpenter can now choose from multiple instance sizes within a family, weighted by preference.

## Why
The old model pinned each NodePool to a single instance type (e.g. `r7a.48xlarge`). When a job needed 4 vCPUs, Karpenter still launched a 192-vCPU node. Fleets let Karpenter pick smaller nodes when full-size isn't needed, reducing waste while preserving scheduling isolation.

## How
- Three def formats: `nodepool:` (legacy, still supported), `fleet:` (CPU families), `fleets:` (GPU families with per-GPU-count fleets)
- `derive_fleet_name()` computes fleet names from instance family + GPU count (e.g. `c7i`, `g5-4gpu`)
- Fleet NodePools get a `node-fleet` label and taint for scheduling isolation — runners target a specific fleet, not a specific instance type
- Karpenter uses `weight:` to prefer larger instances (weight 100) over smaller fallbacks (weight 50, 20)
- Comprehensive unit tests for all three formats, fleet derivation, and round-trip validation

## Code examples

**CPU fleet def** (`fleet:` format):
```yaml
fleet:
  name: c7i
  arch: amd64
  gpu: false
  instances:
    - type: c7i.48xlarge
      weight: 100
      node_disk_size: 500
    - type: c7i.24xlarge
      weight: 50
      node_disk_size: 500
```

**GPU fleet def** (`fleets:` format — one fleet per GPU count):
```yaml
fleets:
  - name: g5-1gpu
    arch: amd64
    has_nvme: true
    instances:
      - type: g5.8xlarge
        weight: 100
        node_disk_size: 300
      - type: g5.12xlarge
        weight: 50
        node_disk_size: 300
  - name: g5-4gpu
    ...
```

**Generated NodePool** gains fleet label, taint, and weight:
```yaml
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: c7i-24xlarge
spec:
  weight: 50
  template:
    metadata:
      labels:
        node-fleet: c7i
    spec:
      taints:
        - key: node-fleet
          value: c7i
          effect: NoSchedule
      requirements:
        - key: node.kubernetes.io/instance-type
          operator: In
          values: ["c7i.24xlarge"]
```

## Changes
- `generate_nodepools.py`: new `_process_fleet()`, `_build_fleet_nodepool_def()`, updated `generate_nodepool_yaml()` to emit fleet labels/taints/weights
- `test_generate_nodepools.py`: ~350 new lines covering fleet parsing, fleet name derivation, weight ordering, GPU fleet splitting
- `tests/smoke/test_nodepools.py`: updated to validate both legacy and fleet def formats