### PR TITLE
Bump runner pod memory to 768Mi to prevent OOM under CRI backpressure

### DIFF
--- a/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -1,10 +1,12 @@
 # ARC runner definition: l-x86aavx2-189-704-a10g-8
 # Instance type: g5.48xlarge — 8-GPU A10G, 192c/768Gi node
-# Actual K8s capacity ~710.4Gi. Max job: 189c/704Gi after all overhead.
+# Actual K8s capacity ~710.4Gi. Max job: 189c/703Gi after all overhead
+# (runner sidecar bumped 512Mi -> 768Mi, reclaimed 1Gi from job memory
+# to keep the pair within node-allocatable).
 runner:
   name: l-x86aavx2-189-704-a10g-8
   instance_type: g5.48xlarge
   disk_size: 150
   vcpu: 189
-  memory: 704Gi
+  memory: 703Gi
   gpu: 8

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
@@ -1,10 +1,12 @@
 # ARC runner definition: l-x86aavx2-45-167-a10g-4
 # Instance type: g5.12xlarge — 4-GPU A10G, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 167Gi.
+# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 166Gi
+# (runner sidecar bumped 512Mi -> 768Mi, reclaimed 1Gi from job memory
+# to keep the pair within node-allocatable).
 runner:
   name: l-x86aavx2-45-167-a10g-4
   instance_type: g5.12xlarge
   disk_size: 150
   vcpu: 45
-  memory: 167Gi
+  memory: 166Gi
   gpu: 4

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86iavx512-29-115-t4
 # Instance type: g4dn.8xlarge — 1-GPU T4, 32c/128Gi node
 # Actual K8s capacity ~118.4Gi after VM overhead. With kubelet reserved,
-# DaemonSets, sidecar (750m/512Mi), and hooks overhead (320m/522Mi),
-# max job memory is 115Gi.
+# DaemonSets, sidecar (750m/768Mi), and hooks overhead (320m/522Mi),
+# max job memory is 114Gi.
 runner:
   name: l-x86iavx512-29-115-t4
   instance_type: g4dn.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 115Gi
+  memory: 114Gi
   gpu: 1

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -184,10 +184,13 @@ template:
             value: "git-cache-not-ready"
           - name: ACTIONS_RUNNER_WAIT_FOR_NODE_TAINTS_TIMEOUT_SECONDS
             value: "720"
-          # Memory management: the runner pod shares 512Mi between the .NET
+          # Memory management: the runner pod has 768Mi shared between the .NET
           # runner agent and Node.js container hooks. Without explicit caps,
-          # .NET claims 75% (384Mi) and Node.js claims 50% (256Mi) of the
-          # cgroup — combined 640Mi > 512Mi, guaranteed OOM.
+          # .NET claims 75% (576Mi) and Node.js claims 50% (384Mi) of the
+          # cgroup — combined 960Mi > 768Mi, still guaranteed OOM.
+          # Bumped from 512Mi to give native Node.js stdio buffers (held open
+          # by slow CRI exec during pod-density bursts) headroom; observed
+          # OOMs trace back to native buffers, not V8 heap or .NET managed heap.
           # GCHeapHardLimit is hex: 0xC800000 = 200 MiB managed heap
           - name: DOTNET_GCHeapHardLimit
             value: "C800000"
@@ -210,10 +213,10 @@ template:
           # workspace tar copy/extract and permission fixups
           limits:
             cpu: "750m"
-            memory: "512Mi"
+            memory: "768Mi"
           requests:
             cpu: "750m"
-            memory: "512Mi"
+            memory: "768Mi"
         volumeMounts:
           - name: hook-extensions
             mountPath: /home/runner/hook-extensions

--- a/osdc/scripts/python/analyze_node_utilization.py
+++ b/osdc/scripts/python/analyze_node_utilization.py
@@ -29,8 +29,10 @@ from daemonset_overhead import DaemonSetOverhead, discover_daemonsets
 from instance_specs import ENI_MAX_PODS, INSTANCE_SPECS
 
 # Runner pod sidecar (the ARC orchestrator container, not the $job container)
+# Memory bumped 512 -> 768 to give native Node.js stdio buffers headroom under
+# CRI backpressure; see modules/arc-runners/templates/runner.yaml.tpl L187-193.
 RUNNER_SIDECAR_CPU_M = 750
-RUNNER_SIDECAR_MEM_MI = 512
+RUNNER_SIDECAR_MEM_MI = 768
 
 # ARC container-hooks overhead: injected containers added to the workflow
 # (job) pod by runner-container-hooks beyond the def's vcpu/memory.

