### PR TITLE
Remove stale B200 capacity reservation from nodepool

### DIFF
--- a/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
+++ b/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
@@ -14,6 +14,5 @@ nodepool:
   capacity_type: reserved
   capacity_reservation_ids:
     - cr-0c366fb8339a10f69
-    - cr-08e7fee0b8dc3de5e
   baremetal: true
   user_data_script: scripts/b200-node-setup.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #498
* #496
* __->__ #495

cr-08e7fee0b8dc3de5e no longer exists in any AWS region; describing it returns
InvalidCapacityReservationId.NotFound. Karpenter's capacityReservationSelectorTerms
silently skip unknown IDs, so the effective B200 capacity in us-east-2 is the
remaining cr-0c366fb8339a10f69 (1 × p6-b200.48xlarge = 8 GPUs) until it's
extended before its 2026-05-13 end date.