### PR TITLE
Add PR tofu plan workflow for arc-production

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: true
+      skip_lint_test:
+        description: "Skip `just lint` and `just test` pre-flight checks (firefighting only)"
+        required: false
+        type: boolean
+        default: false
     secrets:
       META_AWS_ACC_ID:
         required: true
@@ -61,9 +66,11 @@ jobs:
         run: uv sync
 
       - name: Lint
+        if: ${{ !inputs.skip_lint_test }}
         run: just lint
 
       - name: Test
+        if: ${{ !inputs.skip_lint_test }}
         run: just test
 
       - name: Configure AWS credentials

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -4,11 +4,7 @@ on:
   workflow_call:
     inputs:
       cluster:
-        description: "Cluster id from clusters.yaml (e.g. arc-staging, arc-production)"
-        required: true
-        type: string
-      role_to_assume:
-        description: "Full ARN of the AWS role to assume via OIDC"
+        description: "Cluster id from clusters.yaml (e.g. arc-staging, arc-cbr-production)"
         required: true
         type: string
       environment:
@@ -16,16 +12,25 @@ on:
         required: false
         type: string
         default: ""
-      run_smoke:
-        description: "Run smoke tests as part of `just deploy`"
-        required: false
-        type: boolean
-        default: true
       taint_nodes:
         description: "Taint ARC runner nodes with NoSchedule before deploy for graceful refresh"
         required: false
         type: boolean
         default: true
+      run_integration:
+        description: "Run integration tests after deploy (requires CANARY_GITHUB_TOKEN)"
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      META_AWS_ACC_ID:
+        required: true
+      META_AWS_DEPLOY_ROLE:
+        description: "Role name in the Meta account to assume (caller picks staging vs prod)"
+        required: true
+      CANARY_GITHUB_TOKEN:
+        description: "GitHub token for integration tests (required if run_integration=true)"
+        required: false
 
 permissions:
   id-token: write
@@ -55,10 +60,16 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
 
+      - name: Lint
+        run: just lint
+
+      - name: Test
+        run: just test
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          role-to-assume: ${{ inputs.role_to_assume }}
+          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
           aws-region: us-west-1
           role-duration-seconds: 7200
 
@@ -66,5 +77,116 @@ jobs:
         run: just deploy "${{ inputs.cluster }}"
         env:
           OSDC_CONFIRM: "yes"
-          OSDC_SMOKE: ${{ inputs.run_smoke && 'yes' || 'no' }}
+          # smoke runs as a dedicated job below, skip the in-deploy step
+          OSDC_SMOKE: "no"
           OSDC_TAINT_NODES: ${{ inputs.taint_nodes && 'yes' || 'no' }}
