### PR TITLE
Drop runner sidecar from workflow-node packing in capacity simulator

### DIFF
--- a/osdc/scripts/python/analyze_node_utilization.py
+++ b/osdc/scripts/python/analyze_node_utilization.py
@@ -28,15 +28,14 @@ from cli_colors import BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW
 from daemonset_overhead import DaemonSetOverhead, discover_daemonsets
 from instance_specs import ENI_MAX_PODS, INSTANCE_SPECS
 
-# Runner pod sidecar (the ARC orchestrator container, not the $job container)
-# Memory bumped 512 -> 1024 to give native Node.js stdio buffers headroom under
-# CRI backpressure; see modules/arc-runners/templates/runner.yaml.tpl L187-193.
-RUNNER_SIDECAR_CPU_M = 750
-RUNNER_SIDECAR_MEM_MI = 1024
-
 # ARC container-hooks overhead: injected containers added to the workflow
 # (job) pod by runner-container-hooks beyond the def's vcpu/memory.
 # Measured from Karpenter scheduling requests vs def values.
+#
+# Note: the runner-orchestrator (sidecar) pod is no longer accounted for
+# here. Per pytorch/ci-infra#500 it is pinned to the dedicated `c7i-runner`
+# NodePool, so it does not consume resources on the workflow node and must
+# not be added into per-workflow-pod totals on c7i / g5 / g4dn / etc.
 HOOKS_OVERHEAD_CPU_M = 320
 HOOKS_OVERHEAD_MEM_MI = 522
 
