### PR TITLE
Move {{MAX_RUNNERS}} placeholder onto its own line in template

### DIFF
--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -243,7 +243,10 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
 
     # maxRunners line is emitted only when the runner def opts in. Leaving it out
     # keeps elastic, Karpenter-managed pools unbounded (the current default).
-    max_runners_line = f"\nmaxRunners: {max_runners}" if max_runners is not None else ""
+    # The placeholder occupies its own line in the template, so substituting an
+    # empty string collapses that line to a blank separator between minRunners
+    # and runnerGroup (matches the style before this field existed).
+    max_runners_line = f"maxRunners: {max_runners}" if max_runners is not None else ""
 
     # Replace all template placeholders
     output_content = template_content

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -25,7 +25,8 @@ MINIMAL_TEMPLATE = textwrap.dedent("""\
     githubConfigUrl: "{{GITHUB_CONFIG_URL}}"
     githubConfigSecret: "{{GITHUB_SECRET_NAME}}"
     runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
-    minRunners: 0{{MAX_RUNNERS}}
+    minRunners: 0
+    {{MAX_RUNNERS}}
     runnerGroup: "{{RUNNER_GROUP}}"
     template:
       spec:

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -2,8 +2,8 @@ githubConfigUrl: "{{GITHUB_CONFIG_URL}}"
 githubConfigSecret: "{{GITHUB_SECRET_NAME}}"
 runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
 
-minRunners: 0{{MAX_RUNNERS}}
-
+minRunners: 0
+{{MAX_RUNNERS}}
 runnerGroup: "{{RUNNER_GROUP}}"
 
 # Listener metrics cardinality control


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #498
* __->__ #497
* #496
* #495

Template is easier to read when the placeholder sits on its own line between
minRunners and runnerGroup. Adjust the substitution to emit "maxRunners: N"
without surrounding newlines so:
  - when set → renders as "minRunners: 0\nmaxRunners: N\nrunnerGroup: ..."
  - when omitted → the placeholder line collapses to a blank separator, matching
    the style before this field existed.