### PR TITLE
Apply maxRunners cap to B200 runner defs

### DIFF
--- a/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
@@ -7,3 +7,5 @@ runner:
   vcpu: 176
   memory: 1800Gi
   gpu: 8
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 8 GPUs per runner = 1 concurrent runner.
+  max_runners: 1

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
@@ -8,3 +8,5 @@ runner:
   vcpu: 22
   memory: 225Gi
   gpu: 1
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 1 GPU per runner = 8 concurrent runners.
+  max_runners: 8

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
@@ -7,3 +7,5 @@ runner:
   vcpu: 44
   memory: 450Gi
   gpu: 2
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 2 GPUs per runner = 4 concurrent runners.
+  max_runners: 4

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
@@ -7,3 +7,5 @@ runner:
   vcpu: 88
   memory: 900Gi
   gpu: 4
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 4 GPUs per runner = 2 concurrent runners.
+  max_runners: 2

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -141,9 +141,17 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     disk_size = runner.get("disk_size", 100)
     runner_group = runner.get("runner_group", "default")
     runner_class = runner.get("runner_class", "")
+    # Optional concurrency cap for fixed-capacity pools (e.g. B200 Capacity Blocks).
+    # Omit to leave the RSS unbounded, which is correct for Karpenter-managed pools
+    # that can scale out on demand.
+    max_runners = runner.get("max_runners")
 
     if not runner_name or not instance_type:
         log_error(f"Invalid definition file: {def_file}")
+        return False
+
+    if max_runners is not None and (not isinstance(max_runners, int) or max_runners < 1):
+        log_error(f"Invalid definition file {def_file}: max_runners must be a positive integer, got {max_runners!r}")
         return False
 
     node_fleet = derive_fleet_name(instance_type)
@@ -233,6 +241,13 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
             "                    operator: DoesNotExist\n"
         )
 
+    # maxRunners line is emitted only when the runner def opts in. Leaving it out
+    # keeps elastic, Karpenter-managed pools unbounded (the current default).
+    # The placeholder occupies its own line in the template, so substituting an
+    # empty string collapses that line to a blank separator between minRunners
+    # and runnerGroup (matches the style before this field existed).
+    max_runners_line = f"maxRunners: {max_runners}" if max_runners is not None else ""
+
     # Replace all template placeholders
     output_content = template_content
     replacements = {
@@ -252,6 +267,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
         "{{GPU_NODE_SELECTOR_AFFINITY}}": gpu_node_selector_affinity,
         "{{GPU_REQUEST}}": gpu_request,
         "{{GPU_LIMIT}}": gpu_limit,
+        "{{MAX_RUNNERS}}": max_runners_line,
         "{{MODULE_NAME}}": module_name,
         "{{RUNNER_IMAGE}}": runner_image,
         "{{RUNNER_GROUP}}": runner_group,

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -25,6 +25,8 @@ MINIMAL_TEMPLATE = textwrap.dedent("""\
     githubConfigUrl: "{{GITHUB_CONFIG_URL}}"
     githubConfigSecret: "{{GITHUB_SECRET_NAME}}"
     runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
+    minRunners: 0
+    {{MAX_RUNNERS}}
     runnerGroup: "{{RUNNER_GROUP}}"
     template:
       spec:
@@ -153,7 +155,16 @@ FAKE_CLUSTERS_YAML = {
 
 
 def make_def_file(
-    tmp_path, name, instance_type, vcpu, memory, gpu=0, disk_size=100, runner_group=None, runner_class=None
+    tmp_path,
+    name,
+    instance_type,
+    vcpu,
+    memory,
+    gpu=0,
+    disk_size=100,
+    runner_group=None,
+    runner_class=None,
+    max_runners=None,
 ):
     """Write a runner def YAML and return the path."""
     runner = {
@@ -168,6 +179,8 @@ def make_def_file(
         runner["runner_group"] = runner_group
     if runner_class is not None:
         runner["runner_class"] = runner_class
+    if max_runners is not None:
+        runner["max_runners"] = max_runners
     content = {"runner": runner}
     p = tmp_path / f"{name}.yaml"
     p.write_text(yaml.dump(content, default_flow_style=False))
@@ -495,6 +508,56 @@ class TestGenerateRunner:
 
         result = generate_runner(p, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners")
         assert result is False
+
+    def test_max_runners_omitted_by_default(self, tmp_path):
+        """Without max_runners in the def, the RSS stays unbounded (no maxRunners key)."""
+        def_file = make_def_file(tmp_path, "elastic-runner", "c7i.24xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "elastic-runner.yaml").read_text()))
+        assert docs[0]["minRunners"] == 0
+        assert "maxRunners" not in docs[0]
+
+    def test_max_runners_applied_when_set(self, tmp_path):
+        """max_runners: N in the def emits maxRunners: N in the helm values."""
+        def_file = make_def_file(tmp_path, "fixed-runner", "p6-b200.48xlarge", 22, 225, gpu=1, max_runners=8)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "fixed-runner.yaml").read_text()))
+        assert docs[0]["minRunners"] == 0
+        assert docs[0]["maxRunners"] == 8
+
+    def test_invalid_max_runners_zero(self, tmp_path):
+        """max_runners must be a positive integer; 0 is rejected."""
+        def_file = make_def_file(tmp_path, "bad-cap", "c7i.24xlarge", 4, 16, max_runners=0)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+
+    def test_invalid_max_runners_non_int(self, tmp_path):
+        """max_runners must be an int, not a string."""
+        def_file = make_def_file(tmp_path, "bad-cap2", "c7i.24xlarge", 4, 16, max_runners="8")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
 
     def test_resource_values_match_def(self, tmp_path):
         def_file = make_def_file(tmp_path, "res-test", "c7i.24xlarge", 48, 96, disk_size=200)

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -3,7 +3,7 @@ githubConfigSecret: "{{GITHUB_SECRET_NAME}}"
 runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
 
 minRunners: 0
-
+{{MAX_RUNNERS}}
 runnerGroup: "{{RUNNER_GROUP}}"
 
 # Listener metrics cardinality control

--- a/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
+++ b/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
@@ -14,6 +14,5 @@ nodepool:
   capacity_type: reserved
   capacity_reservation_ids:
     - cr-0c366fb8339a10f69
-    - cr-08e7fee0b8dc3de5e
   baremetal: true
   user_data_script: scripts/b200-node-setup.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #498
* #496
* #495

Size each B200 runner scale set to the current reserved capacity
(1 × p6-b200.48xlarge = 8 GPUs):

  l-x86iamx-22-225-b200      (1 GPU):  max_runners: 8
  l-x86iamx-44-450-b200-2    (2 GPUs): max_runners: 4
  l-x86iamx-88-900-b200-4    (4 GPUs): max_runners: 2
  l-bx86iamx-176-1800-b200-8 (8 GPUs): max_runners: 1

The cap gates ARC runner creation so surplus jobs queue server-side at
GitHub's Actions Service instead of running into workflow-pod scheduling
failures when the reserved GPU pool is full.