### PR TITLE
Bump zombie-cleanup resource limits to prevent OOM

### DIFF
--- a/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
@@ -53,11 +53,11 @@ spec:
                   value: "PUSHGATEWAY_URL_PLACEHOLDER"
               resources:
                 requests:
-                  cpu: 50m
-                  memory: 64Mi
+                  cpu: 1
+                  memory: 512Mi
                 limits:
-                  cpu: 200m
-                  memory: 128Mi
+                  cpu: 4
+                  memory: 4Gi
               securityContext:
                 readOnlyRootFilesystem: true
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
**Impact:** zombie-cleanup CronJob in all OSDC clusters
**Risk:** low

## What
Increases CPU and memory resource requests and limits for the zombie-cleanup CronJob container to prevent OOMKills.

## Why
The zombie-cleanup CronJob was being OOM-killed during execution. The job lists all pods in the `arc-runners` namespace via the Kubernetes API, which can be memory-intensive at scale. The previous limits (64Mi request / 128Mi limit) were insufficient for clusters with a large number of runner pods.

## How
- Raised memory from 64Mi/128Mi to 512Mi/4Gi (request/limit) to give the job comfortable headroom for listing and processing all pods in the namespace
- Raised CPU from 50m/200m to 1/4 (request/limit) to allow faster pod enumeration and processing, reducing wall-clock time within the 300s `activeDeadlineSeconds` budget
- Generous limits chosen intentionally — this is a short-lived hourly CronJob running on `base-infrastructure` nodes, so over-provisioning has negligible cost while OOM failures leave zombie pods accumulating

## Changes
- `modules/zombie-cleanup/kubernetes/cronjob.yaml`: Updated container resource requests from 50m CPU / 64Mi memory to 1 CPU / 512Mi memory; updated limits from 200m CPU / 128Mi memory to 4 CPU / 4Gi memory

## Notes
- The job runs hourly (`0 * * * *`) with `concurrencyPolicy: Forbid` and a 300s deadline, so the increased requests are only reserved briefly
- If OOMs persist even with 4Gi, the root cause may be an unexpectedly large pod count in the namespace — investigate pod list size rather than further bumping limits