### PR TITLE
Fix harbor-cache-recovery DeadlineExceeded under cluster load

### DIFF
--- a/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
+++ b/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
@@ -14,8 +14,6 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      # Headroom over the script's internal PURGE_BUDGET_SECONDS so it can
-      # exit cleanly (logs final tally) before K8s SIGTERMs the pod.
       activeDeadlineSeconds: 300
       template:
         metadata:

--- a/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
+++ b/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
@@ -54,8 +54,6 @@ spec:
                   value: "MIN_POD_AGE_PLACEHOLDER"
                 - name: DRY_RUN
                   value: "DRY_RUN_PLACEHOLDER"
-                - name: PURGE_BUDGET_SECONDS
-                  value: "240"
               resources:
                 requests:
                   cpu: 50m

--- a/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
+++ b/osdc/modules/harbor-cache-recovery/kubernetes/cronjob.yaml
@@ -14,7 +14,9 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 120
+      # Headroom over the script's internal PURGE_BUDGET_SECONDS so it can
+      # exit cleanly (logs final tally) before K8s SIGTERMs the pod.
+      activeDeadlineSeconds: 300
       template:
         metadata:
           labels:
@@ -52,6 +54,8 @@ spec:
                   value: "MIN_POD_AGE_PLACEHOLDER"
                 - name: DRY_RUN
                   value: "DRY_RUN_PLACEHOLDER"
+                - name: PURGE_BUDGET_SECONDS
+                  value: "240"
               resources:
                 requests:
                   cpu: 50m

