### PR TITLE
Add monitoring for harbor-cache-recovery cronjob

### DIFF
--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -3659,6 +3659,92 @@
         }
       ],
       "description": "Seconds since the most recent successful run. Should stay under 5 minutes (the schedule). >30m indicates the CronJob is stalled or all recent runs failed."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Historical view of the same binary 'is recovery healthy?' signal as the stat above. Green segments = a successful run completed within the previous 10 min. Red segments = no recent success (recovery is broken or the CronJob is not firing).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Unhealthy",
+                  "index": 0,
+                  "color": "red"
+                },
+                "1": {
+                  "text": "Healthy",
+                  "index": 1,
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 49,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "title": "Recovery Healthy? (history)",
+      "type": "state-timeline",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "((time() - max(kube_job_status_completion_time{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})) < bool 600) or vector(0)",
+          "legendFormat": "Recovery",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -3524,16 +3524,30 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Unhealthy",
+                  "index": 0
+                },
+                "1": {
+                  "text": "Healthy",
+                  "index": 1
+                }
+              }
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
-                "color": "red",
+                "color": "green",
                 "value": 1
               }
             ]
@@ -3543,8 +3557,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 4,
+        "h": 4,
+        "w": 8,
         "x": 0,
         "y": 72
       },
@@ -3563,7 +3577,7 @@
         },
         "textMode": "auto"
       },
-      "title": "Last Run Status",
+      "title": "Recovery Healthy?",
       "type": "stat",
       "targets": [
         {
@@ -3571,144 +3585,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "expr": "((time() - max(kube_job_status_completion_time{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})) < bool 600) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "description": "Failed harbor-cache-recovery Jobs currently retained by Kubernetes. Non-zero = recovery is broken; corrupted Harbor cache entries will not be auto-purged."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 72
-      },
-      "id": 49,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "title": "Failed Runs (retained)",
-      "type": "stat",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "count(max by (job_name)(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}) > 0) or vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "description": "Number of failed Job objects retained (CronJob failedJobsHistoryLimit=3). Repeated failures means the recovery is unable to run successfully."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 72
-      },
-      "id": 50,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "title": "OOMKilled Pods",
-      "type": "stat",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "count(max by (pod)(kube_pod_container_status_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})) or vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "description": "Pods last terminated by OOMKill. The script lists every pod cluster-wide; bump memory limits in modules/harbor-cache-recovery/kubernetes/cronjob.yaml."
+      "description": "1 if a successful run completed within the last 10 minutes (2 schedule periods + buffer), 0 otherwise. Driven by the same signal as 'Time Since Last Success' \u2014 a single source of truth."
     },
     {
       "datasource": {
@@ -3743,9 +3625,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
+        "h": 4,
+        "w": 8,
+        "x": 8,
         "y": 72
       },
       "id": 51,
@@ -3777,163 +3659,6 @@
         }
       ],
       "description": "Seconds since the most recent successful run. Should stay under 5 minutes (the schedule). >30m indicates the CronJob is stalled or all recent runs failed."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Succeeded"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "OOMKilled"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 75
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "title": "Recovery Run Trend",
-      "type": "timeseries",
-      "description": "harbor-cache-recovery run outcomes and OOM signature over time.",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(max by (job_name)(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}))",
-          "legendFormat": "Failed",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(max by (job_name)(kube_job_status_succeeded{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}))",
-          "legendFormat": "Succeeded",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(max by (pod)(kube_pod_container_status_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"}))",
-          "legendFormat": "OOMKilled",
-          "refId": "C"
-        }
-      ]
     }
   ],
   "refresh": "30s",

--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -3639,7 +3639,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"} > 0)",
+          "expr": "count(max by (job_name)(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}) > 0) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -3703,7 +3703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(kube_pod_container_status_last_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})",
+          "expr": "count(max by (pod)(kube_pod_container_status_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -3911,7 +3911,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "expr": "sum(max by (job_name)(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}))",
           "legendFormat": "Failed",
           "refId": "A"
         },
@@ -3920,7 +3920,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_job_status_succeeded{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "expr": "sum(max by (job_name)(kube_job_status_succeeded{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"}))",
           "legendFormat": "Succeeded",
           "refId": "B"
         },
@@ -3929,7 +3929,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(kube_pod_container_status_last_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})",
+          "expr": "sum(max by (pod)(kube_pod_container_status_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"}))",
           "legendFormat": "OOMKilled",
           "refId": "C"
         }

