### PR TITLE
Add node-fleet taint toleration to DaemonSets and runners

### DIFF
--- a/osdc/base/kubernetes/git-cache/daemonset.yaml
+++ b/osdc/base/kubernetes/git-cache/daemonset.yaml
@@ -38,6 +38,11 @@ spec:
           operator: Exists
           effect: NoSchedule
 
+        # Karpenter node-fleet taints (used by all nodepools)
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
+
         # BuildKit workload taints (service-specific isolation)
         - key: workload/buildkit-arm64
           operator: Exists

--- a/osdc/base/kubernetes/image-cache-janitor/daemonset.yaml
+++ b/osdc/base/kubernetes/image-cache-janitor/daemonset.yaml
@@ -39,6 +39,11 @@ spec:
           operator: Exists
           effect: NoSchedule
 
+        # Karpenter node-fleet taints (used by all nodepools)
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
+
         # BuildKit workload taints (service-specific isolation)
         - key: workload/buildkit-arm64
           operator: Exists

--- a/osdc/base/kubernetes/node-performance-tuning.yaml
+++ b/osdc/base/kubernetes/node-performance-tuning.yaml
@@ -335,6 +335,11 @@ spec:
           operator: Exists
           effect: NoSchedule
 
+        # Karpenter node-fleet taints (used by all nodepools)
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
+
         # BuildKit workload taints (service-specific isolation)
         - key: workload/buildkit-arm64
           operator: Exists

--- a/osdc/base/kubernetes/nvidia-device-plugin.yaml
+++ b/osdc/base/kubernetes/nvidia-device-plugin.yaml
@@ -36,6 +36,10 @@ spec:
         - key: instance-type
           operator: Exists
           effect: NoSchedule
+        # Tolerate node-fleet taints (Karpenter nodepools use this)
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
         # Git cache startup taint (removed by git-cache-warmer after warm-up)
         - key: git-cache-not-ready
           operator: Exists

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -38,6 +38,9 @@ spec:
         - key: instance-type
           operator: Exists
           effect: NoSchedule
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
         - key: git-cache-not-ready
           operator: Exists
           effect: NoSchedule

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -23,6 +23,15 @@ from pathlib import Path
 
 import yaml
 
+# instance_specs lives in scripts/python/ at the repo root.  Add it to
+# sys.path so the import works both when run directly (deploy.sh) and
+# when run via pytest (pyproject.toml testpaths also adds it).
+_scripts_python = str(Path(__file__).resolve().parents[4] / "scripts" / "python")
+if _scripts_python not in sys.path:
+    sys.path.insert(0, _scripts_python)
+
+from instance_specs import INSTANCE_SPECS  # noqa: E402
+
 # ANSI colors
 GREEN = "\033[0;32m"
 RED = "\033[0;31m"
@@ -40,6 +49,21 @@ def log_error(msg):
 def normalize_name(name):
     """Normalize runner name for K8s resources (replace dots and underscores with dashes)."""
     return name.replace(".", "-").replace("_", "-")
+
+
+def derive_fleet_name(instance_type, gpu_count=0):
+    """Derive the node-fleet name from an instance type.
+
+    Uses the instance's actual GPU count from INSTANCE_SPECS rather than the
+    runner's requested GPU count, since multiple runners with different GPU
+    requests may share the same multi-GPU instance (e.g. B200).
+    """
+    family = instance_type.split(".")[0]  # r7a, g5, c7i, p6-b200, etc.
+    specs = INSTANCE_SPECS.get(instance_type, {})
+    node_gpus = specs.get("gpu", gpu_count)
+    if node_gpus:
+        return f"{family}-{node_gpus}gpu"
+    return family
 
 
 # Kubernetes resource quantity suffixes → multiplier (bytes)
@@ -128,6 +152,8 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     if not runner_name or not instance_type:
         log_error(f"Invalid definition file: {def_file}")
         return False
+
+    node_fleet = derive_fleet_name(instance_type, gpu)
 
     # Cluster-specific values
     github_url = cluster_config.get("github_config_url", "")
@@ -223,6 +249,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
         "{{RUNNER_NAME}}": runner_name,
         "{{RUNNER_NAME_NORMALIZED}}": normalized_name,
         "{{INSTANCE_TYPE}}": instance_type,
