### PR TITLE
Move OSDC workflow secrets to GitHub environments 

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -37,15 +37,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      META_AWS_ACC_ID:
-        required: true
-      META_AWS_DEPLOY_ROLE:
-        description: "Role name in the Meta account to assume (caller picks staging vs prod)"
-        required: true
-      CANARY_GITHUB_TOKEN:
-        description: "GitHub token for integration tests (required if run_integration=true)"
-        required: false
 
 permissions:
   id-token: write

--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -38,3 +38,7 @@ jobs:
       run_compactor: false
       run_janitor: false
       run_load_test: false
+    # secrets: inherit is required for the reusable workflow to pick up
+    # osdc-production environment secrets (META_AWS_ACC_ID, META_AWS_DEPLOY_ROLE,
+    # CANARY_GITHUB_TOKEN). Without it, secrets.* resolves to empty strings.
+    secrets: inherit

--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -36,7 +36,3 @@ jobs:
       skip_lint_test: ${{ inputs.skip_lint_test }}
       run_smoke: false
       run_compactor: false
-    secrets:
-      META_AWS_ACC_ID: ${{ secrets.META_AWS_ACC_ID }}
-      META_AWS_DEPLOY_ROLE: ${{ secrets.META_AWS_DEPLOY_PROD_ROLE }}
-      CANARY_GITHUB_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}

--- a/.github/workflows/osdc-plan-prod.yml
+++ b/.github/workflows/osdc-plan-prod.yml
@@ -26,7 +26,7 @@ jobs:
     # OIDC doesn't work for fork PRs — skip rather than surface a confusing failure.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: arc-staging
+    environment: osdc-staging
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/osdc-plan-prod.yml
+++ b/.github/workflows/osdc-plan-prod.yml
@@ -26,6 +26,7 @@ jobs:
     # OIDC doesn't work for fork PRs — skip rather than surface a confusing failure.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    environment: arc-staging
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -53,7 +53,3 @@ jobs:
       # arc-staging has recycle_karpenter_nodes=true, which makes the taint
       # block a no-op — pass false to be explicit.
       taint_nodes: false
-    secrets:
-      META_AWS_ACC_ID: ${{ secrets.META_AWS_ACC_ID }}
-      META_AWS_DEPLOY_ROLE: ${{ secrets.META_AWS_DEPLOY_STAGING_ROLE }}
-      CANARY_GITHUB_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -53,3 +53,7 @@ jobs:
       taint_nodes: true
       run_janitor: true
       run_load_test: true
+    # secrets: inherit is required for the reusable workflow to pick up
+    # osdc-staging environment secrets (META_AWS_ACC_ID, META_AWS_DEPLOY_ROLE,
+    # CANARY_GITHUB_TOKEN). Without it, secrets.* resolves to empty strings.
+    secrets: inherit


### PR DESCRIPTION
META_AWS_ACC_ID, META_AWS_DEPLOY_ROLE, and CANARY_GITHUB_TOKEN now live in the osdc-staging and osdc-production environments, so callers no longer need to pipe them through workflow_call. Each job in _osdc-deploy.yml already sets environment:, which makes the env-scoped secrets resolve automatically.