### PR TITLE
Skip arc-staging pre-merge deploy on test-only PRs

### DIFF
--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -32,6 +32,12 @@ jobs:
           filters: |
             osdc:
               - 'osdc/**'
+              # Skip staging deploy when the only osdc/ changes are tests.
+              # Unit tests already run on the PR via osdc-test.yml; spinning
+              # up arc-staging adds nothing for a test-only fix.
+              - '!osdc/**/test_*.py'
+              - '!osdc/**/*_test.py'
+              - '!osdc/**/tests/**'
               - '.github/workflows/osdc-deploy-prod.yml'
               - '.github/workflows/osdc-pre-merge.yml'
               - '.github/workflows/_osdc-deploy.yml'


### PR DESCRIPTION
**Impact:** ci-infra merge-queue pipeline.
**Risk:** very low — narrows when staging deploys, no behavior change for production.

## What
Adds three negation patterns to the `dorny/paths-filter` rule in `.github/workflows/osdc-pre-merge.yml` so that PRs touching only test files no longer trigger the arc-staging deploy + smoke / compactor / integration validation in the merge queue.

## Why
PR #510 (a one-line fix to a flaky date-relative unit test) merged through the full pre-merge pipeline, which spins up arc-staging, deploys all OSDC modules, runs the smoke / compactor / integration suites, and tears down. That is ~10–15 minutes of cluster time and EC2 spend for a change that the staging deploy cannot meaningfully validate — the unit test already ran on the PR via `osdc-test.yml`, and infrastructure validation is unaffected by test-file edits.

The path filter today gates the deploy on any change under `osdc/**`. With negation patterns we can keep the affirmative coverage but exclude pytest test files, so test-only PRs flow through with no deploy.

## How
Three negation entries added to the `osdc:` filter list:
- `!osdc/**/test_*.py`
- `!osdc/**/*_test.py`
- `!osdc/**/tests/**`

dorny/paths-filter evaluates each changed file against the rule list: a file is a "match" iff it matches at least one affirmative pattern and none of the negation patterns. If every changed file is excluded, the filter output is `false` and the gated `deploy` job is skipped.

Behavior matrix:
- PR touches only `test_foo.py` -> filter `false` -> deploy skipped.
- PR touches `test_foo.py` + `foo.py` -> `foo.py` matches without exclusion -> filter `true` -> deploy runs (correct: production code changed).
- PR touches `osdc-pre-merge.yml` only -> matches the explicit workflow path -> deploy runs (correct: workflow changes need re-validation).
- PR touches files outside `osdc/**` -> already filtered out today; unchanged.

## Changes
- `.github/workflows/osdc-pre-merge.yml`: add three test-file negation entries to the `osdc:` paths-filter rule, plus an inline comment explaining the intent.

## Notes
- Unit tests and lint stay on the PR-trigger workflows (`osdc-test.yml`, `osdc-lint.yml`), which run on `pull_request` and do not pass through this filter — so a test fix is still validated before merge, just without the staging spin-up.
- Doc-only PRs (`osdc/docs/*.md`) are not exempted by this change. If we want the same skip for docs, follow up with `'!osdc/docs/**'` and/or `'!osdc/**/*.md'`.
- Risk window: any non-test source file accidentally named with a `test_` prefix, `_test` suffix, or under a `tests/` directory will be treated as a test by the filter. Current osdc/ tree follows pytest conventions consistently, so the risk is small.