+
+  smoke:
+    name: Smoke tests
+    needs: deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
+          aws-region: us-west-1
+          role-duration-seconds: 7200
+
+      - name: Run smoke tests
+        run: just smoke "${{ inputs.cluster }}"
+
+  compactor:
+    name: Compactor e2e tests
+    needs: deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
+          aws-region: us-west-1
+          role-duration-seconds: 7200
+
+      - name: Run compactor e2e tests
+        run: just test-compactor "${{ inputs.cluster }}"
+
+  integration:
+    name: Integration tests
+    needs: deploy
+    if: ${{ inputs.run_integration }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Verify gh CLI
+        run: gh --version
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
+          aws-region: us-west-1
+          role-duration-seconds: 7200
+
+      - name: Run integration tests
+        run: just integration-test "${{ inputs.cluster }}" --skip-drain --skip-smoke --skip-compactor
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -16,11 +16,6 @@ on:
         required: false
         type: string
         default: ""
-      ref:
-        description: "Git ref to check out (empty = caller's ref)"
-        required: false
-        type: string
-        default: ""
       run_smoke:
         description: "Run smoke tests as part of `just deploy`"
         required: false
@@ -47,8 +42,6 @@ jobs:
         working-directory: osdc
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
@@ -66,7 +59,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: ${{ inputs.role_to_assume }}
-          aws-region: us-west-2
+          aws-region: us-west-1
           role-duration-seconds: 7200
 
       - name: Deploy ${{ inputs.cluster }}

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -1,0 +1,77 @@
+name: "~ OSDC: Deploy (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        description: "Cluster id from clusters.yaml (e.g. arc-staging, arc-production)"
+        required: true
+        type: string
+      role_to_assume:
+        description: "Full ARN of the AWS role to assume via OIDC"
+        required: true
+        type: string
+      environment:
+        description: "GitHub environment for deployment gating (empty = no gate)"
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Git ref to check out (empty = caller's ref)"
+        required: false
+        type: string
+        default: ""
+      run_smoke:
+        description: "Run smoke tests as part of `just deploy`"
+        required: false
+        type: boolean
+        default: true
+      taint_nodes:
+        description: "Taint ARC runner nodes with NoSchedule before deploy for graceful refresh"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.cluster }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: ${{ inputs.role_to_assume }}
+          aws-region: us-west-2
+          role-duration-seconds: 7200
+
+      - name: Deploy ${{ inputs.cluster }}
+        run: just deploy "${{ inputs.cluster }}"
+        env:
+          OSDC_CONFIRM: "yes"
+          OSDC_SMOKE: ${{ inputs.run_smoke && 'yes' || 'no' }}
+          OSDC_TAINT_NODES: ${{ inputs.taint_nodes && 'yes' || 'no' }}

--- a/.github/workflows/osdc-plan-prod.yml
+++ b/.github/workflows/osdc-plan-prod.yml
@@ -1,0 +1,114 @@
+name: "OSDC: Plan (arc-production)"
+
+on:
+  pull_request:
+    paths:
+      - "osdc/**"
+      - ".github/workflows/osdc-plan-prod.yml"
+      - ".github/workflows/_osdc-deploy.yml"
+
+concurrency:
+  group: osdc-plan-prod-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+defaults:
+  run:
+    working-directory: osdc
+
+jobs:
+  plan:
+    name: tofu plan (arc-production)
+    # OIDC doesn't work for fork PRs — skip rather than surface a confusing failure.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/osdc_gha_plan
+          aws-region: us-west-2
+          role-duration-seconds: 3600
+
+      - name: Run tofu plan
+        id: plan
+        continue-on-error: true
+        env:
+          TF_IN_AUTOMATION: "1"
+        run: |
+          set -o pipefail
+          just plan arc-production 2>&1 | tee plan.txt
+
+      - name: Post plan to PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          MARKER: "<!-- osdc-plan-prod -->"
+        run: |
+          set -euo pipefail
+          # GitHub issue comment body limit is 65536 chars; leave headroom.
+          MAX=60000
+          if [ "$(wc -c < plan.txt)" -gt "$MAX" ]; then
+              head -c "$MAX" plan.txt > plan-trimmed.txt
+              printf '\n... (truncated — see workflow logs for full plan)\n' >> plan-trimmed.txt
+              mv plan-trimmed.txt plan.txt
+          fi
+          if [ "$PLAN_OUTCOME" = "success" ]; then
+              STATUS="✅ Plan succeeded"
+          else
+              STATUS="❌ Plan failed"
+          fi
+          {
+              echo "$MARKER"
+              echo "### tofu plan — arc-production"
+              echo ""
+              echo "$STATUS · commit \`${GITHUB_SHA::8}\` · [run log](${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID})"
+              echo ""
+              echo '<details><summary>Plan output</summary>'
+              echo ""
+              echo '```'
+              cat plan.txt
+              echo '```'
+              echo ""
+              echo '</details>'
+          } > body.md
+
+          EXISTING=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -n1)
+          BODY_JSON=$(jq -Rs '{body: .}' body.md)
+          if [ -n "$EXISTING" ]; then
+              echo "Updating existing comment $EXISTING"
+              echo "$BODY_JSON" | gh api --method PATCH --input - \
+                  "/repos/${REPO}/issues/comments/${EXISTING}" >/dev/null
+          else
+              echo "Creating new comment"
+              echo "$BODY_JSON" | gh api --method POST --input - \
+                  "/repos/${REPO}/issues/${PR_NUMBER}/comments" >/dev/null
+          fi
+
+      - name: Fail the job if plan failed
+        if: steps.plan.outcome != 'success'
+        run: |
+          echo "tofu plan failed — see the plan step logs and the PR comment for details."
+          exit 1

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -171,7 +171,7 @@ clusters:
       cluster_admin_role_names:
         - ossci_gha_terraform
     base:
-      vpc_cidr: "10.1.0.0/16"
+      vpc_cidr: "10.4.0.0/16"
     git_cache:
       central_replicas: 5
       central_cpu_request: "6"

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -162,10 +162,10 @@ clusters:
       - monitoring
       - logging
 
-  arc-production:
-    cluster_name: pytorch-arc-production
-    region: us-west-2
-    state_bucket: ciforge-tfstate-arc-production
+  arc-cbr-production:
+    cluster_name: pytorch-arc-cbr-production
+    region: us-east-2
+    state_bucket: ciforge-tfstate-arc-cbr-prod
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
       cluster_admin_role_names:
