### PR TITLE
Fix Alloy smoke test for StatefulSet

### DIFF
--- a/osdc/modules/monitoring/tests/smoke/test_monitoring.py
+++ b/osdc/modules/monitoring/tests/smoke/test_monitoring.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import pytest
 from helpers import (
     assert_daemonset_healthy,
-    assert_deployment_ready,
     assert_metric_fresh_in_mimir,
+    assert_statefulset_ready,
     fetch_grafana_cloud_credentials,
     filter_deployments,
     find_helm_release,
@@ -213,8 +213,8 @@ class TestAlloy:
         status = release.get("status", "")
         assert status == "deployed", f"Alloy status is '{status}', expected 'deployed'"
 
-    def test_alloy_deployment_ready(self, all_deployments: dict, mon_ns: str) -> None:
-        assert_deployment_ready(all_deployments, mon_ns, "alloy")
+    def test_alloy_statefulset_ready(self, mon_ns: str) -> None:
+        assert_statefulset_ready(mon_ns, "alloy")
 
 
 # ============================================================================

--- a/osdc/tests/smoke/helpers.py
+++ b/osdc/tests/smoke/helpers.py
@@ -431,6 +431,62 @@ def assert_deployment_ready(
     assert ready == desired, f"{name}: {ready}/{desired} replicas ready (after {READY_RETRIES} retries)"
 
 
+def assert_statefulset_ready(
+    namespace: str,
+    name: str,
+    *,
+    rollout_timeout: int = 90,
+) -> None:
+    """Assert a StatefulSet has all replicas ready.
+
+    StatefulSets roll out pods one at a time, so if a rollout is in progress
+    (observedGeneration < generation or updateRevision != currentRevision),
+    we wait up to rollout_timeout seconds before failing.
+
+    Args:
+        namespace: Namespace to filter by.
+        name: StatefulSet name.
+        rollout_timeout: Max seconds to wait for a rollout to finish.
+    """
+    sts = run_kubectl(["get", f"statefulset/{name}"], namespace=namespace)
+    desired = sts["spec"].get("replicas", 1)
+    ready = sts.get("status", {}).get("readyReplicas", 0)
+
+    if desired == ready:
+        return
+
+    # Check if a rollout is in progress
+    meta_gen = sts.get("metadata", {}).get("generation", 0)
+    observed_gen = sts.get("status", {}).get("observedGeneration", 0)
+    update_rev = sts.get("status", {}).get("updateRevision", "")
+    current_rev = sts.get("status", {}).get("currentRevision", "")
+    mid_rollout = observed_gen < meta_gen or update_rev != current_rev
+
+    if mid_rollout:
+        deadline = time.time() + rollout_timeout
+        while time.time() < deadline:
+            time.sleep(READY_RETRY_DELAY)
+            sts = run_kubectl(["get", f"statefulset/{name}"], namespace=namespace)
+            desired = sts["spec"].get("replicas", 1)
+            ready = sts.get("status", {}).get("readyReplicas", 0)
+            if desired == ready:
+                return
+        raise AssertionError(
+            f"{name}: rollout still in progress after {rollout_timeout}s "
+            f"({ready}/{desired} replicas ready). Rollout may be stuck."
+        )
+
+    for _attempt in range(READY_RETRIES):
+        time.sleep(READY_RETRY_DELAY)
+        sts = run_kubectl(["get", f"statefulset/{name}"], namespace=namespace)
+        desired = sts["spec"].get("replicas", 1)
+        ready = sts.get("status", {}).get("readyReplicas", 0)
+        if desired == ready:
+            return
+
+    assert ready == desired, f"{name}: {ready}/{desired} replicas ready (after {READY_RETRIES} retries)"
+
+
 # ---------------------------------------------------------------------------
 # Grafana Cloud remote query helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After #515 switched Alloy from Deployment to StatefulSet for clustering, the smoke test `test_alloy_deployment_ready` fails because it looks for a Deployment that no longer exists.

**Changes:**
- Add `assert_statefulset_ready()` helper in `helpers.py` — mirrors `assert_deployment_ready()` with StatefulSet-specific rollout detection (`updateRevision != currentRevision`)
- Update `test_alloy_deployment_ready` → `test_alloy_statefulset_ready` using the new helper
- Remove unused `assert_deployment_ready` import from test file

## Test plan

- [x] `just smoke arc-staging` — 210 passed, 1 unrelated logging failure
- [x] `test_alloy_statefulset_ready` passes