### PR TITLE
Fix Harbor erratic behavior caused by S3 lifecycle expiration

### DIFF
--- a/osdc/modules/eks/terraform/modules/harbor/main.tf
+++ b/osdc/modules/eks/terraform/modules/harbor/main.tf
@@ -16,22 +16,6 @@ resource "aws_s3_bucket" "harbor_registry" {
   tags = var.tags
 }
 
-# Lifecycle rule: expire cached layers after 30 days
-resource "aws_s3_bucket_lifecycle_configuration" "harbor_registry" {
-  bucket = aws_s3_bucket.harbor_registry.id
-
-  rule {
-    id     = "expire-cached-layers"
-    status = "Enabled"
-
-    filter {}
-
-    expiration {
-      days = 30
-    }
-  }
-}
-
 # Block public access
 resource "aws_s3_bucket_public_access_block" "harbor_registry" {
   bucket = aws_s3_bucket.harbor_registry.id

--- a/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
+++ b/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
@@ -55,10 +55,10 @@ spec:
               resources:
                 requests:
                   cpu: 50m
-                  memory: 64Mi
+                  memory: 1Gi
                 limits:
                   cpu: 200m
-                  memory: 128Mi
+                  memory: 2Gi
               securityContext:
                 readOnlyRootFilesystem: true
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
**Impact:** All clusters using Harbor as a container image proxy cache
**Risk:** medium

## What
Removes the S3 bucket lifecycle rule that expired all objects after 30 days and increases memory limits for the harbor-cache-recovery CronJob.

## Why
The blanket 30-day lifecycle rule on the Harbor S3 bucket was expiring cached container image layers while Harbor still expected them to exist. This caused erratic behavior — Harbor's internal metadata referenced layers that S3 had already deleted, leading to pull failures and inconsistent cache state. The lifecycle filter was unscoped (`filter {}`), meaning it applied to every object in the bucket, including layers that were actively in use.

The harbor-cache-recovery CronJob was also under-provisioned on memory (64Mi request / 128Mi limit), which could cause OOM kills during recovery operations.

## How
- Removed the lifecycle rule entirely rather than scoping it, since Harbor manages its own garbage collection and doesn't expect an external process to delete layers from under it
- Bumped CronJob memory from 64Mi/128Mi to 1Gi/2Gi to give the recovery job headroom for processing larger cache state

## Changes
- **`modules/eks/terraform/modules/harbor/main.tf`**: Removed the `aws_s3_bucket_lifecycle_configuration.harbor_registry` resource that expired all S3 objects after 30 days
- **`modules/harbor-cache-recovery/kubernetes/cronjob.yaml`**: Increased memory request from 64Mi to 1Gi and memory limit from 128Mi to 2Gi

## Notes
- After applying, the lifecycle rule deletion will take effect on the next `tofu apply`. Existing objects that were already expired by the rule are gone — the harbor-cache-recovery CronJob will need to re-warm those entries.
- If S3 storage costs grow without the lifecycle rule, a more targeted expiration strategy (e.g., only expiring objects under a specific prefix or using Harbor's built-in GC) should be considered as a follow-up.