@@ -181,9 +180,14 @@ def compute_allocatable(
 
 
 def per_runner_total(runner: dict) -> tuple[int, int, int]:
-    """Total resources per runner pod (job container + sidecar + hooks overhead)."""
-    cpu = runner["vcpu"] * 1000 + RUNNER_SIDECAR_CPU_M + HOOKS_OVERHEAD_CPU_M
-    mem = runner["memory_mi"] + RUNNER_SIDECAR_MEM_MI + HOOKS_OVERHEAD_MEM_MI
+    """Total resources per workflow pod (job container + hooks overhead).
+
+    The runner-orchestrator pod lives on the dedicated `c7i-runner`
+    NodePool (see ci-infra#500) and does not consume resources on the
+    workflow node, so it is not summed in here.
+    """
+    cpu = runner["vcpu"] * 1000 + HOOKS_OVERHEAD_CPU_M
+    mem = runner["memory_mi"] + HOOKS_OVERHEAD_MEM_MI
     gpu = runner["gpu"]
     return cpu, mem, gpu
 
@@ -367,13 +371,12 @@ def print_node_analysis(
     print(f"  {BOLD}Runners targeting this node:{NC}")
     for r in runners:
         c, m, g = per_runner_total(r)
-        sidecar_note = (
+        breakdown = (
             f" (job: {r['vcpu']}c+{format_mem(r['memory_mi'])},"
-            f" sidecar: {RUNNER_SIDECAR_CPU_M}m+{RUNNER_SIDECAR_MEM_MI}Mi,"
             f" hooks: {HOOKS_OVERHEAD_CPU_M}m+{HOOKS_OVERHEAD_MEM_MI}Mi)"
         )
         gpu_note = f", {r['gpu']} GPU" if r["gpu"] > 0 else ""
-        print(f"    - {r['name']}: {c}m CPU, {format_mem(m)} RAM{gpu_note}{sidecar_note}")
+        print(f"    - {r['name']}: {c}m CPU, {format_mem(m)} RAM{gpu_note}{breakdown}")
 
     # Homogeneous packing: how many of each runner type fits alone?
     print(f"\n  {BOLD}Homogeneous packing (single runner type fills the node):{NC}")

--- a/osdc/scripts/python/test_analyze_node_utilization.py
+++ b/osdc/scripts/python/test_analyze_node_utilization.py
@@ -129,10 +129,12 @@ class TestPerRunnerTotal:
     def test_basic(self):
         runner = {"vcpu": 8, "memory_mi": 16384, "gpu": 0}
         cpu, mem, gpu = per_runner_total(runner)
-        # 8*1000 + 750 (sidecar) + 320 (hooks) = 9070
-        assert cpu == 9070
-        # 16384 + 1024 (sidecar) + 522 (hooks) = 17930
-        assert mem == 17930
+        # 8*1000 + 320 (hooks) = 8320 — runner sidecar lives on c7i-runner
+        # NodePool (ci-infra#500), not on the workflow node, so it is not
+        # included.
+        assert cpu == 8320
+        # 16384 + 522 (hooks) = 16906
+        assert mem == 16906
         assert gpu == 0
 
     def test_with_gpu(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #514
* #511

**Impact:** ci-infra capacity-planning scripts (`just analyze-utilization`
and `just simulate-cluster`).
**Risk:** very low — script-only change, no runtime infrastructure
effect.

## What
Removes the runner-orchestrator pod (`runner` container, ~750m CPU /
1Gi mem) from `per_runner_total()` in
`osdc/scripts/python/analyze_node_utilization.py`. The function now
returns just `job_pod_resources + hooks_overhead`, accurately
reflecting what the workflow node actually carries.

## Why
The simulator's accounting was written when runner pods and their
workflow pods were co-located on the same NodePool. That assumption
no longer holds: ci-infra#500 (Add proactive capacity PoC for ARC
runners) pinned all runner-orchestrator pods to the dedicated
`c7i-runner` NodePool via `nodeSelector: node-fleet: c7i-runner`,
so the runner sidecar no longer competes with the workflow pod for
allocatable on c7i / g5 / g4dn / etc.

Continuing to add `RUNNER_SIDECAR_*` to per-workflow-pod totals
inflated the model by ~750m CPU and ~1Gi memory per pod, which
caused the simulator to:
- over-provision nodes (2113 vs the corrected 2108 — 5 extra nodes
  at peak demand for no real reason),
- mis-flag heavily packed GPU fleets like `l-x86aavx2-189-704-a10g-8`
  as overshooting node-allocatable when in reality their workflow
  pods now fit exactly,
- understate cluster headroom in the homogeneous-packing analysis.

The runner-pool side (c7i-runner) needs its own modeling, but that
is a separate workstream — this commit removes the incorrect
double-count from the existing workflow-pool path.

## How
- Removed `RUNNER_SIDECAR_CPU_M` / `RUNNER_SIDECAR_MEM_MI` constants
  and the `# Runner pod sidecar (...)` block at the top of
  `analyze_node_utilization.py`.
- Replaced with a documentation comment on
  `HOOKS_OVERHEAD_CPU_M` / `HOOKS_OVERHEAD_MEM_MI` explaining that
  the runner orchestrator is intentionally not summed in here, with
  a pointer to ci-infra#500.
- Updated `per_runner_total` to drop the sidecar terms; tightened
  its docstring to describe the new semantics ("workflow pod = job
  + hooks").
- Updated the per-runner breakdown printed by `print_node_analysis`
  to show only `(job: …, hooks: …)` instead of the old
  `(job: …, sidecar: …, hooks: …)` triple. Renamed the local
  `sidecar_note` variable to `breakdown` to reflect the new content.
- Updated `test_analyze_node_utilization.TestPerRunnerTotal.test_basic`
  with new expected values:
  - cpu: 8 * 1000 + 320 (hooks) = **8320** (was 9070)
  - mem: 16384 + 522 (hooks) = **16906** (was 17674 / 17930)
  Comment in the test points the reader at ci-infra#500 for
  context.

`simulate_cluster.py` re-uses `per_runner_total()` from
`analyze_node_utilization`, so it picks up the new accounting
automatically — no edits there.

## Changes
- `osdc/scripts/python/analyze_node_utilization.py`:
  removed RUNNER_SIDECAR_* constants and their documentation block,
  updated `per_runner_total` to drop the sidecar terms, simplified
  the per-runner breakdown print line.
- `osdc/scripts/python/test_analyze_node_utilization.py`:
  expected `per_runner_total` values updated to `(8320, 16906, 0)`.

## Notes
- `just analyze-utilization` after this change drops the count of
  fleets flagged below 90 % homogeneous utilization from 13 (the
  pre-bump baseline modeled with the old assumption) to 12.
- `just simulate-cluster` reports total nodes 2108 (was 2113), peak
  cluster vCPU 91.3 % / memory 95.6 % — both slightly lower as the
  simulator no longer overcounts per-pod cost. Total deployed is
  unchanged (6268/7367); the demand-side picture is identical, only
  supply-side over-provisioning is corrected.
- Documentation refresh for `osdc/docs/node-utilization-optimization.md`
  is intentionally out of scope here; the doc still has examples that
  reference the co-located model and should be updated separately.
- All 13 osdc linters pass; all unit tests pass.