### PR TITLE
Scale pypi-cache replicas from 2 to 4

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -190,7 +190,7 @@ clusters:
       github_secret_name: pytorch-arc-cbr-production
       runner_name_prefix: "mt-"
     pypi_cache:
-      replicas: 2
+      replicas: 4
     modules:
       - karpenter
       - arc


### PR DESCRIPTION
- Increase pypi-cache replica count in pytorch-osdc cluster

PyPI cache was unable to handle load during peak usage, causing failures. Doubling replicas to improve availability and throughput under high concurrency.