### PR TITLE
**Impact:** Grafana dashboards — query and display changes only

### DIFF
--- a/osdc/base/node-compactor/tests/e2e/conftest.py
+++ b/osdc/base/node-compactor/tests/e2e/conftest.py
@@ -39,12 +39,13 @@ from helpers import (
     COMPACTOR_DEPLOYMENT,
     COMPACTOR_NAMESPACE,
     COMPACTOR_NODEPOOL_LABEL,
+    LABEL_NODE_FLEET,
     cleanup_stale_cluster_state,
     delete_all_pods,
     delete_pool_nodes,
     drain_pool_workloads,
     get_compactor_pod_names,
-    get_pool_nodes,
+    get_fleet_nodes,
     patch_compactor_env,
     restart_compactor_pod,
     restore_compactor_env,
@@ -289,6 +290,39 @@ def instance_type(target_nodepool: tuple[str, str]) -> str:
 
 
 @pytest.fixture(scope="session")
+def target_fleet_pools(client: Client, target_nodepool_name: str) -> list[str]:
+    """All managed NodePool names sharing the same node-fleet as the target.
+
+    The compactor groups nodes by fleet (node-fleet label), so e2e tests
+    must clean and monitor ALL pools in the target's fleet to avoid
+    interference from nodes in sibling pools.
+    """
+    fleet_by_pool: dict[str, str] = {}
+    for np in client.list(NodePool):
+        labels = np.get("metadata", {}).get("labels", {}) or {}
+        if labels.get(COMPACTOR_NODEPOOL_LABEL) != "true":
+            continue
+        name = np["metadata"]["name"]
+        template_labels = np.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {}) or {}
+        fleet = template_labels.get(LABEL_NODE_FLEET, "")
+        fleet_by_pool[name] = fleet
+
+    target_fleet = fleet_by_pool.get(target_nodepool_name, "")
+    if not target_fleet:
+        return [target_nodepool_name]
+
+    fleet_pools = [name for name, fleet in fleet_by_pool.items() if fleet == target_fleet]
+    log.info(
+        "Target fleet %r: %d pools %s (target pool: %s)",
+        target_fleet,
+        len(fleet_pools),
+        fleet_pools,
+        target_nodepool_name,
+    )
+    return fleet_pools
+
+
+@pytest.fixture(scope="session")
 def test_namespace(client: Client) -> str:
     """Create the test namespace and clean up after."""
     ns = Namespace(metadata=ObjectMeta(name=TEST_NAMESPACE))
@@ -320,6 +354,7 @@ def compactor_logs() -> CompactorLogCollector:
 def compactor_setup(
     client: Client,
     target_nodepool_name: str,
+    target_fleet_pools: list[str],
     test_namespace: str,
     compactor_logs: CompactorLogCollector,
 ) -> None:
