### PR TITLE
Bump runner-container-hooks to v0.8.9

### DIFF
--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -4,7 +4,7 @@
 #
 # Fix: find -exec stat {} \; -> find -exec stat {} + (10-100x faster)
 # Fix: exit code propagation — OOM-killed processes now correctly report failure
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.8
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.9
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -94,7 +94,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.8"
+              HOOKS_VERSION="0.8.9"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"


### PR DESCRIPTION
**Impact:** All GitHub Actions runner pods on OSDC clusters — affects job reliability and failure diagnostics
**Risk:** low

## What
Updates the patched runner-container-hooks from v0.8.8 to v0.8.9 in the hooks-warmer DaemonSet, pulling in critical resilience fixes and improved observability from [jeanschmidt/runner-container-hooks#2](https://github.com/jeanschmidt/runner-container-hooks/pull/2).

## Why
v0.8.8 had two critical bugs that caused silent job failures:

1. **Broken retry logic** — WebSocket `close`/`error` handlers in `execPodStep`, `execCpToPod`, and `execCpFromPod` were resolving the promise (with exit code 1) instead of rejecting. This meant when a container was OOM-killed or a network drop occurred, the exponential-backoff retry wrappers never saw a retriable error — the promise "succeeded" with a non-zero code, completely bypassing retry machinery.

2. **File copy truncation** — `execCpFromPod` always destroyed the writer stream and closed the WebSocket in a `finally` block, even on success. This could truncate tar data still in transit, causing incomplete file copies from pods.

Both bugs manifested as intermittent, hard-to-diagnose job failures.

## How
- Version bump only in the hooks-warmer DaemonSet — the DaemonSet's idempotency logic (`.version` marker file) handles the rollout automatically on next pod restart
- Rolling update strategy (`maxUnavailable: 25%`) ensures nodes transition gradually
- Runner pods snapshot hooks at startup via the `wait-for-hooks` init container, so in-flight jobs are not affected

## Changes
- `modules/arc-runners/kubernetes/hooks-warmer.yaml`: bump `HOOKS_VERSION` from `0.8.8` to `0.8.9` and update release URL comment

### What's in v0.8.9 ([full diff](https://github.com/jeanschmidt/runner-container-hooks/pull/2))

**Critical fixes:**
- WebSocket `close`/`error` handlers now properly `reject()` instead of `resolve(1)`, restoring retry behavior for OOM kills and network drops
- `execCpFromPod` defers stream cleanup on success until tar extraction completes, preventing file truncation

**Resilience improvements:**
- New `execPodStepOutputWithRetry` wrapper with exponential backoff (factor 3, up to 6 attempts) for RPC setup steps
- 120-second hard timeout on `execCpToPod` and `execCpFromPod` — previously a hung WebSocket could block indefinitely
- `deployRpcServer` retried up to 3 times at the prepare-job level (was single-attempt-fatal)
- Copy operations escalate to `core.warning` after 3 failed attempts
- Alpine detection softened to best-effort (no longer aborts the entire job on failure)

**Observability improvements:**
- Per-attempt diagnostics on RPC deploy failure (collects errors + last 20 lines of `/tmp/rpc-server.log`)
- Elapsed-time tracing at each prepare-job phase (taint wait, pod create, pod running, workspace copy, RPC ready)
- Pod phase wait logs conditions and container waiting reasons every 10 seconds
- Cross-node scheduling detection with `core.warning` when workflow pod lands on a different node than the runner

## Testing
```
============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-04-25 02:50 UTC

  PR Workflow Jobs:
    ✓ test-cpu-x86-avx512            success
    ✓ test-gpu-t4-multi              success
    ✓ test-pypi-cache-defaults       success
    ✓ test-cpu-arm64                 success
    ✓ test-cpu-x86-amx               success
    ✓ test-git-cache                 success
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-gpu-t4                    success
    ✓ test-harbor                    success
    ✓ test-cache-enforcer            success
    ✓ test-release-arm64             success
    ✓ build-arm64 / build            success
    ✓ build-amd64 / build            success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================
```
```
============================================================================================================================================ test session starts ============================================================================================================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ci-infra-code-review/osdc
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0
16 workers [211 items]
....................................................................................................................................................................................s..............................                                                                                   [100%]
========================================================================================================================================== short test summary info ==========================================================================================================================================
SKIPPED [1] modules/monitoring/tests/smoke/test_monitoring.py:173: No dcgm-exporter pods found (no GPU nodes)
====================================================================================================================================== 210 passed, 1 skipped in 32.95s ======================================================================================================================================

Smoke tests completed in 34s
```