### PR TITLE
Bump github-runner module to v20260407

### DIFF
--- a/ali/Terrafile
+++ b/ali/Terrafile
@@ -4,7 +4,7 @@ terraform-aws-vpc:
 terraform-aws-github-runner:
   source: "pytorch/test-infra"
   module-root: "terraform-aws-github-runner"
-  tag: "v20260227-212554"
+  tag: "v20260407-194513"
   assets:
     - "runner-binaries-syncer.zip"
     - "runners.zip"


### PR DESCRIPTION
- Update terraform-aws-github-runner tag from v20260227-212554 to v20260407-194513

Picks up ~5 weeks of upstream changes from pytorch/test-infra.