@@ -334,10 +369,12 @@ def compactor_setup(
         log.info("Compactor scaled to 0 (stale from crashed run) — restoring to 1")
         scale_compactor_deployment(client, 1)
 
-    # Clean stale taints and reservation annotations from pool nodes
-    # left behind by a crashed previous run.
-    log.info("Cleaning stale cluster state from pool %s...", target_nodepool_name)
-    cleanup_stale_cluster_state(client, target_nodepool_name)
+    # Clean stale taints and reservation annotations from ALL fleet pools
+    # (not just the target) — the compactor groups by fleet, so leftover
+    # nodes in sibling pools pollute fleet-level taint decisions.
+    log.info("Cleaning stale cluster state from fleet pools %s...", target_fleet_pools)
+    for pool in target_fleet_pools:
+        cleanup_stale_cluster_state(client, pool)
 
     # Override env vars for fast iteration
     test_overrides = GROUP_A_CONFIG
@@ -382,23 +419,25 @@ def compactor_setup(
     log.info("Starting compactor log capture...")
     compactor_logs.start()
 
-    # Best-effort: drain existing workload pods from target pool
-    log.info("Draining existing workloads from pool %s...", target_nodepool_name)
-    drain_pool_workloads(client, target_nodepool_name, TEST_NAMESPACE)
+    # Best-effort: drain existing workload pods from ALL fleet pools
+    log.info("Draining existing workloads from fleet pools %s...", target_fleet_pools)
+    for pool in target_fleet_pools:
+        drain_pool_workloads(client, pool, TEST_NAMESPACE)
 
-    # Forcefully delete stale nodes so tests start with a clean pool.
-    # Karpenter will re-provision fresh nodes when test pods are created.
-    pool_nodes = get_pool_nodes(client, target_nodepool_name)
-    if pool_nodes:
-        log.info("Deleting %d stale pool nodes...", len(pool_nodes))
-        delete_pool_nodes(client, target_nodepool_name)
+    # Forcefully delete stale nodes from ALL fleet pools so tests start
+    # with a clean fleet. Karpenter re-provisions when test pods arrive.
+    fleet_nodes = get_fleet_nodes(client, target_fleet_pools)
+    if fleet_nodes:
+        log.info("Deleting %d stale fleet nodes across %s...", len(fleet_nodes), target_fleet_pools)
+        for pool in target_fleet_pools:
+            delete_pool_nodes(client, pool)
         wait_for(
-            "pool nodes to be deleted",
-            lambda: len(get_pool_nodes(client, target_nodepool_name)) == 0,
+            "fleet nodes to be deleted",
+            lambda: len(get_fleet_nodes(client, target_fleet_pools)) == 0,
             timeout_s=300,
             poll_s=10,
         )
-        log.info("Pool is empty — ready for tests.")
+        log.info("Fleet is empty — ready for tests.")
 
     # ----- Cleanup on exit (always) -----
 

--- a/osdc/base/node-compactor/tests/e2e/helpers.py
+++ b/osdc/base/node-compactor/tests/e2e/helpers.py
@@ -31,6 +31,7 @@ COMPACTOR_TAINT_KEY = "node-compactor.osdc.io/consolidating"
 INSTANCE_TYPE_TAINT_KEY = "instance-type"
 COMPACTOR_NODEPOOL_LABEL = "osdc.io/node-compactor"
 KARPENTER_NODEPOOL_LABEL = "karpenter.sh/nodepool"
+LABEL_NODE_FLEET = "node-fleet"
 COMPACTOR_DEPLOYMENT = "node-compactor"
 COMPACTOR_NAMESPACE = "kube-system"
 COMPACTOR_POD_LABEL = "app.kubernetes.io/name=node-compactor"
@@ -184,6 +185,42 @@ def partition_pool_nodes(
     return nodes, tainted, untainted
 
 
+def get_fleet_nodes(client: Client, pool_names: list[str]) -> list[Node]:
+    """Return all Ready nodes belonging to any pool in *pool_names*."""
+    nodes = []
+    for pool in pool_names:
+        nodes.extend(get_pool_nodes(client, pool))
+    return nodes
+
+
+def get_fleet_tainted_nodes(client: Client, pool_names: list[str], taint_key: str = COMPACTOR_TAINT_KEY) -> list[str]:
+    """Return tainted node names across all pools in *pool_names*."""
+    result = []
+    for pool in pool_names:
+        result.extend(get_tainted_nodes(client, pool, taint_key))
+    return result
+
+
+def partition_fleet_nodes(
+    client: Client, pool_names: list[str], taint_key: str = COMPACTOR_TAINT_KEY
+) -> tuple[list[Node], list[str], list[str]]:
+    """Single-snapshot partition of fleet nodes into tainted/untainted.
+
+    Lists all nodes once and filters by pool membership to avoid
+    TOCTOU races between per-pool API calls.
+    """
+    pool_set = set(pool_names)
+    nodes = []
+    for node in client.list(Node):
+        if node.metadata and not node.metadata.deletionTimestamp:
+            labels = (node.metadata and node.metadata.labels) or {}
+            if labels.get(KARPENTER_NODEPOOL_LABEL) in pool_set:
+                nodes.append(node)
+    tainted = [node.metadata.name for node in nodes if node.metadata and _node_has_taint(node, taint_key)]
+    untainted = [node.metadata.name for node in nodes if node.metadata and not _node_has_taint(node, taint_key)]
+    return nodes, tainted, untainted
+
+
 def assert_instance_type_taints_preserved(client: Client, nodepool_name: str) -> None:
     """Verify every node with an instance-type label still has its instance-type taint.
 
@@ -250,6 +287,11 @@ def create_test_pod(
             terminationGracePeriodSeconds=0,
             nodeSelector={KARPENTER_NODEPOOL_LABEL: nodepool},
             tolerations=[
+                Toleration(
+                    key="node-fleet",
+                    operator="Exists",
+                    effect="NoSchedule",
+                ),
                 Toleration(
                     key="instance-type",
                     operator="Equal",

--- a/osdc/base/node-compactor/tests/e2e/test_e2e.py
+++ b/osdc/base/node-compactor/tests/e2e/test_e2e.py
@@ -32,11 +32,12 @@ from helpers import (
     delete_all_pods,
     delete_pods,
     get_do_not_disrupt_nodes,
+    get_fleet_nodes,
+    get_fleet_tainted_nodes,
     get_pods_by_node,
     get_pool_nodes,
     get_reserved_nodes,
-    get_tainted_nodes,
-    partition_pool_nodes,
+    partition_fleet_nodes,
     reconfigure_compactor,
     scale_compactor_deployment,
     search_compactor_logs,
@@ -170,19 +171,21 @@ class _CompactorE2EBase:
         target_nodepool_name: str,
         instance_type: str,
         compactor_logs: CompactorLogCollector,
+        target_fleet_pools: list[str],
     ) -> None:
         self.client = client
         self.ns = test_namespace
         self.pool = target_nodepool_name
         self.itype = instance_type
         self.logs = compactor_logs
+        self.fleet_pools = target_fleet_pools
 
     def _taint_diagnostics(self) -> str:
-        """Dump current pool state for timeout diagnostics."""
-        nodes, tainted, untainted = partition_pool_nodes(self.client, self.pool)
+        """Dump current fleet state for timeout diagnostics."""
+        nodes, tainted, untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         pods_by_node = get_pods_by_node(self.client, self.ns)
         lines = [
-            f"Pool {self.pool}: {len(nodes)} nodes, {len(tainted)} tainted, {len(untainted)} untainted",
+            f"Fleet {self.fleet_pools}: {len(nodes)} nodes, {len(tainted)} tainted, {len(untainted)} untainted",
             f"Tainted: {tainted}",
             f"Untainted: {untainted}",
             f"Pods by node: {pods_by_node}",
@@ -224,14 +227,14 @@ class TestGroupA_Bare(_CompactorE2EBase):
         wait_for_stable(
             "compactor taint state after scale-up",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
         )
 
-        nodes, tainted, untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, tainted, untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         log.info("A1 result: %d nodes, %d tainted, %d untainted", len(nodes), len(tainted), len(untainted))
         assert len(nodes) >= 3, f"Expected >= 3 nodes, got {len(nodes)}"
         assert len(untainted) >= 1, f"Expected >= 1 untainted (min_nodes), got {len(untainted)}"
@@ -244,7 +247,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
     # A2
     def test_empty_nodes_get_tainted(self) -> None:
         """Remove pods from all-but-one node -> drained nodes get tainted."""
-        initial_tainted = set(get_tainted_nodes(self.client, self.pool))
+        initial_tainted = set(get_fleet_tainted_nodes(self.client, self.fleet_pools))
         log.info("A2: Initially tainted nodes: %s", initial_tainted)
 
         pods_by_node = get_pods_by_node(self.client, self.ns)
@@ -265,7 +268,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
         wait_for(
             f"drained nodes {drained_set} tainted or deleted",
             lambda: all(
-                n in set(get_tainted_nodes(self.client, self.pool))
+                n in set(get_fleet_tainted_nodes(self.client, self.fleet_pools))
                 or n not in {nd.metadata.name for nd in get_pool_nodes(self.client, self.pool)}
                 for n in drained_set
             ),
@@ -273,7 +276,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
             on_timeout=self._taint_diagnostics,
         )
 
-        nodes, tainted, untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, tainted, untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         log.info("A2 result: %d nodes, %d tainted, %d untainted", len(nodes), len(tainted), len(untainted))
         surviving_drained = drained_set & {n.metadata.name for n in nodes}
         assert surviving_drained.issubset(set(tainted)), (
@@ -289,12 +292,12 @@ class TestGroupA_Bare(_CompactorE2EBase):
         """After consolidateAfter, empty tainted nodes are removed."""
         wait_for(
             "all tainted nodes deleted",
-            lambda: len(get_tainted_nodes(self.client, self.pool)) == 0,
+            lambda: len(get_fleet_tainted_nodes(self.client, self.fleet_pools)) == 0,
             timeout_s=KARPENTER_DELETE_TIMEOUT,
             poll_s=5,
         )
 
-        nodes, tainted, _untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, tainted, _untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         log.info("A3 result: %d nodes remain, %d tainted", len(nodes), len(tainted))
         assert len(nodes) >= 1, f"Expected >= 1 surviving node, got {len(nodes)}"
         assert len(tainted) == 0, f"Expected 0 tainted, got {len(tainted)}: {tainted}"
@@ -307,8 +310,8 @@ class TestGroupA_Bare(_CompactorE2EBase):
         wait_for_stable(
             "compactor taint state before burst drain",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
@@ -332,7 +335,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
 
         wait_for(
             f"{n_drained} nodes tainted",
-            lambda: len(get_tainted_nodes(self.client, self.pool)) >= n_drained,
+            lambda: len(get_fleet_tainted_nodes(self.client, self.fleet_pools)) >= n_drained,
             timeout_s=TAINT_TIMEOUT,
             on_timeout=self._taint_diagnostics,
         )
@@ -365,8 +368,8 @@ class TestGroupA_Bare(_CompactorE2EBase):
         wait_for_stable(
             "compactor taint state after pod deletion",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
@@ -375,7 +378,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
         # Poll for min_nodes enforcement — the compactor may need an extra
         # cycle to stabilize after Karpenter scales down empty tainted nodes.
         def _check_min_nodes() -> bool:
-            ns, _t, ut = partition_pool_nodes(self.client, self.pool)
+            ns, _t, ut = partition_fleet_nodes(self.client, self.fleet_pools)
             return len(ns) == 0 or len(ut) >= 1
 
         wait_for(
@@ -385,7 +388,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
             poll_s=5,
         )
 
-        nodes, _tainted, untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, _tainted, untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         if len(nodes) == 0:
             pytest.skip("Pool has 0 nodes (Karpenter scaled down)")
 
@@ -398,7 +401,7 @@ class TestGroupA_Bare(_CompactorE2EBase):
     # A6
     def test_sigterm_removes_taints(self) -> None:
         """Scale compactor to 0 -> SIGTERM cleanup -> verify taints removed."""
-        nodes, tainted, _untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, tainted, _untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         if len(nodes) == 0:
             pytest.skip("Pool has 0 nodes; cannot verify taint cleanup")
 
@@ -407,14 +410,14 @@ class TestGroupA_Bare(_CompactorE2EBase):
             try:
                 wait_for(
                     "at least 1 tainted node for cleanup test",
-                    lambda: len(get_tainted_nodes(self.client, self.pool)) > 0,
+                    lambda: len(get_fleet_tainted_nodes(self.client, self.fleet_pools)) > 0,
                     timeout_s=TAINT_TIMEOUT,
                     poll_s=5,
                 )
             except TimeoutError:
                 pytest.skip("No tainted nodes available to verify cleanup")
 
-        nodes_before, tainted_before, _ = partition_pool_nodes(self.client, self.pool)
+        nodes_before, tainted_before, _ = partition_fleet_nodes(self.client, self.fleet_pools)
         node_names_before = {n.metadata.name for n in nodes_before}
         log.info("A6: %d nodes, %d tainted before shutdown", len(nodes_before), len(tainted_before))
 
@@ -423,12 +426,12 @@ class TestGroupA_Bare(_CompactorE2EBase):
         try:
             wait_for(
                 "all compactor taints cleared after graceful shutdown",
-                lambda: len(get_tainted_nodes(self.client, self.pool)) == 0,
+                lambda: len(get_fleet_tainted_nodes(self.client, self.fleet_pools)) == 0,
                 timeout_s=TAINT_TIMEOUT,
                 poll_s=5,
             )
 
-            nodes_after, tainted_after, _untainted_after = partition_pool_nodes(self.client, self.pool)
+            nodes_after, tainted_after, _untainted_after = partition_fleet_nodes(self.client, self.fleet_pools)
             surviving_tainted = node_names_before & set(tainted_before)
             surviving_nodes = {n.metadata.name for n in nodes_after}
             cleaned = surviving_tainted & surviving_nodes
@@ -485,15 +488,15 @@ class TestGroupB_AntiFlap(_CompactorE2EBase):
         wait_for_stable(
             "drained nodes remain untainted (min_node_age protection)",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=COMPACTOR_CYCLE * 3,
             timeout_s=TAINT_TIMEOUT,
         )
 
         # Assert: drained nodes that still exist are NOT tainted
-        nodes, tainted, _untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, tainted, _untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         surviving_drained = drained_set & {n.metadata.name for n in nodes}
         newly_tainted = surviving_drained & set(tainted)
         assert len(newly_tainted) == 0, f"Expected 0 drained nodes tainted with min_node_age=3600, got {newly_tainted}"
@@ -505,7 +508,7 @@ class TestGroupB_AntiFlap(_CompactorE2EBase):
         wait_for(
             f"drained nodes {surviving_drained} tainted or deleted (min_node_age=0)",
             lambda: all(
-                n in set(get_tainted_nodes(self.client, self.pool))
+                n in set(get_fleet_tainted_nodes(self.client, self.fleet_pools))
                 or n not in {nd.metadata.name for nd in get_pool_nodes(self.client, self.pool)}
                 for n in surviving_drained
             ),
@@ -540,8 +543,8 @@ class TestGroupB_AntiFlap(_CompactorE2EBase):
         wait_for_stable(
             "compactor stabilized before rate limit test",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
@@ -560,8 +563,8 @@ class TestGroupB_AntiFlap(_CompactorE2EBase):
         wait_for_stable(
             "all surplus nodes tainted (rate-limited across cycles)",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
@@ -616,7 +619,7 @@ class TestGroupB_AntiFlap(_CompactorE2EBase):
         wait_for(
             f"drained nodes {drained_set} tainted or deleted after fleet cooldown",
             lambda: all(
-                n in set(get_tainted_nodes(self.client, self.pool))
+                n in set(get_fleet_tainted_nodes(self.client, self.fleet_pools))
                 or n not in {nd.metadata.name for nd in get_pool_nodes(self.client, self.pool)}
                 for n in drained_set
             ),
@@ -658,8 +661,8 @@ class TestGroupC_Reservation(_CompactorE2EBase):
         wait_for_stable(
             "compactor stabilized with reservation config",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
                 sorted(get_reserved_nodes(self.client, self.pool)),
             ),
             stable_s=STABLE_WINDOW,
@@ -698,8 +701,8 @@ class TestGroupC_Reservation(_CompactorE2EBase):
         wait_for_stable(
             "compactor taint state after drain with reservation",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
                 sorted(get_reserved_nodes(self.client, self.pool)),
             ),
             stable_s=STABLE_WINDOW,
@@ -708,7 +711,7 @@ class TestGroupC_Reservation(_CompactorE2EBase):
 
         # Assert: reserved node is NOT tainted
         reserved = get_reserved_nodes(self.client, self.pool)
-        tainted = set(get_tainted_nodes(self.client, self.pool))
+        tainted = set(get_fleet_tainted_nodes(self.client, self.fleet_pools))
         assert len(reserved) >= 1, "Expected at least 1 reserved node after drain"
         assert not reserved.intersection(tainted), (
             f"Reserved nodes {reserved} should NOT be tainted, but found in tainted set {tainted}"
@@ -723,15 +726,15 @@ class TestGroupC_Reservation(_CompactorE2EBase):
         wait_for_stable(
             "compactor taint state after pod deletion with reservation",
             lambda: (
-                sorted(get_tainted_nodes(self.client, self.pool)),
-                len(get_pool_nodes(self.client, self.pool)),
+                sorted(get_fleet_tainted_nodes(self.client, self.fleet_pools)),
+                len(get_fleet_nodes(self.client, self.fleet_pools)),
                 sorted(get_reserved_nodes(self.client, self.pool)),
             ),
             stable_s=STABLE_WINDOW,
             timeout_s=TAINT_TIMEOUT,
         )
 
-        nodes, _tainted, untainted = partition_pool_nodes(self.client, self.pool)
+        nodes, _tainted, untainted = partition_fleet_nodes(self.client, self.fleet_pools)
         if len(nodes) == 0:
             pytest.skip("Pool has 0 nodes (Karpenter scaled down)")
 
@@ -782,10 +785,10 @@ class TestGroupC_Reservation(_CompactorE2EBase):
             # Verify taints removed
             wait_for(
                 "all compactor taints cleared after shutdown",
-                lambda: len(get_tainted_nodes(self.client, self.pool)) == 0,
+                lambda: len(get_fleet_tainted_nodes(self.client, self.fleet_pools)) == 0,
                 timeout_s=TAINT_TIMEOUT,
                 poll_s=5,
-                on_timeout=lambda: f"Remaining tainted: {get_tainted_nodes(self.client, self.pool)}",
+                on_timeout=lambda: f"Remaining tainted: {get_fleet_tainted_nodes(self.client, self.fleet_pools)}",
             )
 
             # Verify reservation annotations removed — cleanup runs sequentially


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #486
* __->__ #476
* #474
* #485
* #473
* #469
* #468
* #467
* #466
* #465
* #464

**Risk:** low — dashboard-only, no code or infrastructure changes; mismatched labels would show empty panels (not wrong data)

## What
Update two Grafana dashboards to use the `fleet` label instead of `nodepool` for compactor metrics that now group by fleet, and add a `$fleet` template variable for filtering.

## Why
The node compactor was changed (f51c8b9) to emit metrics grouped by fleet instead of nodepool. Without updating the dashboards, all fleet-level panels would show no data — creating a monitoring blind spot during compaction events. Additionally, the `pending_pods_compatible` panel was filtering on a `nodepool` label that this metric never had, so it was silently returning empty results.

## How
- Replaced `nodepool` → `fleet` in PromQL queries and legend formats for fleet-level metrics (managed nodes, tainted nodes, surplus, spare capacity, cooldown)
- Added `$fleet` template variable (multi-select, regex `.*` for "all") sourced from `label_values(node_compactor_managed_nodes, fleet)`
- Fixed `pending_pods_compatible` panel — removed the nonexistent `nodepool` filter, simplified to cluster-only query
- Left `nodepool` label intact on per-node metrics (utilization, reserved nodes, rate limits) which still operate at nodepool granularity

## Changes
- `modules/monitoring/dashboards/autoscaling-node-lifecycle.json`: `nodepool` → `fleet` on 9 PromQL queries + legend formats, added `$fleet` template variable, fixed `pending_pods_compatible` query
- `modules/monitoring/dashboards/oncall-summary.json`: `nodepool` → `fleet` on 2 summary panel queries

Signed-off-by: Jean Schmidt <contato@jschmidt.me>