### PR TITLE
Bump arc-cbr-production pypi-cache replicas from 2 to 4

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -190,7 +190,7 @@ clusters:
       github_secret_name: pytorch-arc-cbr-production
       runner_name_prefix: "mt-"
     pypi_cache:
-      replicas: 2
+      replicas: 4
     modules:
       - karpenter
       - arc


### PR DESCRIPTION
The pypi-cache-cpu nginx pods were SIGKILLed by liveness-probe failures (exit 137) under a sudden ~1300-runner stampede when an ARC listener's capacity monitor crashed and released its backlog all at once. Doubling the replica count gives the per-deployment nginx pool more headroom to absorb similar bursts before probes time out.