--- a/osdc/scripts/python/test_analyze_node_utilization.py
+++ b/osdc/scripts/python/test_analyze_node_utilization.py
@@ -131,8 +131,8 @@ class TestPerRunnerTotal:
         cpu, mem, gpu = per_runner_total(runner)
         # 8*1000 + 750 (sidecar) + 320 (hooks) = 9070
         assert cpu == 9070
-        # 16384 + 512 (sidecar) + 522 (hooks) = 17418
-        assert mem == 17418
+        # 16384 + 768 (sidecar) + 522 (hooks) = 17674
+        assert mem == 17674
         assert gpu == 0
 
     def test_with_gpu(self):


### PR DESCRIPTION
**Impact:** All ARC runner pods across OSDC clusters — affects job reliability when nodes are under high pod-density / CRI load. **Risk:** low

## What
Increases memory request and limit on the `runner` container in the ARC runner scale set template from 512Mi to 768Mi, and updates the matching constant in the cluster simulator so capacity modeling stays in sync.

## Why
Two PyTorch CI jobs on 2026-04-28 failed because the runner pod (the one hosting the GitHub Actions agent + Node.js container hooks) OOMKilled mid-prepare_job:

- pytorch/pytorch run #25068774574 (lintrunner-noclang-all) — runner `mt-l-x86iamx-8-16-6kzqd-runner-gmxpk` on c7i.48xlarge node ip-10-4-55-181. Containerd recorded TaskOOM on the runner main container.
- pytorch/pytorch run #25069893231 (linux-jammy-py3.14t-clang18 / build-osdc) — runner `mt-l-x86iavx512-8-64-tk8zz-runner-fz8ns` on r7a.24xlarge node ip-10-4-23-113. Runner OOM at 18:16:16 (exit 137
  + TaskOOM ×2); workflow pod orphaned ~10 minutes until GitHub's lost-runner heartbeat timeout fired at 18:25:51.

In both cases the underlying trigger was kubelet/CRI overload during a pod-density burst (~25 runner pods scheduled to one node within 60s); kubelet's housekeeping loop fell 30+ seconds behind its 1s target, containerd reported `failed to delete task: context deadline exceeded` on multiple sibling shims, and the runner pod's hook stdio buffers accumulated past the 512Mi cgroup limit while waiting on slow CRI exec.

The OOM is a tail consequence of CRI saturation, but the 512Mi cap left no headroom: explicit caps allocate 200Mi (.NET managed heap via `DOTNET_GCHeapHardLimit`) + 128Mi (V8 heap via `--max-old-space-size`) = 328Mi out of 512Mi, leaving only ~184Mi for native Node.js stdio buffers, OS, and process overhead. When CRI exec hangs, native buffers grow beyond that margin. `NODE_OPTIONS=--max-old-space-size` covers V8 heap only — not native allocations such as tar stream and exec WebSocket buffers — and the existing template comment already flagged this gap.