--- a/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
@@ -41,10 +41,6 @@ CACHE_CORRUPTION_INDICATORS = (
 DEFAULT_MIN_POD_AGE_SECONDS = 120
 DEFAULT_HARBOR_URL = "http://harbor.harbor-system.svc.cluster.local:80"
 HARBOR_REQUEST_TIMEOUT_SECONDS = 10
-# Wall-clock budget for the purge loop. Must stay comfortably below
-# activeDeadlineSeconds in cronjob.yaml so the script can log a final tally
-# before K8s SIGTERMs the pod.
-PURGE_BUDGET_SECONDS = 240
 
 
 def get_config() -> dict:
@@ -266,23 +262,15 @@ def main() -> int:
 
     purged = 0
     failed = 0
-    skipped = 0
     for info in unique_repos.values():
-        # Bail out before issuing a request that could blow the K8s
-        # activeDeadlineSeconds. Remaining repos will be picked up on the next
-        # */5 cron run.
-        if time.monotonic() - start >= PURGE_BUDGET_SECONDS:
-            skipped = len(unique_repos) - purged - failed
-            log.warning("Budget %ds exhausted; skipping %d remaining repos", PURGE_BUDGET_SECONDS, skipped)
-            break
         if purge_cached_repo(session, config["harbor_url"], info["harbor_project"], info["repo_path"]):
             purged += 1
         else:
             failed += 1
 
     elapsed = time.monotonic() - start
-    log.info("Done in %.1fs: %d purged, %d failed, %d skipped", elapsed, purged, failed, skipped)
-    return 1 if failed > 0 or skipped > 0 else 0
+    log.info("Done in %.1fs: %d purged, %d failed", elapsed, purged, failed)
+    return 1 if failed > 0 else 0
 
 
 if __name__ == "__main__":

--- a/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
@@ -40,8 +40,11 @@ CACHE_CORRUPTION_INDICATORS = (
 
 DEFAULT_MIN_POD_AGE_SECONDS = 120
 DEFAULT_HARBOR_URL = "http://harbor.harbor-system.svc.cluster.local:80"
-DEFAULT_PURGE_BUDGET_SECONDS = 240
 HARBOR_REQUEST_TIMEOUT_SECONDS = 10
+# Wall-clock budget for the purge loop. Must stay comfortably below
+# activeDeadlineSeconds in cronjob.yaml so the script can log a final tally
+# before K8s SIGTERMs the pod.
+PURGE_BUDGET_SECONDS = 240
 
 
 def get_config() -> dict:
@@ -50,7 +53,6 @@ def get_config() -> dict:
         "harbor_password": os.environ.get("HARBOR_ADMIN_PASSWORD", ""),
         "min_pod_age_seconds": int(os.environ.get("MIN_POD_AGE_SECONDS", str(DEFAULT_MIN_POD_AGE_SECONDS))),
         "dry_run": os.environ.get("DRY_RUN", "false").lower() in ("true", "1", "yes"),
-        "purge_budget_seconds": int(os.environ.get("PURGE_BUDGET_SECONDS", str(DEFAULT_PURGE_BUDGET_SECONDS))),
     }
 
 
@@ -223,10 +225,9 @@ def main() -> int:
         return 1
 
     log.info(
-        "Starting: dry_run=%s min_age=%ds budget=%ds",
+        "Starting: dry_run=%s min_age=%ds",
         config["dry_run"],
         config["min_pod_age_seconds"],
-        config["purge_budget_seconds"],
     )
 
     kube = Client()
@@ -266,14 +267,13 @@ def main() -> int:
     purged = 0
     failed = 0
     skipped = 0
-    budget = config["purge_budget_seconds"]
     for info in unique_repos.values():
         # Bail out before issuing a request that could blow the K8s
         # activeDeadlineSeconds. Remaining repos will be picked up on the next
         # */5 cron run.
-        if time.monotonic() - start >= budget:
+        if time.monotonic() - start >= PURGE_BUDGET_SECONDS:
             skipped = len(unique_repos) - purged - failed
-            log.warning("Budget %ds exhausted; skipping %d remaining repos", budget, skipped)
+            log.warning("Budget %ds exhausted; skipping %d remaining repos", PURGE_BUDGET_SECONDS, skipped)
             break
         if purge_cached_repo(session, config["harbor_url"], info["harbor_project"], info["repo_path"]):
             purged += 1

--- a/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py
@@ -40,6 +40,8 @@ CACHE_CORRUPTION_INDICATORS = (
 
 DEFAULT_MIN_POD_AGE_SECONDS = 120
 DEFAULT_HARBOR_URL = "http://harbor.harbor-system.svc.cluster.local:80"
+DEFAULT_PURGE_BUDGET_SECONDS = 240
+HARBOR_REQUEST_TIMEOUT_SECONDS = 10
 
 
 def get_config() -> dict:
@@ -48,6 +50,7 @@ def get_config() -> dict:
         "harbor_password": os.environ.get("HARBOR_ADMIN_PASSWORD", ""),
         "min_pod_age_seconds": int(os.environ.get("MIN_POD_AGE_SECONDS", str(DEFAULT_MIN_POD_AGE_SECONDS))),
         "dry_run": os.environ.get("DRY_RUN", "false").lower() in ("true", "1", "yes"),
+        "purge_budget_seconds": int(os.environ.get("PURGE_BUDGET_SECONDS", str(DEFAULT_PURGE_BUDGET_SECONDS))),
     }
 
 
@@ -169,7 +172,10 @@ def create_harbor_session(harbor_url: str, admin_password: str) -> requests.Sess
     session.cookies = _NoCookieJar()
     session.auth = ("admin", admin_password)
     session.headers.update({"Content-Type": "application/json", "Accept": "application/json"})
-    retry = Retry(total=3, backoff_factor=1, status_forcelist=[502, 503, 504])
+    # total=1: a single retry only. Corrupted entries that don't purge this run
+    # get another shot in 5 minutes — better than burning the deadline on one
+    # slow repo and leaving the rest of the queue untouched.
+    retry = Retry(total=1, backoff_factor=1, status_forcelist=[502, 503, 504])
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
@@ -177,7 +183,7 @@ def create_harbor_session(harbor_url: str, admin_password: str) -> requests.Sess
 
 
 def fetch_csrf_token(session: requests.Session, harbor_url: str) -> None:
-    resp = session.get(f"{harbor_url}/api/v2.0/systeminfo", timeout=10)
+    resp = session.get(f"{harbor_url}/api/v2.0/systeminfo", timeout=HARBOR_REQUEST_TIMEOUT_SECONDS)
     resp.raise_for_status()
     csrf_token = resp.headers.get("X-Harbor-CSRF-Token")
     if csrf_token:
@@ -190,7 +196,7 @@ def purge_cached_repo(session: requests.Session, harbor_url: str, project: str, 
     encoded_path = repo_path.replace("/", "%252F")
     url = f"{harbor_url}/api/v2.0/projects/{project}/repositories/{encoded_path}"
     try:
-        resp = session.delete(url, timeout=30)
+        resp = session.delete(url, timeout=HARBOR_REQUEST_TIMEOUT_SECONDS)
         if resp.status_code == 200:
             log.info("Purged: %s/%s", project, repo_path)
             return True
@@ -217,9 +223,10 @@ def main() -> int:
         return 1
 
     log.info(
-        "Starting: dry_run=%s min_age=%ds",
+        "Starting: dry_run=%s min_age=%ds budget=%ds",
         config["dry_run"],
         config["min_pod_age_seconds"],
+        config["purge_budget_seconds"],
     )
 
     kube = Client()
@@ -258,15 +265,24 @@ def main() -> int:
 
     purged = 0
     failed = 0
+    skipped = 0
+    budget = config["purge_budget_seconds"]
     for info in unique_repos.values():
+        # Bail out before issuing a request that could blow the K8s
+        # activeDeadlineSeconds. Remaining repos will be picked up on the next
+        # */5 cron run.
+        if time.monotonic() - start >= budget:
+            skipped = len(unique_repos) - purged - failed
+            log.warning("Budget %ds exhausted; skipping %d remaining repos", budget, skipped)
+            break
         if purge_cached_repo(session, config["harbor_url"], info["harbor_project"], info["repo_path"]):
             purged += 1
         else:
             failed += 1
 
     elapsed = time.monotonic() - start
-    log.info("Done in %.1fs: %d purged, %d failed", elapsed, purged, failed)
-    return 1 if failed > 0 else 0
+    log.info("Done in %.1fs: %d purged, %d failed, %d skipped", elapsed, purged, failed, skipped)
+    return 1 if failed > 0 or skipped > 0 else 0
 
 
 if __name__ == "__main__":

--- a/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
@@ -354,6 +354,7 @@ class TestGetConfig:
         assert config["harbor_password"] == ""
         assert config["min_pod_age_seconds"] == 120
         assert config["dry_run"] is False
+        assert config["purge_budget_seconds"] == 240
 
     def test_custom_values(self):
         env = {
@@ -361,6 +362,7 @@ class TestGetConfig:
             "HARBOR_ADMIN_PASSWORD": "pw",
             "MIN_POD_AGE_SECONDS": "60",
             "DRY_RUN": "true",
+            "PURGE_BUDGET_SECONDS": "30",
         }
         with patch.dict("os.environ", env, clear=True):
             config = get_config()
@@ -368,6 +370,7 @@ class TestGetConfig:
         assert config["harbor_password"] == "pw"  # noqa: S105
         assert config["min_pod_age_seconds"] == 60
         assert config["dry_run"] is True
+        assert config["purge_budget_seconds"] == 30
 
     @pytest.mark.parametrize("value", ["true", "True", "1", "yes"])
     def test_dry_run_truthy(self, value):
@@ -501,6 +504,30 @@ class TestMain:
         ):
             mock_cls.return_value.list.side_effect = Exception("API error")
             assert main() == 1
+
+    def test_budget_exhausted_skips_remaining(self):
+        # Two distinct corrupted repos. Budget=0 means we never even attempt
+        # the first purge; both are reported as skipped and main() returns 1.
+        images = [
+            ("grafana/alloy:v1.14.0", "failed size validation: 1 != 2"),
+            ("ghcr.io/actions/runner:v3", "failed precondition"),
+        ]
+        pods = []
+        for img, msg in images:
+            cs = _make_container_status(image=img, reason="ImagePullBackOff", message=msg)
+            pods.append(_make_pod(name=f"pod-{img}", container_statuses=[cs]))
+        session = MagicMock()
+        session.get.return_value = MagicMock(headers={})
+        session.headers = {}
+        env = {"HARBOR_ADMIN_PASSWORD": "pw", "PURGE_BUDGET_SECONDS": "0"}
+        with (
+            patch("harbor_cache_recovery.Client") as mock_cls,
+            patch("harbor_cache_recovery.create_harbor_session", return_value=session),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            mock_cls.return_value.list.return_value = pods
+            assert main() == 1
+            session.delete.assert_not_called()
 
 
 # ============================================================================

--- a/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
@@ -502,31 +502,6 @@ class TestMain:
             mock_cls.return_value.list.side_effect = Exception("API error")
             assert main() == 1
 
-    def test_budget_exhausted_skips_remaining(self):
-        # Two distinct corrupted repos. With budget patched to 0 we never even
-        # attempt the first purge; both are reported as skipped and main()
-        # returns 1.
-        images = [
-            ("grafana/alloy:v1.14.0", "failed size validation: 1 != 2"),
-            ("ghcr.io/actions/runner:v3", "failed precondition"),
-        ]
-        pods = []
-        for img, msg in images:
-            cs = _make_container_status(image=img, reason="ImagePullBackOff", message=msg)
-            pods.append(_make_pod(name=f"pod-{img}", container_statuses=[cs]))
-        session = MagicMock()
-        session.get.return_value = MagicMock(headers={})
-        session.headers = {}
-        with (
-            patch("harbor_cache_recovery.Client") as mock_cls,
-            patch("harbor_cache_recovery.create_harbor_session", return_value=session),
-            patch("harbor_cache_recovery.PURGE_BUDGET_SECONDS", 0),
-            patch.dict("os.environ", {"HARBOR_ADMIN_PASSWORD": "pw"}, clear=True),
-        ):
-            mock_cls.return_value.list.return_value = pods
-            assert main() == 1
-            session.delete.assert_not_called()
-
 
 # ============================================================================
 # Constants

--- a/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
+++ b/osdc/modules/harbor-cache-recovery/scripts/python/test_harbor_cache_recovery.py
@@ -354,7 +354,6 @@ class TestGetConfig:
         assert config["harbor_password"] == ""
         assert config["min_pod_age_seconds"] == 120
         assert config["dry_run"] is False
-        assert config["purge_budget_seconds"] == 240
 
     def test_custom_values(self):
         env = {
@@ -362,7 +361,6 @@ class TestGetConfig:
             "HARBOR_ADMIN_PASSWORD": "pw",
             "MIN_POD_AGE_SECONDS": "60",
             "DRY_RUN": "true",
-            "PURGE_BUDGET_SECONDS": "30",
         }
         with patch.dict("os.environ", env, clear=True):
             config = get_config()
@@ -370,7 +368,6 @@ class TestGetConfig:
         assert config["harbor_password"] == "pw"  # noqa: S105
         assert config["min_pod_age_seconds"] == 60
         assert config["dry_run"] is True
-        assert config["purge_budget_seconds"] == 30
 
     @pytest.mark.parametrize("value", ["true", "True", "1", "yes"])
     def test_dry_run_truthy(self, value):
@@ -506,8 +503,9 @@ class TestMain:
             assert main() == 1
 
     def test_budget_exhausted_skips_remaining(self):
-        # Two distinct corrupted repos. Budget=0 means we never even attempt
-        # the first purge; both are reported as skipped and main() returns 1.
+        # Two distinct corrupted repos. With budget patched to 0 we never even
+        # attempt the first purge; both are reported as skipped and main()
+        # returns 1.
         images = [
             ("grafana/alloy:v1.14.0", "failed size validation: 1 != 2"),
             ("ghcr.io/actions/runner:v3", "failed precondition"),
@@ -519,11 +517,11 @@ class TestMain:
         session = MagicMock()
         session.get.return_value = MagicMock(headers={})
         session.headers = {}
-        env = {"HARBOR_ADMIN_PASSWORD": "pw", "PURGE_BUDGET_SECONDS": "0"}
         with (
             patch("harbor_cache_recovery.Client") as mock_cls,
             patch("harbor_cache_recovery.create_harbor_session", return_value=session),
-            patch.dict("os.environ", env, clear=True),
+            patch("harbor_cache_recovery.PURGE_BUDGET_SECONDS", 0),
+            patch.dict("os.environ", {"HARBOR_ADMIN_PASSWORD": "pw"}, clear=True),
         ):
             mock_cls.return_value.list.return_value = pods
             assert main() == 1


### PR DESCRIPTION
**Impact:** All clusters running the harbor-cache-recovery CronJob
**Risk:** low

## What

Three small changes to the harbor-cache-recovery module so the CronJob
stops timing out during job bursts:

- Bump `activeDeadlineSeconds` 120 → 300s
- Drop Harbor session retries from `Retry(total=3)` → `Retry(total=1)`
- Drop per-request `timeout` 30s → 10s (now `HARBOR_REQUEST_TIMEOUT_SECONDS`)

## Why

Production hit `DeadlineExceeded` on 2026-04-29 21:40 UTC. Pod-creation
metrics show a ~800-pod burst landed in the cluster 5–10 minutes before
that cron tick — when the recovery script started, it had to enumerate a
much larger pod set than usual, and Harbor itself was likely under the
same pressure.

The 120s deadline left no slack for either of those, and on top of that a
single unhealthy Harbor purge could singlehandedly blow the budget:
`Retry(total=3, backoff_factor=1)` at `timeout=30s` is up to ~30s × 3 +
1+2+4s backoff ≈ 100s on one repo, before we even touch the rest of the
queue.

## How

- `activeDeadlineSeconds: 300` gives the script room to enumerate a busy
  cluster + work through a backlog of corrupted entries.
- `Retry(total=1)` caps the worst-case time any one repo can consume.
  If a repo doesn't purge this run, it gets another shot in 5 minutes
  via the next */5 cron tick — better than burning the whole deadline on
  one slow repo and leaving the rest of the queue untouched.
- `timeout=10s` further bounds per-request cost so the worst case per
  repo is ~20s.

No new env vars, no in-script wall-clock budget — `activeDeadlineSeconds`
is the only deadline, and the existing `HarborCacheRecoveryFailing`
alert (added in #505) catches it when the deadline is hit.

## Changes

- **`modules/harbor-cache-recovery/kubernetes/cronjob.yaml`**:
  `activeDeadlineSeconds: 120` → `300`
- **`modules/harbor-cache-recovery/scripts/python/harbor_cache_recovery.py`**:
  `Retry(total=3)` → `Retry(total=1)` with explanatory comment;
  `timeout=30` → `timeout=10` via new `HARBOR_REQUEST_TIMEOUT_SECONDS`
  module constant

## Testing

- Existing unit test suite (65 tests) passes unchanged
- No new test cases needed — the change is configuration-level (timeout
  values, retry counts, deadline). Behavior is exercised in integration
  by the */5 cron schedule and surfaced by the existing
  `HarborCacheRecoveryFailing` / `HarborCacheRecoveryStale` alerts.

## Notes

- Follow-up to #504, which fixed the underlying S3-lifecycle corruption
  driving the cache-purge workload, and to #505, which added monitoring
  so this kind of degradation surfaces on the oncall dashboard instead
  of via downstream CI failures.
- If `DeadlineExceeded` recurs at 300s, the next levers are reducing the
  scope of `client.list(Pod, namespace="*")` (e.g. label-selector for
  pods in `Waiting`) or running the purge loop concurrently.
