### PR TITLE
Add deploy-status recipe for deployment state inspection

### DIFF
--- a/osdc/justfile
+++ b/osdc/justfile
@@ -149,6 +149,25 @@ deploy-history cluster:
         --sort-by=.metadata.creationTimestamp \
         -o custom-columns='NAME:.metadata.name,AGE:.metadata.creationTimestamp'
 
+# Human-readable deploy status: current versions and recent history
+deploy-status cluster name='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    NAME="{{name}}"
+
+    just kubeconfig "$CLUSTER"
+
+    ARGS=("$CLUSTER")
+    [[ -n "$NAME" ]] && ARGS+=("$NAME")
+
+    kubectl get configmaps -n osdc-system \
+        -l app.kubernetes.io/managed-by=osdc-deploy-log \
+        -o json \
+    | python3 "{{SCRIPTS}}/deploy-status.py" "${ARGS[@]}"
+
 # Update kubeconfig for a cluster (aws eks update-kubeconfig)
 kubeconfig cluster:
     @export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \

--- a/osdc/scripts/deploy-status.py
+++ b/osdc/scripts/deploy-status.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Format OSDC deploy audit log as human-readable status.
+
+Reads kubectl ConfigMap JSON from stdin and prints current deploy state
+plus recent deploy history.
+
+Usage:
+    kubectl get configmaps -n osdc-system -l ... -o json \
+        | python3 deploy-status.py <cluster> [name]
+
+    cluster: cluster ID (for display)
+    name:    optional module or command name to filter
+"""
+
+import contextlib
+import json
+import sys
+
+_TTY = sys.stdout.isatty()
+BOLD = "\033[1m" if _TTY else ""
+DIM = "\033[2m" if _TTY else ""
+GREEN = "\033[32m" if _TTY else ""
+RED = "\033[31m" if _TTY else ""
+YELLOW = "\033[33m" if _TTY else ""
+NC = "\033[0m" if _TTY else ""
+
+_PREFIX = "osdc-deploy-"
+_SCOPES = {"module": 7, "cmd": 4}
+_KINDS = ("start", "finish", "history")
+
+
+def fmt_duration(val):
+    """Format seconds string to human-readable duration."""
+    try:
+        s = int(val)
+    except (ValueError, TypeError):
+        return "-"
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m{s}s" if s else f"{m}m"
+    h, m = divmod(m, 60)
+    return f"{h}h{m}m" if m else f"{h}h"
+
+
+def colorize_status(status):
+    """Return ANSI-colored status string."""
+    colors = {"completed": GREEN, "failed": RED, "started": YELLOW}
+    c = colors.get(status, "")
+    return f"{c}{status}{NC}" if c else status
+
+
+def parse_configmaps(items):
+    """Categorize deploy-log ConfigMaps into start/finish/history dicts.
+
+    Returns (start, finish, history) where:
+    - start/finish: dict of (scope, name) -> data dict
+    - history: dict of (scope, name) -> list of parsed JSONL entries
+    """
+    start, finish, history = {}, {}, {}
+
+    for cm in items:
+        cm_name = cm["metadata"]["name"]
+        data = cm.get("data", {})
+
+        if not cm_name.startswith(_PREFIX):
+            continue
+
+        rest = cm_name[len(_PREFIX) :]
+
+        scope = None
+        for s, slen in _SCOPES.items():
+            if rest.startswith(s + "-"):
+                scope = s
+                after = rest[slen:]
+                break
+        if not scope:
+            continue
+
+        for kind in _KINDS:
+            if after.startswith(kind + "-"):
+                name = after[len(kind) + 1 :]
+                key = (scope, name)
+
+                if kind == "history":
+                    entries = []
+                    for line in data.get("entries", "").strip().split("\n"):
+                        if line.strip():
+                            with contextlib.suppress(json.JSONDecodeError):
+                                entries.append(json.loads(line))
+                    history[key] = entries
+                elif kind == "start":
+                    start[key] = data
+                else:
+                    finish[key] = data
+                break
+
+    return start, finish, history
+
+
+def find_in_progress(start, finish):
+    """Return set of keys where start timestamp is newer than finish."""
+    result = set()
+    for key, sdata in start.items():
+        fdata = finish.get(key, {})
+        if sdata.get("timestamp", "") > fdata.get("timestamp", ""):
+            result.add(key)
+    return result
+
+
+def print_current(start, finish, in_progress, name_filter):
+    """Print current deploy state grouped by scope."""
+    all_keys = sorted(set(finish.keys()) | in_progress)
+    modules = []
+    commands = []
+
+    for key in all_keys:
+        scope, name = key
+        if name_filter and name != name_filter:
+            continue
+
+        is_running = key in in_progress
+
+        if is_running and key in start:
+            d = start[key]
+            status_str = f"{YELLOW}in progress{NC}"
+            duration_str = ""
+        elif key in finish:
+            d = finish[key]
+            status_str = colorize_status(d.get("status", "unknown"))
+            dur = fmt_duration(d.get("duration"))
+            duration_str = dur if dur != "-" else ""
+        else:
+            continue
+
+        entry = {
+            "name": name,
+            "status": status_str,
+            "commit": d.get("commit", "?"),
+            "branch": d.get("branch", "?"),
+            "user": d.get("user", "?"),
+            "timestamp": d.get("timestamp", "?"),
+            "duration": duration_str,
+            "prev": finish.get(key) if is_running and key in finish else None,
+        }
+
+        if scope == "module":
+            modules.append(entry)
+        else:
+            commands.append(entry)
+
+    if not modules and not commands:
+        print("  No deploy records found.")
+        print()
+        return
+
+    for label, items in [("Modules", modules), ("Commands", commands)]:
+        if not items:
+            continue
+        print(f"  {BOLD}{label}{NC}")
+        print()
+        for e in items:
+            print(f"    {BOLD}{e['name']}{NC}")
+            print(f"      Status:    {e['status']}")
+            print(f"      Commit:    {e['commit']} ({DIM}{e['branch']}{NC})")
+            print(f"      Deployed:  {e['timestamp']}  by {e['user']}")
+            if e["duration"]:
+                print(f"      Duration:  {e['duration']}")
+            if e["prev"]:
+                p = e["prev"]
+                prev_dur = fmt_duration(p.get("duration"))
+                dur_suffix = f"  ({prev_dur})" if prev_dur != "-" else ""
+                print(
+                    f"      {DIM}Previous:  {p.get('commit', '?')}"
+                    f" ({p.get('branch', '?')})"
+                    f"  {p.get('timestamp', '?')}"
+                    f"  by {p.get('user', '?')}{dur_suffix}{NC}"
+                )
+            print()
+
+
+def print_history(history, name_filter, limit):
+    """Print deploy history as a table."""
+    targets = sorted((k, v) for k, v in history.items() if not name_filter or k[1] == name_filter)
+
+    if not targets:
+        print("  No history records found.")
+        print()
+        return
+
+    for (scope, name), entries in targets:
+        scope_label = "Module" if scope == "module" else "Command"
+
+        display = list(entries) if name_filter else [e for e in entries if e.get("event") == "finish"]
+
+        if not display:
+            continue
+
+        total = len(display)
+        shown = display[-limit:]
+        shown.reverse()
+
+        header = f"  {BOLD}{scope_label}: {name}{NC}"
+        if total > limit:
+            header += f" {DIM}(last {limit} of {total}){NC}"
+        print(header)
+        print(f"    {DIM}{'TIMESTAMP':<22} {'STATUS':<11} {'COMMIT':<9} {'BRANCH':<14} {'USER':<12} {'DURATION'}{NC}")
+
+        for e in shown:
+            st = e.get("status", "?")
+            ev = e.get("event", "?")
+            disp = f"{ev}/{st}" if name_filter else st
+            c = {"completed": GREEN, "failed": RED, "started": YELLOW}.get(st, "")
+            print(
+                f"    {e.get('ts', '?'):<22} {c}{disp:<11}{NC}"
+                f" {e.get('commit', '?'):<9}"
+                f" {e.get('branch', '?'):<14}"
+                f" {e.get('user', '?'):<12}"
+                f" {fmt_duration(e.get('duration'))}"
+            )
+
+        print()
+
+
+def main():
+    cluster = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+    name_filter = sys.argv[2] if len(sys.argv) > 2 else None
+
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        print("Error: invalid JSON input", file=sys.stderr)
+        sys.exit(1)
+
+    items = data.get("items", [])
+    start, finish, history = parse_configmaps(items)
+    in_progress = find_in_progress(start, finish)
+
+    print()
+    print(f"{BOLD}Deploy Status: {cluster}{NC}")
+    print("═" * 70)
+    print()
+
+    print(f"── Current Versions {'─' * 52}")
+    print()
+    print_current(start, finish, in_progress, name_filter)
+
+    print(f"── Deploy History {'─' * 54}")
+    print()
+    print_history(history, name_filter, limit=20 if name_filter else 10)
+
+
+if __name__ == "__main__":
+    main()

--- a/osdc/scripts/test_deploy_status.py
+++ b/osdc/scripts/test_deploy_status.py
@@ -1,0 +1,315 @@
+"""Tests for deploy-status.py."""
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_spec = importlib.util.spec_from_file_location(
+    "deploy_status",
+    Path(__file__).resolve().parent / "deploy-status.py",
+)
+deploy_status = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_status)
+
+
+# -- helpers --
+
+
+def _make_cm(name, data):
+    return {"metadata": {"name": name}, "data": data}
+
+
+def _finish_cm(scope, name, **data):
+    return _make_cm(f"osdc-deploy-{scope}-finish-{name}", data)
+
+
+def _start_cm(scope, name, **data):
+    return _make_cm(f"osdc-deploy-{scope}-start-{name}", data)
+
+
+def _history_cm(scope, name, entries):
+    return _make_cm(
+        f"osdc-deploy-{scope}-history-{name}",
+        {"entries": "\n".join(json.dumps(e) for e in entries)},
+    )
+
+
+# -- fmt_duration --
+
+
+class TestFmtDuration:
+    def test_seconds(self):
+        assert deploy_status.fmt_duration("45") == "45s"
+
+    def test_minutes_and_seconds(self):
+        assert deploy_status.fmt_duration("125") == "2m5s"
+
+    def test_exact_minute(self):
+        assert deploy_status.fmt_duration("60") == "1m"
+
+    def test_hours_and_minutes(self):
+        assert deploy_status.fmt_duration("3665") == "1h1m"
+
+    def test_exact_hour(self):
+        assert deploy_status.fmt_duration("3600") == "1h"
+
+    def test_zero(self):
+        assert deploy_status.fmt_duration("0") == "0s"
+
+    def test_invalid_string(self):
+        assert deploy_status.fmt_duration("abc") == "-"
+
+    def test_none(self):
+        assert deploy_status.fmt_duration(None) == "-"
+
+    def test_empty_string(self):
+        assert deploy_status.fmt_duration("") == "-"
+
+
+# -- parse_configmaps --
+
+
+class TestParseConfigmaps:
+    def test_finish_module(self):
+        items = [_finish_cm("module", "arc-runners", commit="abc1234", status="completed", duration="245")]
+        start, finish, history = deploy_status.parse_configmaps(items)
+        assert ("module", "arc-runners") in finish
+        assert finish[("module", "arc-runners")]["commit"] == "abc1234"
+        assert not start
+        assert not history
+
+    def test_start_module(self):
+        items = [_start_cm("module", "arc-runners", commit="abc1234", status="started")]
+        start, finish, history = deploy_status.parse_configmaps(items)
+        assert ("module", "arc-runners") in start
+        assert not finish
+        assert not history
+
+    def test_history_module(self):
+        entries = [
+            {"ts": "2026-04-20T15:30:00Z", "event": "finish", "commit": "abc"},
+            {"ts": "2026-04-19T10:00:00Z", "event": "finish", "commit": "def"},
+        ]
+        items = [_history_cm("module", "arc-runners", entries)]
+        start, finish, history = deploy_status.parse_configmaps(items)
+        assert len(history[("module", "arc-runners")]) == 2
+        assert not start
+        assert not finish
+
+    def test_cmd_scope(self):
+        items = [_finish_cm("cmd", "deploy", commit="abc", status="completed")]
+        _, finish, _ = deploy_status.parse_configmaps(items)
+        assert ("cmd", "deploy") in finish
+
+    def test_ignores_unrelated_configmaps(self):
+        items = [_make_cm("some-other-configmap", {"key": "val"})]
+        start, finish, history = deploy_status.parse_configmaps(items)
+        assert not start
+        assert not finish
+        assert not history
+
+    def test_invalid_json_in_history_skipped(self):
+        items = [
+            _make_cm(
+                "osdc-deploy-module-history-test",
+                {
+                    "entries": '{"valid": true}\nnot json\n{"also": "valid"}',
+                },
+            )
+        ]
+        _, _, history = deploy_status.parse_configmaps(items)
+        assert len(history[("module", "test")]) == 2
+
+    def test_empty_history_entries(self):
+        items = [_make_cm("osdc-deploy-module-history-test", {"entries": ""})]
+        _, _, history = deploy_status.parse_configmaps(items)
+        assert history[("module", "test")] == []
+
+    def test_module_name_with_hyphens(self):
+        items = [_finish_cm("module", "arc-runners-b200", commit="abc", status="completed")]
+        _, finish, _ = deploy_status.parse_configmaps(items)
+        assert ("module", "arc-runners-b200") in finish
+
+    def test_all_types_together(self):
+        items = [
+            _start_cm("module", "arc", commit="a", status="started", timestamp="T2"),
+            _finish_cm("module", "arc", commit="a", status="completed", timestamp="T1"),
+            _history_cm("module", "arc", [{"ts": "T1", "event": "finish"}]),
+        ]
+        start, finish, history = deploy_status.parse_configmaps(items)
+        assert ("module", "arc") in start
+        assert ("module", "arc") in finish
+        assert ("module", "arc") in history
+
+    def test_missing_data_key(self):
+        items = [{"metadata": {"name": "osdc-deploy-module-finish-x"}}]
+        _, finish, _ = deploy_status.parse_configmaps(items)
+        assert ("module", "x") in finish
+        assert finish[("module", "x")] == {}
+
+
+# -- find_in_progress --
+
+
+class TestFindInProgress:
+    def test_in_progress(self):
+        start = {("module", "arc"): {"timestamp": "2026-04-20T16:00:00Z"}}
+        finish = {("module", "arc"): {"timestamp": "2026-04-20T15:00:00Z"}}
+        assert deploy_status.find_in_progress(start, finish) == {("module", "arc")}
+
+    def test_completed(self):
+        start = {("module", "arc"): {"timestamp": "2026-04-20T15:00:00Z"}}
+        finish = {("module", "arc"): {"timestamp": "2026-04-20T16:00:00Z"}}
+        assert deploy_status.find_in_progress(start, finish) == set()
+
+    def test_no_finish_yet(self):
+        start = {("module", "arc"): {"timestamp": "2026-04-20T15:00:00Z"}}
+        finish = {}
+        assert deploy_status.find_in_progress(start, finish) == {("module", "arc")}
+
+    def test_same_timestamp(self):
+        start = {("module", "arc"): {"timestamp": "2026-04-20T15:00:00Z"}}
+        finish = {("module", "arc"): {"timestamp": "2026-04-20T15:00:00Z"}}
+        assert deploy_status.find_in_progress(start, finish) == set()
+
+
+# -- colorize_status --
+
+
+class TestColorizeStatus:
+    def test_known_statuses(self):
+        for status in ("completed", "failed", "started"):
+            result = deploy_status.colorize_status(status)
+            assert status in result
+
+    def test_unknown_status(self):
+        assert deploy_status.colorize_status("unknown") == "unknown"
+
+
+# -- output integration --
+
+
+def _capture_main(items, cluster="test-cluster", name_filter=None):
+    """Run main() with given items and capture stdout."""
+    data = json.dumps({"items": items})
+    argv = ["deploy-status.py", cluster]
+    if name_filter:
+        argv.append(name_filter)
+
+    buf = io.StringIO()
+    with (
+        patch.object(sys, "argv", argv),
+        patch.object(sys, "stdin", io.StringIO(data)),
+        patch.object(sys, "stdout", buf),
+    ):
+        deploy_status.main()
+    return buf.getvalue()
+
+
+class TestMainOutput:
+    def test_empty_cluster(self):
+        out = _capture_main([])
+        assert "test-cluster" in out
+        assert "No deploy records found" in out
+        assert "No history records found" in out
+
+    def test_current_state_shown(self):
+        items = [
+            _finish_cm(
+                "module",
+                "harbor",
+                commit="abc1234",
+                branch="main",
+                user="alice",
+                timestamp="2026-04-20T15:00:00Z",
+                status="completed",
+                duration="120",
+                module="harbor",
+            ),
+        ]
+        out = _capture_main(items)
+        assert "harbor" in out
+        assert "abc1234" in out
+        assert "alice" in out
+        assert "completed" in out
+        assert "2m" in out
+
+    def test_history_shown(self):
+        entries = [
+            {
+                "ts": "2026-04-20T15:00:00Z",
+                "event": "finish",
+                "commit": "abc",
+                "branch": "main",
+                "user": "alice",
+                "status": "completed",
+                "duration": "60",
+            },
+        ]
+        items = [_history_cm("module", "harbor", entries)]
+        out = _capture_main(items)
+        assert "harbor" in out
+        assert "abc" in out
+        assert "1m" in out
+
+    def test_name_filter(self):
+        items = [
+            _finish_cm("module", "harbor", commit="abc", status="completed"),
+            _finish_cm("module", "arc", commit="def", status="completed"),
+        ]
+        out = _capture_main(items, name_filter="harbor")
+        assert "harbor" in out
+        assert "abc" in out
+        # arc should not appear in the current versions section
+        assert "def" not in out
+
+    def test_in_progress_shown(self):
+        items = [
+            _start_cm(
+                "module",
+                "arc",
+                commit="new123",
+                branch="feat",
+                user="bob",
+                timestamp="2026-04-20T16:00:00Z",
+                status="started",
+                module="arc",
+            ),
+            _finish_cm(
+                "module",
+                "arc",
+                commit="old456",
+                branch="main",
+                user="alice",
+                timestamp="2026-04-20T15:00:00Z",
+                status="completed",
+                duration="100",
+                module="arc",
+            ),
+        ]
+        out = _capture_main(items)
+        assert "in progress" in out
+        assert "new123" in out
+        assert "Previous" in out
+        assert "old456" in out
+
+    def test_history_limit_default(self):
+        entries = [
+            {"ts": f"2026-04-{i:02d}T00:00:00Z", "event": "finish", "commit": f"c{i}", "status": "completed"}
+            for i in range(1, 16)
+        ]
+        items = [_history_cm("module", "test", entries)]
+        out = _capture_main(items)
+        assert "last 10 of 15" in out
+
+    def test_history_limit_filtered(self):
+        entries = [
+            {"ts": f"2026-04-{i:02d}T00:00:00Z", "event": "finish", "commit": f"c{i}", "status": "completed"}
+            for i in range(1, 25)
+        ]
+        items = [_history_cm("module", "test", entries)]
+        out = _capture_main(items, name_filter="test")
+        assert "last 20 of 24" in out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #486
* #476
* #474
* #485
* #473
* #469
* #468
* #467
* #466
* #465
* #464

**Impact:** dev tooling — new just recipe, no runtime effect
**Risk:** low — read-only CLI tool

## What
Add a `just deploy-status` recipe that reads deployed ConfigMap metadata and
displays module deployment state (versions, timestamps, content hashes).

## Why
No quick way to inspect what's currently deployed across modules without
running multiple kubectl commands and parsing output manually.

## How
- justfile recipe pipes `kubectl get configmaps` JSON into `deploy-status.py`
- Python script parses ConfigMap metadata and formats deployment state
- Comprehensive unit test suite

## Changes
- `justfile`: new `deploy-status` recipe
- `scripts/deploy-status.py`: deployment state parser and formatter
- `scripts/test_deploy_status.py`: unit tests

## Testing
- `just test` — unit tests cover parsing, formatting, edge cases
- `just deploy-status` — run against a cluster to verify output