### PR TITLE
Change default topology policy to best-effort

### DIFF
--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -126,7 +126,7 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     weight = nodepool_def.get("weight")
 
     # Per-def kubelet topology overrides (e.g. B200 needs single-numa-node/pod)
-    topology_policy = nodepool_def.get("topology_manager_policy", "restricted")
+    topology_policy = nodepool_def.get("topology_manager_policy", "best-effort")
     topology_scope = nodepool_def.get("topology_manager_scope", "container")
 
     # Read optional user data script for embedding as a MIME part

--- a/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
@@ -464,7 +464,7 @@ class TestGenerateNodepoolYaml:
         docs = self._parse(output)
         ec2 = docs[1]
         userdata = ec2["spec"]["userData"]
-        assert "topologyManagerPolicy: restricted" in userdata
+        assert "topologyManagerPolicy: best-effort" in userdata
         assert "topologyManagerScope: container" in userdata
 
     def test_topology_manager_custom(self):


### PR DESCRIPTION
**Impact:** All Karpenter-managed nodepools that don't explicitly set `topology_manager_policy`
**Risk:** medium

## What
Changes the default kubelet `topologyManagerPolicy` from `restricted` to `best-effort` for all generated nodepools.

## Why
The `restricted` policy requires contiguous NUMA-aligned CPU allocations, which causes large pods to fail scheduling with `TopologyAffinityError` when the kernel cannot satisfy the strict NUMA alignment constraint. The `best-effort` policy still attempts NUMA-optimal placement but allows the kubelet to admit pods even when perfect alignment isn't possible, eliminating the scheduling failures.

## How
- The change is a single default-value flip in the nodepool generator — any nodepool definition that explicitly sets `topology_manager_policy` (e.g. B200 with `single-numa-node`) is unaffected
- `best-effort` was chosen over `none` to retain NUMA awareness without the hard admission failure

## Changes
- `generate_nodepools.py`: Change default `topology_manager_policy` from `"restricted"` to `"best-effort"`
- `test_generate_nodepools.py`: Update `test_topology_manager_defaults` assertion to expect `"best-effort"`

## Notes
- A stale comment at `test_generate_nodepools.py:717` still references `topology_manager_policy="restricted"` as the default — consider updating it for accuracy.
- Nodepools that explicitly override `topology_manager_policy` (e.g. B200 with `single-numa-node`) are not affected by this change.
- Existing running nodes retain their kubelet config until they are recycled by Karpenter; the new default only applies to newly provisioned nodes.

## Testing
- `just test` — unit tests updated and passing
- After deploy: monitor for `TopologyAffinityError` events disappearing on new nodes
- Verify large pod scheduling succeeds on newly provisioned nodes
- Spot-check kubelet config on a new node: `kubectl get node <node> -o jsonpath='{.status.config}'` or inspect `/var/lib/kubelet/config.yaml` via SSM