### PR TITLE
Require known instance types in fleet derivation

### DIFF
--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -123,6 +123,7 @@ Runs on nodes with `workload-type` in `[github-runner, buildkit]`.
 |-----------|------|--------|-------|------------|
 | `git-cache-not-ready=true` | Startup taint | `NoSchedule` | All Karpenter NodePools | git-cache-warmer DaemonSet |
 | `instance-type={type}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (scheduling constraint) |
+| `node-fleet={fleet}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (fleet-based scheduling) |
 | `workload/buildkit-{arch}=true` | Permanent | `NoSchedule` | BuildKit NodePools | Never (scheduling constraint) |
 | `nvidia.com/gpu=true` | Permanent | `NoSchedule` | GPU NodePools only | Never (scheduling constraint) |
 | `node-compactor.osdc.io/consolidating=true` | Runtime (dynamic) | `NoSchedule` | Applied by node-compactor | node-compactor controller (protected by `min_node_age`: 900s) |
@@ -130,11 +131,14 @@ Runs on nodes with `workload-type` in `[github-runner, buildkit]`.
 
 ## Toleration Pattern
 
-All DaemonSets targeting runner and buildkit nodes use a consistent toleration set covering both `instance-type` (runner NodePools) and `workload/buildkit-*` (BuildKit NodePools) taints:
+All DaemonSets targeting runner and buildkit nodes use a consistent toleration set covering `instance-type`, `node-fleet` (runner NodePools) and `workload/buildkit-*` (BuildKit NodePools) taints:
 
 ```yaml
 tolerations:
   - key: instance-type
+    operator: Exists
+    effect: NoSchedule
+  - key: node-fleet
     operator: Exists
     effect: NoSchedule
   - key: workload/buildkit-arm64

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -51,16 +51,20 @@ def normalize_name(name):
     return name.replace(".", "-").replace("_", "-")
 
 
-def derive_fleet_name(instance_type, gpu_count=0):
+def derive_fleet_name(instance_type):
     """Derive the node-fleet name from an instance type.
 
     Uses the instance's actual GPU count from INSTANCE_SPECS rather than the
     runner's requested GPU count, since multiple runners with different GPU
     requests may share the same multi-GPU instance (e.g. B200).
     """
+    if instance_type not in INSTANCE_SPECS:
+        raise ValueError(
+            f"Instance type '{instance_type}' not found in INSTANCE_SPECS. "
+            f"Add it to scripts/python/instance_specs.py before using it."
+        )
     family = instance_type.split(".")[0]  # r7a, g5, c7i, p6-b200, etc.
-    specs = INSTANCE_SPECS.get(instance_type, {})
-    node_gpus = specs.get("gpu", gpu_count)
+    node_gpus = INSTANCE_SPECS[instance_type].get("gpu", 0)
     if node_gpus:
         return f"{family}-{node_gpus}gpu"
     return family
@@ -153,7 +157,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
         log_error(f"Invalid definition file: {def_file}")
         return False
 
-    node_fleet = derive_fleet_name(instance_type, gpu)
+    node_fleet = derive_fleet_name(instance_type)
 
     # Cluster-specific values
     github_url = cluster_config.get("github_config_url", "")

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -202,8 +202,9 @@ class TestDeriveFleetName:
     def test_derive_fleet_name_metal(self):
         assert derive_fleet_name("c7i.metal-24xl") == "c7i"
 
-    def test_derive_fleet_name_unknown_gpu_fallback(self):
-        assert derive_fleet_name("z99.xlarge", gpu_count=4) == "z99-4gpu"
+    def test_derive_fleet_name_unknown_raises(self):
+        with pytest.raises(ValueError, match="not found in INSTANCE_SPECS"):
+            derive_fleet_name("z99.xlarge")
 
 
 # ============================================================================
@@ -324,7 +325,7 @@ class TestResolveValue:
 
 class TestGenerateRunner:
     def test_non_gpu_runner(self, tmp_path):
-        def_file = make_def_file(tmp_path, "cpu-runner", "m5.xlarge", 4, 16)
+        def_file = make_def_file(tmp_path, "cpu-runner", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -347,7 +348,7 @@ class TestGenerateRunner:
         assert helm["githubConfigUrl"] == "https://github.com/test-org"
         assert helm["githubConfigSecret"] == "gh-secret"
         assert helm["runnerScaleSetName"] == "staging-cpu-runner"
-        assert helm["template"]["spec"]["nodeSelector"]["node-fleet"] == "m5"
+        assert helm["template"]["spec"]["nodeSelector"]["node-fleet"] == "m6i"
 
         # ConfigMap doc
         cm = docs[1]
@@ -408,7 +409,7 @@ class TestGenerateRunner:
         assert "nvidia.com/gpu" in keys
 
     def test_no_placeholders_remaining(self, tmp_path):
-        def_file = make_def_file(tmp_path, "test-runner", "c5.xlarge", 2, 4)
+        def_file = make_def_file(tmp_path, "test-runner", "c7i.24xlarge", 2, 4)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -423,7 +424,7 @@ class TestGenerateRunner:
         assert "}}" not in content
 
     def test_normalized_name_in_output(self, tmp_path):
-        def_file = make_def_file(tmp_path, "runner.with_dots", "m5.xlarge", 4, 16)
+        def_file = make_def_file(tmp_path, "runner.with_dots", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -440,7 +441,7 @@ class TestGenerateRunner:
 
     def test_invalid_def_no_name(self, tmp_path):
         p = tmp_path / "bad.yaml"
-        p.write_text(yaml.dump({"runner": {"instance_type": "m5.xlarge"}}, default_flow_style=False))
+        p.write_text(yaml.dump({"runner": {"instance_type": "m6i.32xlarge"}}, default_flow_style=False))
         output_dir = tmp_path / "out"
         output_dir.mkdir()
 
@@ -457,7 +458,7 @@ class TestGenerateRunner:
         assert result is False
 
     def test_resource_values_match_def(self, tmp_path):
-        def_file = make_def_file(tmp_path, "res-test", "c6i.12xlarge", 48, 96, disk_size=200)
+        def_file = make_def_file(tmp_path, "res-test", "c7i.24xlarge", 48, 96, disk_size=200)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -477,7 +478,7 @@ class TestGenerateRunner:
 
     def test_memory_bytes_env_var(self, tmp_path):
         """TORCH_CI_MAX_MEMORY env var contains memory in bytes."""
-        def_file = make_def_file(tmp_path, "mem-test", "c6i.12xlarge", 48, 96, disk_size=200)
+        def_file = make_def_file(tmp_path, "mem-test", "c7i.24xlarge", 48, 96, disk_size=200)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -497,7 +498,7 @@ class TestGenerateRunner:
 
     def test_pypi_cache_env_vars(self, tmp_path):
         """All pypi-cache env vars are present with correct CPU defaults."""
-        def_file = make_def_file(tmp_path, "cache-test", "m5.xlarge", 4, 16)
+        def_file = make_def_file(tmp_path, "cache-test", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -526,7 +527,7 @@ class TestGenerateRunner:
 
     def test_runner_group_default(self, tmp_path):
         """Runner group defaults to 'default' when not specified."""
-        def_file = make_def_file(tmp_path, "grp-test", "m5.xlarge", 4, 16)
+        def_file = make_def_file(tmp_path, "grp-test", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -541,7 +542,7 @@ class TestGenerateRunner:
 
     def test_runner_group_custom(self, tmp_path):
         """Runner group can be overridden in the def (org-scoped URL)."""
-        def_file = make_def_file(tmp_path, "rel-grp", "m5.xlarge", 4, 16, runner_group="release-runners")
+        def_file = make_def_file(tmp_path, "rel-grp", "m6i.32xlarge", 4, 16, runner_group="release-runners")
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -556,7 +557,7 @@ class TestGenerateRunner:
 
     def test_runner_group_repo_scoped_override(self, tmp_path):
         """Runner group forced to 'default' when githubConfigUrl is repo-scoped."""
-        def_file = make_def_file(tmp_path, "rel-repo", "m5.xlarge", 4, 16, runner_group="release-runners")
+        def_file = make_def_file(tmp_path, "rel-repo", "m6i.32xlarge", 4, 16, runner_group="release-runners")
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -603,7 +604,7 @@ class TestGenerateRunner:
 
     def test_regular_runner_anti_affinity(self, tmp_path):
         """Regular runners get anti-affinity to avoid release nodes."""
-        def_file = make_def_file(tmp_path, "reg-runner", "m5.xlarge", 4, 16)
+        def_file = make_def_file(tmp_path, "reg-runner", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         cluster_config = {
@@ -643,7 +644,7 @@ class TestGenerateRunner:
                 {
                     "runner": {
                         "name": "nodisk",
-                        "instance_type": "m5.xlarge",
+                        "instance_type": "m6i.32xlarge",
                         "vcpu": 2,
                         "memory": "4Gi",
                     }
@@ -707,7 +708,7 @@ class TestMain:
 
         defs_dir = tmp_path / "defs"
         defs_dir.mkdir()
-        make_def_file(defs_dir, "runner1", "m5.xlarge", 2, 4)
+        make_def_file(defs_dir, "runner1", "m6i.32xlarge", 2, 4)
 
         monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
         monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
@@ -725,8 +726,8 @@ class TestMain:
 
         defs_dir = tmp_path / "defs"
         defs_dir.mkdir()
-        make_def_file(defs_dir, "runner-a", "m5.xlarge", 2, 4)
-        make_def_file(defs_dir, "runner-b", "g4dn.xlarge", 4, 16, gpu=1)
+        make_def_file(defs_dir, "runner-a", "m6i.32xlarge", 2, 4)
+        make_def_file(defs_dir, "runner-b", "g4dn.8xlarge", 4, 16, gpu=1)
 
         output_dir = tmp_path / "out"
 
@@ -752,7 +753,7 @@ class TestMain:
 
         defs_dir = tmp_path / "defs"
         defs_dir.mkdir()
-        make_def_file(defs_dir, "runner-a", "m5.xlarge", 2, 4)
+        make_def_file(defs_dir, "runner-a", "m6i.32xlarge", 2, 4)
 
         output_dir = tmp_path / "out"
         output_dir.mkdir()

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -376,9 +376,14 @@ def _process_nodepool(nodepool_def, def_file, defs_dir, output_dir, module_name)
     )
 
     # Auto-derive fleet name for legacy defs so nodes get the node-fleet label/taint
+    if instance_type not in INSTANCE_SPECS:
+        log_error(
+            f"Instance type '{instance_type}' not found in INSTANCE_SPECS. "
+            f"Add it to scripts/python/instance_specs.py before using it."
+        )
+        return 0
     family = instance_type.split(".")[0]
-    specs = INSTANCE_SPECS.get(instance_type, {})
-    node_gpus = specs.get("gpu", 0)
+    node_gpus = INSTANCE_SPECS[instance_type].get("gpu", 0)
     nodepool_def["fleet_name"] = f"{family}-{node_gpus}gpu" if node_gpus else family
 
     content = generate_nodepool_yaml(nodepool_def, module_name, defs_dir)

--- a/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
@@ -30,7 +30,7 @@ def _make_nodepool_def(**overrides) -> dict:
     """Build a minimal nodepool def dict with sensible defaults."""
     base = {
         "name": "test-pool",
-        "instance_type": "m5.4xlarge",
+        "instance_type": "m6i.32xlarge",
         "node_disk_size": 200,
         "gpu": False,
     }
@@ -117,7 +117,7 @@ class TestDetectArch:
         assert _detect_arch("m8gd.24xlarge", None) == "arm64"
 
     def test_non_graviton_m5(self):
-        assert _detect_arch("m5.4xlarge", None) == "amd64"
+        assert _detect_arch("m6i.32xlarge", None) == "amd64"
 
     def test_non_graviton_r5(self):
         assert _detect_arch("r5.24xlarge", None) == "amd64"
@@ -778,7 +778,7 @@ class TestMain:
         defs_dir = self._create_defs(
             tmp_path,
             [
-                _make_nodepool_def(name="pool-a", instance_type="m5.4xlarge"),
+                _make_nodepool_def(name="pool-a", instance_type="m6i.32xlarge"),
                 _make_nodepool_def(name="pool-b", instance_type="r5.24xlarge"),
             ],
         )
@@ -847,11 +847,29 @@ class TestMain:
         # Missing name → invalid, aborts with error return code
         assert result == 1
 
+    def test_legacy_nodepool_unknown_instance_type(self, tmp_path):
+        """Legacy nodepool defs with instance types not in INSTANCE_SPECS fail."""
+        defs_dir = self._create_defs(
+            tmp_path,
+            [_make_nodepool_def(name="unknown-pool", instance_type="z99.xlarge")],
+        )
+        output_dir = tmp_path / "generated"
+
+        env = {
+            "NODEPOOLS_DEFS_DIR": str(defs_dir),
+            "NODEPOOLS_OUTPUT_DIR": str(output_dir),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = main()
+
+        assert result == 0
+        assert not list(output_dir.glob("*.yaml"))
+
     def test_output_files_are_parseable_yaml(self, tmp_path):
         defs_dir = self._create_defs(
             tmp_path,
             [
-                _make_nodepool_def(name="parseable", instance_type="m5.4xlarge"),
+                _make_nodepool_def(name="parseable", instance_type="m6i.32xlarge"),
             ],
         )
         output_dir = tmp_path / "generated"
@@ -986,7 +1004,7 @@ class TestMain:
         defs_dir = tmp_path / "defs"
         defs_dir.mkdir()
         (defs_dir / "legacy.yaml").write_text(
-            yaml.dump({"nodepool": _make_nodepool_def(name="legacy-pool", instance_type="m5.4xlarge")})
+            yaml.dump({"nodepool": _make_nodepool_def(name="legacy-pool", instance_type="r7i.48xlarge")})
         )
         fleet_data = {
             "fleet": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #486
* #476
* #474
* #485
* #473
* #469
* __->__ #468
* #467
* #466
* #465
* #464

**Impact:** nodepool and runner generation — config-time validation only
**Risk:** low — fails fast on bad config instead of producing silent wrong output

Make `derive_fleet_name()` and nodepool generation fail explicitly when an instance type is missing from `INSTANCE_SPECS`, instead of silently falling back to a potentially wrong fleet name.

Previously, an unknown instance type (e.g. a typo like `g5.8xlareg` or a new size not yet in `INSTANCE_SPECS`) would silently produce a fleet name with 0 GPUs or use the runner's requested GPU count. On multi-GPU instances, this could cause a runner requesting 1 GPU to schedule on a node with 8 GPUs (or vice versa). Failing early surfaces these errors at generation time.

- Removed the `gpu_count` fallback parameter from `derive_fleet_name()` — GPU count is always read from `INSTANCE_SPECS`
- Added explicit `ValueError` when an instance type is not found
- Updated tests to use instance types that exist in `INSTANCE_SPECS`

**Before** — silent fallback:
```python
derive_fleet_name("g5.8xlareg", gpu_count=1)  # → "g5-1gpu" (wrong, typo not caught)
derive_fleet_name("z9.xlarge")                 # → "z9" (unknown family, no error)
```

**After** — explicit failure:
```python
derive_fleet_name("g5.8xlareg")  # → ValueError: Unknown instance type 'g5.8xlareg'
derive_fleet_name("g5.8xlarge")  # → "g5-1gpu" (correct, from INSTANCE_SPECS)
```

- `generate_runners.py`: removed `gpu_count` parameter from `derive_fleet_name()`, added `ValueError` for unknown types
- `generate_nodepools.py`: added validation that all fleet instance types exist in `INSTANCE_SPECS`
- `test_generate_runners.py`: updated test instance types, added unknown-type error tests
- `test_generate_nodepools.py`: added tests for unknown instance type rejection
- `docs/node-warmup-and-scheduling-gates.md`: documented `node-fleet` taint in node init sequence

Signed-off-by: Jean Schmidt <contato@jschmidt.me>