### PR TITLE
Fall through pypi-cache /whl on upstream 5xx instead of failing

### DIFF
--- a/osdc/modules/pypi-cache/kubernetes/nginx.conf
+++ b/osdc/modules/pypi-cache/kubernetes/nginx.conf
@@ -382,8 +382,14 @@ http {
             proxy_cache_use_stale error timeout updating
                                   http_500 http_502 http_503;
 
+            # Convert transient upstream 5xx to 404 so uv/pip fall through
+            # to the default index instead of failing the whole CI job.
+            # proxy_cache_use_stale only helps when a cached entry exists;
+            # cold pods (one cache per replica, NVMe hostPath) hit upstream
+            # directly and any 5xx propagated to the client.
             proxy_intercept_errors on;
             error_page 403 =404 @pytorch_not_found;
+            error_page 500 502 503 504 =404 @pytorch_not_found;
 
             proxy_connect_timeout 5s;
             proxy_read_timeout 10s;


### PR DESCRIPTION
The /whl location proxies to download.pytorch.org and only intercepted 403 → 404. Transient 5xx from CloudFront/pytorch.org propagated to the client.

Single uv/pip clients are pinned to one pod via kube-proxy iptables hashing, so a single bad pod or a single transient upstream 5xx fails the whole CI step (uv's 3 internal retries reuse the same connection).

Convert 500/502/503/504 to 404 the same way 403 is handled so callers fall through to the default index rather than aborting.

Here is an example 503 from upstream https://github.com/pytorch/pytorch/actions/runs/25145496556/job/73706203960#step:9:137