+        "{{NODE_FLEET}}": node_fleet,
         "{{VCPU}}": str(vcpu),
         "{{MEMORY}}": str(memory),
         "{{MEMORY_BYTES}}": str(parse_memory_bytes(memory)),

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 from generate_runners import (
+    derive_fleet_name,
     generate_runner,
     get_cluster_config,
     load_clusters_yaml,
@@ -31,12 +32,15 @@ MINIMAL_TEMPLATE = textwrap.dedent("""\
           - name: runner
             image: {{RUNNER_IMAGE}}
         nodeSelector:
-          instance-type: "{{INSTANCE_TYPE}}"
+          node-fleet: "{{NODE_FLEET}}"
     {{RUNNER_CLASS_NODE_SELECTOR}}{{RUNNER_CLASS_AFFINITY}}
         tolerations:
-          - key: instance-type
+          - key: node-fleet
             operator: Equal
-            value: "{{INSTANCE_TYPE}}"
+            value: "{{NODE_FLEET}}"
+            effect: NoSchedule
+          - key: instance-type
+            operator: Exists
             effect: NoSchedule{{GPU_TOLERATIONS}}
     ---
     apiVersion: v1
@@ -56,18 +60,21 @@ MINIMAL_TEMPLATE = textwrap.dedent("""\
                 - weight: 50
                   preference:
                     matchExpressions:
-                      - key: instance-type
+                      - key: node-fleet
                         operator: In
                         values:
-                          - "{{INSTANCE_TYPE}}"
+                          - "{{NODE_FLEET}}"
                       - key: workload-type
                         operator: In
                         values:
                           - github-runner{{GPU_NODE_SELECTOR_AFFINITY}}
           tolerations:
-            - key: instance-type
+            - key: node-fleet
               operator: Equal
-              value: "{{INSTANCE_TYPE}}"
+              value: "{{NODE_FLEET}}"
+              effect: NoSchedule
+            - key: instance-type
+              operator: Exists
               effect: NoSchedule{{GPU_JOB_TOLERATIONS}}
           containers:
             - name: "$job"
@@ -172,6 +179,31 @@ class TestNormalizeName:
 
     def test_empty_string(self):
         assert normalize_name("") == ""
+
+
+# ============================================================================
+# derive_fleet_name
+# ============================================================================
+
+
+class TestDeriveFleetName:
+    def test_derive_fleet_name_cpu(self):
+        assert derive_fleet_name("r7a.48xlarge") == "r7a"
+
+    def test_derive_fleet_name_gpu(self):
+        assert derive_fleet_name("g5.8xlarge") == "g5-1gpu"
+
+    def test_derive_fleet_name_gpu_multi(self):
+        assert derive_fleet_name("g5.48xlarge") == "g5-8gpu"
+
+    def test_derive_fleet_name_b200(self):
+        assert derive_fleet_name("p6-b200.48xlarge") == "p6-b200-8gpu"
+
+    def test_derive_fleet_name_metal(self):
+        assert derive_fleet_name("c7i.metal-24xl") == "c7i"
+
+    def test_derive_fleet_name_unknown_gpu_fallback(self):
+        assert derive_fleet_name("z99.xlarge", gpu_count=4) == "z99-4gpu"
 
 
 # ============================================================================
@@ -315,7 +347,7 @@ class TestGenerateRunner:
         assert helm["githubConfigUrl"] == "https://github.com/test-org"
         assert helm["githubConfigSecret"] == "gh-secret"
         assert helm["runnerScaleSetName"] == "staging-cpu-runner"
-        assert helm["template"]["spec"]["nodeSelector"]["instance-type"] == "m5.xlarge"
+        assert helm["template"]["spec"]["nodeSelector"]["node-fleet"] == "m5"
 
         # ConfigMap doc
         cm = docs[1]
@@ -331,7 +363,7 @@ class TestGenerateRunner:
         assert prefs[0]["weight"] == 50
         match_exprs = prefs[0]["preference"]["matchExpressions"]
         keys = [e["key"] for e in match_exprs]
-        assert "instance-type" in keys
+        assert "node-fleet" in keys
         assert "workload-type" in keys
         assert "nvidia.com/gpu" not in keys  # CPU runner has no GPU affinity
 
@@ -371,7 +403,7 @@ class TestGenerateRunner:
         assert len(prefs) == 1
         match_exprs = prefs[0]["preference"]["matchExpressions"]
         keys = [e["key"] for e in match_exprs]
-        assert "instance-type" in keys
+        assert "node-fleet" in keys
         assert "workload-type" in keys
         assert "nvidia.com/gpu" in keys
 

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -95,14 +95,17 @@ template:
     # Schedule runner pods on compute nodes
     nodeSelector:
       workload-type: github-runner
-      instance-type: "{{INSTANCE_TYPE}}"
+      node-fleet: "{{NODE_FLEET}}"
 {{RUNNER_CLASS_NODE_SELECTOR}}
 {{RUNNER_CLASS_AFFINITY}}
-    # Tolerate instance-type taint + git-cache startup taint
+    # Tolerate node-fleet + instance-type taints and git-cache startup taint
     tolerations:
-      - key: instance-type
+      - key: node-fleet
         operator: Equal
-        value: "{{INSTANCE_TYPE}}"
+        value: "{{NODE_FLEET}}"
+        effect: NoSchedule
+      - key: instance-type
+        operator: Exists
         effect: NoSchedule
       - key: git-cache-not-ready
         operator: Equal
@@ -257,31 +260,34 @@ data:
       serviceAccountName: arc-workflow
       automountServiceAccountToken: false
 
-      # Prefer scheduling job pods on same instance type as runner.
-      # Tolerations enforce instance-type constraints (every NodePool taints
-      # with instance-type=<type>:NoSchedule), so nodeSelector is not needed.
+      # Prefer scheduling job pods on same node fleet as runner.
+      # Tolerations enforce node-fleet constraints (every NodePool taints
+      # with node-fleet=<fleet>:NoSchedule), so nodeSelector is not needed.
       # The hooks inject a weight-100 same-node preference at runtime;
-      # this weight-50 preference is the fallback for same-instance-type nodes.
+      # this weight-50 preference is the fallback for same-fleet nodes.
       affinity:
         nodeAffinity:
 {{RUNNER_CLASS_JOB_AFFINITY}}          preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 50
               preference:
                 matchExpressions:
-                  - key: instance-type
+                  - key: node-fleet
                     operator: In
                     values:
-                      - "{{INSTANCE_TYPE}}"
+                      - "{{NODE_FLEET}}"
                   - key: workload-type
                     operator: In
                     values:
                       - github-runner{{GPU_NODE_SELECTOR_AFFINITY}}
 
-      # Tolerate instance-type taint
+      # Tolerate node-fleet + instance-type taints
       tolerations:
-        - key: instance-type
+        - key: node-fleet
           operator: Equal
-          value: "{{INSTANCE_TYPE}}"
+          value: "{{NODE_FLEET}}"
+          effect: NoSchedule
+        - key: instance-type
+          operator: Exists
           effect: NoSchedule{{GPU_JOB_TOLERATIONS}}
 
       containers:

--- a/osdc/modules/cache-enforcer/kubernetes/daemonset.yaml
+++ b/osdc/modules/cache-enforcer/kubernetes/daemonset.yaml
@@ -42,6 +42,9 @@ spec:
         - key: instance-type
           operator: Exists
           effect: NoSchedule
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
         - key: git-cache-not-ready
           operator: Exists
           effect: NoSchedule

--- a/osdc/modules/monitoring/kubernetes/dcgm-exporter/daemonset.yaml
+++ b/osdc/modules/monitoring/kubernetes/dcgm-exporter/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
         - key: instance-type
           operator: Exists
           effect: NoSchedule
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
         # Git cache may not be ready yet
         - key: git-cache-not-ready
           operator: Exists


### PR DESCRIPTION

**Impact:** all DaemonSets on runner/GPU nodes + runner pod scheduling
**Risk:** low — adding a toleration for a taint that doesn't exist yet is a no-op; safe to land before or after fleet NodePools

## What
Update all workloads that run on runner nodes to tolerate the new `node-fleet` taint, and update runner scheduling to select nodes by fleet name.

## Why
Fleet NodePools (PRs #460–#461) add a `node-fleet` taint. Without matching tolerations, DaemonSet pods won't schedule on fleet-tainted nodes, and runners won't be able to target the right fleet.

## How
- DaemonSets use `operator: Exists` — they run on *all* fleet nodes regardless of fleet name
- Runner pods use exact-match tolerations and `nodeSelector` — each runner targets a *specific* fleet
- `derive_fleet_name()` in `generate_runners.py` computes the fleet name from the runner's instance type (e.g. `c7i.48xlarge` → `c7i`, `g5.8xlarge` → `g5-1gpu`)
- The runner template injects the fleet name into both `nodeSelector` and tolerations

## Code examples

**DaemonSet toleration** (wildcard — matches any fleet):
```yaml
tolerations:
  - key: "node-fleet"
    operator: "Exists"
    effect: "NoSchedule"
```

**Runner pod scheduling** (targets specific fleet):
```yaml
spec:
  nodeSelector:
    node-fleet: "c7i"           # or "g5-1gpu" for GPU
  tolerations:
    - key: "node-fleet"
      value: "c7i"
      operator: "Equal"
      effect: "NoSchedule"
    - key: "instance-type"      # backward compat
      operator: "Exists"
      effect: "NoSchedule"
```

**Fleet name derivation** in runner generation:
```python
# CPU: family name only
derive_fleet_name("c7i.48xlarge")  # → "c7i"
derive_fleet_name("m8g.16xlarge")  # → "m8g"

# GPU: family + GPU count
derive_fleet_name("g5.8xlarge")    # → "g5-1gpu"
derive_fleet_name("g5.48xlarge")   # → "g5-8gpu"
```

## Changes

**Base DaemonSets** (added `node-fleet` toleration):
- `base/kubernetes/git-cache/daemonset.yaml`
- `base/kubernetes/image-cache-janitor/daemonset.yaml`
- `base/kubernetes/node-performance-tuning.yaml`
- `base/kubernetes/nvidia-device-plugin.yaml`

**Module DaemonSets** (added `node-fleet` toleration):
- `modules/arc-runners/kubernetes/hooks-warmer.yaml`
- `modules/cache-enforcer/kubernetes/daemonset.yaml`
- `modules/monitoring/kubernetes/dcgm-exporter/daemonset.yaml`

**Runner scheduling**:
- `modules/arc-runners/templates/runner.yaml.tpl` — added `node-fleet` nodeSelector + toleration
- `modules/arc-runners/scripts/python/generate_runners.py` — added `derive_fleet_name()`, injects `NODE_FLEET` into template
- `modules/arc-runners/scripts/python/test_generate_runners.py` — tests for fleet name derivation and template rendering