### PR TITLE
Increase Alloy memory limits to fix prod OOMKill

### DIFF
--- a/osdc/modules/monitoring/helm/alloy-values.yaml
+++ b/osdc/modules/monitoring/helm/alloy-values.yaml
@@ -21,13 +21,15 @@ controller:
       effect: NoSchedule
 
 alloy:
+  clustering:
+    enabled: true
   resources:
     requests:
       cpu: 250m
-      memory: 512Mi
+      memory: 1536Mi
     limits:
       cpu: "2"
-      memory: 1Gi
+      memory: 2560Mi
   configMap:
     content: |-
       // Discover and scrape all ServiceMonitor targets across namespaces.


### PR DESCRIPTION
## Summary

Prod Alloy pods are OOMKilled at 1Gi memory limit. Increase to 2.5Gi.

- requests: 512Mi → 1.5Gi
- limits: 1Gi → 2.5Gi

Prod has significantly more scrape targets than staging, causing higher memory usage.

solved duplicate replica issue：
 clustering:
    enabled: true