--- a/osdc/modules/monitoring/dashboards/oncall-summary.json
+++ b/osdc/modules/monitoring/dashboards/oncall-summary.json
@@ -3501,6 +3501,439 @@
           "refId": "D"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 47,
+      "title": "Harbor Cache Recovery",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 72
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Last Run Status",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Failed harbor-cache-recovery Jobs currently retained by Kubernetes. Non-zero = recovery is broken; corrupted Harbor cache entries will not be auto-purged."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 72
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Failed Runs (retained)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"} > 0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Number of failed Job objects retained (CronJob failedJobsHistoryLimit=3). Repeated failures means the recovery is unable to run successfully."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 72
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "OOMKilled Pods",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(kube_pod_container_status_last_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Pods last terminated by OOMKill. The script lists every pod cluster-wide; bump memory limits in modules/harbor-cache-recovery/kubernetes/cronjob.yaml."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 72
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Time Since Last Success",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "time() - max(kube_job_status_completion_time{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "description": "Seconds since the most recent successful run. Should stay under 5 minutes (the schedule). >30m indicates the CronJob is stalled or all recent runs failed."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OOMKilled"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Recovery Run Trend",
+      "type": "timeseries",
+      "description": "harbor-cache-recovery run outcomes and OOM signature over time.",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_job_status_failed{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "legendFormat": "Failed",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_job_status_succeeded{namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\", cluster=\"$cluster\"})",
+          "legendFormat": "Succeeded",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_container_status_last_terminated_reason{namespace=\"harbor-system\", pod=~\"harbor-cache-recovery-.*\", reason=\"OOMKilled\", cluster=\"$cluster\"})",
+          "legendFormat": "OOMKilled",
+          "refId": "C"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/osdc/modules/monitoring/helm/values.yaml
+++ b/osdc/modules/monitoring/helm/values.yaml
@@ -110,15 +110,19 @@ kube-state-metrics:
         #   pod: info (node mapping), error indicators, restart count, status reasons
         - action: keep
           sourceLabels: [__name__]
-          regex: "kube_daemonset_status_(desired_number_scheduled|number_ready|number_available|number_unavailable)|kube_deployment_status_(replicas_ready|replicas_available|replicas_unavailable|condition)|kube_deployment_spec_replicas|kube_(namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job)_.*|kube_pod_info|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_exitcode|kube_pod_container_status_restarts_total|kube_pod_status_reason"
+          regex: "kube_daemonset_status_(desired_number_scheduled|number_ready|number_available|number_unavailable)|kube_deployment_status_(replicas_ready|replicas_available|replicas_unavailable|condition)|kube_deployment_spec_replicas|kube_(namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job)_.*|kube_pod_info|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_terminated_reason|kube_pod_container_status_last_terminated_exitcode|kube_pod_container_status_restarts_total|kube_pod_status_reason"
         # Drop low-value node metrics
         - action: drop
           sourceLabels: [__name__]
           regex: "kube_node_status_addresses"
-        # Drop successful terminations (only keep actual errors)
+        # Drop successful terminations (only keep actual errors).
+        # Both `_last_terminated_reason` (after restart) and `_terminated_reason`
+        # (current state) are emitted by KSM — `last_` only fires for restarting
+        # containers, so non-restarting pods (e.g. Job/CronJob with restartPolicy=Never)
+        # need the non-`last` variant. Drop benign Completed reasons from both.
         - action: drop
           sourceLabels: [__name__, reason]
-          regex: "kube_pod_container_status_last_terminated_reason;Completed"
+          regex: "kube_pod_container_status_(last_)?terminated_reason;Completed"
         - action: drop
           sourceLabels: [__name__, container_exit_code]
           regex: "kube_pod_container_status_last_terminated_exitcode;0"

--- a/osdc/modules/monitoring/kubernetes/alerts/harbor-cache-recovery-alerts.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/harbor-cache-recovery-alerts.yaml
@@ -1,0 +1,82 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: harbor-cache-recovery-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: osdc-monitoring
+spec:
+  groups:
+    - name: harbor-cache-recovery
+      rules:
+        # The recovery CronJob runs every 5 minutes and purges corrupted entries
+        # from Harbor's pull-through proxy caches. When it stops working, poisoned
+        # cache entries persist and cause fleet-wide ImagePullBackOff failures
+        # (see osdc/modules/harbor-cache-recovery for context).
+        #
+        # Each scheduled run produces a fresh Job object — we cannot watch a
+        # long-lived pod, so all alerts target the Job objects (kept by KSM via
+        # the kube_job_.* allowlist in monitoring/helm/values.yaml).
+        - alert: HarborCacheRecoveryFailing
+          expr: |
+            max(
+              kube_job_status_failed{namespace="harbor-system", job_name=~"harbor-cache-recovery-.*"}
+            ) > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "harbor-cache-recovery cronjob is failing"
+            description: >-
+              The harbor-cache-recovery CronJob has had failing runs for at least
+              15 minutes (≥3 consecutive runs at the */5 schedule). Poisoned
+              Harbor proxy-cache entries will not be auto-purged, which surfaces
+              as fleet-wide ImagePullBackOff against ghcr.io / docker.io / etc.
+              Inspect with:
+              kubectl -n harbor-system get jobs.batch,pods -l app.kubernetes.io/name=harbor-cache-recovery;
+              kubectl -n harbor-system describe pod <last failed pod>.
+
+        - alert: HarborCacheRecoveryOOM
+          # Faster-firing companion alert — surfaces the most common root cause
+          # (script OOMKilled while listing pods cluster-wide) directly, so the
+          # responder doesn't have to dig through pod descriptions.
+          expr: |
+            max(
+              kube_pod_container_status_last_terminated_reason{
+                namespace="harbor-system",
+                pod=~"harbor-cache-recovery-.*",
+                reason="OOMKilled"
+              }
+            ) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "harbor-cache-recovery pod was OOMKilled"
+            description: >-
+              The harbor-cache-recovery pod hit its memory limit. Bump the limits
+              in osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml. Until
+              that ships, manually purge corrupted Harbor entries via the API
+              (see harbor_cache_recovery.py:purge_cached_repo).
+
+        - alert: HarborCacheRecoveryStale
+          # Catches the case where the CronJob isn't running at all — suspended,
+          # controller stuck, no successful Job objects produced. 1800s = 30 min,
+          # i.e. 6× the */5 schedule, so this fires only after sustained absence.
+          expr: |
+            (time()
+              - max(kube_job_status_completion_time{
+                  namespace="harbor-system",
+                  job_name=~"harbor-cache-recovery-.*"
+                })
+            ) > 1800
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "harbor-cache-recovery has not completed successfully in >30m"
+            description: >-
+              No successful run of harbor-cache-recovery has been observed in
+              the last 30 minutes. Auto-purge of corrupted Harbor cache entries
+              is silently disabled. Check the CronJob status and recent Job
+              objects in the harbor-system namespace.

--- a/osdc/modules/monitoring/kubernetes/alerts/harbor-cache-recovery-alerts.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/harbor-cache-recovery-alerts.yaml
@@ -40,9 +40,14 @@ spec:
           # Faster-firing companion alert — surfaces the most common root cause
           # (script OOMKilled while listing pods cluster-wide) directly, so the
           # responder doesn't have to dig through pod descriptions.
+          #
+          # We use `kube_pod_container_status_terminated_reason` (no `_last_`)
+          # because the recovery pods have restartPolicy=Never. KSM only emits
+          # `_last_terminated_reason` after a container restart; non-restarting
+          # pods only populate the current `_terminated_reason` series.
           expr: |
             max(
-              kube_pod_container_status_last_terminated_reason{
+              kube_pod_container_status_terminated_reason{
                 namespace="harbor-system",
                 pod=~"harbor-cache-recovery-.*",
                 reason="OOMKilled"

--- a/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - gpu-alerts.yaml
   - node-compactor-alerts.yaml
   - zombie-cleanup-alerts.yaml
+  - harbor-cache-recovery-alerts.yaml


### PR DESCRIPTION
Add monitoring so that next time harbor-cache-recovery breaks, oncall sees it directly on the dashboard — instead of finding out via downstream CI failures.
- Recovery Healthy? stat — green "Healthy" / red "Unhealthy"
- Time Since Last Success stat — seconds, with yellow/red thresholds
- Recovery Healthy? (history) state-timeline — full-width historical strip

### Testing

[Preview](https://pytorchci.grafana.net/d/osdc-oncall-summary-20260427-preview/osdc3a-oncall-summary-preview-2026-04-27?orgId=1&from=now-1h&to=now&timezone=browser&var-datasource=grafanacloud-prom&var-cluster=pytorch-arc-cbr-production&refresh=30s)

