### PR TITLE
Reduce Grafana Cloud DPM: drop kube_pod_status_reason and fix Alloy clustering

### DIFF
--- a/osdc/modules/monitoring/deploy.sh
+++ b/osdc/modules/monitoring/deploy.sh
@@ -132,8 +132,8 @@ EOF
     grafana/alloy
 
   rm -f "$ALLOY_OVERRIDE"
-  kubectl rollout restart deployment/alloy -n "$NAMESPACE"
-  kubectl rollout status deployment/alloy -n "$NAMESPACE" --timeout=3m
+  kubectl rollout restart statefulset/alloy -n "$NAMESPACE"
+  kubectl rollout status statefulset/alloy -n "$NAMESPACE" --timeout=3m
   echo "Alloy installed — pushing metrics to Grafana Cloud."
 else
   echo "No grafana-cloud-credentials secret found, skipping Alloy (no remote metrics push)."

--- a/osdc/modules/monitoring/helm/alloy-values.yaml
+++ b/osdc/modules/monitoring/helm/alloy-values.yaml
@@ -8,7 +8,7 @@
 # via a temporary override file.
 
 controller:
-  type: deployment
+  type: statefulset
   replicas: 2
 
   # Run on base infrastructure nodes

--- a/osdc/modules/monitoring/helm/alloy-values.yaml
+++ b/osdc/modules/monitoring/helm/alloy-values.yaml
@@ -21,6 +21,8 @@ controller:
       effect: NoSchedule
 
 alloy:
+  clustering:
+    enabled: true
   resources:
     requests:
       cpu: 250m

--- a/osdc/modules/monitoring/helm/values.yaml
+++ b/osdc/modules/monitoring/helm/values.yaml
@@ -107,10 +107,10 @@ kube-state-metrics:
         #   daemonset: health status (desired/ready/available/unavailable)
         #   deployment: replica status + conditions + desired count
         #   namespace/node/statefulset/pv/hpa/job: all metrics (low cardinality)
-        #   pod: info (node mapping), error indicators, restart count, status reasons
+        #   pod: info (node mapping), error indicators, restart count
         - action: keep
           sourceLabels: [__name__]
-          regex: "kube_daemonset_status_(desired_number_scheduled|number_ready|number_available|number_unavailable)|kube_deployment_status_(replicas_ready|replicas_available|replicas_unavailable|condition)|kube_deployment_spec_replicas|kube_(namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job)_.*|kube_pod_info|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_terminated_reason|kube_pod_container_status_last_terminated_exitcode|kube_pod_container_status_restarts_total|kube_pod_status_reason"
+          regex: "kube_daemonset_status_(desired_number_scheduled|number_ready|number_available|number_unavailable)|kube_deployment_status_(replicas_ready|replicas_available|replicas_unavailable|condition)|kube_deployment_spec_replicas|kube_(namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job)_.*|kube_pod_info|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_terminated_reason|kube_pod_container_status_last_terminated_exitcode|kube_pod_container_status_restarts_total"
         # Drop low-value node metrics
         - action: drop
           sourceLabels: [__name__]
@@ -126,11 +126,6 @@ kube-state-metrics:
         - action: drop
           sourceLabels: [__name__, container_exit_code]
           regex: "kube_pod_container_status_last_terminated_exitcode;0"
-        # Drop routine pod status reasons (spot reclaim, scheduling changes)
-        # Keep only non-routine errors: Evicted, NodeLost, UnexpectedAdmissionError
-        - action: drop
-          sourceLabels: [__name__, reason]
-          regex: "kube_pod_status_reason;(Shutdown|NodeAffinity)"
   tolerations:
     - key: CriticalAddonsOnly
       operator: Equal


### PR DESCRIPTION
## Summary
this should fix logging dpm >1 issue, (verified in stage arc). long story short,we have 2 replica of alloy pods, , missing alloy headless service and static name causes them unable to discover each other, so instead of distribute the scrape work , they scrape independently

Two changes to reduce Grafana Cloud DPM (Data Points per Minute):

### 1. Drop `kube_pod_status_reason` from KSM metrics
- The same information is available via `kube_pod_container_status_last_terminated_reason` at lower cardinality

### 2. Fix Alloy clustering (DPM ~2x → ~1x)

All KSM metrics showed DPM ≈ 1.97 instead of the expected 1.0. Root cause: Alloy was deployed as a **Deployment** with `clustering { enabled = true }` in the config, but clustering requires a **headless service** for peer discovery. Without it, both replicas independently scraped all targets, doubling the DPM. 

**Fix:**
- Switch `controller.type` from `deployment` to `statefulset` (creates headless service automatically)
- Add `alloy.clustering.enabled: true` in helm values (tells the chart to configure peer discovery)
- Update `deploy.sh` to reference `statefulset/alloy` instead of `deployment/alloy`

this fix turns alloy replica with name alloy-1 and alloy-0, and enabaled the headless service , this allow peer discovery among the alloy replica, so each of them scrape 50% of metrics, instead of deplicate
```
kubectl -n monitoring get svc | grep alloy
alloy-cluster                                    ClusterIP   None             <none>        12345/TCP   11m
```

### Expected DPM impact

| Change | Series reduced | DPM reduction |
|--------|---------------|---------------|
| Drop `kube_pod_status_reason` | ~8,400 series | ~8,400 DPM |
| Fix Alloy clustering | All series | ~50% of total DPM |

## Test plan

- [x] Deployed to staging (`arc-staging`)
- [x] Verified Alloy clustering: both peers discovered, targets distributed
- [x] Verified `kube_pod_status_reason` no longer in KSM keep list
- [x] Monitor Grafana Cloud DPM dashboard for ~50% reduction over next hour
- [ ] Update cluster-health dashboard to remove "Evicted / NodeLost Pods" panel