### PR TITLE
Add fleet-aware grouping to node compactor

### DIFF
--- a/osdc/base/node-compactor/scripts/python/compactor.py
+++ b/osdc/base/node-compactor/scripts/python/compactor.py
@@ -27,7 +27,7 @@ import time
 import metrics as m
 from discovery import build_node_states, discover_managed_nodes
 from lightkube import ApiError, Client
-from models import Config
+from models import LABEL_NODE_FLEET, Config, NodeState
 from packing import _count_spare_nodes, compute_taints, select_reserved_nodes
 from phantom import apply_pending_phantom_load
 from prometheus_client import start_http_server
@@ -40,6 +40,11 @@ from taints import (
 )
 
 log = logging.getLogger("compactor")
+
+
+def _fleet_group_key(ns: NodeState) -> str:
+    """Group nodes by fleet (node-fleet label), falling back to nodepool."""
+    return ns.labels.get(LABEL_NODE_FLEET) or ns.nodepool
 
 
 # ============================================================================
@@ -76,11 +81,8 @@ def reconcile(
         m.refresh_gauge(m.tainted_nodes, {})
         return
 
-    # Instrumentation point 1: managed nodes per nodepool
-    pool_node_counts: dict[str, int] = {}
-    for _node_name, pool_name in managed_names.items():
-        pool_node_counts[pool_name] = pool_node_counts.get(pool_name, 0) + 1
-    m.refresh_gauge(m.managed_nodes, {(pool_name,): count for pool_name, count in pool_node_counts.items()})
+    # Instrumentation point 1: managed nodes per fleet
+    # (deferred until fleet_groups is built, after node_states)
 
     node_states, pending_pods = build_node_states(client, cfg, managed_names)
     if not node_states:
@@ -105,35 +107,42 @@ def reconcile(
         total_pods,
     )
 
-    # Instrumentation point 2: workload pods and utilization per nodepool/node
-    pool_pod_counts: dict[str, int] = {}
+    # Instrumentation point 2: workload pods per fleet, utilization per node
+    fleet_pod_counts: dict[str, int] = {}
     utilization: dict[tuple[str, ...], float] = {}
     for node_name, ns in node_states.items():
         pool = managed_names.get(node_name, "unknown")
-        pool_pod_counts[pool] = pool_pod_counts.get(pool, 0) + ns.workload_pod_count
+        fk = _fleet_group_key(ns)
+        fleet_pod_counts[fk] = fleet_pod_counts.get(fk, 0) + ns.workload_pod_count
         if ns.allocatable_cpu > 0:
             utilization[(node_name, pool, "cpu")] = ns.total_cpu_used / ns.allocatable_cpu
         if ns.allocatable_memory > 0:
             utilization[(node_name, pool, "memory")] = ns.total_memory_used / ns.allocatable_memory
     m.refresh_gauge(m.node_utilization_ratio, utilization)
-    m.refresh_gauge(m.workload_pods, {(pool_name,): count for pool_name, count in pool_pod_counts.items()})
+    m.refresh_gauge(m.workload_pods, {(fk,): count for fk, count in fleet_pod_counts.items()})
 
     # Instrumentation point 3: pending pods
     burst_untaint = check_pending_pods(cfg, node_states, pending_pods)
     m.pending_pods_compatible.set(len(pending_pods))
 
-    # Record fleet cooldown for pools that had burst untaints
+    # Record fleet cooldown for fleets that had burst untaints
     if fleet_cooldown_times is not None:
         for node_name in burst_untaint:
             ns = node_states.get(node_name)
             if ns:
-                fleet_cooldown_times[ns.nodepool] = time.time()
+                fleet_cooldown_times[_fleet_group_key(ns)] = time.time()
 
-    # Build pool_groups once — used by reservations, spare capacity, fleet cooldown.
+    # Build fleet_groups (for fleet-level metrics/decisions) and pool_groups
+    # (for per-nodepool metrics like reservations).
+    fleet_groups: dict[str, list] = {}
     pool_groups: dict[str, list] = {}
-    for node_name, ns in node_states.items():
-        pool = managed_names.get(node_name, "unknown")
-        pool_groups.setdefault(pool, []).append(ns)
+    for _node_name, ns in node_states.items():
+        fleet_key = _fleet_group_key(ns)
+        fleet_groups.setdefault(fleet_key, []).append(ns)
+        pool_groups.setdefault(ns.nodepool, []).append(ns)
+
+    # Instrumentation point 1: managed nodes per fleet (deferred from above)
+    m.refresh_gauge(m.managed_nodes, {(fk,): float(len(nodes)) for fk, nodes in fleet_groups.items()})
 
     # Capacity reservation: protect nodes from Karpenter deletion (before compute_taints).
     all_reserved: set[str] = set()
@@ -150,7 +159,7 @@ def reconcile(
     m.refresh_gauge(m.reserved_nodes, reserved_counts)
 
     desired_taint, desired_untaint, mandatory_untaint, rate_limited = compute_taints(
-        node_states, cfg, reserved_nodes=all_reserved
+        node_states, cfg, reserved_nodes=all_reserved, group_key=_fleet_group_key
     )
 
     # Log and emit metrics for rate-limited nodes
@@ -165,17 +174,17 @@ def reconcile(
         for pool, count in pool_rate_limited.items():
             m.rate_limit_blocks.labels(nodepool=pool).inc(count)
 
-    # Instrumentation: spare capacity per pool
+    # Instrumentation: spare capacity per fleet
     spare_actual: dict[tuple[str, ...], float] = {}
     spare_req: dict[tuple[str, ...], float] = {}
-    for pool, nodes_in_pool in pool_groups.items():
+    for fleet_key, nodes_in_fleet in fleet_groups.items():
         required = max(
             cfg.spare_capacity_nodes,
-            math.ceil(len(nodes_in_pool) * cfg.spare_capacity_ratio),
+            math.ceil(len(nodes_in_fleet) * cfg.spare_capacity_ratio),
         )
-        spare_req[(pool,)] = float(required)
-        spare_actual[(pool,)] = float(
-            _count_spare_nodes(nodes_in_pool, None, desired_taint, cfg.spare_capacity_threshold)
+        spare_req[(fleet_key,)] = float(required)
+        spare_actual[(fleet_key,)] = float(
+            _count_spare_nodes(nodes_in_fleet, None, desired_taint, cfg.spare_capacity_threshold)
         )
     m.refresh_gauge(m.spare_capacity_gauge, spare_actual)
     m.refresh_gauge(m.spare_capacity_required, spare_req)
@@ -184,21 +193,21 @@ def reconcile(
     desired_untaint |= burst_untaint
     desired_taint -= burst_untaint
 
-    # Fleet cooldown: block new taints in pools that recently had a burst untaint.
+    # Fleet cooldown: block new taints in fleets that recently had a burst untaint.
     now_fleet = time.time()
     fleet_blocked: set[str] = set()
     if fleet_cooldown_times is not None and cfg.fleet_cooldown > 0:
         for node_name in list(desired_taint):
             ns = node_states.get(node_name)
-            if ns and ns.nodepool in fleet_cooldown_times:
-                pool_nodes = [n for n in node_states.values() if n.nodepool == ns.nodepool]
-                surplus_count = sum(1 for n in pool_nodes if n.name in desired_taint or n.is_tainted)
-                # Override: halve cooldown if >50% of pool is surplus
+            if ns and _fleet_group_key(ns) in fleet_cooldown_times:
+                fleet_nodes = [n for n in node_states.values() if _fleet_group_key(n) == _fleet_group_key(ns)]
+                surplus_count = sum(1 for n in fleet_nodes if n.name in desired_taint or n.is_tainted)
+                # Override: halve cooldown if >50% of fleet is surplus
                 effective_cooldown = cfg.fleet_cooldown
-                if surplus_count > len(pool_nodes) * 0.5:
+                if surplus_count > len(fleet_nodes) * 0.5:
                     effective_cooldown = cfg.fleet_cooldown // 2
 
-                elapsed = now_fleet - fleet_cooldown_times[ns.nodepool]
+                elapsed = now_fleet - fleet_cooldown_times[_fleet_group_key(ns)]
                 if elapsed < effective_cooldown:
                     desired_taint.discard(node_name)
                     fleet_blocked.add(node_name)
@@ -210,30 +219,31 @@ def reconcile(
                 len(fleet_blocked),
                 ", ".join(sorted(fleet_blocked)),
             )
-            # Count blocks per pool
-            pool_block_counts: dict[str, int] = {}
+            # Count blocks per fleet
+            fleet_block_counts: dict[str, int] = {}
             for node_name in fleet_blocked:
                 ns = node_states.get(node_name)
                 if ns:
-                    pool_block_counts[ns.nodepool] = pool_block_counts.get(ns.nodepool, 0) + 1
-            for pool, count in pool_block_counts.items():
-                m.fleet_cooldown_blocks.labels(nodepool=pool).inc(count)
+                    fk = _fleet_group_key(ns)
+                    fleet_block_counts[fk] = fleet_block_counts.get(fk, 0) + 1
+            for fleet_key, count in fleet_block_counts.items():
+                m.fleet_cooldown_blocks.labels(fleet=fleet_key).inc(count)
 
-        # Emit fleet_cooldown_remaining gauge per pool
+        # Emit fleet_cooldown_remaining gauge per fleet
         cooldown_remaining: dict[tuple[str, ...], float] = {}
-        for pool, last_burst_time in fleet_cooldown_times.items():
+        for fleet_key, last_burst_time in fleet_cooldown_times.items():
             remaining = max(0.0, cfg.fleet_cooldown - (now_fleet - last_burst_time))
-            cooldown_remaining[(pool,)] = remaining
+            cooldown_remaining[(fleet_key,)] = remaining
         m.refresh_gauge(m.fleet_cooldown_remaining, cooldown_remaining)
 
-    # Instrumentation point 4: tainted nodes per nodepool (after compute)
-    pool_taint_counts: dict[str, int] = {}
+    # Instrumentation point 4: tainted nodes per fleet (after compute)
+    fleet_taint_counts: dict[str, int] = {}
     for node_name, ns in node_states.items():
-        pool = managed_names.get(node_name, "unknown")
         will_be_tainted = (ns.is_tainted or node_name in desired_taint) and node_name not in desired_untaint
         if will_be_tainted:
-            pool_taint_counts[pool] = pool_taint_counts.get(pool, 0) + 1
-    m.refresh_gauge(m.tainted_nodes, {(pool_name,): count for pool_name, count in pool_taint_counts.items()})
+            fk = _fleet_group_key(ns)
+            fleet_taint_counts[fk] = fleet_taint_counts.get(fk, 0) + 1
+    m.refresh_gauge(m.tainted_nodes, {(fk,): count for fk, count in fleet_taint_counts.items()})
 
     # Apply cooldown: skip untaint for recently tainted nodes.
     # Exempt: burst untaint (urgent) and mandatory untaint (min_nodes safety).

--- a/osdc/base/node-compactor/scripts/python/metrics.py
+++ b/osdc/base/node-compactor/scripts/python/metrics.py
@@ -30,19 +30,19 @@ def refresh_gauge(gauge: Gauge, current: dict[tuple[str, ...], float]) -> None:
 managed_nodes = Gauge(
     "node_compactor_managed_nodes",
     "Total nodes under compactor management",
-    ["nodepool"],
+    ["fleet"],
 )
 
 tainted_nodes = Gauge(
     "node_compactor_tainted_nodes",
     "Currently tainted nodes (NoSchedule)",
-    ["nodepool"],
+    ["fleet"],
 )
 
 workload_pods = Gauge(
     "node_compactor_workload_pods",
     "Workload pods on managed nodes",
-    ["nodepool"],
+    ["fleet"],
 )
 
 pending_pods_compatible = Gauge(
@@ -59,13 +59,13 @@ node_utilization_ratio = Gauge(
 spare_capacity_gauge = Gauge(
     "compactor_spare_capacity_nodes",
     "Number of spare capacity nodes (low utilization, untainted)",
-    ["nodepool"],
+    ["fleet"],
 )
 
 spare_capacity_required = Gauge(
     "compactor_spare_capacity_required",
     "Required spare capacity nodes",
-    ["nodepool"],
+    ["fleet"],
 )
 
 reserved_nodes = Gauge(
@@ -96,7 +96,7 @@ cooldown_blocks_total = Counter(
 fleet_cooldown_blocks = Counter(
     "compactor_fleet_cooldown_blocks_total",
     "Taint operations blocked by fleet cooldown",
-    ["nodepool"],
+    ["fleet"],
 )
 
 rate_limit_blocks = Counter(
@@ -114,7 +114,7 @@ phantom_load_pods = Gauge(
 fleet_cooldown_remaining = Gauge(
     "compactor_fleet_cooldown_remaining_seconds",
     "Seconds remaining in fleet cooldown",
-    ["nodepool"],
+    ["fleet"],
 )
 
 # --- Histogram ---

--- a/osdc/base/node-compactor/scripts/python/models.py
+++ b/osdc/base/node-compactor/scripts/python/models.py
@@ -16,6 +16,7 @@ log = logging.getLogger("compactor")
 
 ANNOTATION_CAPACITY_RESERVED = "node-compactor.osdc.io/capacity-reserved"
 ANNOTATION_DO_NOT_DISRUPT = "karpenter.sh/do-not-disrupt"
+LABEL_NODE_FLEET = "node-fleet"
 
 # ============================================================================
 # Configuration

--- a/osdc/base/node-compactor/scripts/python/packing.py
+++ b/osdc/base/node-compactor/scripts/python/packing.py
@@ -3,6 +3,7 @@
 import logging
 import math
 from collections import defaultdict
+from collections.abc import Callable
 
 from models import Config, NodeState, PodInfo
 
@@ -89,18 +90,27 @@ def _pods_fit_on_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> bool:
     return True
 
 
-def select_reserved_nodes(pool_nodes: dict[str, list[NodeState]], cfg: Config) -> dict[str, set[str]]:
+def select_reserved_nodes(group_nodes: dict[str, list[NodeState]], cfg: Config) -> dict[str, set[str]]:
     """Select nodes per pool for capacity reservation (do-not-disrupt).
 
     Only young nodes (< max_uptime_hours) are eligible. Selection priority:
     lowest utilization first (ready-to-use capacity), then oldest
     youngest-pod age (closer to draining), then newest node as tiebreaker.
 
+    Accepts any grouping (e.g. fleet-grouped data) but internally
+    re-groups by NodePool, since reservations are per-NodePool.
+
     Returns {pool_name: {node_names}} with up to
     cfg.capacity_reservation_nodes per pool.
     """
     if cfg.capacity_reservation_nodes <= 0:
         return {}
+
+    # Reservations are per-NodePool — re-group internally regardless of caller grouping
+    pool_nodes: dict[str, list[NodeState]] = defaultdict(list)
+    for nodes in group_nodes.values():
+        for ns in nodes:
+            pool_nodes[ns.nodepool].append(ns)
 
     result: dict[str, set[str]] = {}
     for pool_name, nodes in pool_nodes.items():
@@ -126,7 +136,10 @@ def select_reserved_nodes(pool_nodes: dict[str, list[NodeState]], cfg: Config) -
 
 
 def compute_taints(
-    node_states: dict[str, NodeState], cfg: Config, reserved_nodes: set[str] | None = None
+    node_states: dict[str, NodeState],
+    cfg: Config,
+    reserved_nodes: set[str] | None = None,
+    group_key: Callable[[NodeState], str] | None = None,
 ) -> tuple[set[str], set[str], set[str], set[str]]:
     """Decide which nodes to taint and which to untaint.
 
@@ -142,9 +155,11 @@ def compute_taints(
     if not node_states:
         return set(), set(), set(), set()
 
-    pools: dict[str, list[NodeState]] = defaultdict(list)
+    key_fn = group_key or (lambda ns: ns.nodepool)
+
+    groups: dict[str, list[NodeState]] = defaultdict(list)
     for ns in node_states.values():
-        pools[ns.nodepool].append(ns)
+        groups[key_fn(ns)].append(ns)
 
     to_taint: set[str] = set()
     to_untaint: set[str] = set()
@@ -153,31 +168,31 @@ def compute_taints(
 
     reserved = reserved_nodes or set()
 
-    for _pool_name, pool_nodes in pools.items():
+    for _group_name, group_nodes in groups.items():
         all_workload_pods = []
-        for node in pool_nodes:
+        for node in group_nodes:
             all_workload_pods.extend(p for p in node.workload_pods if not p.is_phantom)
 
-        min_needed = bin_pack_min_nodes(all_workload_pods, pool_nodes)
+        min_needed = bin_pack_min_nodes(all_workload_pods, group_nodes)
         min_needed = max(min_needed, cfg.min_nodes)
 
-        surplus = len(pool_nodes) - min_needed
+        surplus = len(group_nodes) - min_needed
         if surplus <= 0:
             # All nodes are needed — untaint any that are tainted.
             # This is a min_nodes enforcement: mandatory.
-            for node in pool_nodes:
+            for node in group_nodes:
                 if node.is_tainted:
                     to_untaint.add(node.name)
                     mandatory_untaint.add(node.name)
             continue
 
-        # Compute required spare capacity for this pool.
+        # Compute required spare capacity for this group.
         # spare_capacity_nodes is a floor, spare_capacity_ratio scales with
-        # pool size. The effective requirement is the max of both.
+        # group size. The effective requirement is the max of both.
         # Setting both to 0 disables the feature.
         required_spare = max(
             cfg.spare_capacity_nodes,
-            math.ceil(len(pool_nodes) * cfg.spare_capacity_ratio),
+            math.ceil(len(group_nodes) * cfg.spare_capacity_ratio),
         )
 
         # Exclude young nodes and reserved nodes from taint candidates.
@@ -185,7 +200,7 @@ def compute_taints(
         # provisioning and the compactor's reconcile cycle). Reserved nodes
         # are protected from disruption to maintain ready-to-use capacity.
         eligible = []
-        for node in pool_nodes:
+        for node in group_nodes:
             if node.name in reserved:
                 log.debug("Skipping %s: capacity-reserved", node.name)
                 if node.is_tainted:
@@ -207,6 +222,7 @@ def compute_taints(
             is_old = 1 if node.uptime_hours > cfg.max_uptime_hours else 0
             return (
                 -is_old,
+                node.allocatable_cpu,
                 node.utilization,
                 -node.youngest_pod_age_seconds,
             )
@@ -270,7 +286,7 @@ def compute_taints(
             # with utilization at or below the threshold.
             if required_spare > 0:
                 spare_after = _count_spare_nodes(
-                    pool_nodes,
+                    group_nodes,
                     node.name,
                     to_taint,
                     cfg.spare_capacity_threshold,
@@ -293,10 +309,10 @@ def compute_taints(
                 new_taint_count += 1
 
         # Spare capacity recovery: untaint low-utilization tainted nodes
-        # if the pool doesn't meet the spare capacity requirement.
+        # if the group doesn't meet the spare capacity requirement.
         if required_spare > 0:
             current_spare = _count_spare_nodes(
-                pool_nodes,
+                group_nodes,
                 None,
                 to_taint,
                 cfg.spare_capacity_threshold,
@@ -308,7 +324,7 @@ def compute_taints(
                 tainted_low = sorted(
                     (
                         n
-                        for n in pool_nodes
+                        for n in group_nodes
                         if n.is_tainted and n.name not in to_untaint and n.utilization <= cfg.spare_capacity_threshold
                     ),
                     key=lambda n: n.utilization,

--- a/osdc/base/node-compactor/scripts/python/test_compactor.py
+++ b/osdc/base/node-compactor/scripts/python/test_compactor.py
@@ -7,9 +7,9 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from compactor import main, reconcile
+from compactor import _fleet_group_key, main, reconcile
 from lightkube import ApiError
-from models import Config, NodeState, PodInfo, parse_cpu, parse_memory
+from models import LABEL_NODE_FLEET, Config, NodeState, PodInfo, parse_cpu, parse_memory
 from packing import _pods_fit_on_nodes, bin_pack_min_nodes, compute_taints
 
 # ============================================================================
@@ -615,6 +615,434 @@ class TestComputeTaints:
         to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg)
         # All 3 eligible, min_nodes=1 -> surplus=2
         assert len(to_taint) == 2
+
+
+# ============================================================================
+# Fleet-aware helpers
+# ============================================================================
+
+
+def make_fleet_node(name, nodepool, fleet, cpu=16.0, mem=64 * GiB, is_tainted=False, creation_time=None):
+    """Create a NodeState with a node-fleet label for fleet-aware tests."""
+    node = make_node(name, nodepool=nodepool, cpu=cpu, mem=mem, is_tainted=is_tainted, creation_time=creation_time)
+    node.labels[LABEL_NODE_FLEET] = fleet
+    return node
+
+
+# ============================================================================
+# Fleet capacity tests (compute_taints with group_key)
+# ============================================================================
+
+
+class TestFleetCapacity:
+    """Tests for fleet-aware grouping via the group_key parameter."""
+
+    def test_fleet_groups_multiple_nodepools(self):
+        """Nodes in different NodePools but same fleet are grouped together.
+
+        Fleet "m8g" has a 16-CPU node (m8g-8xlarge) and a 192-CPU node
+        (m8g-48xlarge). One pod needs 10 CPU. Fleet needs 1 node -> surplus=1.
+        The 16-CPU node should be tainted (smaller, less capacity).
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_small = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n_big = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        n_big.pods = [make_pod("p1", cpu=10.0, node_name="n-big")]
+
+        nodes = {"n-small": n_small, "n-big": n_big}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        assert "n-small" in to_taint, "Smaller node in fleet should be tainted"
+        assert "n-big" not in to_taint, "Larger node with workload should not be tainted"
+
+    def test_fleet_surplus_across_pools(self):
+        """3 nodes in 3 different NodePools, all fleet 'r7a'. Pods fit on 1 node.
+
+        Surplus=2, so 2 nodes should be tainted.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n1 = make_fleet_node("n1", nodepool="r7a-4xlarge", fleet="r7a", cpu=192.0)
+        n2 = make_fleet_node("n2", nodepool="r7a-8xlarge", fleet="r7a", cpu=192.0)
+        n3 = make_fleet_node("n3", nodepool="r7a-16xlarge", fleet="r7a", cpu=192.0)
+        n1.pods = [make_pod("p1", cpu=100.0, node_name="n1")]
+
+        nodes = {"n1": n1, "n2": n2, "n3": n3}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        assert len(to_taint) == 2, "Surplus is 2, so 2 nodes should be tainted"
+
+    def test_non_fleet_nodes_grouped_by_nodepool(self):
+        """Nodes without 'node-fleet' label fall back to nodepool grouping.
+
+        Two nodepools, 2 nodes each, no fleet labels. Each pool independent.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n1 = make_node("n1", nodepool="pool-a", cpu=16.0)
+        n2 = make_node("n2", nodepool="pool-a", cpu=16.0)
+        n3 = make_node("n3", nodepool="pool-b", cpu=16.0)
+        n4 = make_node("n4", nodepool="pool-b", cpu=16.0)
+        nodes = {"n1": n1, "n2": n2, "n3": n3, "n4": n4}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # No fleet label -> group_key returns nodepool -> same behavior as before.
+        pool_a_tainted = to_taint & {"n1", "n2"}
+        pool_b_tainted = to_taint & {"n3", "n4"}
+        assert len(pool_a_tainted) == 1
+        assert len(pool_b_tainted) == 1
+
+    def test_mixed_fleet_and_non_fleet(self):
+        """Fleet nodes and non-fleet nodes are grouped independently.
+
+        Fleet "m8g" has 2 nodes, nodepool "standalone" has 2 nodes (no fleet).
+        Each group processes independently.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        f1 = make_fleet_node("f1", nodepool="m8g-8xl", fleet="m8g", cpu=16.0)
+        f2 = make_fleet_node("f2", nodepool="m8g-48xl", fleet="m8g", cpu=192.0)
+        s1 = make_node("s1", nodepool="standalone", cpu=16.0)
+        s2 = make_node("s2", nodepool="standalone", cpu=16.0)
+
+        nodes = {"f1": f1, "f2": f2, "s1": s1, "s2": s2}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # Fleet "m8g": 2 nodes, no pods, surplus=1 -> 1 tainted
+        fleet_tainted = to_taint & {"f1", "f2"}
+        assert len(fleet_tainted) == 1
+
+        # Nodepool "standalone": 2 nodes, no pods, surplus=1 -> 1 tainted
+        standalone_tainted = to_taint & {"s1", "s2"}
+        assert len(standalone_tainted) == 1
+
+    def test_fleet_bin_packing_heterogeneous_sizes(self):
+        """Fleet with 16-CPU and 192-CPU nodes. Pods need 180 CPU total.
+
+        bin_pack_min_nodes should correctly account for heterogeneous capacity.
+        180 CPU does not fit on the 16-CPU node alone, so the 192-CPU node
+        is needed. With 2 nodes and min_needed=1, surplus=1.
+        The 16-CPU node should be tainted (smaller capacity).
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_small = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n_big = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        # Place pods totalling 180 CPU on the big node
+        n_big.pods = [make_pod(f"p{i}", cpu=20.0, node_name="n-big") for i in range(9)]
+
+        nodes = {"n-small": n_small, "n-big": n_big}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # bin_pack: 9 pods * 20 CPU = 180 total. n_big has 192 CPU, n_small has 16.
+        # FFD: biggest bin first (192), all 9 pods fit on n_big. min_needed=1.
+        # surplus=1. n_small tainted.
+        assert "n-small" in to_taint
+        assert "n-big" not in to_taint
+
+    def test_fleet_safety_check_cross_pool(self):
+        """Pods on a 16-CPU node that fit on a 192-CPU node in the same fleet.
+
+        Safety check should consider remaining capacity across different
+        NodePools within the same fleet.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_small = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n_small.pods = [make_pod("p-small", cpu=10.0, node_name="n-small")]
+        n_big = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        n_big.pods = [make_pod("p-big", cpu=50.0, node_name="n-big")]
+
+        nodes = {"n-small": n_small, "n-big": n_big}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # bin_pack: 2 pods (10+50=60 CPU). n_big has 192 CPU -> fits on 1 node.
+        # surplus=1. n_small is the candidate (lower CPU, lower util).
+        # Safety: n_small's pod (10 CPU) can fit on n_big (192-50=142 free).
+        # Taint allowed.
+        assert "n-small" in to_taint
+        assert "n-big" not in to_taint
+
+    def test_group_key_none_uses_nodepool(self):
+        """Calling compute_taints with group_key=None groups by nodepool (backward compat).
+
+        Two NodePools, each with 2 nodes. Without fleet grouping, each pool
+        is independent.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n1 = make_node("n1", nodepool="pool-a", cpu=16.0)
+        n2 = make_node("n2", nodepool="pool-a", cpu=16.0)
+        n3 = make_node("n3", nodepool="pool-b", cpu=16.0)
+        n4 = make_node("n4", nodepool="pool-b", cpu=16.0)
+        nodes = {"n1": n1, "n2": n2, "n3": n3, "n4": n4}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=None)
+
+        pool_a_tainted = to_taint & {"n1", "n2"}
+        pool_b_tainted = to_taint & {"n3", "n4"}
+        assert len(pool_a_tainted) == 1
+        assert len(pool_b_tainted) == 1
+
+
+# ============================================================================
+# Taint priority tests (allocatable_cpu in sort key)
+# ============================================================================
+
+
+class TestTaintPriority:
+    """Tests for the updated taint priority that includes allocatable_cpu."""
+
+    def test_taint_priority_smallest_first(self):
+        """Fleet with 16-CPU and 192-CPU nodes, both idle.
+
+        Smallest allocatable_cpu should be tainted first since it has less
+        capacity to offer.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_small = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n_big = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+
+        nodes = {"n-small": n_small, "n-big": n_big}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # Both idle, surplus=1. n_small has lower allocatable_cpu -> tainted first.
+        assert "n-small" in to_taint
+        assert "n-big" not in to_taint
+
+    def test_taint_priority_old_still_wins(self):
+        """Large old node vs small young node. Old node tainted first.
+
+        The -is_old component has the highest priority in the sort key.
+        """
+        cfg = make_config(
+            min_nodes=1,
+            max_uptime_hours=24,
+            spare_capacity_nodes=0,
+            spare_capacity_ratio=0.0,
+        )
+        n_big_old = make_fleet_node(
+            "n-big-old",
+            nodepool="m8g-48xlarge",
+            fleet="m8g",
+            cpu=192.0,
+            creation_time=NOW - timedelta(hours=50),
+        )
+        n_small_young = make_fleet_node(
+            "n-small-young",
+            nodepool="m8g-8xlarge",
+            fleet="m8g",
+            cpu=16.0,
+            creation_time=NOW - timedelta(hours=2),
+        )
+
+        nodes = {"n-big-old": n_big_old, "n-small-young": n_small_young}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # Old node (>24h) has is_old=1 -> -is_old=-1 -> sorts first.
+        # Despite having more CPU, old wins the priority.
+        assert "n-big-old" in to_taint
+        assert "n-small-young" not in to_taint
+
+    def test_taint_priority_same_cpu_falls_through_to_utilization(self):
+        """Two nodes with same allocatable_cpu. Lower utilization tainted first.
+
+        When is_old and allocatable_cpu are equal, utilization determines order.
+        """
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_low_util = make_fleet_node("n-low-util", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n_low_util.pods = [make_pod("p1", cpu=2.0, node_name="n-low-util")]
+
+        n_high_util = make_fleet_node("n-high-util", nodepool="m8g-8xlarge-v2", fleet="m8g", cpu=16.0)
+        n_high_util.pods = [make_pod("p2", cpu=12.0, node_name="n-high-util")]
+
+        n_keep = make_fleet_node("n-keep", nodepool="m8g-8xlarge-v3", fleet="m8g", cpu=16.0)
+        n_keep.pods = [make_pod("p3", cpu=14.0, node_name="n-keep")]
+
+        nodes = {"n-low-util": n_low_util, "n-high-util": n_high_util, "n-keep": n_keep}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # 3 nodes. bin_pack: 3 pods (2+12+14=28 CPU). 16 per node -> need 2.
+        # surplus=1. Same CPU -> lower utilization tainted first.
+        assert "n-low-util" in to_taint
+        assert len(to_taint) == 1
+
+
+# ============================================================================
+# Fleet cooldown tests (cross-NodePool)
+# ============================================================================
+
+
+class TestFleetCooldownCrossPool:
+    """Tests for fleet cooldown spanning multiple NodePools."""
+
+    @patch("compactor.pathlib.Path.touch")
+    @patch("compactor.remove_taint")
+    @patch("compactor.apply_taint")
+    @patch("compactor.compute_taints")
+    @patch("compactor.check_pending_pods")
+    @patch("compactor.build_node_states")
+    @patch("compactor.discover_managed_nodes")
+    def test_fleet_cooldown_spans_nodepools(
+        self,
+        mock_discover,
+        mock_build,
+        mock_check,
+        mock_compute,
+        mock_apply,
+        mock_remove,
+        mock_touch,
+    ):
+        """Burst untaint on NodePool m8g-48xlarge should block taint on a node
+        in NodePool m8g-8xlarge when both are in the same fleet 'm8g'.
+
+        The fleet cooldown key is the fleet name (or nodepool if no fleet),
+        so all NodePools sharing a fleet share the cooldown.
+        """
+        client = MagicMock()
+        cfg = make_config(fleet_cooldown=900)
+        taint_times: dict[str, float] = {}
+        fleet_cooldown_times: dict[str, float] = {}
+
+        # Iteration 1: burst untaint on n-big (nodepool m8g-48xlarge)
+        n_big = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0, is_tainted=True)
+        n_small = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        node_states = {"n-big": n_big, "n-small": n_small}
+
+        mock_discover.return_value = {"n-big": "m8g-48xlarge", "n-small": "m8g-8xlarge"}
+        mock_build.return_value = (node_states, [])
+        mock_check.return_value = {"n-big"}  # burst untaint for n-big
+        mock_compute.return_value = (set(), set(), set(), set())
+
+        reconcile(client, cfg, taint_times, fleet_cooldown_times)
+
+        # Fleet cooldown should be recorded for the fleet "m8g"
+        assert "m8g" in fleet_cooldown_times
+
+        # Iteration 2: compactor wants to taint n-small (different NodePool,
+        # same fleet). Fleet cooldown is keyed on fleet (not nodepool),
+        # so this should be blocked. Both NodePools share the fleet "m8g",
+        # fleet-aware cooldown lands.
+        mock_discover.reset_mock()
+        mock_build.reset_mock()
+        mock_check.reset_mock()
+        mock_compute.reset_mock()
+        mock_apply.reset_mock()
+        mock_remove.reset_mock()
+
+        n_big_2 = make_fleet_node("n-big", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        n_small_2 = make_fleet_node("n-small", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        node_states_2 = {"n-big": n_big_2, "n-small": n_small_2}
+
+        mock_discover.return_value = {"n-big": "m8g-48xlarge", "n-small": "m8g-8xlarge"}
+        mock_build.return_value = (node_states_2, [])
+        mock_check.return_value = set()
+        mock_compute.return_value = ({"n-small"}, set(), set(), set())
+
+        reconcile(client, cfg, taint_times, fleet_cooldown_times)
+
+        # n-small should NOT be tainted because the fleet's cooldown is active
+        # (burst happened on sibling NodePool m8g-48xlarge)
+        apply_calls = [c[0][1] for c in mock_apply.call_args_list]
+        assert "n-small" not in apply_calls
+
+    @patch("compactor.pathlib.Path.touch")
+    @patch("compactor.remove_taint")
+    @patch("compactor.apply_taint")
+    @patch("compactor.compute_taints")
+    @patch("compactor.check_pending_pods")
+    @patch("compactor.build_node_states")
+    @patch("compactor.discover_managed_nodes")
+    def test_fleet_cooldown_does_not_span_fleets(
+        self,
+        mock_discover,
+        mock_build,
+        mock_check,
+        mock_compute,
+        mock_apply,
+        mock_remove,
+        mock_touch,
+    ):
+        """Burst on fleet 'm8g' should NOT block fleet 'r7a'.
+
+        Fleet cooldown is per-fleet, so different fleets are independent.
+        """
+        client = MagicMock()
+        cfg = make_config(fleet_cooldown=900)
+        taint_times: dict[str, float] = {}
+        # Only fleet "m8g" has active cooldown
+        fleet_cooldown_times: dict[str, float] = {"m8g": time.time()}
+
+        n_m8g = make_fleet_node("n-m8g", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        n_r7a = make_fleet_node("n-r7a", nodepool="r7a-4xlarge", fleet="r7a", cpu=192.0)
+        node_states = {"n-m8g": n_m8g, "n-r7a": n_r7a}
+
+        mock_discover.return_value = {"n-m8g": "m8g-48xlarge", "n-r7a": "r7a-4xlarge"}
+        mock_build.return_value = (node_states, [])
+        mock_check.return_value = set()
+        mock_compute.return_value = ({"n-m8g", "n-r7a"}, set(), set(), set())
+
+        reconcile(client, cfg, taint_times, fleet_cooldown_times)
+
+        # n-r7a (fleet "r7a") should be tainted -- no cooldown for that fleet
+        apply_calls = [c[0][1] for c in mock_apply.call_args_list]
+        assert "n-r7a" in apply_calls
+        # n-m8g should be blocked by its fleet's cooldown
+        assert "n-m8g" not in apply_calls
+
+    @patch("compactor.pathlib.Path.touch")
+    @patch("compactor.remove_taint")
+    @patch("compactor.apply_taint")
+    @patch("compactor.compute_taints")
+    @patch("compactor.check_pending_pods")
+    @patch("compactor.build_node_states")
+    @patch("compactor.discover_managed_nodes")
+    def test_fleet_cooldown_surplus_uses_full_fleet(
+        self,
+        mock_discover,
+        mock_build,
+        mock_check,
+        mock_compute,
+        mock_apply,
+        mock_remove,
+        mock_touch,
+    ):
+        """Surplus override counts all fleet nodes, not just one NodePool.
+
+        4 nodes across 2 NodePools in fleet "m8g". 3 tainted + 1 to-taint = 4/4.
+        >50% surplus -> cooldown halved (450s). With 500s elapsed, taint proceeds.
+        """
+        client = MagicMock()
+        cfg = make_config(fleet_cooldown=900)
+        taint_times: dict[str, float] = {}
+        # Fleet cooldown was 500 seconds ago: past half (450s) but within full (900s)
+        fleet_cooldown_times: dict[str, float] = {"m8g": time.time() - 500}
+
+        # 4 nodes across 2 NodePools, all fleet "m8g"
+        n1 = make_fleet_node("n1", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0, is_tainted=True)
+        n2 = make_fleet_node("n2", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0, is_tainted=True)
+        n3 = make_fleet_node("n3", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0, is_tainted=True)
+        n4 = make_fleet_node("n4", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0, is_tainted=False)
+        node_states = {"n1": n1, "n2": n2, "n3": n3, "n4": n4}
+
+        mock_discover.return_value = {
+            "n1": "m8g-48xlarge",
+            "n2": "m8g-48xlarge",
+            "n3": "m8g-8xlarge",
+            "n4": "m8g-8xlarge",
+        }
+        mock_build.return_value = (node_states, [])
+        mock_check.return_value = set()
+        mock_compute.return_value = ({"n4"}, set(), set(), set())
+
+        reconcile(client, cfg, taint_times, fleet_cooldown_times)
+
+        # With >50% surplus across the full fleet, effective cooldown = 450s.
+        # 500s elapsed > 450s -> taint should proceed.
+        mock_apply.assert_called_once_with(client, "n4", cfg.taint_key, cfg.dry_run)
 
 
 # ============================================================================

--- a/osdc/base/node-compactor/scripts/python/test_reservations.py
+++ b/osdc/base/node-compactor/scripts/python/test_reservations.py
@@ -12,6 +12,7 @@ from lightkube import ApiError
 from models import (
     ANNOTATION_CAPACITY_RESERVED,
     ANNOTATION_DO_NOT_DISRUPT,
+    LABEL_NODE_FLEET,
     Config,
     NodeState,
     PodInfo,
@@ -138,8 +139,8 @@ class TestSelectReservedNodes:
     def test_selects_young_nodes_only(self):
         """Old nodes (>= max_uptime_hours) are excluded."""
         cfg = make_config(capacity_reservation_nodes=2, max_uptime_hours=48)
-        young = make_node("young", creation_time=NOW - timedelta(hours=1))
-        old = make_node("old", creation_time=NOW - timedelta(hours=49))
+        young = make_node("young", nodepool="pool", creation_time=NOW - timedelta(hours=1))
+        old = make_node("old", nodepool="pool", creation_time=NOW - timedelta(hours=49))
         pool_nodes = {"pool": [young, old]}
 
         result = select_reserved_nodes(pool_nodes, cfg)
@@ -158,8 +159,8 @@ class TestSelectReservedNodes:
     def test_sort_lowest_utilization_first(self):
         """Nodes with lowest utilization are selected first."""
         cfg = make_config(capacity_reservation_nodes=1)
-        low = make_node("low")
-        high = make_node("high")
+        low = make_node("low", nodepool="pool")
+        high = make_node("high", nodepool="pool")
         _add_workload(high, cpu=12.0, mem=48 * GiB)
         pool_nodes = {"pool": [high, low]}
 
@@ -169,7 +170,7 @@ class TestSelectReservedNodes:
     def test_count_limited(self):
         """Only selects up to capacity_reservation_nodes per pool."""
         cfg = make_config(capacity_reservation_nodes=2)
-        nodes = [make_node(f"n-{i}") for i in range(5)]
+        nodes = [make_node(f"n-{i}", nodepool="pool") for i in range(5)]
         pool_nodes = {"pool": nodes}
 
         result = select_reserved_nodes(pool_nodes, cfg)
@@ -193,8 +194,8 @@ class TestSelectReservedNodes:
         """When utilization and pod age are equal, the node with highest
         uptime is selected first (sort key uses -uptime_seconds)."""
         cfg = make_config(capacity_reservation_nodes=1)
-        older = make_node("older", creation_time=NOW - timedelta(hours=10))
-        newer = make_node("newer", creation_time=NOW - timedelta(hours=1))
+        older = make_node("older", nodepool="pool", creation_time=NOW - timedelta(hours=10))
+        newer = make_node("newer", nodepool="pool", creation_time=NOW - timedelta(hours=1))
         pool_nodes = {"pool": [older, newer]}
 
         result = select_reserved_nodes(pool_nodes, cfg)
@@ -573,6 +574,69 @@ class TestComputeTaintsWithReservation:
         to_taint, _untaint, _mandatory, _rate = compute_taints(nodes, cfg, reserved_nodes=reserved)
 
         assert len(to_taint) == 0
+
+
+# ============================================================================
+# Reservation re-grouping with fleet grouping
+# ============================================================================
+
+
+def make_fleet_node(
+    name,
+    nodepool,
+    fleet,
+    cpu=16.0,
+    mem=64 * GiB,
+    is_tainted=False,
+    is_reserved=False,
+    creation_time=None,
+):
+    """Create a NodeState with a node-fleet label for fleet-aware tests."""
+    node = make_node(
+        name,
+        nodepool=nodepool,
+        cpu=cpu,
+        mem=mem,
+        is_tainted=is_tainted,
+        is_reserved=is_reserved,
+        creation_time=creation_time,
+    )
+    node.labels[LABEL_NODE_FLEET] = fleet
+    return node
+
+
+class TestReservedNodesWithFleetGrouping:
+    """Tests that reservations remain per-NodePool even when compute_taints
+    uses fleet-level grouping."""
+
+    def test_reserved_nodes_grouped_by_nodepool_despite_fleet_grouping(self):
+        """select_reserved_nodes groups by NodePool, not by fleet.
+
+        Even when compute_taints uses fleet grouping via group_key,
+        capacity reservations are matched per-NodePool because
+        select_reserved_nodes takes pool_nodes keyed by NodePool name.
+        """
+        cfg = make_config(capacity_reservation_nodes=1, max_uptime_hours=48)
+
+        # Two NodePools in the same fleet "m8g"
+        n1 = make_fleet_node("n1", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n2 = make_fleet_node("n2", nodepool="m8g-8xlarge", fleet="m8g", cpu=16.0)
+        n3 = make_fleet_node("n3", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+        n4 = make_fleet_node("n4", nodepool="m8g-48xlarge", fleet="m8g", cpu=192.0)
+
+        # Build pool_nodes by NodePool (how the compactor builds it)
+        pool_nodes = {
+            "m8g-8xlarge": [n1, n2],
+            "m8g-48xlarge": [n3, n4],
+        }
+
+        result = select_reserved_nodes(pool_nodes, cfg)
+
+        # Each NodePool gets independent reservation selection
+        assert "m8g-8xlarge" in result
+        assert "m8g-48xlarge" in result
+        assert len(result["m8g-8xlarge"]) == 1
+        assert len(result["m8g-48xlarge"]) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #486
* #476
* #474
* #485
* __->__ #473
* #469
* #468
* #467
* #466
* #465
* #464

----

- Group nodes by `node-fleet` label instead of NodePool for capacity
  decisions, cooldown, and metrics; fall back to NodePool when absent
- Add `group_key` callable to `compute_taints()` for late-binding
  group strategy (backward compatible: None = per-NodePool)
- Taint smaller instances first within a fleet (`allocatable_cpu` in
  sort key) so larger, more-packable nodes are preserved
- Re-group by NodePool inside `select_reserved_nodes()` since capacity
  reservations are per-instance-type, not per-fleet
- Build both `fleet_groups` and `pool_groups` in compactor so each
  metric uses the correct grouping dimension
- Add `LABEL_NODE_FLEET` constant as single source of truth; guard
  against empty-string values

Nodes sharing a `node-fleet` label now form a single capacity domain
for bin-packing, spare capacity, and fleet cooldown. This lets the
compactor consolidate across heterogeneous instance types (e.g. drain
all m8g.8xlarge nodes when pods fit on the m8g.48xlarge in the same
fleet). Reservations intentionally stay per-NodePool because they map
to AWS capacity reservation IDs by instance type.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>