@@ -178,17 +178,25 @@ clusters:
       central_cpu_limit: "15"
       central_memory_request: "8Gi"
       central_memory_limit: "32Gi"
+    node_compactor:
+      min_node_age_seconds: 900
+    buildkit:
+      arm64_instance_type: c7gd.16xlarge
+      amd64_instance_type: m6id.24xlarge
+      pods_per_node: 2
     arc-runners:
       github_config_url: "https://github.com/pytorch"
-      github_secret_name: pytorch-arc-production
-      runner_name_prefix: ""
+      github_secret_name: pytorch-arc-cbr-production
+      runner_name_prefix: "mt-"
     pypi_cache:
       replicas: 2
     modules:
       - karpenter
       - arc
       - nodepools
+      - nodepools-b200
       - arc-runners
+      - arc-runners-b200
       - buildkit
       - pypi-cache
       - cache-enforcer

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -44,8 +44,8 @@ def clusters_yaml(tmp_path):
                 "harbor": {"core_replicas": 1},
                 "monitoring": {"grafana_cloud_url": "https://staging.example.com"},
             },
-            "arc-production": {
-                "cluster_name": "pytorch-arc-production",
+            "arc-cbr-production": {
+                "cluster_name": "pytorch-arc-cbr-production",
                 "aws_region": "us-east-2",
                 "modules": [
                     "eks",
@@ -74,8 +74,8 @@ def cfg_staging(clusters_yaml):
 
 @pytest.fixture
 def cfg_production(clusters_yaml):
-    """Return loaded config for arc-production."""
-    return load_cluster_config(clusters_yaml, "arc-production")
+    """Return loaded config for arc-cbr-production."""
+    return load_cluster_config(clusters_yaml, "arc-cbr-production")
 
 
 @pytest.fixture
@@ -184,13 +184,13 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-production",
-            "pytorch-arc-production",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
             b200_enabled=True,
         )
         assert "name: cbr integration test" in result
-        assert "runs-on: pytorch-arc-production" in result
-        assert "echo arc-production" in result
+        assert "runs-on: pytorch-arc-cbr-production" in result
+        assert "echo arc-cbr-production" in result
 
     def test_b200_removed_when_disabled(self, workflow_template):
         result = generate_workflow(
@@ -210,8 +210,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-production",
-            "pytorch-arc-production",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
             b200_enabled=True,
         )
         assert "b200-job:" in result
@@ -805,7 +805,7 @@ class TestClearStagingPools:
     @patch("phases.run_cmd")
     def test_skips_non_staging(self, mock_run):
         """Should return immediately for non-staging clusters."""
-        clear_staging_pools("arc-production")
+        clear_staging_pools("arc-cbr-production")
         mock_run.assert_not_called()
 
     @patch("phases.run_cmd")

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -498,6 +498,61 @@ deploy-module cluster module:
     deploy_log_finish module "$CLUSTER" "$MODULE" "$DEPLOY_LOG_MOD_START"
     deploy_log_finish cmd "$CLUSTER" "deploy-module-$MODULE" "$DEPLOY_LOG_CMD_START"
 
+# Run `tofu plan` for base + every terraform-backed module of a cluster.
+# Read-only: no apply, no k8s/helm side effects. Safe to run from CI on PRs.
+plan cluster:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export OSDC_ROOT="{{ROOT}}"
+    export OSDC_UPSTREAM="{{UPSTREAM}}"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    REGION=$(uv run {{CFG}} "$CLUSTER" region)
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+    BUCKET=$(uv run {{CFG}} "$CLUSTER" state_bucket)
+    TFVARS=$(uv run {{CFG}} "$CLUSTER" tfvars)
+    STATE_REGION="us-west-2"
+
+    if ! aws s3api head-bucket --bucket "${BUCKET}" --region "${STATE_REGION}" 2>/dev/null; then
+        echo "ERROR: State bucket '${BUCKET}' does not exist. Run: just bootstrap ${CLUSTER}"
+        exit 1
+    fi
+
+    echo "━━━ PLAN: Base (${CLUSTER}) ━━━"
+    cd {{UPSTREAM}}/modules/eks/terraform
+    tofu init -reconfigure -input=false -no-color \
+        -backend-config="bucket=${BUCKET}" \
+        -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
+        -backend-config="region=${STATE_REGION}" \
+        -backend-config="dynamodb_table=ciforge-terraform-locks" >/dev/null
+    eval tofu plan -input=false -no-color $TFVARS
+
+    for MODULE in $(uv run {{CFG}} "$CLUSTER" modules); do
+        if [[ -d "{{ROOT}}/modules/$MODULE" ]]; then
+            MODULE_DIR="{{ROOT}}/modules/$MODULE"
+        elif [[ -d "{{UPSTREAM}}/modules/$MODULE" ]]; then
+            MODULE_DIR="{{UPSTREAM}}/modules/$MODULE"
+        else
+            continue
+        fi
+        [[ -f "$MODULE_DIR/terraform/main.tf" ]] || continue
+
+        echo ""
+        echo "━━━ PLAN: Module $MODULE (${CLUSTER}) ━━━"
+        cd "$MODULE_DIR/terraform"
+        tofu init -reconfigure -input=false -no-color \
+            -backend-config="bucket=${BUCKET}" \
+            -backend-config="key=${CLUSTER}/${MODULE}/terraform.tfstate" \
+            -backend-config="region=${STATE_REGION}" \
+            -backend-config="dynamodb_table=ciforge-terraform-locks" >/dev/null
+        tofu plan -input=false -no-color \
+            -var="cluster_name=${CNAME}" \
+            -var="aws_region=${REGION}" \
+            -var="state_bucket=${BUCKET}" \
+            -var="cluster_id=${CLUSTER}"
+    done
+
 # Terminate all Karpenter-managed nodes (they will be reprovisioned on demand)
 recycle-nodes cluster:
     #!/usr/bin/env bash

--- a/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-bx86iamx-176-1800-b200-8 (8x NVIDIA B200, full node)
+# Scheduled on NodePool: p6-b200-48xlarge (from nodepools-b200 module)
+runner:
+  name: l-bx86iamx-176-1800-b200-8
+  instance_type: p6-b200.48xlarge
+  disk_size: 200
+  vcpu: 176
+  memory: 1800Gi
+  gpu: 8

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
@@ -1,0 +1,10 @@
+# ARC runner definition: l-x86iamx-22-225-b200 (1x NVIDIA B200)
+# Scheduled on NodePool: p6-b200-48xlarge (from nodepools-b200 module)
+# Resource math: 176 usable vCPU / 8 GPUs = 22 vCPU/GPU, 1800 GiB / 8 = 225 GiB/GPU
+runner:
+  name: l-x86iamx-22-225-b200
+  instance_type: p6-b200.48xlarge
+  disk_size: 200
+  vcpu: 22
+  memory: 225Gi
+  gpu: 1

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-x86iamx-44-450-b200-2 (2x NVIDIA B200)
+# Scheduled on NodePool: p6-b200-48xlarge (from nodepools-b200 module)
+runner:
+  name: l-x86iamx-44-450-b200-2
+  instance_type: p6-b200.48xlarge
+  disk_size: 200
+  vcpu: 44
+  memory: 450Gi
+  gpu: 2

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-x86iamx-88-900-b200-4 (4x NVIDIA B200)
+# Scheduled on NodePool: p6-b200-48xlarge (from nodepools-b200 module)
+runner:
+  name: l-x86iamx-88-900-b200-4
+  instance_type: p6-b200.48xlarge
+  disk_size: 200
+  vcpu: 88
+  memory: 900Gi
+  gpu: 4

--- a/osdc/modules/arc-runners-b200/deploy.sh
+++ b/osdc/modules/arc-runners-b200/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# B200 GPU ARC Runners — delegates to upstream deploy with local definitions.
+# Called by: just deploy-module <cluster> arc-runners-b200
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$(cd "$MODULE_DIR/../.." && pwd)}"
+
+export ARC_RUNNERS_DEFS_DIR="$MODULE_DIR/defs"
+export ARC_RUNNERS_OUTPUT_DIR="$MODULE_DIR/generated"
+export ARC_RUNNERS_MODULE_NAME="arc-runners-b200"
+exec "$UPSTREAM_ROOT/modules/arc-runners/deploy.sh" "$@"

--- a/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
+++ b/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
@@ -1,0 +1,19 @@
+# Karpenter NodePool definition: p6-b200.48xlarge (GPU compute, 8x NVIDIA B200)
+# Used by: l-x86iamx-22-225-b200, l-x86iamx-44-450-b200-2, l-x86iamx-88-900-b200-4, l-bx86iamx-176-1800-b200-8
+# Capacity: AWS Capacity Blocks (reserved)
+# Node disk: 100Gi OS only — NVMe instance storage (8x3840GB) handles container data
+nodepool:
+  name: p6-b200-48xlarge
+  instance_type: p6-b200.48xlarge
+  arch: amd64
+  node_disk_size: 100
+  gpu: true
+  has_nvme: true
+  topology_manager_policy: single-numa-node
+  topology_manager_scope: pod
+  capacity_type: reserved
+  capacity_reservation_ids:
+    - cr-0c366fb8339a10f69
+    - cr-08e7fee0b8dc3de5e
+  baremetal: true
+  user_data_script: scripts/b200-node-setup.sh

--- a/osdc/modules/nodepools-b200/deploy.sh
+++ b/osdc/modules/nodepools-b200/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# B200 GPU NodePools — delegates to upstream deploy with local definitions.
+# Called by: just deploy-module <cluster> nodepools-b200
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$(cd "$MODULE_DIR/../.." && pwd)}"
+
+export NODEPOOLS_DEFS_DIR="$MODULE_DIR/defs"
+export NODEPOOLS_OUTPUT_DIR="$MODULE_DIR/generated"
+export NODEPOOLS_MODULE_NAME="nodepools-b200"
+exec "$UPSTREAM_ROOT/modules/nodepools/deploy.sh" "$@"

