### PR TITLE
Run integration tests after prod deployment

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_smoke:
+        description: "Run smoke tests after deploy"
+        required: false
+        type: boolean
+        default: true
       run_integration:
         description: "Run integration tests after deploy (requires CANARY_GITHUB_TOKEN)"
         required: false
@@ -96,6 +101,7 @@ jobs:
   smoke:
     name: Smoke tests
     needs: deploy
+    if: ${{ inputs.run_smoke }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 30

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_compactor:
+        description: "Run compactor e2e tests after deploy"
+        required: false
+        type: boolean
+        default: true
       skip_lint_test:
         description: "Skip `just lint` and `just test` pre-flight checks (firefighting only)"
         required: false
@@ -125,6 +130,7 @@ jobs:
   compactor:
     name: Compactor e2e tests
     needs: deploy
+    if: ${{ inputs.run_compactor }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 30

--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -37,6 +37,10 @@ jobs:
       # Integration tests target pytorch-canary via CANARY_GITHUB_TOKEN —
       # they don't belong in a prod deploy. Always skip.
       run_integration: false
+      # Compactor e2e tests patch the cluster-wide compactor Deployment,
+      # drain the target NodePool, and provision real capacity — too
+      # disruptive for prod. Validated against arc-staging pre-merge.
+      run_compactor: false
     secrets:
       META_AWS_ACC_ID: ${{ secrets.META_AWS_ACC_ID }}
       META_AWS_DEPLOY_ROLE: ${{ secrets.META_AWS_DEPLOY_PROD_ROLE }}

--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -34,13 +34,9 @@ jobs:
       environment: osdc-production
       taint_nodes: ${{ inputs.taint_nodes }}
       skip_lint_test: ${{ inputs.skip_lint_test }}
-      # Integration tests target pytorch-canary via CANARY_GITHUB_TOKEN —
-      # they don't belong in a prod deploy. Always skip.
-      run_integration: false
-      # Compactor e2e tests patch the cluster-wide compactor Deployment,
-      # drain the target NodePool, and provision real capacity — too
-      # disruptive for prod. Validated against arc-staging pre-merge.
+      run_smoke: false
       run_compactor: false
     secrets:
       META_AWS_ACC_ID: ${{ secrets.META_AWS_ACC_ID }}
       META_AWS_DEPLOY_ROLE: ${{ secrets.META_AWS_DEPLOY_PROD_ROLE }}
+      CANARY_GITHUB_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}


### PR DESCRIPTION
Run integration tests after prod deployment and skip other post-deployment tests that manipulating the clusters

### Testing

https://github.com/pytorch/ci-infra/actions/runs/24802393183