### PR TITLE
Fix flaky date-relative test in test_wants_collector

### DIFF
--- a/osdc/modules/pypi-cache/scripts/python/test_wants_collector.py
+++ b/osdc/modules/pypi-cache/scripts/python/test_wants_collector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import signal
@@ -830,9 +831,13 @@ class TestCleanupOldLogs:
 
     def test_old_files_deleted(self, tmp_path):
         """Files older than max_age_days are deleted."""
+        # Use a date 10 days ago so the test is stable regardless of when
+        # it runs — a hardcoded date becomes stale once today drifts past
+        # max_age_days from it.
+        recent_date = datetime.date.today() - datetime.timedelta(days=10)
         old = tmp_path / "fallback.2020-01-01.log"
         old.write_text("old data")
-        recent = tmp_path / "fallback.2026-03-29.log"
+        recent = tmp_path / f"fallback.{recent_date.isoformat()}.log"
         recent.write_text("recent data")
 
         cleanup_old_logs(tmp_path, max_age_days=30)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #512
* #511
* __->__ #510

**Impact:** osdc unit-test suite reliability.
**Risk:** very low — test-only change.

## What
Replaces the hardcoded date `2026-03-29` in
`TestCleanupOldLogs.test_old_files_deleted` with a date computed
relative to `datetime.date.today()`.

## Why
The test creates a "recent" fallback log file dated `2026-03-29` and
asserts it survives `cleanup_old_logs(max_age_days=30)`. The
implementation uses `datetime.date.today()` to compute the cutoff, so
the assertion only holds while today is within 30 days of `2026-03-29`
(i.e., on or before `2026-04-28`). On `2026-04-29` and later the file
is correctly identified as 31+ days old and deleted, breaking the
test deterministically.

The test was authored assuming "the hardcoded date will stay recent
enough" — a calendar bomb that fires once `today - 30 days` exceeds
`2026-03-29`. Surfaced when CI ran on 2026-04-29; local `just test`
runs from the day prior had passed.

## How
- Added `import datetime` to the test file.
- Set `recent_date = datetime.date.today() - datetime.timedelta(days=10)`
  inside the test, then constructed the filename from
  `recent_date.isoformat()`. 10 days is a safe margin: well under the
  30-day deletion threshold and far enough from "today" that midnight
  transitions across timezones can't flip the assertion.

The other tests in `TestCleanupOldLogs` are unaffected:
- `fallback.2020-01-01.log` references are intentionally ancient
  (always > 30 days old) — kept as-is.
- `test_date_unknown_kept` and `test_non_matching_files_kept` don't
  depend on dates.
- `test_oserror_on_unlink_ignored` reuses `2020-01-01` — also fine.

## Changes
- `modules/pypi-cache/scripts/python/test_wants_collector.py`: added
  `import datetime`; replaced hardcoded `fallback.2026-03-29.log`
  with a filename computed from `today - 10 days`.

## Notes
- Unrelated to the runner-memory-bump and scale-set rename work in
  the prior commits on this branch — this is a pre-existing test
  bug surfaced by the calendar.
- All 13 osdc linters pass; all unit tests pass.