Bumping to 768Mi gives ~440Mi for native buffers and overhead — more than 2x the previous headroom — without touching managed heap caps or changing per-pod density meaningfully (workflow pod's 8 vCPU request remains the binding scheduling constraint; pair memory goes from 16.5Gi to 16.75Gi, ~21 pairs per c7i.48xlarge either way).

## How
- Single value change in the runner scale set template at lines 216 and 219 (limit and request, kept equal for Guaranteed QoS).
- Comment block at lines 187-193 updated with the new budget math (576Mi + 384Mi > 768Mi still requires explicit caps) and a note pointing to native-buffer headroom as the motivation.
- `scripts/python/analyze_node_utilization.py:RUNNER_SIDECAR_MEM_MI` bumped 512 -> 768 so the cluster simulator's per-pod accounting matches reality, plus the matching expected value updated in `test_analyze_node_utilization.py`.
- Existing managed heap caps unchanged: DOTNET_GCHeapHardLimit (200Mi) and NODE_OPTIONS=--max-old-space-size=128 still apply — the OOM was not a managed-heap problem.
- Per-fleet `defs/*.yaml` and the generator script unchanged: runner pod memory is hardcoded in the template, so a single edit propagates to all 35+ fleets when `deploy.sh` regenerates `generated/*.yaml`.

## Changes
- `modules/arc-runners/templates/runner.yaml.tpl`: runner container `resources.limits.memory` and `resources.requests.memory` 512Mi → 768Mi; comment block updated.
- `scripts/python/analyze_node_utilization.py`: `RUNNER_SIDECAR_MEM_MI` 512 -> 768.
- `scripts/python/test_analyze_node_utilization.py`: expected per-runner total memory updated to reflect new constant (16384 + 768 + 522 = 17674).

## Test plan

- [x] `just lint` — all 13 linters pass
- [x] `just test` — all unit tests pass (98.82% coverage)
- [x] `just analyze-utilization` — confirmed regression scope: 3 GPU fleets newly flagged (l-x86aavx2-189-704-a10g-8,
l-x86aavx2-45-167-a10g-4, l-x86iavx512-29-115-t4); total deployed runners unchanged in mixed packing
- [x] `just simulate-cluster` — total nodes 2113 unchanged; vCPU 93.6% unchanged; memory 95.8% → 96.0%; weighted MAPE unchanged

```
Monte Carlo Cluster Simulation
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Seed: 42  |  MAPE threshold: 15%  |  Runners: 38  |  DaemonSets: 13
Peak target runner types: 30 (mapped from 38 old labels)

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Cluster Simulation Results
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Nodes by instance type:

  Instance Type          Nodes  vCPU Used vCPU Total   Mem Used  Mem Total   GPU
  ──────────────────────────────────────────────────────────────────────────────
  c7a.48xlarge             267   47487.9c   51006.3c  90587.6Gi  92372.6Gi     -
  c7i.metal-24xl            36    3350.5c    3429.9c   6057.4Gi   6061.1Gi     -
  g4dn.12xlarge            157    7233.0c    7425.3c  27201.8Gi  27242.4Gi 628/628
  g4dn.8xlarge              89    2676.2c    2788.8c  10258.1Gi  10342.6Gi 89/89
  g4dn.metal                79    7510.5c    7518.8c  27275.5Gi  27311.5Gi 632/632
  g5.12xlarge               58    2672.1c    2743.1c   9701.1Gi   9750.7Gi 232/232
  g5.48xlarge               40    7602.8c    7637.4c  28170.4Gi  28205.0Gi 320/320
  g5.8xlarge               596   17921.7c   18675.7c  68098.8Gi  68133.7Gi 596/596
  g6.12xlarge               26    1197.8c    1229.7c   4504.8Gi   4511.5Gi 104/104
  g6.8xlarge               388   11667.2c   12158.0c  44332.8Gi  44355.5Gi 388/388
  m6i.32xlarge              27    3403.9c    3434.3c  12535.0Gi  12540.9Gi     -
  m7i.48xlarge              48    8569.2c    9169.7c  32715.3Gi  33655.9Gi     -
  m8g.16xlarge              29    1829.0c    1837.3c   6590.5Gi   6601.0Gi     -
  m8g.48xlarge              15    2650.4c    2865.5c  10069.6Gi  10517.5Gi     -
  r7a.48xlarge             138   22129.1c   26362.8c 173080.4Gi 194796.0Gi     -
  r7g.16xlarge             120    7448.4c    7602.6c  55711.2Gi  55737.3Gi     -

Deployment accuracy:

  Total deployed: 6268 / 7367 target
  Weighted MAPE: 15.0%

  Runner                              Deployed   Target     Diff
  ───────────────────────────────────────────────────────────────
  l-arm64g2-6-32                            61       73      -12
  l-arm64g3-16-62                           62       76      -14
  l-arm64g3-61-463                         120      153      -33
  l-arm64g4-16-62                           68       76       -8
  l-barm64g4-62-226                         29       39      -10
  l-bx86iamx-92-167                         36       45       -9
  l-bx86iavx512-94-344-t4-8                 79       91      -12
  l-x86aavx2-189-703-a10g-8                 40       42       -2
  l-x86aavx2-29-113-a10g                   596      695      -99
  l-x86aavx2-29-113-l4                     388      422      -34
  l-x86aavx2-45-166-a10g-4                  58       80      -22
  l-x86aavx2-45-172-l4-4                    26       29       -3
  l-x86aavx512-125-463                      27       24       +3
  l-x86iamx-32-128                         131      174      -43
  l-x86iamx-8-32                           345      384      -39
  l-x86iavx2-40-160                         23       30       -7
  l-x86iavx2-8-32                           18       18       +0
  l-x86iavx512-16-128                       83       89       -6
  l-x86iavx512-16-32                      1154     1384     -230
  l-x86iavx512-2-4                           9       15       -6
  l-x86iavx512-29-114-t4                    89      104      -15
  l-x86iavx512-32-256                       12       12       +0
  l-x86iavx512-37-67                        38       65      -27
  l-x86iavx512-45-172-t4-4                 157      183      -26
  l-x86iavx512-46-85                       160      189      -29
  l-x86iavx512-48-384                      364      417      -53
  l-x86iavx512-8-16                       2050     2400     -350
  l-x86iavx512-8-64                         19       28       -9
  l-x86iavx512-94-192                        2        2       +0
  l-x86iavx512-94-768                       24       28       -4

Cluster-wide utilization:

  vCPU:    93.6%  (155350 / 165885 cores)
  Memory:  96.0%  (606890 / 632135 GiB)
  GPU:    100.0%  (2989 / 2989 GPUs across 1433 nodes)

  Total nodes: 2113
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```