--- a/osdc/modules/nodepools-b200/scripts/b200-node-setup.sh
+++ b/osdc/modules/nodepools-b200/scripts/b200-node-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---- Registry mirror configuration (Harbor pull-through cache) ----
+echo "Post-bootstrap: Configuring registry mirrors..."
+HARBOR_PORT=30002
+
+for registry_project in \
+  "docker.io dockerhub-cache https://docker.io" \
+  "ghcr.io ghcr-cache https://ghcr.io" \
+  "public.ecr.aws ecr-public-cache https://public.ecr.aws" \
+  "nvcr.io nvcr-cache https://nvcr.io" \
+  "registry.k8s.io k8s-cache https://registry.k8s.io" \
+  "quay.io quay-cache https://quay.io"; do
+  # shellcheck disable=SC2086  # Intentional word-splitting
+  set -- $registry_project
+  registry=$1
+  project=$2
+  upstream=$3
+  mkdir -p "/etc/containerd/certs.d/$registry"
+  cat >"/etc/containerd/certs.d/$registry/hosts.toml" <<MIRRORS
+server = "$upstream"
+
+[host."http://localhost:$HARBOR_PORT/v2/$project"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+  override_path = true
+
+[host."$upstream"]
+  capabilities = ["pull", "resolve"]
+MIRRORS
+done
+echo "Registry mirrors configured for 6 registries"
+
+# ---- CPU performance tuning ----
+echo "Post-bootstrap: Configuring performance settings for p6-b200.48xlarge..."
+
+for cpu_governor in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+  if [ -f "$cpu_governor" ]; then
+    echo "performance" >"$cpu_governor" || true
+  fi
+done
+
+cat >/etc/systemd/system/cpu-performance.service <<'EOFS'
+[Unit]
+Description=Set CPU governor to performance mode
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c \
+  'for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; \
+  do echo performance > $gov 2>/dev/null || true; done'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOFS
+
+# daemon-reload + enable only — do NOT 'systemctl start' here.
+# This script runs inside cloud-init (cloud-final.service), and the service
+# unit has After=multi-user.target, creating a systemd deadlock:
+#   cloud-final waits for this script → script waits for systemctl start →
+#   systemd waits for multi-user.target → multi-user.target waits for cloud-final.
+# The CPU governors are already set directly above; the service is only
+# needed for persistence across reboots.
+systemctl daemon-reload
+systemctl enable cpu-performance.service
+
+# Enable GPU persistence mode for consistent performance
+nvidia-smi -pm 1 || true
+echo "Performance configuration complete for p6-b200.48xlarge"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #482
* #483
* __->__ #481
* #480
* #484
* #479

Steps:
1. Checkout → just / mise / uv → uv sync
2. OIDC AWS creds against arn:aws:iam::${META_AWS_ACC_ID}:role/${META_AWS_DEPLOY_PLAN_ROLE} (read-only + state bucket R/W)
3. just plan arc-cbr-production (runs tofu plan for base + every terraform-backed module), output captured to plan.txt,
continue-on-error: true so the comment step always runs
4. Post sticky PR comment: truncates to ~60k to stay under GitHub's 65k limit, wraps plan in a <details>
5. Fails the job if the plan step failed, after the comment is posted
