### PR TITLE
Add GPU resource tracking to node compactor

### DIFF
--- a/osdc/base/node-compactor/scripts/python/compactor.py
+++ b/osdc/base/node-compactor/scripts/python/compactor.py
@@ -118,6 +118,8 @@ def reconcile(
             utilization[(node_name, pool, "cpu")] = ns.total_cpu_used / ns.allocatable_cpu
         if ns.allocatable_memory > 0:
             utilization[(node_name, pool, "memory")] = ns.total_memory_used / ns.allocatable_memory
+        if ns.allocatable_gpu > 0:
+            utilization[(node_name, pool, "gpu")] = ns.total_gpu_used / ns.allocatable_gpu
     m.refresh_gauge(m.node_utilization_ratio, utilization)
     m.refresh_gauge(m.workload_pods, {(fk,): count for fk, count in fleet_pod_counts.items()})
 

--- a/osdc/base/node-compactor/scripts/python/discovery.py
+++ b/osdc/base/node-compactor/scripts/python/discovery.py
@@ -14,6 +14,7 @@ from models import (
     parse_cpu,
     parse_memory,
     pod_cpu_request,
+    pod_gpu_request,
     pod_memory_request,
 )
 
@@ -106,6 +107,7 @@ def build_node_states(
             nodepool=labels.get("karpenter.sh/nodepool", "unknown"),
             allocatable_cpu=parse_cpu(alloc.get("cpu", "0")),
             allocatable_memory=parse_memory(alloc.get("memory", "0")),
+            allocatable_gpu=int(alloc.get("nvidia.com/gpu", 0)),
             creation_time=creation,
             is_tainted=is_tainted,
             is_reserved=is_reserved,
@@ -207,6 +209,7 @@ def build_node_states(
                 namespace=pod.metadata.namespace,
                 cpu_request=pod_cpu_request(pod),
                 memory_request=pod_memory_request(pod),
+                gpu_request=pod_gpu_request(pod),
                 node_name=node_name,
                 is_daemonset=is_daemonset_pod(pod),
                 start_time=start_time,

--- a/osdc/base/node-compactor/scripts/python/models.py
+++ b/osdc/base/node-compactor/scripts/python/models.py
@@ -96,6 +96,7 @@ class PodInfo:
     node_name: str
     is_daemonset: bool
     start_time: datetime | None = None
+    gpu_request: int = 0
     is_phantom: bool = False
 
 
@@ -108,6 +109,7 @@ class NodeState:
     allocatable_cpu: float  # cores
     allocatable_memory: int  # bytes
     creation_time: datetime
+    allocatable_gpu: int = 0
     pods: list[PodInfo] = field(default_factory=list)
     is_tainted: bool = False
     is_reserved: bool = False  # has capacity-reservation annotation
@@ -134,6 +136,11 @@ class NodeState:
         return sum(p.memory_request for p in self.pods if p.is_daemonset)
 
     @property
+    def daemonset_gpu(self) -> int:
+        """Total GPU requests from DaemonSet pods."""
+        return sum(p.gpu_request for p in self.pods if p.is_daemonset)
+
+    @property
     def cpu_used(self) -> float:
         """CPU used by workload (non-DaemonSet) pods."""
         return sum(p.cpu_request for p in self.workload_pods)
@@ -154,6 +161,16 @@ class NodeState:
         return sum(p.memory_request for p in self.pods)
 
     @property
+    def gpu_used(self) -> int:
+        """GPU used by workload (non-DaemonSet) pods."""
+        return sum(p.gpu_request for p in self.workload_pods)
+
+    @property
+    def total_gpu_used(self) -> int:
+        """Total GPU used by ALL pods (workload + DaemonSet)."""
+        return sum(p.gpu_request for p in self.pods)
+
+    @property
     def cpu_utilization(self) -> float:
         if self.allocatable_cpu <= 0:
             return 0.0
@@ -166,9 +183,18 @@ class NodeState:
         return self.memory_used / self.allocatable_memory
 
     @property
+    def gpu_utilization(self) -> float:
+        if self.allocatable_gpu <= 0:
+            return 0.0
+        return self.gpu_used / self.allocatable_gpu
+
+    @property
     def utilization(self) -> float:
-        """Max of CPU and memory utilization (conservative estimate)."""
-        return max(self.cpu_utilization, self.memory_utilization)
+        """Max of CPU, memory, and GPU utilization (conservative estimate)."""
+        values = [self.cpu_utilization, self.memory_utilization]
+        if self.allocatable_gpu > 0:
+            values.append(self.gpu_utilization)
+        return max(values)
 
     @property
     def uptime_seconds(self) -> float:
@@ -261,4 +287,14 @@ def pod_memory_request(pod: Pod) -> int:
         for c in pod.spec.containers:
             if c.resources and c.resources.requests and "memory" in c.resources.requests:
                 total += parse_memory(c.resources.requests["memory"])
+    return total
+
+
+def pod_gpu_request(pod: Pod) -> int:
+    """Sum nvidia.com/gpu requests across all containers in a pod."""
+    total = 0
+    if pod.spec and pod.spec.containers:
+        for c in pod.spec.containers:
+            if c.resources and c.resources.requests and "nvidia.com/gpu" in c.resources.requests:
+                total += int(c.resources.requests["nvidia.com/gpu"])
     return total

--- a/osdc/base/node-compactor/scripts/python/packing.py
+++ b/osdc/base/node-compactor/scripts/python/packing.py
@@ -22,7 +22,7 @@ def bin_pack_min_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> int:
     if not pods or not nodes:
         return 0
 
-    sorted_pods = sorted(pods, key=lambda p: p.cpu_request, reverse=True)
+    sorted_pods = sorted(pods, key=lambda p: (p.gpu_request, p.cpu_request), reverse=True)
 
     bins: list[dict] = []
     for node in sorted(nodes, key=lambda n: n.allocatable_cpu, reverse=True):
@@ -30,6 +30,7 @@ def bin_pack_min_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> int:
             {
                 "cpu_remaining": node.allocatable_cpu - node.daemonset_cpu,
                 "mem_remaining": node.allocatable_memory - node.daemonset_memory,
+                "gpu_remaining": node.allocatable_gpu - node.daemonset_gpu,
             }
         )
 
@@ -37,9 +38,14 @@ def bin_pack_min_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> int:
     for pod in sorted_pods:
         placed = False
         for b in bins[:nodes_used]:
-            if b["cpu_remaining"] >= pod.cpu_request and b["mem_remaining"] >= pod.memory_request:
+            if (
+                b["cpu_remaining"] >= pod.cpu_request
+                and b["mem_remaining"] >= pod.memory_request
+                and (pod.gpu_request == 0 or b["gpu_remaining"] >= pod.gpu_request)
+            ):
                 b["cpu_remaining"] -= pod.cpu_request
                 b["mem_remaining"] -= pod.memory_request
+                b["gpu_remaining"] -= pod.gpu_request
                 placed = True
                 break
         if not placed:
@@ -47,6 +53,7 @@ def bin_pack_min_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> int:
                 b = bins[nodes_used]
                 b["cpu_remaining"] -= pod.cpu_request
                 b["mem_remaining"] -= pod.memory_request
+                b["gpu_remaining"] -= pod.gpu_request
                 nodes_used += 1
             else:
                 return len(bins)
@@ -73,16 +80,22 @@ def _pods_fit_on_nodes(pods: list[PodInfo], nodes: list[NodeState]) -> bool:
             {
                 "cpu_remaining": node.allocatable_cpu - node.total_cpu_used,
                 "mem_remaining": node.allocatable_memory - node.total_memory_used,
+                "gpu_remaining": node.allocatable_gpu - node.total_gpu_used,
             }
         )
 
-    sorted_pods = sorted(pods, key=lambda p: p.cpu_request, reverse=True)
+    sorted_pods = sorted(pods, key=lambda p: (p.gpu_request, p.cpu_request), reverse=True)
     for pod in sorted_pods:
         placed = False
         for b in bins:
-            if b["cpu_remaining"] >= pod.cpu_request and b["mem_remaining"] >= pod.memory_request:
+            if (
+                b["cpu_remaining"] >= pod.cpu_request
+                and b["mem_remaining"] >= pod.memory_request
+                and (pod.gpu_request == 0 or b["gpu_remaining"] >= pod.gpu_request)
+            ):
                 b["cpu_remaining"] -= pod.cpu_request
                 b["mem_remaining"] -= pod.memory_request
+                b["gpu_remaining"] -= pod.gpu_request
                 placed = True
                 break
         if not placed:
@@ -116,6 +129,12 @@ def select_reserved_nodes(group_nodes: dict[str, list[NodeState]], cfg: Config) 
     for pool_name, nodes in pool_nodes.items():
         young = [n for n in nodes if n.uptime_hours < cfg.max_uptime_hours]
         if not young:
+            log.info(
+                "Reservation: pool %s has %d node(s) but none younger than %dh",
+                pool_name,
+                len(nodes),
+                cfg.max_uptime_hours,
+            )
             continue
 
         # Sort: lowest utilization, then oldest youngest-pod (closer to
@@ -131,6 +150,13 @@ def select_reserved_nodes(group_nodes: dict[str, list[NodeState]], cfg: Config) 
         selected = {n.name for n in young[: cfg.capacity_reservation_nodes]}
         if selected:
             result[pool_name] = selected
+            log.info(
+                "Reservation: pool %s — selected %s (from %d eligible, %d total)",
+                pool_name,
+                sorted(selected),
+                len(young),
+                len(nodes),
+            )
 
     return result
 
@@ -223,6 +249,7 @@ def compute_taints(
             return (
                 -is_old,
                 node.allocatable_cpu,
+                node.allocatable_gpu,
                 node.utilization,
                 -node.youngest_pod_age_seconds,
             )

--- a/osdc/base/node-compactor/scripts/python/phantom.py
+++ b/osdc/base/node-compactor/scripts/python/phantom.py
@@ -9,7 +9,7 @@ import logging
 from datetime import UTC, datetime
 
 import metrics as m
-from models import Config, NodeState, PodInfo, pod_cpu_request, pod_memory_request
+from models import Config, NodeState, PodInfo, pod_cpu_request, pod_gpu_request, pod_memory_request
 from taints import _pod_matches_node
 
 log = logging.getLogger("compactor")
@@ -51,9 +51,10 @@ def apply_pending_phantom_load(
     if not untainted_nodes:
         return
 
-    # Track phantom CPU/memory per node to enforce the cap
+    # Track phantom CPU/memory/GPU per node to enforce the cap
     phantom_cpu: dict[str, float] = {}
     phantom_memory: dict[str, int] = {}
+    phantom_gpu: dict[str, int] = {}
 
     placed_count = 0
     target_nodes: set[str] = set()
@@ -70,6 +71,7 @@ def apply_pending_phantom_load(
 
         cpu_req = pod_cpu_request(pod)
         mem_req = pod_memory_request(pod)
+        gpu_req = pod_gpu_request(pod)
 
         # Find all compatible untainted nodes
         compatible = [ns for ns in untainted_nodes if _pod_matches_node(pod, ns)]
@@ -85,6 +87,7 @@ def apply_pending_phantom_load(
             # Check phantom load cap: only phantom pods count toward the 30% cap
             current_phantom_cpu = phantom_cpu.get(node_name, 0.0)
             current_phantom_mem = phantom_memory.get(node_name, 0)
+            current_phantom_gpu = phantom_gpu.get(node_name, 0)
 
             if candidate.allocatable_cpu > 0:
                 phantom_cpu_ratio = (current_phantom_cpu + cpu_req) / candidate.allocatable_cpu
@@ -96,6 +99,11 @@ def apply_pending_phantom_load(
                 if phantom_mem_ratio > PHANTOM_LOAD_CAP:
                     continue
 
+            if candidate.allocatable_gpu > 0:
+                phantom_gpu_ratio = (current_phantom_gpu + gpu_req) / candidate.allocatable_gpu
+                if phantom_gpu_ratio > PHANTOM_LOAD_CAP:
+                    continue
+
             # Place the phantom pod
             pod_name = f"phantom-{pod.metadata.name}" if pod.metadata else f"phantom-{placed_count}"
             pod_ns = pod.metadata.namespace if pod.metadata else "unknown"
@@ -105,6 +113,7 @@ def apply_pending_phantom_load(
                 namespace=pod_ns,
                 cpu_request=cpu_req,
                 memory_request=mem_req,
+                gpu_request=gpu_req,
                 node_name=node_name,
                 is_daemonset=False,
                 is_phantom=True,
@@ -113,15 +122,17 @@ def apply_pending_phantom_load(
 
             phantom_cpu[node_name] = current_phantom_cpu + cpu_req
             phantom_memory[node_name] = current_phantom_mem + mem_req
+            phantom_gpu[node_name] = current_phantom_gpu + gpu_req
 
             placed_count += 1
             target_nodes.add(node_name)
             log.debug(
-                "Phantom placement: %s -> %s (cpu=%.2f, mem=%d MiB)",
+                "Phantom placement: %s -> %s (cpu=%.2f, mem=%d MiB, gpu=%d)",
                 pod_name,
                 node_name,
                 cpu_req,
                 mem_req // (1024 * 1024),
+                gpu_req,
             )
             break
 

--- a/osdc/base/node-compactor/scripts/python/taints.py
+++ b/osdc/base/node-compactor/scripts/python/taints.py
@@ -10,6 +10,7 @@ from models import (
     Config,
     NodeState,
     pod_cpu_request,
+    pod_gpu_request,
     pod_memory_request,
 )
 
@@ -78,7 +79,16 @@ def _pod_matches_node(pod, node_state: NodeState) -> bool:
     remaining_memory = node_state.allocatable_memory - node_state.total_memory_used
     if pod_cpu_request(pod) > remaining_cpu:
         return False
-    return not pod_memory_request(pod) > remaining_memory
+    if pod_memory_request(pod) > remaining_memory:
+        return False
+    gpu_req = pod_gpu_request(pod)
+    if gpu_req > 0:
+        if node_state.allocatable_gpu == 0:
+            return False
+        remaining_gpu = node_state.allocatable_gpu - node_state.total_gpu_used
+        if gpu_req > remaining_gpu:
+            return False
+    return True
 
 
 def _any_term_matches(terms: list, node_labels: dict) -> bool:
@@ -155,6 +165,7 @@ def check_pending_pods(cfg: Config, node_states: dict[str, NodeState], pending_p
             nodepool=tnode.nodepool,
             allocatable_cpu=tnode.allocatable_cpu,
             allocatable_memory=tnode.allocatable_memory,
+            allocatable_gpu=tnode.allocatable_gpu,
             creation_time=tnode.creation_time,
             pods=tnode.pods,
             is_tainted=tnode.is_tainted,
@@ -186,6 +197,7 @@ def check_pending_pods(cfg: Config, node_states: dict[str, NodeState], pending_p
     # Calculate total resource demand of compatible pending pods only
     total_cpu_demand = sum(pod_cpu_request(pod) for pod in compatible_pending)
     total_mem_demand = sum(pod_memory_request(pod) for pod in compatible_pending)
+    total_gpu_demand = sum(pod_gpu_request(pod) for pod in compatible_pending)
 
     # Sort by highest utilization first (least wasteful to untaint)
     compatible_tainted.sort(key=lambda n: n.utilization, reverse=True)
@@ -194,21 +206,27 @@ def check_pending_pods(cfg: Config, node_states: dict[str, NodeState], pending_p
     nodes_to_untaint: set[str] = set()
     cumulative_cpu = 0.0
     cumulative_mem = 0
+    cumulative_gpu = 0
 
     for tnode in compatible_tainted:
         nodes_to_untaint.add(tnode.name)
         # Available capacity = allocatable minus currently used
         cumulative_cpu += tnode.allocatable_cpu - tnode.total_cpu_used
         cumulative_mem += tnode.allocatable_memory - tnode.total_memory_used
+        cumulative_gpu += tnode.allocatable_gpu - tnode.total_gpu_used
 
-        if cumulative_cpu >= total_cpu_demand and cumulative_mem >= total_mem_demand:
+        cpu_met = cumulative_cpu >= total_cpu_demand
+        mem_met = cumulative_mem >= total_mem_demand
+        gpu_met = total_gpu_demand == 0 or cumulative_gpu >= total_gpu_demand
+        if cpu_met and mem_met and gpu_met:
             break
 
     log.info(
-        "Found %d compatible pending pod(s) (%.1f CPU, %d MiB), untainting %d node(s) to absorb: %s",
+        "Found %d compatible pending pod(s) (%.1f CPU, %d MiB, %d GPU), untainting %d node(s) to absorb: %s",
         len(compatible_pending),
         total_cpu_demand,
         total_mem_demand // (1024 * 1024),
+        total_gpu_demand,
         len(nodes_to_untaint),
         ", ".join(sorted(nodes_to_untaint)),
     )

--- a/osdc/base/node-compactor/scripts/python/test_compactor.py
+++ b/osdc/base/node-compactor/scripts/python/test_compactor.py
@@ -46,6 +46,7 @@ def make_node(
     nodepool: str = "default",
     cpu: float = 16.0,
     mem: int = 64 * GiB,
+    gpu: int = 0,
     is_tainted: bool = False,
     creation_time: datetime | None = None,
 ) -> NodeState:
@@ -54,6 +55,7 @@ def make_node(
         nodepool=nodepool,
         allocatable_cpu=cpu,
         allocatable_memory=mem,
+        allocatable_gpu=gpu,
         creation_time=creation_time or NOW - timedelta(hours=1),
         is_tainted=is_tainted,
     )
@@ -63,6 +65,7 @@ def make_pod(
     name: str = "pod",
     cpu: float = 1.0,
     mem: int = 4 * GiB,
+    gpu: int = 0,
     node_name: str = "node-1",
     is_daemonset: bool = False,
     start_time: datetime | None = None,
@@ -72,6 +75,7 @@ def make_pod(
         namespace="default",
         cpu_request=cpu,
         memory_request=mem,
+        gpu_request=gpu,
         node_name=node_name,
         is_daemonset=is_daemonset,
         start_time=start_time,
@@ -622,9 +626,11 @@ class TestComputeTaints:
 # ============================================================================
 
 
-def make_fleet_node(name, nodepool, fleet, cpu=16.0, mem=64 * GiB, is_tainted=False, creation_time=None):
+def make_fleet_node(name, nodepool, fleet, cpu=16.0, mem=64 * GiB, gpu=0, is_tainted=False, creation_time=None):
     """Create a NodeState with a node-fleet label for fleet-aware tests."""
-    node = make_node(name, nodepool=nodepool, cpu=cpu, mem=mem, is_tainted=is_tainted, creation_time=creation_time)
+    node = make_node(
+        name, nodepool=nodepool, cpu=cpu, mem=mem, gpu=gpu, is_tainted=is_tainted, creation_time=creation_time
+    )
     node.labels[LABEL_NODE_FLEET] = fleet
     return node
 
@@ -869,6 +875,240 @@ class TestTaintPriority:
         # surplus=1. Same CPU -> lower utilization tainted first.
         assert "n-low-util" in to_taint
         assert len(to_taint) == 1
+
+
+# ============================================================================
+# GPU packing tests
+# ============================================================================
+
+
+class TestGPUPacking:
+    """Tests for 3D bin-packing with GPU dimension."""
+
+    def test_gpu_pods_fit_on_gpu_node(self):
+        """A 4-GPU pod fits on an 8-GPU node -> min_nodes = 1."""
+        nodes = [make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)]
+        pods = [make_pod("p1", cpu=4.0, mem=16 * GiB, gpu=4)]
+        assert bin_pack_min_nodes(pods, nodes) == 1
+
+    def test_gpu_pods_dont_fit_without_gpu(self):
+        """A 1-GPU pod cannot fit on a CPU-only node (gpu=0)."""
+        nodes = [make_node("n1", cpu=96.0, mem=256 * GiB, gpu=0)]
+        pods = [make_pod("p1", cpu=4.0, mem=16 * GiB, gpu=1)]
+        # Pod needs GPU but node has none -> can't place, return len(bins)=1
+        assert bin_pack_min_nodes(pods, nodes) == 1
+
+    def test_mixed_gpu_packing(self):
+        """8-GPU node, one 4-GPU pod + two 1-GPU pods -> all fit on 1 node."""
+        nodes = [make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)]
+        pods = [
+            make_pod("p1", cpu=4.0, mem=16 * GiB, gpu=4),
+            make_pod("p2", cpu=2.0, mem=8 * GiB, gpu=1),
+            make_pod("p3", cpu=2.0, mem=8 * GiB, gpu=1),
+        ]
+        # 6 GPUs used out of 8, fits on 1 node
+        assert bin_pack_min_nodes(pods, nodes) == 1
+
+    def test_gpu_exhaustion_needs_second_node(self):
+        """Three 4-GPU pods need 12 GPUs total, 8-GPU nodes -> 2 nodes."""
+        nodes = [make_node(f"n{i}", cpu=96.0, mem=256 * GiB, gpu=8) for i in range(3)]
+        pods = [make_pod(f"p{i}", cpu=4.0, mem=16 * GiB, gpu=4) for i in range(3)]
+        # 12 GPUs total: 2 pods on node1 (8 GPU), 1 pod on node2 (4 GPU)
+        assert bin_pack_min_nodes(pods, nodes) == 2
+
+    def test_gpu_sort_priority(self):
+        """Pods sorted by GPU descending first -- 4-GPU pod placed before high-CPU 0-GPU pod."""
+        nodes = [make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)]
+        pods = [
+            make_pod("high-cpu", cpu=80.0, mem=16 * GiB, gpu=0),
+            make_pod("gpu-pod", cpu=4.0, mem=16 * GiB, gpu=4),
+        ]
+        # Both fit on the same 8-GPU, 96-CPU node. Sorted by (gpu, cpu) desc:
+        # gpu-pod (4,4) > high-cpu (0,80). Both placed on n1. 1 node needed.
+        assert bin_pack_min_nodes(pods, nodes) == 1
+
+    def test_non_gpu_pods_on_gpu_node(self):
+        """CPU-only pods fit on GPU nodes regardless of GPU capacity."""
+        nodes = [make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)]
+        pods = [make_pod(f"p{i}", cpu=8.0, mem=16 * GiB, gpu=0) for i in range(4)]
+        # 32 CPU out of 96, no GPU demand -> all fit on 1 node
+        assert bin_pack_min_nodes(pods, nodes) == 1
+
+    def test_pods_fit_on_nodes_gpu(self):
+        """_pods_fit_on_nodes checks GPU dimension -- GPU pods from a taint
+        candidate must fit on remaining GPU nodes."""
+        # Remaining node has 8 GPUs, 4 already used
+        remaining = make_node("remain", cpu=96.0, mem=256 * GiB, gpu=8)
+        remaining.pods = [make_pod("existing", cpu=4.0, mem=8 * GiB, gpu=4, node_name="remain")]
+
+        # Displaced pod needs 3 GPUs -> 4 remaining on the node -> fits
+        displaced = [make_pod("disp", cpu=4.0, mem=8 * GiB, gpu=3)]
+        assert _pods_fit_on_nodes(displaced, [remaining]) is True
+
+        # Displaced pod needs 5 GPUs -> only 4 remaining -> doesn't fit
+        displaced_big = [make_pod("disp-big", cpu=4.0, mem=8 * GiB, gpu=5)]
+        assert _pods_fit_on_nodes(displaced_big, [remaining]) is False
+
+        # Displaced pod needs GPU but remaining node has no GPU -> doesn't fit
+        cpu_only = make_node("cpu-only", cpu=96.0, mem=256 * GiB, gpu=0)
+        displaced_gpu = [make_pod("disp-gpu", cpu=4.0, mem=8 * GiB, gpu=1)]
+        assert _pods_fit_on_nodes(displaced_gpu, [cpu_only]) is False
+
+
+# ============================================================================
+# GPU utilization tests
+# ============================================================================
+
+
+class TestGPUUtilization:
+    """Tests for GPU utilization properties on NodeState."""
+
+    def test_gpu_utilization_property(self):
+        """8-GPU node, 4-GPU workload pod -> gpu_utilization = 0.5."""
+        node = make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)
+        node.pods = [make_pod("p1", cpu=4.0, mem=8 * GiB, gpu=4, node_name="n1")]
+        assert node.gpu_utilization == pytest.approx(0.5)
+
+    def test_utilization_includes_gpu(self):
+        """8-GPU node with low CPU but high GPU -> utilization = GPU value."""
+        node = make_node("n1", cpu=96.0, mem=256 * GiB, gpu=8)
+        # Low CPU (10%), low memory, but high GPU (87.5%)
+        node.pods = [make_pod("p1", cpu=10.0, mem=8 * GiB, gpu=7, node_name="n1")]
+        assert node.gpu_utilization == pytest.approx(7.0 / 8.0)
+        assert node.utilization == pytest.approx(7.0 / 8.0)
+
+    def test_utilization_ignores_gpu_on_cpu_node(self):
+        """CPU-only node -> utilization is max(cpu, mem), GPU not included."""
+        node = make_node("n1", cpu=16.0, mem=64 * GiB, gpu=0)
+        node.pods = [make_pod("p1", cpu=12.0, mem=8 * GiB, node_name="n1")]
+        # CPU utilization = 12/16 = 0.75, memory = 8/64 = 0.125
+        assert node.gpu_utilization == 0.0
+        assert node.utilization == pytest.approx(0.75)
+
+
+# ============================================================================
+# GPU taint priority tests
+# ============================================================================
+
+
+class TestGPUTaintPriority:
+    """Tests for taint priority sort including allocatable_gpu."""
+
+    def test_taint_priority_keeps_larger_gpu_node(self):
+        """Two nodes same CPU, one with 8 GPU, one with 1 GPU.
+        The 1-GPU node is tainted first (lower allocatable_gpu in sort key)."""
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_big_gpu = make_fleet_node("n-big-gpu", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+        n_small_gpu = make_fleet_node("n-small-gpu", nodepool="gpu-1", fleet="gpu", cpu=96.0, gpu=1)
+
+        nodes = {"n-big-gpu": n_big_gpu, "n-small-gpu": n_small_gpu}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # Both idle, surplus=1. n_small_gpu has lower allocatable_gpu -> tainted first.
+        assert "n-small-gpu" in to_taint
+        assert "n-big-gpu" not in to_taint
+
+    def test_gpu_fleet_surplus_taints_correct_node(self):
+        """Fleet with 3 GPU nodes, only 1 GPU pod -> surplus should taint
+        the least-utilized/smallest nodes."""
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n1 = make_fleet_node("n1", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+        n1.pods = [make_pod("p1", cpu=4.0, mem=8 * GiB, gpu=4, node_name="n1")]
+        n2 = make_fleet_node("n2", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+        n3 = make_fleet_node("n3", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+
+        nodes = {"n1": n1, "n2": n2, "n3": n3}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # 1 pod (4 GPU, 4 CPU). bin_pack: fits on 1 node. surplus=2.
+        # n2 and n3 are idle (lower utilization) -> tainted.
+        assert len(to_taint) == 2
+        assert "n1" not in to_taint
+
+    def test_gpu_safety_check_prevents_stranding(self):
+        """Taint candidate has GPU pods. Remaining nodes have enough CPU/memory
+        but no GPU -> safety check prevents tainting (pods can't fit)."""
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        # GPU node with a GPU pod
+        n_gpu = make_node("n-gpu", nodepool="mixed", cpu=96.0, mem=256 * GiB, gpu=8)
+        n_gpu.pods = [make_pod("gpu-pod", cpu=4.0, mem=8 * GiB, gpu=4, node_name="n-gpu")]
+        # CPU-only node (no GPU)
+        n_cpu = make_node("n-cpu", nodepool="mixed", cpu=96.0, mem=256 * GiB, gpu=0)
+
+        nodes = {"n-gpu": n_gpu, "n-cpu": n_cpu}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg)
+
+        # bin_pack: 1 pod (4 CPU, 4 GPU). Needs a GPU node -> min_needed=1.
+        # surplus=1. n_cpu is first candidate (0 util, 0 GPU -> sorts first).
+        # n_cpu is empty -> tainted (no pods to check safety for).
+        # n_gpu cannot be tainted because its GPU pod can't fit on n_cpu.
+        assert "n-gpu" not in to_taint
+
+
+# ============================================================================
+# GPU fleet capacity tests
+# ============================================================================
+
+
+class TestGPUFleetCapacity:
+    """Fleet-aware GPU tests."""
+
+    def test_gpu_fleet_mixed_instances(self):
+        """Fleet with heterogeneous GPU nodes (1-GPU and 8-GPU), mixed
+        GPU workloads -> correct bin-packing and surplus calculation."""
+        cfg = make_config(min_nodes=1, spare_capacity_nodes=0, spare_capacity_ratio=0.0)
+        n_big = make_fleet_node("n-big", nodepool="gpu-8xl", fleet="gpu", cpu=96.0, gpu=8)
+        n_small = make_fleet_node("n-small", nodepool="gpu-1xl", fleet="gpu", cpu=16.0, gpu=1)
+        # Place a 4-GPU pod on the big node
+        n_big.pods = [make_pod("p1", cpu=4.0, mem=8 * GiB, gpu=4, node_name="n-big")]
+
+        nodes = {"n-big": n_big, "n-small": n_small}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # bin_pack: 1 pod (4 GPU, 4 CPU). Sorted by (gpu, cpu) desc: p1(4,4).
+        # Bins sorted by cpu desc: n_big(96), n_small(16).
+        # p1 fits on n_big (8 GPU). min_needed=1. surplus=1.
+        # n_small tainted (lower cpu, lower gpu).
+        assert "n-small" in to_taint
+        assert "n-big" not in to_taint
+
+    def test_gpu_fleet_spare_capacity(self):
+        """Fleet with GPU nodes: spare capacity threshold includes GPU
+        utilization when checking if a node is low-utilization.
+
+        GPU utilization factors into the max(cpu, mem, gpu) utilization,
+        so a node with high GPU usage is NOT a spare node.
+        """
+        cfg = make_config(
+            min_nodes=1,
+            spare_capacity_nodes=1,
+            spare_capacity_ratio=0.0,
+            spare_capacity_threshold=0.4,
+        )
+        # 3 nodes in same fleet: one heavily used, two idle
+        n_busy = make_fleet_node("n-busy", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+        n_busy.pods = [make_pod("p1", cpu=80.0, mem=8 * GiB, gpu=7, node_name="n-busy")]
+        n_idle1 = make_fleet_node("n-idle1", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+        n_idle2 = make_fleet_node("n-idle2", nodepool="gpu-8", fleet="gpu", cpu=96.0, gpu=8)
+
+        nodes = {"n-busy": n_busy, "n-idle1": n_idle1, "n-idle2": n_idle2}
+
+        to_taint, _to_untaint, _mandatory, _rate_limited = compute_taints(nodes, cfg, group_key=_fleet_group_key)
+
+        # bin_pack: 1 pod -> min_needed=1. surplus=2.
+        # Taint priority (same cpu/gpu, by utilization): n-idle1(0%), n-idle2(0%), n-busy(87.5%).
+        # Candidate n-idle1: spare_after = {n-idle2} = 1 >= 1 required -> tainted.
+        # Candidate n-idle2: spare_after = 0 < 1 required -> blocked (spare capacity).
+        # Candidate n-busy: spare_after = {n-idle2} = 1 >= 1 (n-busy is >0.4 so not spare) -> tainted.
+        # Result: n-idle1 and n-busy tainted, n-idle2 preserved as spare.
+        assert len(to_taint) == 2
+        assert "n-idle1" in to_taint
+        assert "n-busy" in to_taint
+        assert "n-idle2" not in to_taint
 
 
 # ============================================================================

--- a/osdc/base/node-compactor/scripts/python/test_phantom.py
+++ b/osdc/base/node-compactor/scripts/python/test_phantom.py
@@ -126,14 +126,14 @@ class TestPhantomLeastUtilized(unittest.TestCase):
             name="node-a",
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("w1", "ns", 4.0, 1 * GiB, "node-a", False, datetime.now(UTC))],
+            pods=[PodInfo("w1", "ns", 4.0, 1 * GiB, "node-a", False, start_time=datetime.now(UTC))],
         )
         # node-b: 12.5% utilized (1/8 CPU)
         node_b = make_node_state(
             name="node-b",
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("w2", "ns", 1.0, 1 * GiB, "node-b", False, datetime.now(UTC))],
+            pods=[PodInfo("w2", "ns", 1.0, 1 * GiB, "node-b", False, start_time=datetime.now(UTC))],
         )
         states = {"node-a": node_a, "node-b": node_b}
         pod = make_pending_pod(cpu="1", memory="1Gi", age_seconds=60)
@@ -287,7 +287,7 @@ class TestPhantomLoadCap(unittest.TestCase):
             name="node-1",
             allocatable_cpu=10.0,
             allocatable_memory=100 * GiB,
-            pods=[PodInfo("real-1", "ns", 5.0, 1 * GiB, "node-1", False, datetime.now(UTC))],
+            pods=[PodInfo("real-1", "ns", 5.0, 1 * GiB, "node-1", False, start_time=datetime.now(UTC))],
         )
         states = {"node-1": node}
 

--- a/osdc/base/node-compactor/scripts/python/test_taints.py
+++ b/osdc/base/node-compactor/scripts/python/test_taints.py
@@ -442,7 +442,7 @@ class TestPodMatchesNodeResources(unittest.TestCase):
         node = make_node_state(
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("p1", "ns", 2.0, 4 * GiB, "node-1", False, NOW)],
+            pods=[PodInfo("p1", "ns", 2.0, 4 * GiB, "node-1", False, start_time=NOW)],
         )
         pod = make_pod(cpu="4", memory="16Gi")
         self.assertTrue(_pod_matches_node(pod, node))
@@ -452,7 +452,7 @@ class TestPodMatchesNodeResources(unittest.TestCase):
         node = make_node_state(
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("p1", "ns", 7.0, 1 * GiB, "node-1", False, NOW)],
+            pods=[PodInfo("p1", "ns", 7.0, 1 * GiB, "node-1", False, start_time=NOW)],
         )
         pod = make_pod(cpu="2", memory="1Gi")
         self.assertFalse(_pod_matches_node(pod, node))
@@ -462,7 +462,7 @@ class TestPodMatchesNodeResources(unittest.TestCase):
         node = make_node_state(
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("p1", "ns", 1.0, 30 * GiB, "node-1", False, NOW)],
+            pods=[PodInfo("p1", "ns", 1.0, 30 * GiB, "node-1", False, start_time=NOW)],
         )
         pod = make_pod(cpu="1", memory="4Gi")
         self.assertFalse(_pod_matches_node(pod, node))
@@ -472,7 +472,7 @@ class TestPodMatchesNodeResources(unittest.TestCase):
         node = make_node_state(
             allocatable_cpu=4.0,
             allocatable_memory=8 * GiB,
-            pods=[PodInfo("ds", "ns", 3.0, 6 * GiB, "node-1", True, NOW)],
+            pods=[PodInfo("ds", "ns", 3.0, 6 * GiB, "node-1", True, start_time=NOW)],
         )
         pod = make_pod(cpu="2", memory="1Gi")
         self.assertFalse(_pod_matches_node(pod, node))
@@ -601,7 +601,7 @@ class TestCheckPendingPods(unittest.TestCase):
             allocatable_cpu=4.0,
             allocatable_memory=8 * GiB,
             pods=[
-                PodInfo("p", "ns", 2.0, 4 * GiB, "node-a", False, NOW),
+                PodInfo("p", "ns", 2.0, 4 * GiB, "node-a", False, start_time=NOW),
             ],
         )
         # Node B: 2 CPU free, 4 GiB free
@@ -612,7 +612,7 @@ class TestCheckPendingPods(unittest.TestCase):
             allocatable_cpu=4.0,
             allocatable_memory=8 * GiB,
             pods=[
-                PodInfo("p2", "ns", 2.0, 4 * GiB, "node-b", False, NOW),
+                PodInfo("p2", "ns", 2.0, 4 * GiB, "node-b", False, start_time=NOW),
             ],
         )
         # Total demand: 3 CPU, 6 GiB -- needs both nodes
@@ -633,7 +633,7 @@ class TestCheckPendingPods(unittest.TestCase):
             node_taints=[compactor_taint],
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("p1", "ns", 2.0, 1 * GiB, "node-a", False, NOW)],
+            pods=[PodInfo("p1", "ns", 2.0, 1 * GiB, "node-a", False, start_time=NOW)],
         )
         # Node B: high utilization (75% CPU used)
         ns_b = make_node_state(
@@ -642,7 +642,7 @@ class TestCheckPendingPods(unittest.TestCase):
             node_taints=[compactor_taint],
             allocatable_cpu=8.0,
             allocatable_memory=32 * GiB,
-            pods=[PodInfo("p2", "ns", 6.0, 1 * GiB, "node-b", False, NOW)],
+            pods=[PodInfo("p2", "ns", 6.0, 1 * GiB, "node-b", False, start_time=NOW)],
         )
         # Small demand: 1 CPU -- only need 1 node
         pod = make_pod(cpu="1", memory="1Gi")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #486
* #476
* #474
* __->__ #485
* #473
* #469
* #468
* #467
* #466
* #465
* #464

**Impact:** node compactor — bin packing, phantom pods, taint/untaint, metrics
**Risk:** medium — adds a third resource dimension to all capacity decisions

## What
Teach the node compactor to track GPU as a first-class resource alongside CPU
and memory, so it can make correct taint/untaint decisions for GPU nodes in
unified single-fleet GPU pools.

## Why
With GPU fleet unification, pods requesting 1 GPU and pods requesting 8 GPUs
share a single fleet (e.g. "g5"). The compactor can no longer rely on fleet
isolation to keep GPU workloads separated. Without GPU awareness, the compactor
could taint GPU nodes thinking workloads fit on CPU-only nodes, stranding GPU
pods. It could also fail to untaint GPU nodes when pending GPU pods need them.

## How
- Added `gpu_request` to PodInfo and `allocatable_gpu` to NodeState
- GPU properties on NodeState: daemonset_gpu, gpu_used, total_gpu_used, gpu_utilization
- Bin packing sorts pods by (gpu, cpu) descending and tracks gpu_remaining per bin
- Phantom pod placement respects 30% GPU cap per node
- Taint/untaint checks GPU fit in _pod_matches_node and tracks GPU demand in check_pending_pods
- Taint priority prefers tainting smaller-GPU nodes first (preserving larger nodes)
- Node utilization includes GPU as max(cpu, mem, gpu) when node has GPUs
- GPU utilization emitted as a Prometheus gauge

## Changes
- `models.py`: PodInfo.gpu_request, NodeState.allocatable_gpu, GPU properties, pod_gpu_request()
- `discovery.py`: reads nvidia.com/gpu from node allocatable and pod requests
- `packing.py`: GPU dimension in bin_pack_min_nodes, _pods_fit_on_nodes, taint priority
- `phantom.py`: GPU tracking in phantom load placement with 30% cap
- `taints.py`: GPU in _pod_matches_node and check_pending_pods untaint loop
- `compactor.py`: GPU utilization metric emission
- `test_compactor.py`: 4 new test classes (16 tests) for GPU packing/utilization/taint/fleet
- `test_phantom.py`, `test_taints.py`: PodInfo constructor keyword arg fixes

## Testing
- `just test` — all unit tests pass including 16 new GPU-specific tests
- GPU packing: verifies pods land on GPU nodes, exhaustion triggers second node, sort priority
- GPU taint: verifies smaller-GPU nodes tainted first, safety check prevents GPU pod stranding
- GPU phantom: verifies 30% cap respected, GPU demand tracked
- GPU utilization: verifies max(cpu, mem, gpu) calculation