### PR TITLE
Add max_burst_capacity to ARC runners

### DIFF
--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1232,21 +1232,33 @@ workload-test cluster *args:
 # ANALYSIS
 # ============================================================================
 
-# Analyze runner-to-node packing efficiency
-analyze-utilization *args:
+# Generate ARC runner manifests for a cluster (standalone — also runs as part of `deploy-module <cluster> arc-runners`)
+generate-runners cluster:
     @export OSDC_ROOT="{{ROOT}}"; \
     export OSDC_UPSTREAM="{{UPSTREAM}}"; \
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \
-    uv run {{SCRIPTS}}/python/analyze_node_utilization.py {{args}}
+    uv run {{UPSTREAM}}/modules/arc-runners/scripts/python/generate_runners.py {{cluster}}; \
+    if [ -d "{{UPSTREAM}}/modules/arc-runners-b200/defs" ]; then \
+        ARC_RUNNERS_DEFS_DIR="{{UPSTREAM}}/modules/arc-runners-b200/defs" \
+        ARC_RUNNERS_OUTPUT_DIR="{{UPSTREAM}}/modules/arc-runners-b200/generated" \
+        ARC_RUNNERS_MODULE_NAME="arc-runners-b200" \
+        uv run {{UPSTREAM}}/modules/arc-runners/scripts/python/generate_runners.py {{cluster}}; \
+    fi
+
+# Analyze runner-to-node packing efficiency
+analyze-utilization cluster *args: (generate-runners cluster)
+    @export OSDC_ROOT="{{ROOT}}"; \
+    export OSDC_UPSTREAM="{{UPSTREAM}}"; \
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \
+    uv run {{SCRIPTS}}/python/analyze_node_utilization.py --cluster {{cluster}} {{args}}
 
 # Monte Carlo cluster simulation for PyTorch CI load
-simulate-cluster *args:
+simulate-cluster cluster *args: (generate-runners cluster)
     @export OSDC_ROOT="{{ROOT}}"; \
     export OSDC_UPSTREAM="{{UPSTREAM}}"; \
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \
     uv run {{SCRIPTS}}/python/simulate_cluster_cli.py \
-        --upstream-dir "{{UPSTREAM}}" \
-        --consumer-root "{{ROOT}}" \
+        --cluster {{cluster}} \
         {{args}}
 
 # ============================================================================

--- a/osdc/scripts/python/analyze_node_utilization.py
+++ b/osdc/scripts/python/analyze_node_utilization.py
@@ -3,49 +3,57 @@
 # requires-python = ">=3.12"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-"""Analyze runner-to-node packing efficiency.
+"""Analyze runner-to-node packing efficiency for the split-pool topology.
 
-Groups runners by instance type, computes all valid combinations that fit
-on a node (after subtracting kubelet + DaemonSet + runner sidecar overhead),
-and reports suboptimal configurations where resources are wasted.
+Post-PROACTIVE_CAPACITY model (see PROACTIVE_CAPACITY.md):
+  * Runner pods (~750m / 512Mi each) live on a dedicated ``c7i-runner`` pool.
+  * Workflow pods (vcpu + memory + GPU + hooks overhead) live on per-runner-class
+    workflow pools (m8g, c7i, g5, p6-b200, etc., plus their ``-release`` variants).
+
+Pod sizes are read from the freshly-generated runner manifests on disk
+(the ``just analyze-utilization`` recipe regenerates them first).
 
 Usage:
-    uv run scripts/python/analyze_node_utilization.py [--threshold 90] [--show-daemonsets]
-
-Reads:
-    - modules/arc-runners/defs/*.yaml (+ consumer overrides)
-    - modules/nodepools/defs/*.yaml (+ consumer overrides)
+    uv run scripts/python/analyze_node_utilization.py --cluster <cluster_id> [--threshold 90]
 """
+
+from __future__ import annotations
 
 import argparse
 import os
 import sys
-from itertools import combinations_with_replacement
 from pathlib import Path
 
-import yaml
-from cli_colors import BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW
+from cli_colors import BOLD, GREEN, NC, RED, YELLOW
+from cluster_topology import ClusterTopology, RunnerEntry, resolve_cluster
 from daemonset_overhead import DaemonSetOverhead, discover_daemonsets
 from instance_specs import ENI_MAX_PODS, INSTANCE_SPECS
+from packing import (
+    compute_node_slack,
+    find_maximal_combos,
+    find_valid_combos,
+    print_combo,
+)
+from utilization_report import (
+    analyze_pool,
+    per_runner_pod_total,
+    per_workflow_pod_total,
+)
 
-# Runner pod sidecar (the ARC orchestrator container, not the $job container)
-RUNNER_SIDECAR_CPU_M = 750
-RUNNER_SIDECAR_MEM_MI = 512
-
-# ARC container-hooks overhead: injected containers added to the workflow
-# (job) pod by runner-container-hooks beyond the def's vcpu/memory.
-# Measured from Karpenter scheduling requests vs def values.
+# ARC container-hooks overhead: extra containers injected into the workflow
+# (job) pod by runner-container-hooks. Measured at runtime from Karpenter
+# scheduling requests vs the def's vcpu/memory; not present in any YAML and
+# not yet a tunable knob.
 HOOKS_OVERHEAD_CPU_M = 320
 HOOKS_OVERHEAD_MEM_MI = 522
 
 
 def kubelet_reserved(vcpu: int, memory_gib: int, max_pods: int) -> tuple[int, int]:
-    """Estimate EKS kubelet reserved resources (milliCPU, MiB).
+    """EKS kubelet reserved resources (milliCPU, MiB).
 
-    EKS formula (from awslabs/amazon-eks-ami nodeadm source):
-    - CPU: 60m first core, 10m next, 5m next 2, 2.5m/core after
-    - Memory: 255Mi + 11Mi * max_pods + ~100Mi eviction threshold
-      (max_pods is derived from ENI limits, NOT vCPU count)
+    Formula from awslabs/amazon-eks-ami nodeadm source:
+      CPU: 60m first core, 10m next, 5m next 2, 2.5m/core after.
+      Memory: 255Mi + 11Mi * max_pods + ~100Mi eviction threshold.
     """
     if vcpu <= 1:
         reserved_cpu = 60
@@ -55,20 +63,32 @@ def kubelet_reserved(vcpu: int, memory_gib: int, max_pods: int) -> tuple[int, in
         reserved_cpu = 80
     else:
         reserved_cpu = 80 + int((vcpu - 4) * 2.5)
-
     reserved_mem = 255 + 11 * max_pods + 100
     return reserved_cpu, reserved_mem
 
 
 def compute_daemonset_overhead(
     daemonsets: list[DaemonSetOverhead],
+    *,
     is_gpu: bool,
+    fleet_name: str | None = None,
 ) -> tuple[int, int]:
-    """Total DaemonSet overhead on a runner node (milliCPU, MiB)."""
+    """Sum CPU + memory of DaemonSets running on a node of (is_gpu, fleet_name).
+
+    Filtering rules:
+      - gpu_only DaemonSets are skipped when is_gpu=False.
+      - When fleet_name is provided: keep DaemonSets with fleet_selector=None
+        OR fleet_selector==fleet_name. DaemonSets pinned to a different fleet
+        are excluded.
+      - When fleet_name is None: include ALL DaemonSets (legacy semantics for
+        callers that don't know their pool yet).
+    """
     total_cpu = 0
     total_mem = 0
     for ds in daemonsets:
         if ds.gpu_only and not is_gpu:
+            continue
+        if fleet_name is not None and ds.fleet_selector is not None and ds.fleet_selector != fleet_name:
             continue
         total_cpu += ds.cpu_millicores
         total_mem += ds.memory_mib
@@ -76,7 +96,7 @@ def compute_daemonset_overhead(
 
 
 def parse_memory(value: str) -> int:
-    """Parse Kubernetes memory string to MiB."""
+    """Kubernetes memory string -> MiB. Plain numbers are bytes."""
     value = str(value)
     if value.endswith("Gi"):
         return int(float(value[:-2]) * 1024)
@@ -84,198 +104,7 @@ def parse_memory(value: str) -> int:
         return int(float(value[:-2]))
     if value.endswith("Ki"):
         return int(float(value[:-2]) / 1024)
-    # Plain number = bytes
     return int(int(value) / (1024 * 1024))
-
-
-def load_runner_defs(dirs: list[Path]) -> list[dict]:
-    """Load all runner definitions from the given directories.
-
-    Directories are processed in order. If a runner name appears in
-    multiple directories, the last one wins (consumer overrides upstream).
-    Duplicate resolved paths are skipped.
-    """
-    by_name: dict[str, dict] = {}
-    seen_dirs: set[Path] = set()
-    for d in dirs:
-        resolved = d.resolve()
-        if resolved in seen_dirs or not d.exists():
-            continue
-        seen_dirs.add(resolved)
-        for f in sorted(d.glob("*.yaml")):
-            with open(f) as fh:
-                data = yaml.safe_load(fh)
-            if not data or "runner" not in data:
-                continue
-            r = data["runner"]
-            by_name[r["name"]] = {
-                "name": r["name"],
-                "instance_type": r["instance_type"],
-                "vcpu": int(r["vcpu"]),
-                "memory_mi": parse_memory(r["memory"]),
-                "gpu": int(r.get("gpu", 0)),
-                "file": f.name,
-            }
-    return list(by_name.values())
-
-
-def load_nodepool_defs(dirs: list[Path]) -> dict:
-    """Load nodepool defs and return a dict of instance_type -> def.
-
-    Duplicate resolved paths are skipped. Last-wins for same instance_type.
-    """
-    nodepools = {}
-    seen_dirs: set[Path] = set()
-    for d in dirs:
-        resolved = d.resolve()
-        if resolved in seen_dirs or not d.exists():
-            continue
-        seen_dirs.add(resolved)
-        for f in sorted(d.glob("*.yaml")):
-            with open(f) as fh:
-                data = yaml.safe_load(fh)
-            if not data or "nodepool" not in data:
-                continue
-            np = data["nodepool"]
-            nodepools[np["instance_type"]] = {
-                "name": np["name"],
-                "gpu": np.get("gpu", False),
-            }
-    return nodepools
-
-
-def compute_allocatable(
-    instance_type: str,
-    daemonsets: list[DaemonSetOverhead],
-) -> dict:
-    """Compute allocatable resources for an instance type after overhead."""
-    if instance_type not in INSTANCE_SPECS:
-        return None
-    spec = INSTANCE_SPECS[instance_type]
-    is_gpu = spec["gpu"] > 0
-
-    max_pods = ENI_MAX_PODS.get(instance_type, spec["vcpu"])  # fallback to vcpu if unknown
-    kube_cpu, kube_mem = kubelet_reserved(spec["vcpu"], spec["memory_gib"], max_pods)
-    ds_cpu, ds_mem = compute_daemonset_overhead(daemonsets, is_gpu)
-
-    total_cpu_m = spec["vcpu"] * 1000
-    total_mem_mi = spec["memory_mi"]
-
-    alloc_cpu_m = total_cpu_m - kube_cpu - ds_cpu
-    alloc_mem_mi = total_mem_mi - kube_mem - ds_mem
-
-    return {
-        "total_cpu_m": total_cpu_m,
-        "total_mem_mi": total_mem_mi,
-        "kube_reserved_cpu_m": kube_cpu,
-        "kube_reserved_mem_mi": kube_mem,
-        "ds_cpu_m": ds_cpu,
-        "ds_mem_mi": ds_mem,
-        "allocatable_cpu_m": alloc_cpu_m,
-        "allocatable_mem_mi": alloc_mem_mi,
-        "allocatable_gpu": spec["gpu"],
-        "is_gpu": is_gpu,
-    }
-
-
-def per_runner_total(runner: dict) -> tuple[int, int, int]:
-    """Total resources per runner pod (job container + sidecar + hooks overhead)."""
-    cpu = runner["vcpu"] * 1000 + RUNNER_SIDECAR_CPU_M + HOOKS_OVERHEAD_CPU_M
-    mem = runner["memory_mi"] + RUNNER_SIDECAR_MEM_MI + HOOKS_OVERHEAD_MEM_MI
-    gpu = runner["gpu"]
-    return cpu, mem, gpu
-
-
-def find_valid_combos(
-    runners: list[dict],
-    alloc: dict,
-    max_pods: int = 20,
-) -> list[dict]:
-    """Find all valid combinations of runner pods that fit on the node.
-
-    Uses combinations_with_replacement to find multi-pod packings.
-    Returns list of combo dicts with utilization info.
-    """
-    combos = []
-    avail_cpu = alloc["allocatable_cpu_m"]
-    avail_mem = alloc["allocatable_mem_mi"]
-    avail_gpu = alloc["allocatable_gpu"]
-
-    # Cap the max number of pods we'll consider per combo
-    # (a node with 96 vCPU and 2-vCPU runners = 48 pods max, but in practice
-    # the largest combos are what matter for waste analysis)
-    max_count = min(max_pods, max(1, avail_cpu // 1000))
-
-    for count in range(1, max_count + 1):
-        for combo in combinations_with_replacement(range(len(runners)), count):
-            total_cpu = 0
-            total_mem = 0
-            total_gpu = 0
-            for idx in combo:
-                c, m, g = per_runner_total(runners[idx])
-                total_cpu += c
-                total_mem += m
-                total_gpu += g
-
-            # Check if combo fits
-            if total_cpu > avail_cpu:
-                continue
-            if total_mem > avail_mem:
-                continue
-            if total_gpu > avail_gpu:
-                continue
-
-            cpu_util = total_cpu / avail_cpu * 100 if avail_cpu > 0 else 0
-            mem_util = total_mem / avail_mem * 100 if avail_mem > 0 else 0
-            gpu_util = total_gpu / avail_gpu * 100 if avail_gpu > 0 else 0
-
-            runner_names = [runners[i]["name"] for i in combo]
-            combos.append(
-                {
-                    "runners": runner_names,
-                    "count": count,
-                    "cpu_used_m": total_cpu,
-                    "mem_used_mi": total_mem,
-                    "gpu_used": total_gpu,
-                    "cpu_util": cpu_util,
-                    "mem_util": mem_util,
-                    "gpu_util": gpu_util,
-                    "cpu_waste_m": avail_cpu - total_cpu,
-                    "mem_waste_mi": avail_mem - total_mem,
-                    "gpu_waste": avail_gpu - total_gpu,
-                }
-            )
-
-    return combos
-
-
-def find_maximal_combos(combos: list[dict], alloc: dict, runners: list[dict]) -> list[dict]:
-    """Filter to maximal combos: those where no additional runner can fit.
-
-    These are the realistic packing scenarios — a node is full when you
-    can't add any more pods.
-    """
-    avail_cpu = alloc["allocatable_cpu_m"]
-    avail_mem = alloc["allocatable_mem_mi"]
-    avail_gpu = alloc["allocatable_gpu"]
-
-    maximal = []
-    for combo in combos:
-        # Check if any runner could still fit
-        can_add_more = False
-        for r in runners:
-            c, m, g = per_runner_total(r)
-            if (
-                combo["cpu_used_m"] + c <= avail_cpu
-                and combo["mem_used_mi"] + m <= avail_mem
-                and combo["gpu_used"] + g <= avail_gpu
-            ):
-                can_add_more = True
-                break
-        if not can_add_more:
-            maximal.append(combo)
-
-    return maximal
 
 
 def format_mem(mi: int) -> str:
@@ -285,367 +114,252 @@ def format_mem(mi: int) -> str:
     return f"{mi}Mi"
 
 
-def compute_node_slack(
-    alloc: dict,
-    runners: list[dict],
-    homogeneous_only: bool = False,
+def compute_allocatable(
+    instance_type: str,
+    daemonsets: list[DaemonSetOverhead],
+    *,
+    fleet_name: str | None = None,
 ) -> dict | None:
-    """Compute min/max unused CPU and memory across maximal combos.
+    """Allocatable resources for an instance after kubelet + DaemonSet overhead.
 
-    When homogeneous_only is True (or >8 runner types), only considers
-    single-runner-type packings. Otherwise enumerates all mixed combos.
-
-    Returns dict with min_cpu_m, max_cpu_m, min_mem_mi, max_mem_mi,
-    or None if no valid combos exist.
+    ``fleet_name`` is forwarded to ``compute_daemonset_overhead`` so DaemonSets
+    pinned to a different fleet are excluded.  When None, every DaemonSet is
+    included (matches the pre-pool-aware behavior).
     """
-    if homogeneous_only or len(runners) > 8:
-        slacks = []
-        for r in runners:
-            c, m, g = per_runner_total(r)
-            max_by_cpu = alloc["allocatable_cpu_m"] // c if c > 0 else 999
-            max_by_mem = alloc["allocatable_mem_mi"] // m if m > 0 else 999
-            max_by_gpu = alloc["allocatable_gpu"] // g if g > 0 else 999
-            max_pods = min(max_by_cpu, max_by_mem, max_by_gpu)
-            if max_pods == 0:
-                continue
-            slacks.append(
-                {
-                    "cpu_m": alloc["allocatable_cpu_m"] - max_pods * c,
-                    "mem_mi": alloc["allocatable_mem_mi"] - max_pods * m,
-                }
-            )
-        if not slacks:
-            return None
-        return {
-            "min_cpu_m": min(s["cpu_m"] for s in slacks),
-            "max_cpu_m": max(s["cpu_m"] for s in slacks),
-            "min_mem_mi": min(s["mem_mi"] for s in slacks),
-            "max_mem_mi": max(s["mem_mi"] for s in slacks),
-        }
-
-    all_combos = find_valid_combos(runners, alloc)
-    maximal = find_maximal_combos(all_combos, alloc, runners)
-    if not maximal:
+    if instance_type not in INSTANCE_SPECS:
         return None
+    spec = INSTANCE_SPECS[instance_type]
+    is_gpu = spec["gpu"] > 0
 
+    max_pods = ENI_MAX_PODS.get(instance_type, spec["vcpu"])
+    kube_cpu, kube_mem = kubelet_reserved(spec["vcpu"], spec["memory_gib"], max_pods)
+    ds_cpu, ds_mem = compute_daemonset_overhead(daemonsets, is_gpu=is_gpu, fleet_name=fleet_name)
+
+    total_cpu_m = spec["vcpu"] * 1000
+    total_mem_mi = spec["memory_mi"]
     return {
-        "min_cpu_m": min(c["cpu_waste_m"] for c in maximal),
-        "max_cpu_m": max(c["cpu_waste_m"] for c in maximal),
-        "min_mem_mi": min(c["mem_waste_mi"] for c in maximal),
-        "max_mem_mi": max(c["mem_waste_mi"] for c in maximal),
+        "total_cpu_m": total_cpu_m,
+        "total_mem_mi": total_mem_mi,
+        "kube_reserved_cpu_m": kube_cpu,
+        "kube_reserved_mem_mi": kube_mem,
+        "ds_cpu_m": ds_cpu,
+        "ds_mem_mi": ds_mem,
+        "allocatable_cpu_m": total_cpu_m - kube_cpu - ds_cpu,
+        "allocatable_mem_mi": total_mem_mi - kube_mem - ds_mem,
+        "allocatable_gpu": spec["gpu"],
+        "is_gpu": is_gpu,
     }
 
 
-def print_node_analysis(
-    instance_type: str,
-    alloc: dict,
-    runners: list[dict],
+# ---------------------------------------------------------------------------
+# Section printers — each uses analyze_pool() with its own pod_total_fn
+# ---------------------------------------------------------------------------
+
+
+def print_workflow_pool_section(
+    topology: ClusterTopology,
+    daemonsets: list[DaemonSetOverhead],
+    *,
     threshold: float,
-):
-    """Analyze and print utilization for one node type."""
+) -> tuple[int, dict[str, dict]]:
+    print(f"\n{BOLD}{'━' * 80}{NC}")
+    print(f"{BOLD}WORKFLOW POOL PACKING{NC}")
+    print(f"{BOLD}{'━' * 80}{NC}")
+
+    schedulable = [r for r in topology.runners if r.schedulable]
+    if not schedulable:
+        print("  (no schedulable runners)")
+        return 0, {}
+
+    below_total = 0
+    all_slacks: dict[str, dict] = {}
+    for fleet in sorted(topology.workflow_pool_fleets):
+        for runner_class in (None, "release"):
+            pool_runners = [r for r in schedulable if r.workflow_fleet == fleet and r.runner_class == runner_class]
+            if not pool_runners:
+                continue
+            pool_nodepools = [np for np in topology.nodepools if np.fleet == fleet and np.runner_class == runner_class]
+            label_suffix = "/release" if runner_class else ""
+            below, slacks = analyze_pool(
+                f"Workflow Pool [{fleet}{label_suffix}]",
+                fleet,
+                pool_nodepools,
+                pool_runners,
+                daemonsets,
+                threshold=threshold,
+                pod_total_fn=per_workflow_pod_total,
+                compute_allocatable_fn=compute_allocatable,
+            )
+            below_total += below
+            prefix = f"{fleet}{label_suffix}"
+            for k, v in slacks.items():
+                all_slacks[f"{prefix}/{k}"] = v
+    return below_total, all_slacks
+
+
+def print_runner_pool_section(
+    topology: ClusterTopology,
+    daemonsets: list[DaemonSetOverhead],
+    *,
+    threshold: float,
+) -> tuple[int, dict[str, dict]]:
+    print(f"\n{BOLD}{'━' * 80}{NC}")
+    print(f"{BOLD}RUNNER POOL PACKING{NC}")
+    print(f"{BOLD}{'━' * 80}{NC}")
+
+    if topology.runner_pool_fleet is None:
+        print(f"  {YELLOW}No c7i-runner pool found — runner pods cannot be analyzed{NC}")
+        return 0, {}
+    schedulable = [r for r in topology.runners if r.schedulable]
+    pool_nodepools = [np for np in topology.nodepools if np.fleet == topology.runner_pool_fleet]
+    return analyze_pool(
+        f"Runner Pool [{topology.runner_pool_fleet}]",
+        topology.runner_pool_fleet,
+        pool_nodepools,
+        schedulable,
+        daemonsets,
+        threshold=threshold,
+        pod_total_fn=per_runner_pod_total,
+        compute_allocatable_fn=compute_allocatable,
+    )
+
+
+def print_unschedulable_section(topology: ClusterTopology) -> None:
+    print(f"\n{BOLD}{'━' * 80}{NC}")
+    print(f"{BOLD}UNSCHEDULABLE RUNNERS{NC}")
+    print(f"{BOLD}{'━' * 80}{NC}")
+    unsched = [r for r in topology.runners if not r.schedulable]
+    if not unsched:
+        print(f"  {GREEN}(all runners are schedulable on the deployed pools){NC}")
+        return
+    for r in sorted(unsched, key=lambda x: x.name):
+        print(
+            f"  {RED}{r.name}{NC}  {r.instance_type}"
+            f"  workflow_fleet={r.workflow_fleet}"
+            f"  runner_class={r.runner_class}"
+            f"  reason={r.schedulable_reason}"
+        )
+
+
+def _print_summary(
+    workflow_below: int,
+    runner_below: int,
+    threshold: float,
+    workflow_slacks: dict[str, dict],
+    runner_slacks: dict[str, dict],
+) -> None:
+    total_below = workflow_below + runner_below
     print(f"\n{'━' * 80}")
-    print(f"{BOLD}{CYAN}Node Type: {instance_type}{NC}")
-    spec = INSTANCE_SPECS[instance_type]
-    print(
-        f"  Total: {spec['vcpu']} vCPU, {spec['memory_gib']}Gi advertised"
-        f" ({format_mem(spec['memory_mi'])} actual)" + (f", {spec['gpu']} GPU" if spec["gpu"] > 0 else "")
-    )
-    print(f"  Kubelet reserved: {alloc['kube_reserved_cpu_m']}m CPU, {format_mem(alloc['kube_reserved_mem_mi'])} RAM")
-    print(f"  DaemonSet overhead: {alloc['ds_cpu_m']}m CPU, {format_mem(alloc['ds_mem_mi'])} RAM")
-    print(
-        f"  {GREEN}Allocatable for runners: "
-        f"{alloc['allocatable_cpu_m']}m CPU ({alloc['allocatable_cpu_m'] / 1000:.1f} cores), "
-        f"{format_mem(alloc['allocatable_mem_mi'])} RAM"
-        + (f", {alloc['allocatable_gpu']} GPU" if alloc["allocatable_gpu"] > 0 else "")
-        + f"{NC}"
-    )
-    print()
-
-    # List runners targeting this node
-    print(f"  {BOLD}Runners targeting this node:{NC}")
-    for r in runners:
-        c, m, g = per_runner_total(r)
-        sidecar_note = (
-            f" (job: {r['vcpu']}c+{format_mem(r['memory_mi'])},"
-            f" sidecar: {RUNNER_SIDECAR_CPU_M}m+{RUNNER_SIDECAR_MEM_MI}Mi,"
-            f" hooks: {HOOKS_OVERHEAD_CPU_M}m+{HOOKS_OVERHEAD_MEM_MI}Mi)"
-        )
-        gpu_note = f", {r['gpu']} GPU" if r["gpu"] > 0 else ""
-        print(f"    - {r['name']}: {c}m CPU, {format_mem(m)} RAM{gpu_note}{sidecar_note}")
-
-    # Homogeneous packing: how many of each runner type fits alone?
-    print(f"\n  {BOLD}Homogeneous packing (single runner type fills the node):{NC}")
-    for r in runners:
-        c, m, g = per_runner_total(r)
-        max_by_cpu = alloc["allocatable_cpu_m"] // c if c > 0 else 999
-        max_by_mem = alloc["allocatable_mem_mi"] // m if m > 0 else 999
-        max_by_gpu = alloc["allocatable_gpu"] // g if g > 0 else 999
-        max_pods = min(max_by_cpu, max_by_mem, max_by_gpu)
-
-        used_cpu = max_pods * c
-        used_mem = max_pods * m
-        used_gpu = max_pods * g
-        cpu_pct = used_cpu / alloc["allocatable_cpu_m"] * 100
-        mem_pct = used_mem / alloc["allocatable_mem_mi"] * 100
-        gpu_pct = used_gpu / alloc["allocatable_gpu"] * 100 if alloc["allocatable_gpu"] > 0 else 100
-
-        bottleneck = (
-            "CPU"
-            if max_by_cpu <= max_by_mem and max_by_cpu <= max_by_gpu
-            else ("MEM" if max_by_mem <= max_by_gpu else "GPU")
-        )
-        waste_cpu = alloc["allocatable_cpu_m"] - used_cpu
-        waste_mem = alloc["allocatable_mem_mi"] - used_mem
-
-        color = (
-            GREEN
-            if min(cpu_pct, mem_pct) >= threshold
-            else (YELLOW if min(cpu_pct, mem_pct) >= threshold * 0.9 else RED)
-        )
-
-        print(f"    {color}{r['name']}{NC}: {max_pods} pods")
+    if total_below > 0:
         print(
-            f"      CPU: {cpu_pct:5.1f}% ({used_cpu}m / {alloc['allocatable_cpu_m']}m) "
-            f"waste: {waste_cpu}m ({waste_cpu / 1000:.1f} cores)"
+            f"{RED}{BOLD}Found {total_below} runner type(s) below {threshold}% utilization "
+            f"(workflow: {workflow_below}, runner pool: {runner_below}){NC}"
         )
-        print(
-            f"      MEM: {mem_pct:5.1f}% ({format_mem(used_mem)} / {format_mem(alloc['allocatable_mem_mi'])}) "
-            f"waste: {format_mem(waste_mem)}"
-        )
-        if alloc["allocatable_gpu"] > 0:
-            print(f"      GPU: {gpu_pct:5.1f}% ({used_gpu} / {alloc['allocatable_gpu']})")
-        print(f"      Bottleneck: {bottleneck}")
-
-    # Find maximal mixed combos (only if few enough runners to enumerate)
-    if len(runners) <= 8:
-        print(f"\n  {BOLD}Maximal mixed combos (node fully packed, no room for another pod):{NC}")
-        all_combos = find_valid_combos(runners, alloc)
-        maximal = find_maximal_combos(all_combos, alloc, runners)
-
-        if not maximal:
-            print(f"    {DIM}(no valid combos found){NC}")
-            return
-
-        # Sort by worst utilization (min of CPU%, MEM%) descending
-        maximal.sort(key=lambda c: min(c["cpu_util"], c["mem_util"]), reverse=True)
-
-        # Show top 5 best and worst 5
-        best = maximal[:5]
-        worst = maximal[-5:] if len(maximal) > 5 else []
-
-        print(f"    Total maximal combos: {len(maximal)}")
-        print()
-        print(f"    {GREEN}Top {len(best)} most efficient:{NC}")
-        for i, combo in enumerate(best):
-            _print_combo(combo, alloc, threshold, i + 1)
-
-        if worst:
-            seen = {tuple(sorted(b["runners"])) for b in best}
-            worst = [w for w in worst if tuple(sorted(w["runners"])) not in seen]
-            if worst:
-                print(f"\n    {RED}Bottom {len(worst)} least efficient (money on the table):{NC}")
-                for i, combo in enumerate(worst):
-                    _print_combo(combo, alloc, threshold, i + 1)
     else:
-        print(f"\n  {DIM}(too many runner types ({len(runners)}) to enumerate mixed combos){NC}")
+        print(f"{GREEN}{BOLD}All runner types achieve >= {threshold}% utilization{NC}")
+
+    combined: dict[str, dict] = {}
+    for k, v in workflow_slacks.items():
+        combined[f"workflow:{k}"] = v
+    for k, v in runner_slacks.items():
+        combined[f"runner:{k}"] = v
+    if not combined:
+        return
+    print(f"\n{BOLD}Unused resource headroom per node (homogeneous packing only):{NC}\n")
+    print(f"  {'Section/Node Type':<40} {'Min CPU':>10} {'Max CPU':>10} {'Min MEM':>10} {'Max MEM':>10}")
+    print(f"  {'─' * 84}")
+    for key in sorted(combined):
+        s = combined[key]
+        print(
+            f"  {key:<40} {s['min_cpu_m']:>7}m   {s['max_cpu_m']:>7}m  "
+            f" {format_mem(s['min_mem_mi']):>8}   {format_mem(s['max_mem_mi']):>8}"
+        )
 
 
-def _print_combo(combo: dict, alloc: dict, threshold: float, rank: int):
-    """Print a single combo's utilization."""
-    from collections import Counter
-
-    counts = Counter(combo["runners"])
-    desc = ", ".join(f"{n}x{name}" for name, n in sorted(counts.items()))
-    min_util = min(combo["cpu_util"], combo["mem_util"])
-    color = GREEN if min_util >= threshold else (YELLOW if min_util >= threshold * 0.9 else RED)
-    print(f"      {color}#{rank}{NC} [{desc}]")
-    print(
-        f"         CPU: {combo['cpu_util']:5.1f}%  "
-        f"MEM: {combo['mem_util']:5.1f}%"
-        + (f"  GPU: {combo['gpu_util']:5.1f}%" if alloc["allocatable_gpu"] > 0 else "")
-        + f"  waste: {combo['cpu_waste_m'] / 1000:.1f}c + {format_mem(combo['mem_waste_mi'])}"
-    )
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Analyze runner-to-node packing efficiency",
-    )
+def _walk_up_for_osdc() -> Path:
+    """Walk up from this file to find the upstream osdc/ root."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _resolve_roots() -> tuple[Path, Path]:
+    """Resolve (upstream_root, consumer_root) from env vars or by walking up."""
+    upstream = Path(os.environ.get("OSDC_UPSTREAM") or _walk_up_for_osdc()).resolve()
+    consumer_env = os.environ.get("OSDC_ROOT")
+    if consumer_env and Path(consumer_env).is_dir():
+        consumer = Path(consumer_env).resolve()
+    else:
+        candidate = upstream.parent.parent
+        consumer = candidate if (candidate / "clusters.yaml").exists() else upstream
+    return upstream, consumer.resolve()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze runner-to-node packing efficiency (split-pool topology)")
+    parser.add_argument("--cluster", required=True, help="Cluster id from clusters.yaml")
     parser.add_argument(
         "--threshold",
         type=float,
         default=90.0,
         help="Utilization threshold %% below which combos are flagged (default: 90)",
     )
-    parser.add_argument(
-        "--show-daemonsets",
-        action="store_true",
-        help="Print discovered DaemonSets and their resource overhead, then exit",
-    )
-    args = parser.parse_args(argv)
+    return parser.parse_args(argv)
 
-    # Resolve directories
-    script_dir = Path(__file__).resolve().parent
-    upstream_dir = script_dir.parent.parent  # upstream/osdc
-    # Check if we're in a consumer repo
-    osdc_root_env = os.environ.get("OSDC_ROOT", "")
-    consumer_root = Path(osdc_root_env).resolve() if osdc_root_env else None
-    if consumer_root is None or not consumer_root.is_dir():
-        # Try to find consumer root by walking up
-        candidate = upstream_dir.parent.parent  # consumer osdc/
-        consumer_root = candidate if (candidate / "clusters.yaml").exists() else upstream_dir
-    consumer_root = consumer_root.resolve()
 
-    # Discover DaemonSet overhead dynamically from manifests
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    upstream_root, consumer_root = _resolve_roots()
+
     daemonsets = discover_daemonsets(
-        upstream_dir,
-        consumer_root=consumer_root if consumer_root != upstream_dir else None,
+        upstream_root,
+        consumer_root=consumer_root if consumer_root != upstream_root else None,
     )
+    topology = resolve_cluster(args.cluster, upstream_root=upstream_root, consumer_root=consumer_root)
 
-    if args.show_daemonsets:
-        print(f"{BOLD}Discovered DaemonSets ({len(daemonsets)}):{NC}\n")
-        for ds in daemonsets:
-            gpu_tag = f" {YELLOW}[GPU-only]{NC}" if ds.gpu_only else ""
-            print(f"  {ds.name}: {ds.cpu_millicores}m CPU, {ds.memory_mib}Mi RAM{gpu_tag}")
-            print(f"    {DIM}source: {ds.source}{NC}")
-        return 0
-
-    # Collect runner defs from upstream + consumer
-    runner_dirs = [
-        upstream_dir / "modules" / "arc-runners" / "defs",
-    ]
-    # Add consumer runner def dirs
-    if consumer_root != upstream_dir:
-        consumer_modules = consumer_root / "modules"
-        if consumer_modules.exists():
-            for mod_dir in sorted(consumer_modules.iterdir()):
-                defs = mod_dir / "defs"
-                if defs.exists() and any(defs.glob("*.yaml")):
-                    # Check if any def has runner key
-                    for f in defs.glob("*.yaml"):
-                        with open(f) as fh:
-                            d = yaml.safe_load(fh)
-                        if d and "runner" in d:
-                            runner_dirs.append(defs)
-                            break
-
-    # Collect nodepool defs
-    nodepool_dirs = [
-        upstream_dir / "modules" / "nodepools" / "defs",
-    ]
-    if consumer_root != upstream_dir:
-        consumer_modules = consumer_root / "modules"
-        if consumer_modules.exists():
-            for mod_dir in sorted(consumer_modules.iterdir()):
-                defs = mod_dir / "defs"
-                if defs.exists() and any(defs.glob("*.yaml")):
-                    for f in defs.glob("*.yaml"):
-                        with open(f) as fh:
-                            d = yaml.safe_load(fh)
-                        if d and "nodepool" in d:
-                            nodepool_dirs.append(defs)
-                            break
-
-    print(f"{BOLD}Node Utilization Analysis{NC}")
+    print(f"{BOLD}Node Utilization Analysis — cluster '{args.cluster}'{NC}")
     print(f"{'━' * 80}")
-    print(f"Runner def dirs: {', '.join(str(d) for d in runner_dirs)}")
-    print(f"NodePool def dirs: {', '.join(str(d) for d in nodepool_dirs)}")
-    print(f"Utilization threshold: {args.threshold}%")
+    print(f"Region: {topology.region}")
+    print(f"Modules: {', '.join(topology.modules)}")
+    print(f"Workflow fleets: {', '.join(sorted(topology.workflow_pool_fleets)) or '(none)'}")
+    print(f"Runner pool: {topology.runner_pool_fleet or '(none)'}")
+    print(f"Runners: {len(topology.runners)} ({sum(1 for r in topology.runners if r.schedulable)} schedulable)")
+    print(f"DaemonSets: {len(daemonsets)}")
+    print(f"Threshold: {args.threshold}%")
 
-    runners = load_runner_defs(runner_dirs)
-    _nodepools = load_nodepool_defs(nodepool_dirs)  # loaded for future use
-
-    if not runners:
-        print(f"{RED}No runner definitions found{NC}")
-        return 1
-
-    # Group runners by instance type
-    by_instance: dict[str, list[dict]] = {}
-    for r in runners:
-        by_instance.setdefault(r["instance_type"], []).append(r)
-
-    # Warn about unknown instance types
-    unknown = [it for it in by_instance if it not in INSTANCE_SPECS]
-    if unknown:
-        print(f"\n{RED}Unknown instance types (add to INSTANCE_SPECS): {unknown}{NC}")
-
-    # Analyze each instance type and collect slack data
-    total_issues = 0
-    node_slacks: dict[str, dict] = {}
-    for instance_type in sorted(by_instance.keys()):
-        if instance_type not in INSTANCE_SPECS:
-            continue
-        alloc = compute_allocatable(instance_type, daemonsets)
-        type_runners = by_instance[instance_type]
-        print_node_analysis(instance_type, alloc, type_runners, args.threshold)
-
-        # Compute slack for summary (homogeneous only — excludes mixed combos)
-        slack = compute_node_slack(alloc, type_runners, homogeneous_only=True)
-        if slack:
-            node_slacks[instance_type] = slack
-
-        # Count suboptimal homogeneous packings
-        for r in type_runners:
-            c, m, g = per_runner_total(r)
-            max_by_cpu = alloc["allocatable_cpu_m"] // c if c > 0 else 999
-            max_by_mem = alloc["allocatable_mem_mi"] // m if m > 0 else 999
-            max_by_gpu = alloc["allocatable_gpu"] // g if g > 0 else 999
-            max_pods = min(max_by_cpu, max_by_mem, max_by_gpu)
-            used_cpu = max_pods * c
-            used_mem = max_pods * m
-            cpu_pct = used_cpu / alloc["allocatable_cpu_m"] * 100
-            mem_pct = used_mem / alloc["allocatable_mem_mi"] * 100
-            if min(cpu_pct, mem_pct) < args.threshold:
-                total_issues += 1
-
-    print(f"\n{'━' * 80}")
-    if total_issues > 0:
-        print(
-            f"{RED}{BOLD}Found {total_issues} runner type(s) with homogeneous utilization below {args.threshold}%{NC}"
-        )
-    else:
-        print(f"{GREEN}{BOLD}All runner types achieve >= {args.threshold}% utilization in homogeneous packing{NC}")
-
-    # --- Slack / headroom summary ---
-    if node_slacks:
-        print(f"\n{'━' * 80}")
-        print(f"{BOLD}Unused resource headroom per node (homogeneous packing only):{NC}\n")
-        print(f"  {'Node Type':<22} {'Min CPU':>10} {'Max CPU':>10} {'Min MEM':>10} {'Max MEM':>10}")
-        print(f"  {'─' * 64}")
-
-        global_min_cpu = None
-        global_max_cpu = None
-        global_min_mem = None
-        global_max_mem = None
-
-        for inst in sorted(node_slacks.keys()):
-            s = node_slacks[inst]
-            print(
-                f"  {inst:<22} {s['min_cpu_m']:>7}m   {s['max_cpu_m']:>7}m  "
-                f" {format_mem(s['min_mem_mi']):>8}   {format_mem(s['max_mem_mi']):>8}"
-            )
-            if global_min_cpu is None or s["min_cpu_m"] < global_min_cpu:
-                global_min_cpu = s["min_cpu_m"]
-            if global_max_cpu is None or s["max_cpu_m"] > global_max_cpu:
-                global_max_cpu = s["max_cpu_m"]
-            if global_min_mem is None or s["min_mem_mi"] < global_min_mem:
-                global_min_mem = s["min_mem_mi"]
-            if global_max_mem is None or s["max_mem_mi"] > global_max_mem:
-                global_max_mem = s["max_mem_mi"]
-
-        print(f"  {'─' * 64}")
-        print(
-            f"  {BOLD}{'WORST CASE':<22}{NC} {global_min_cpu:>7}m   {global_max_cpu:>7}m  "
-            f" {format_mem(global_min_mem):>8}   {format_mem(global_max_mem):>8}"
-        )
-        print()
-        print(
-            f"  The tightest node has only {BOLD}{global_min_cpu}m CPU{NC}"
-            f" and {BOLD}{format_mem(global_min_mem)} RAM{NC} free."
-        )
-        print("  Any new DaemonSet must fit within these limits or runners will fail to schedule.")
-
+    workflow_below, workflow_slacks = print_workflow_pool_section(topology, daemonsets, threshold=args.threshold)
+    runner_below, runner_slacks = print_runner_pool_section(topology, daemonsets, threshold=args.threshold)
+    print_unschedulable_section(topology)
+    _print_summary(workflow_below, runner_below, args.threshold, workflow_slacks, runner_slacks)
     return 0
+
+
+# Re-export combo helpers + RunnerEntry so the simulator and tests have a
+# stable import surface.
+__all__ = [
+    "HOOKS_OVERHEAD_CPU_M",
+    "HOOKS_OVERHEAD_MEM_MI",
+    "RunnerEntry",
+    "compute_allocatable",
+    "compute_daemonset_overhead",
+    "compute_node_slack",
+    "find_maximal_combos",
+    "find_valid_combos",
+    "format_mem",
+    "kubelet_reserved",
+    "main",
+    "parse_args",
+    "parse_memory",
+    "per_runner_pod_total",
+    "per_workflow_pod_total",
+    "print_combo",
+    "print_runner_pool_section",
+    "print_unschedulable_section",
+    "print_workflow_pool_section",
+]
 
 
 if __name__ == "__main__":

--- a/osdc/scripts/python/cluster_topology.py
+++ b/osdc/scripts/python/cluster_topology.py
@@ -1,0 +1,397 @@
+"""Resolve cluster topology — fleets, nodepools, and runners — for a given cluster.
+
+Answers "for cluster X, which fleets/nodepools are deployed, and which runners are
+schedulable here?" Consumed by analyze_node_utilization.py and simulate_cluster.py.
+
+Inputs (disk only, no live cluster access):
+  1. <consumer_root>/clusters.yaml — cluster -> modules + per-cluster overrides.
+  2. <upstream_root>/modules/nodepools[-b200]/defs/*.yaml — fleet/fleets/legacy
+     nodepool schemas. Honors ``exclude_regions:`` like generate_nodepools.py.
+  3. <upstream_root>/modules/arc-runners[-b200]/generated/*.yaml — we READ the
+     generator's output rather than re-rendering templates.
+
+IMPORTANT: caller MUST run ``generate-runners`` first if generated/ may be stale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class NodePoolEntry:
+    """Deployed Karpenter NodePool. runner_class='release' when from a release sub-fleet."""
+
+    name: str
+    fleet: str
+    instance_type: str
+    arch: str  # "amd64" | "arm64"
+    gpu: bool
+    runner_class: str | None
+
+
+@dataclass
+class RunnerEntry:
+    """Runner scale-set from a generated manifest. schedulable_reason explains False."""
+
+    name: str
+    scale_set_name: str
+    instance_type: str
+    workflow_fleet: str
+    runner_class: str | None
+    runner_pod_cpu_m: int
+    runner_pod_mem_mi: int
+    workflow_pod_cpu_m: int
+    workflow_pod_mem_mi: int
+    workflow_pod_gpu: int
+    schedulable: bool
+    schedulable_reason: str | None
+
+
+@dataclass
+class ClusterTopology:
+    """Full topology — runner_pool_fleet is 'c7i-runner' when present, else None (warns)."""
+
+    cluster_id: str
+    region: str
+    modules: list[str]
+    nodepools: list[NodePoolEntry]
+    runner_pool_fleet: str | None
+    workflow_pool_fleets: set[str] = field(default_factory=set)
+    runners: list[RunnerEntry] = field(default_factory=list)
+
+
+def is_excluded_for_region(def_block: dict[str, Any], region: str | None) -> bool:
+    """Mirror generate_nodepools._is_excluded_for_region. No-op when region/key absent."""
+    if not region:
+        return False
+    return region in (def_block.get("exclude_regions") or [])
+
+
+def derive_fleet_name(instance_type: str) -> str:
+    """Instance family prefix: c7i.48xlarge -> c7i, p6-b200.48xlarge -> p6-b200."""
+    return instance_type.split(".")[0]
+
+
+def fleet_nodepool_name(fleet_name: str, instance_type: str, name_suffix: str = "") -> str:
+    """Mirror generate_nodepools._fleet_nodepool_name. <instance>-<size>; <fleet>-<size> when names diverge."""
+    instance_family = instance_type.split(".")[0]
+    if fleet_name == instance_family:
+        name = instance_type.replace(".", "-")
+    else:
+        instance_size = instance_type.split(".", 1)[1].replace(".", "-")
+        name = f"{fleet_name}-{instance_size}"
+    return f"{name}{name_suffix}" if name_suffix else name
+
+
+def parse_cpu(value: str | int | float) -> int:
+    """K8s CPU string -> milliCPU. ``"6"`` -> 6000, ``"750m"`` -> 750, ``"6.5"`` -> 6500."""
+    if isinstance(value, int | float):
+        return int(value * 1000)
+    s = str(value).strip()
+    if s.endswith("m"):
+        return int(float(s[:-1]))
+    return int(float(s) * 1000)
+
+
+def parse_memory(value: str | int) -> int:
+    """K8s memory string -> MiB. Plain numbers = bytes (matches analyze_node_utilization)."""
+    s = str(value).strip()
+    if s.endswith("Gi"):
+        return int(float(s[:-2]) * 1024)
+    if s.endswith("Mi"):
+        return int(float(s[:-2]))
+    if s.endswith("Ki"):
+        return int(float(s[:-2]) / 1024)
+    return int(int(s) / (1024 * 1024))
+
+
+def _load_cluster_entry(cluster_id: str, consumer_root: Path) -> dict[str, Any]:
+    path = consumer_root / "clusters.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"clusters.yaml not found at {path}")
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not data or "clusters" not in data:
+        raise ValueError(f"{path}: missing 'clusters' top-level key")
+    clusters = data.get("clusters") or {}
+    if cluster_id not in clusters:
+        known = ", ".join(sorted(clusters.keys()))
+        raise KeyError(f"Cluster '{cluster_id}' not in clusters.yaml (known: {known})")
+    entry = clusters[cluster_id]
+    if not isinstance(entry, dict):
+        raise ValueError(f"clusters.yaml: cluster '{cluster_id}' is not a mapping")
+    return entry
+
+
+def _build_nodepool_entry(
+    fleet_data: dict[str, Any],
+    inst: dict[str, Any],
+    *,
+    name_suffix: str = "",
+    runner_class: str | None = None,
+) -> NodePoolEntry:
+    instance_type = inst["type"]
+    fleet_name = fleet_data["name"]
+    return NodePoolEntry(
+        name=fleet_nodepool_name(fleet_name, instance_type, name_suffix),
+        fleet=fleet_name,
+        instance_type=instance_type,
+        arch=fleet_data.get("arch", "amd64"),
+        gpu=bool(fleet_data.get("gpu", False)),
+        runner_class=runner_class,
+    )
+
+
+def _entries_from_fleet(fleet_data: dict[str, Any], region: str | None) -> list[NodePoolEntry]:
+    if is_excluded_for_region(fleet_data, region):
+        return []
+    entries: list[NodePoolEntry] = []
+    for inst in fleet_data.get("instances") or []:
+        entries.append(_build_nodepool_entry(fleet_data, inst))
+    for inst in fleet_data.get("release") or []:
+        entries.append(_build_nodepool_entry(fleet_data, inst, name_suffix="-release", runner_class="release"))
+    return entries
+
+
+def _entries_from_legacy_pool(pool_data: dict[str, Any], region: str | None) -> list[NodePoolEntry]:
+    """Legacy ``nodepool:`` block (b200 currently). Fleet auto-derived from instance_type."""
+    if is_excluded_for_region(pool_data, region):
+        return []
+    instance_type = pool_data["instance_type"]
+    return [
+        NodePoolEntry(
+            name=pool_data["name"],
+            fleet=derive_fleet_name(instance_type),
+            instance_type=instance_type,
+            arch=pool_data.get("arch", "amd64"),
+            gpu=bool(pool_data.get("gpu", False)),
+            runner_class=None,
+        )
+    ]
+
+
+def _walk_nodepool_defs(defs_dir: Path, region: str | None) -> list[NodePoolEntry]:
+    entries: list[NodePoolEntry] = []
+    for def_file in sorted(defs_dir.glob("*.yaml")):
+        with open(def_file) as f:
+            data = yaml.safe_load(f) or {}
+        if "fleet" in data:
+            entries.extend(_entries_from_fleet(data["fleet"], region))
+        elif "fleets" in data:
+            for fleet_data in data["fleets"]:
+                entries.extend(_entries_from_fleet(fleet_data, region))
+        elif "nodepool" in data:
+            entries.extend(_entries_from_legacy_pool(data["nodepool"], region))
+        else:
+            print(f"[cluster_topology] WARN: {def_file.name}: missing 'fleet'/'fleets'/'nodepool' key")
+    return entries
+
+
+def load_nodepools(modules: list[str], region: str | None, *, upstream_root: Path) -> list[NodePoolEntry]:
+    """Walk nodepools/ (and nodepools-b200/ if enabled) defs, honoring both schemas + region filter."""
+    entries: list[NodePoolEntry] = []
+    for module_name in ("nodepools", "nodepools-b200"):
+        if module_name not in modules:
+            continue
+        defs_dir = upstream_root / "modules" / module_name / "defs"
+        if defs_dir.exists():
+            entries.extend(_walk_nodepool_defs(defs_dir, region))
+        else:
+            print(f"[cluster_topology] WARN: {module_name} defs dir not found: {defs_dir}")
+    return entries
+
+
+def _container_requests(container: dict[str, Any]) -> dict[str, str]:
+    return ((container or {}).get("resources") or {}).get("requests") or {}
+
+
+def _extract_workflow_fleet(pod_spec: dict[str, Any]) -> str | None:
+    """Search preferred nodeAffinity matchExpressions for the node-fleet value (no hardcoded indices)."""
+    node_aff = ((pod_spec or {}).get("affinity") or {}).get("nodeAffinity") or {}
+    for pref in node_aff.get("preferredDuringSchedulingIgnoredDuringExecution") or []:
+        for expr in ((pref or {}).get("preference") or {}).get("matchExpressions") or []:
+            if expr.get("key") == "node-fleet":
+                values = expr.get("values") or []
+                if values:
+                    return str(values[0])
+    return None
+
+
+def _extract_runner_class(pod_spec: dict[str, Any]) -> str | None:
+    """Search required nodeAffinity for osdc.io/runner-class In value. None when DoesNotExist."""
+    node_aff = ((pod_spec or {}).get("affinity") or {}).get("nodeAffinity") or {}
+    required = node_aff.get("requiredDuringSchedulingIgnoredDuringExecution") or {}
+    for term in required.get("nodeSelectorTerms") or []:
+        for expr in term.get("matchExpressions") or []:
+            if expr.get("key") == "osdc.io/runner-class" and expr.get("operator") == "In":
+                values = expr.get("values") or []
+                if values:
+                    return str(values[0])
+    return None
+
+
+def _resolve_instance_type_from_def(generated_path: Path, runner_name: str) -> str | None:
+    """Look up the runner's instance_type from its source def file (sibling to generated/)."""
+    def_file = generated_path.parent.parent / "defs" / f"{runner_name}.yaml"
+    if not def_file.exists():
+        return None
+    with open(def_file) as f:
+        data = yaml.safe_load(f) or {}
+    inst = (data.get("runner") or {}).get("instance_type")
+    return str(inst) if inst else None
+
+
+def _warn_skip(path: Path, reason: str) -> None:
+    print(f"[cluster_topology] WARN: {path.name}: {reason} — skipping")
+
+
+def _parse_one_generated(path: Path) -> RunnerEntry | None:
+    """Parse a single generated runner manifest into a RunnerEntry (no schedulability set)."""
+    with open(path) as f:
+        docs = list(yaml.safe_load_all(f))
+    if len(docs) < 2:
+        _warn_skip(path, f"expected 2 YAML docs, got {len(docs)}")
+        return None
+
+    helm_values, configmap = docs[0] or {}, docs[1] or {}
+    if not isinstance(helm_values, dict) or not isinstance(configmap, dict):
+        _warn_skip(path, "malformed docs")
+        return None
+
+    # Doc 1: Helm values, runner pod under template.spec.
+    containers = ((helm_values.get("template") or {}).get("spec") or {}).get("containers") or []
+    if not containers:
+        _warn_skip(path, "no runner containers")
+        return None
+    runner_requests = _container_requests(containers[0])
+
+    # Doc 2: ConfigMap with workflow pod YAML string at data['job-pod.yaml'].
+    if configmap.get("kind") != "ConfigMap":
+        _warn_skip(path, "doc 2 is not a ConfigMap")
+        return None
+    job_pod_yaml = (configmap.get("data") or {}).get("job-pod.yaml")
+    if not job_pod_yaml:
+        _warn_skip(path, "ConfigMap missing data['job-pod.yaml']")
+        return None
+    workflow_spec = (yaml.safe_load(job_pod_yaml) or {}).get("spec") or {}
+    workflow_containers = workflow_spec.get("containers") or []
+    if not workflow_containers:
+        _warn_skip(path, "no workflow containers")
+        return None
+    workflow_requests = _container_requests(workflow_containers[0])
+
+    cm_name = (configmap.get("metadata") or {}).get("name") or ""
+    runner_name = cm_name.removeprefix("arc-runner-hook-") if cm_name else path.stem
+
+    workflow_fleet = _extract_workflow_fleet(workflow_spec)
+    if not workflow_fleet:
+        _warn_skip(path, "could not determine workflow node-fleet")
+        return None
+
+    # instance_type isn't in the generated file directly — pull from the source def.
+    instance_type = _resolve_instance_type_from_def(path, runner_name) or f"{workflow_fleet}.unknown"
+
+    return RunnerEntry(
+        name=runner_name,
+        scale_set_name=str(helm_values.get("runnerScaleSetName") or runner_name),
+        instance_type=instance_type,
+        workflow_fleet=workflow_fleet,
+        runner_class=_extract_runner_class(workflow_spec),
+        runner_pod_cpu_m=parse_cpu(runner_requests.get("cpu", "0")),
+        runner_pod_mem_mi=parse_memory(runner_requests.get("memory", "0")),
+        workflow_pod_cpu_m=parse_cpu(workflow_requests.get("cpu", "0")),
+        workflow_pod_mem_mi=parse_memory(workflow_requests.get("memory", "0")),
+        workflow_pod_gpu=int(workflow_requests.get("nvidia.com/gpu", 0) or 0),
+        schedulable=True,
+        schedulable_reason=None,
+    )
+
+
+def load_runners(modules: list[str], *, upstream_root: Path) -> list[RunnerEntry]:
+    """Read generated runner manifests for the modules enabled on this cluster."""
+    runners: list[RunnerEntry] = []
+    for module_name in ("arc-runners", "arc-runners-b200"):
+        if module_name not in modules:
+            continue
+        gen_dir = upstream_root / "modules" / module_name / "generated"
+        if not gen_dir.exists():
+            print(f"[cluster_topology] WARN: generated runner dir not found: {gen_dir}")
+            continue
+        for path in sorted(gen_dir.glob("*.yaml")):
+            entry = _parse_one_generated(path)
+            if entry is not None:
+                runners.append(entry)
+    return runners
+
+
+def _release_pool_exists(nodepools: list[NodePoolEntry], fleet: str) -> bool:
+    return any(p.fleet == fleet and p.runner_class == "release" for p in nodepools)
+
+
+def _mark_schedulability(
+    runners: list[RunnerEntry],
+    nodepools: list[NodePoolEntry],
+    workflow_pool_fleets: set[str],
+) -> None:
+    """Set schedulable + schedulable_reason on each runner in-place."""
+    available = sorted(workflow_pool_fleets) or "none"
+    for runner in runners:
+        if runner.workflow_fleet not in workflow_pool_fleets:
+            runner.schedulable = False
+            runner.schedulable_reason = (
+                f"workflow_fleet '{runner.workflow_fleet}' not in deployed workflow pools (available: {available})"
+            )
+            continue
+        if runner.runner_class == "release" and not _release_pool_exists(nodepools, runner.workflow_fleet):
+            runner.schedulable = False
+            runner.schedulable_reason = (
+                f"runner_class=release but no '{runner.workflow_fleet}-*-release' nodepool deployed"
+            )
+            continue
+        runner.schedulable = True
+        runner.schedulable_reason = None
+
+
+def resolve_cluster(
+    cluster_id: str,
+    *,
+    upstream_root: Path,
+    consumer_root: Path,
+) -> ClusterTopology:
+    """Resolve full topology. Caller MUST run ``generate-runners`` first if generated/ may be stale."""
+    cluster_entry = _load_cluster_entry(cluster_id, consumer_root)
+    region = cluster_entry.get("region")
+    modules = list(cluster_entry.get("modules") or [])
+
+    nodepools = load_nodepools(modules, region, upstream_root=upstream_root)
+    runners = load_runners(modules, upstream_root=upstream_root)
+
+    # c7i-runner is the dedicated runner-pod fleet (PROACTIVE_CAPACITY.md). When
+    # absent, runners share workflow fleets — warn but don't fail.
+    fleets_present = {p.fleet for p in nodepools}
+    runner_pool_fleet = "c7i-runner" if "c7i-runner" in fleets_present else None
+    if runner_pool_fleet is None:
+        print(
+            f"[cluster_topology] WARN: cluster '{cluster_id}': no 'c7i-runner' fleet deployed; "
+            "runner pods will share workflow fleets"
+        )
+    workflow_pool_fleets = {f for f in fleets_present if f != runner_pool_fleet}
+
+    _mark_schedulability(runners, nodepools, workflow_pool_fleets)
+
+    return ClusterTopology(
+        cluster_id=cluster_id,
+        region=str(region) if region else "",
+        modules=modules,
+        nodepools=nodepools,
+        runner_pool_fleet=runner_pool_fleet,
+        workflow_pool_fleets=workflow_pool_fleets,
+        runners=runners,
+    )

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -31,27 +31,32 @@ class DaemonSetOverhead:
     memory_mib: int
     gpu_only: bool
     source: str  # e.g. "base/kubernetes/nvidia-device-plugin.yaml" or "constant:helm"
+    # If set, the DaemonSet runs ONLY on nodes with the matching `node-fleet`
+    # label (e.g. "c7i-runner"). When None, the DaemonSet runs on all fleets.
+    fleet_selector: str | None = None
 
 
 # ---------------------------------------------------------------------------
 # Constants for DaemonSets not discoverable from raw YAML manifests
 # ---------------------------------------------------------------------------
 
-# Helm-deployed DaemonSets — values from their respective Helm charts
+# Helm-deployed DaemonSets — values from their respective Helm charts.
+# These run on every node (no fleet pinning), so fleet_selector=None.
 HELM_DAEMONSETS: list[DaemonSetOverhead] = [
     # kube-prometheus-stack node-exporter (chart defaults)
     # Values from modules/monitoring/helm/values.yaml
-    DaemonSetOverhead("node-exporter", 15, 32, False, "constant:helm:kube-prometheus-stack"),
+    DaemonSetOverhead("node-exporter", 15, 32, False, "constant:helm:kube-prometheus-stack", fleet_selector=None),
     # Alloy logging DaemonSet
     # Values from modules/logging/helm/alloy-logging-values.yaml
-    DaemonSetOverhead("alloy-logging", 100, 256, False, "constant:helm:alloy-logging"),
+    DaemonSetOverhead("alloy-logging", 100, 256, False, "constant:helm:alloy-logging", fleet_selector=None),
 ]
 
-# EKS-managed addon DaemonSets — not in our manifests at all
+# EKS-managed addon DaemonSets — not in our manifests at all.
+# These run on every node (no fleet pinning), so fleet_selector=None.
 EKS_ADDON_DAEMONSETS: list[DaemonSetOverhead] = [
-    DaemonSetOverhead("kube-proxy", 50, 80, False, "constant:eks-addon"),
-    DaemonSetOverhead("vpc-cni", 50, 128, False, "constant:eks-addon"),
-    DaemonSetOverhead("ebs-csi-node", 10, 50, False, "constant:eks-addon"),
+    DaemonSetOverhead("kube-proxy", 50, 80, False, "constant:eks-addon", fleet_selector=None),
+    DaemonSetOverhead("vpc-cni", 50, 128, False, "constant:eks-addon", fleet_selector=None),
+    DaemonSetOverhead("ebs-csi-node", 10, 50, False, "constant:eks-addon", fleet_selector=None),
 ]
 
 
@@ -118,6 +123,46 @@ def _is_gpu_only(pod_spec: dict) -> bool:
     return False
 
 
+def _extract_fleet_selector(pod_spec: dict) -> str | None:
+    """Return the single `node-fleet` value the pod is pinned to, if any.
+
+    Checks (in order):
+    - spec.template.spec.nodeSelector["node-fleet"] -> use as-is
+    - spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution
+        .nodeSelectorTerms[*].matchExpressions[*] for a matchExpression where
+        key == "node-fleet" AND operator == "In" AND values has exactly one entry.
+
+    Returns:
+        The single fleet name (e.g. "c7i-runner") if the DaemonSet is pinned
+        to ONE fleet. Returns None if no node-fleet selector is present, OR if
+        the matchExpression allows multiple fleets / uses a different operator
+        (treated as "runs on multiple fleets — include everywhere").
+    """
+    # nodeSelector check (simple key/value map)
+    node_selector = pod_spec.get("nodeSelector", {}) or {}
+    if "node-fleet" in node_selector:
+        return str(node_selector["node-fleet"])
+
+    # nodeAffinity matchExpressions check
+    affinity = pod_spec.get("affinity", {}) or {}
+    node_affinity = affinity.get("nodeAffinity", {}) or {}
+    required = node_affinity.get("requiredDuringSchedulingIgnoredDuringExecution", {}) or {}
+    for term in required.get("nodeSelectorTerms", []) or []:
+        for expr in term.get("matchExpressions", []) or []:
+            if expr.get("key") != "node-fleet":
+                continue
+            if expr.get("operator") != "In":
+                # Different operator (NotIn, Exists, etc.) — treat as "all fleets".
+                return None
+            values = expr.get("values", []) or []
+            if len(values) == 1:
+                return str(values[0])
+            # Zero or multiple values — DS runs on multiple fleets, treat as "all".
+            return None
+
+    return None
+
+
 def _extract_container_resources(containers: list[dict]) -> tuple[int, int]:
     """Sum CPU and memory requests across all containers.
 
@@ -163,10 +208,20 @@ def _discover_from_yaml(search_dirs: list[Path]) -> list[DaemonSetOverhead]:
                 cpu, mem = _extract_container_resources(containers)
 
                 gpu_only = _is_gpu_only(pod_spec)
+                fleet_selector = _extract_fleet_selector(pod_spec)
 
                 # Build a short relative source path
                 source = str(yaml_file)
-                results.append(DaemonSetOverhead(name, cpu, mem, gpu_only, source))
+                results.append(
+                    DaemonSetOverhead(
+                        name=name,
+                        cpu_millicores=cpu,
+                        memory_mib=mem,
+                        gpu_only=gpu_only,
+                        source=source,
+                        fleet_selector=fleet_selector,
+                    )
+                )
 
     return results
 

--- a/osdc/scripts/python/packing.py
+++ b/osdc/scripts/python/packing.py
@@ -1,0 +1,166 @@
+"""Combo enumeration + slack helpers for runner-to-node packing.
+
+Operates on plain (cpu_m, mem_mi, gpu) tuples so the same code can analyze
+runner-pool packings (runner pods only) and workflow-pool packings (workflow
+pods + GPU + hooks overhead) without caring about which pod type it is.
+
+Consumed by:
+  * analyze_node_utilization.py — per-pool packing analysis & summaries.
+  * tests — unit tests for the combo math.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations_with_replacement
+
+from cli_colors import GREEN, NC, RED, YELLOW
+
+PodCost = tuple[int, int, int]
+
+
+def _format_mem(mi: int) -> str:
+    """Local copy to avoid an import cycle with analyze_node_utilization."""
+    if abs(mi) >= 1024:
+        return f"{mi / 1024:.1f}Gi"
+    return f"{mi}Mi"
+
+
+def find_valid_combos(
+    pod_costs: list[PodCost],
+    pod_names: list[str],
+    alloc: dict,
+    max_pods: int = 20,
+) -> list[dict]:
+    """All combinations of ``pod_costs`` (with replacement) that fit on a node.
+
+    ``pod_costs[i]`` and ``pod_names[i]`` describe the same logical pod. Returns
+    one dict per fitting combo with utilization + waste metrics.
+    """
+    if len(pod_costs) != len(pod_names):
+        raise ValueError("pod_costs and pod_names must be the same length")
+
+    combos: list[dict] = []
+    avail_cpu = alloc["allocatable_cpu_m"]
+    avail_mem = alloc["allocatable_mem_mi"]
+    avail_gpu = alloc["allocatable_gpu"]
+
+    # Cap combo size: a 96 vCPU node with 2 vCPU pods = 48 max, but waste analysis
+    # cares about the largest combos so we cap to a sensible upper bound.
+    max_count = min(max_pods, max(1, avail_cpu // 1000))
+
+    for count in range(1, max_count + 1):
+        for combo in combinations_with_replacement(range(len(pod_costs)), count):
+            total_cpu = total_mem = total_gpu = 0
+            for idx in combo:
+                c, m, g = pod_costs[idx]
+                total_cpu += c
+                total_mem += m
+                total_gpu += g
+            if total_cpu > avail_cpu or total_mem > avail_mem or total_gpu > avail_gpu:
+                continue
+
+            cpu_util = total_cpu / avail_cpu * 100 if avail_cpu > 0 else 0
+            mem_util = total_mem / avail_mem * 100 if avail_mem > 0 else 0
+            gpu_util = total_gpu / avail_gpu * 100 if avail_gpu > 0 else 0
+            combos.append(
+                {
+                    "runners": [pod_names[i] for i in combo],
+                    "count": count,
+                    "cpu_used_m": total_cpu,
+                    "mem_used_mi": total_mem,
+                    "gpu_used": total_gpu,
+                    "cpu_util": cpu_util,
+                    "mem_util": mem_util,
+                    "gpu_util": gpu_util,
+                    "cpu_waste_m": avail_cpu - total_cpu,
+                    "mem_waste_mi": avail_mem - total_mem,
+                    "gpu_waste": avail_gpu - total_gpu,
+                }
+            )
+    return combos
+
+
+def find_maximal_combos(combos: list[dict], alloc: dict, pod_costs: list[PodCost]) -> list[dict]:
+    """Filter to combos where no additional pod (from ``pod_costs``) can still fit."""
+    avail_cpu = alloc["allocatable_cpu_m"]
+    avail_mem = alloc["allocatable_mem_mi"]
+    avail_gpu = alloc["allocatable_gpu"]
+
+    maximal: list[dict] = []
+    for combo in combos:
+        can_add_more = False
+        for c, m, g in pod_costs:
+            if (
+                combo["cpu_used_m"] + c <= avail_cpu
+                and combo["mem_used_mi"] + m <= avail_mem
+                and combo["gpu_used"] + g <= avail_gpu
+            ):
+                can_add_more = True
+                break
+        if not can_add_more:
+            maximal.append(combo)
+    return maximal
+
+
+def compute_node_slack(
+    alloc: dict,
+    pod_costs: list[PodCost],
+    homogeneous_only: bool = False,
+) -> dict | None:
+    """Min/max unused CPU + MEM across maximal combos.
+
+    When ``homogeneous_only`` is True (or pod_costs has >8 entries), only
+    considers single-pod-type packings. Otherwise enumerates all mixed combos.
+    Returns None if no valid combos exist.
+    """
+    if homogeneous_only or len(pod_costs) > 8:
+        slacks: list[dict] = []
+        for c, m, g in pod_costs:
+            max_by_cpu = alloc["allocatable_cpu_m"] // c if c > 0 else 999
+            max_by_mem = alloc["allocatable_mem_mi"] // m if m > 0 else 999
+            max_by_gpu = alloc["allocatable_gpu"] // g if g > 0 else 999
+            max_pods = min(max_by_cpu, max_by_mem, max_by_gpu)
+            if max_pods == 0:
+                continue
+            slacks.append(
+                {
+                    "cpu_m": alloc["allocatable_cpu_m"] - max_pods * c,
+                    "mem_mi": alloc["allocatable_mem_mi"] - max_pods * m,
+                }
+            )
+        if not slacks:
+            return None
+        return {
+            "min_cpu_m": min(s["cpu_m"] for s in slacks),
+            "max_cpu_m": max(s["cpu_m"] for s in slacks),
+            "min_mem_mi": min(s["mem_mi"] for s in slacks),
+            "max_mem_mi": max(s["mem_mi"] for s in slacks),
+        }
+
+    pod_names = [f"p{i}" for i in range(len(pod_costs))]
+    all_combos = find_valid_combos(pod_costs, pod_names, alloc)
+    maximal = find_maximal_combos(all_combos, alloc, pod_costs)
+    if not maximal:
+        return None
+    return {
+        "min_cpu_m": min(c["cpu_waste_m"] for c in maximal),
+        "max_cpu_m": max(c["cpu_waste_m"] for c in maximal),
+        "min_mem_mi": min(c["mem_waste_mi"] for c in maximal),
+        "max_mem_mi": max(c["mem_waste_mi"] for c in maximal),
+    }
+
+
+def print_combo(combo: dict, alloc: dict, threshold: float, rank: int) -> None:
+    """Print one combo's utilization + waste."""
+    counts = Counter(combo["runners"])
+    desc = ", ".join(f"{n}x{name}" for name, n in sorted(counts.items()))
+    min_util = min(combo["cpu_util"], combo["mem_util"])
+    color = GREEN if min_util >= threshold else (YELLOW if min_util >= threshold * 0.9 else RED)
+    print(f"      {color}#{rank}{NC} [{desc}]")
+    print(
+        f"         CPU: {combo['cpu_util']:5.1f}%  "
+        f"MEM: {combo['mem_util']:5.1f}%"
+        + (f"  GPU: {combo['gpu_util']:5.1f}%" if alloc["allocatable_gpu"] > 0 else "")
+        + f"  waste: {combo['cpu_waste_m'] / 1000:.1f}c + {_format_mem(combo['mem_waste_mi'])}"
+    )

--- a/osdc/scripts/python/sim_placement.py
+++ b/osdc/scripts/python/sim_placement.py
@@ -1,0 +1,166 @@
+"""Best-fit placement and node-provisioning helpers for the split-pool simulator.
+
+Extracted from ``simulate_cluster.py`` to keep that module under the 400-line
+ceiling. Operates on the ``SimNode`` dataclass defined there. All placement
+matches on ``(fleet, runner_class)`` for workflow nodes and ``fleet`` only
+for runner-pool nodes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from analyze_node_utilization import HOOKS_OVERHEAD_CPU_M, HOOKS_OVERHEAD_MEM_MI, compute_allocatable
+from instance_specs import INSTANCE_SPECS
+
+if TYPE_CHECKING:
+    from cluster_topology import NodePoolEntry, RunnerEntry
+    from daemonset_overhead import DaemonSetOverhead
+    from simulate_cluster import SimNode
+
+
+# ---------------------------------------------------------------------------
+# Pod cost helpers — per-pod resource totals
+# ---------------------------------------------------------------------------
+
+
+def per_runner_pod_total(runner: RunnerEntry) -> tuple[int, int, int]:
+    """Runner pod cost (cpu_m, mem_mi, gpu) — sidecar only, no hooks overhead.
+
+    The runner pod runs on the runner pool and never carries the workflow
+    container or its hooks. GPU is always 0.
+    """
+    return runner.runner_pod_cpu_m, runner.runner_pod_mem_mi, 0
+
+
+def per_workflow_pod_total(runner: RunnerEntry) -> tuple[int, int, int]:
+    """Workflow pod cost (cpu_m, mem_mi, gpu) — job container + hooks overhead."""
+    cpu = runner.workflow_pod_cpu_m + HOOKS_OVERHEAD_CPU_M
+    mem = runner.workflow_pod_mem_mi + HOOKS_OVERHEAD_MEM_MI
+    return cpu, mem, runner.workflow_pod_gpu
+
+
+def _allocatable_for(
+    instance_type: str,
+    daemonsets: list[DaemonSetOverhead],
+    fleet_name: str,
+) -> tuple[int, int] | None:
+    """Wrap ``compute_allocatable`` to return ``(cpu_m, mem_mi)`` or None."""
+    alloc = compute_allocatable(instance_type, daemonsets, fleet_name=fleet_name)
+    if alloc is None:
+        return None
+    return alloc["allocatable_cpu_m"], alloc["allocatable_mem_mi"]
+
+
+# ---------------------------------------------------------------------------
+# Best-fit placement
+# ---------------------------------------------------------------------------
+
+
+def _best_fit_node(candidates: list[SimNode], cpu_m: int, mem_mi: int, gpu: int) -> SimNode | None:
+    """Pick the candidate with the tightest remaining capacity that fits.
+
+    Score = remaining CPU + remaining memory + (GPU-scaled remaining GPU).
+    Lower score wins. Returns None when nothing fits.
+    """
+    best: SimNode | None = None
+    best_score: float = float("inf")
+    for node in candidates:
+        if not node.can_fit(cpu_m, mem_mi, gpu):
+            continue
+        score: float = node.remaining_cpu_m + node.remaining_mem_mi
+        if node.gpu > 0:
+            # Scale GPU remaining to be comparable to CPU+mem magnitude — a
+            # raw GPU count of 1-8 would be drowned out by 100k CPU / mem.
+            gpu_scale = (node.cpu_m + node.mem_mi) / max(node.gpu, 1)
+            score += node.remaining_gpu * gpu_scale
+        if score < best_score:
+            best_score = score
+            best = node
+    return best
+
+
+def best_fit_place_workflow(runner: RunnerEntry, workflow_nodes: list[SimNode]) -> SimNode | None:
+    """Place one workflow pod on the best-fit existing workflow node.
+
+    Matches on ``(fleet, runner_class)`` so release runners only land on
+    release nodes and CPU runners never land on GPU nodes of the wrong fleet.
+    """
+    cpu, mem, gpu = per_workflow_pod_total(runner)
+    candidates = [
+        n for n in workflow_nodes if n.fleet == runner.workflow_fleet and n.runner_class == runner.runner_class
+    ]
+    return _best_fit_node(candidates, cpu, mem, gpu)
+
+
+def best_fit_place_runner(
+    runner_pool_fleet: str,
+    runner_pod_cpu_m: int,
+    runner_pod_mem_mi: int,
+    runner_nodes: list[SimNode],
+) -> SimNode | None:
+    """Place one runner pod on the best-fit existing runner-pool node."""
+    candidates = [n for n in runner_nodes if n.fleet == runner_pool_fleet]
+    return _best_fit_node(candidates, runner_pod_cpu_m, runner_pod_mem_mi, 0)
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+def provision_workflow_node(runner: RunnerEntry, daemonsets: list[DaemonSetOverhead]):
+    """Create a workflow-pool node sized for ``runner.instance_type``.
+
+    Returns None when the instance is not in INSTANCE_SPECS so the caller
+    can mark the runner as failed and stop drawing it.
+    """
+    # Local import avoids a cycle: simulate_cluster imports from sim_placement.
+    from simulate_cluster import SimNode
+
+    instance_type = runner.instance_type
+    alloc = _allocatable_for(instance_type, daemonsets, fleet_name=runner.workflow_fleet)
+    if alloc is None:
+        return None
+    cpu_m, mem_mi = alloc
+    gpu = INSTANCE_SPECS[instance_type]["gpu"]
+    return SimNode(
+        instance_type=instance_type,
+        fleet=runner.workflow_fleet,
+        runner_class=runner.runner_class,
+        cpu_m=cpu_m,
+        mem_mi=mem_mi,
+        gpu=gpu,
+    )
+
+
+def provision_runner_node(
+    runner_pool_fleet: str,
+    nodepools: list[NodePoolEntry],
+    daemonsets: list[DaemonSetOverhead],
+):
+    """Create a runner-pool node using the largest instance from that fleet.
+
+    Karpenter's weighted scoring prefers larger instances first when the
+    pool has demand, so picking the largest matches observed behavior.
+    Returns None when the fleet has no nodepools or the chosen instance
+    is unknown.
+    """
+    from simulate_cluster import SimNode
+
+    candidates = [np for np in nodepools if np.fleet == runner_pool_fleet]
+    if not candidates:
+        return None
+    chosen = max(candidates, key=lambda np: INSTANCE_SPECS.get(np.instance_type, {"vcpu": 0})["vcpu"])
+    alloc = _allocatable_for(chosen.instance_type, daemonsets, fleet_name=runner_pool_fleet)
+    if alloc is None:
+        return None
+    cpu_m, mem_mi = alloc
+    return SimNode(
+        instance_type=chosen.instance_type,
+        fleet=runner_pool_fleet,
+        runner_class=None,
+        cpu_m=cpu_m,
+        mem_mi=mem_mi,
+        gpu=0,
+    )

--- a/osdc/scripts/python/simulate_cluster.py
+++ b/osdc/scripts/python/simulate_cluster.py
@@ -1,123 +1,202 @@
-"""Monte Carlo cluster simulation library for PyTorch CI load.
+"""Monte Carlo cluster simulation library for PyTorch CI load (split-pool model).
 
-Places runners one-at-a-time using best-fit bin-packing (Karpenter-like)
-until deployed counts approximate observed peak concurrency.
+Each runner deployment now occupies TWO pods on TWO different node pools (per
+PROACTIVE_CAPACITY.md):
 
-CLI entry point: simulate_cluster_cli.py
+  1. A workflow pod on the per-runner-class workflow pool (heavy: vCPU + memory
+     + GPU + container-hooks overhead).
+  2. A runner pod on the dedicated ``c7i-runner`` runner pool (light: ~750m
+     CPU + ~512Mi memory).
+
+The simulator runs both placements per runner draw and reports utilization for
+both pools separately. Workload data is sourced from ``pytorch_workload_data``
+(global pytorch/pytorch snapshot). Cluster topology is supplied by
+``cluster_topology.resolve_cluster``.
+
+Placement / provisioning helpers live in ``sim_placement`` to keep this file
+under the 400-line ceiling. They are re-exported from this module so callers
+have a single entry point.
+
+CLI entry point: ``simulate_cluster_cli.py``.
 """
 
-import random
-from dataclasses import dataclass, field
+from __future__ import annotations
 
-from analyze_node_utilization import compute_allocatable, per_runner_total
-from daemonset_overhead import DaemonSetOverhead
+import random
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from sim_placement import (
+    best_fit_place_runner,
+    best_fit_place_workflow,
+    per_runner_pod_total,
+    per_workflow_pod_total,
+    provision_runner_node,
+    provision_workflow_node,
+)
+
+if TYPE_CHECKING:
+    from cluster_topology import ClusterTopology, NodePoolEntry, RunnerEntry
+    from daemonset_overhead import DaemonSetOverhead
+
+
+# Re-export placement helpers so simulate_cluster remains the public entry
+# point — callers import from here, not from sim_placement directly.
+__all__ = [
+    "PoolUtilization",
+    "SimNode",
+    "SimResult",
+    "SimulationUtilization",
+    "best_fit_place_runner",
+    "best_fit_place_workflow",
+    "build_peak_targets",
+    "build_weighted_pool",
+    "compute_utilization",
+    "per_runner_pod_total",
+    "per_workflow_pod_total",
+    "provision_runner_node",
+    "provision_workflow_node",
+    "run_simulation",
+    "weighted_mape",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class SimNode:
-    """A simulated cluster node."""
+    """A simulated cluster node.
+
+    ``fleet`` is the ``node-fleet`` label (e.g. ``c7i-runner``, ``g4dn``)
+    and disambiguates workflow vs runner pool nodes. ``runner_class`` is
+    set only for release-tagged workflow nodes; runner-pool nodes always
+    have ``runner_class=None``.
+    """
 
     instance_type: str
-    total_cpu_m: int
-    total_mem_mi: int
-    total_gpu: int
+    fleet: str
+    runner_class: str | None
+    cpu_m: int
+    mem_mi: int
+    gpu: int
     used_cpu_m: int = 0
     used_mem_mi: int = 0
     used_gpu: int = 0
-    runner_count: int = 0
+    pod_count: int = 0
 
     @property
     def remaining_cpu_m(self) -> int:
-        return self.total_cpu_m - self.used_cpu_m
+        return self.cpu_m - self.used_cpu_m
 
     @property
     def remaining_mem_mi(self) -> int:
-        return self.total_mem_mi - self.used_mem_mi
+        return self.mem_mi - self.used_mem_mi
 
     @property
     def remaining_gpu(self) -> int:
-        return self.total_gpu - self.used_gpu
+        return self.gpu - self.used_gpu
 
-    def fits(self, cpu_m: int, mem_mi: int, gpu: int) -> bool:
+    def can_fit(self, cpu_m: int, mem_mi: int, gpu: int) -> bool:
         return self.remaining_cpu_m >= cpu_m and self.remaining_mem_mi >= mem_mi and self.remaining_gpu >= gpu
+
+    def allocate(self, cpu_m: int, mem_mi: int, gpu: int) -> None:
+        self.used_cpu_m += cpu_m
+        self.used_mem_mi += mem_mi
+        self.used_gpu += gpu
+        self.pod_count += 1
+
+
+@dataclass
+class PoolUtilization:
+    """Per-pool resource accounting (workflow OR runner pool)."""
+
+    nodes: int = 0
+    used_cpu_m: int = 0
+    total_cpu_m: int = 0
+    used_mem_mi: int = 0
+    total_mem_mi: int = 0
+    used_gpu: int = 0
+    total_gpu: int = 0
+
+    @property
+    def cpu_pct(self) -> float:
+        return (self.used_cpu_m / self.total_cpu_m * 100) if self.total_cpu_m > 0 else 0.0
+
+    @property
+    def mem_pct(self) -> float:
+        return (self.used_mem_mi / self.total_mem_mi * 100) if self.total_mem_mi > 0 else 0.0
+
+    @property
+    def gpu_pct(self) -> float:
+        return (self.used_gpu / self.total_gpu * 100) if self.total_gpu > 0 else 0.0
+
+
+@dataclass
+class SimulationUtilization:
+    """Utilization broken out by pool."""
+
+    workflow: PoolUtilization
+    runner: PoolUtilization
 
 
 @dataclass
 class SimResult:
-    """Result of a simulation run."""
+    """Result of a simulation run.
 
-    nodes: list[SimNode] = field(default_factory=list)
+    ``workflow_nodes`` are nodes from the per-runner-class workflow pools;
+    ``runner_nodes`` are nodes from the dedicated runner pool. ``skipped``
+    lists target runner names that were not in topology or were not
+    schedulable.
+    """
+
+    workflow_nodes: list[SimNode] = field(default_factory=list)
+    runner_nodes: list[SimNode] = field(default_factory=list)
     deployed: dict[str, int] = field(default_factory=dict)
     targets: dict[str, int] = field(default_factory=dict)
-    skipped_labels: dict[str, str] = field(default_factory=dict)
+    skipped: list[str] = field(default_factory=list)
 
 
-def build_peak_targets(
-    old_to_new: dict[str, str],
-    peak_concurrent: dict[str, int],
-) -> tuple[dict[str, int], dict[str, str]]:
-    """Collapse old labels to new, summing peaks. Returns (targets, skipped)."""
-    targets: dict[str, int] = {}
-    skipped: dict[str, str] = {}
-    for old_label, peak in peak_concurrent.items():
-        if old_label not in old_to_new:
-            skipped[old_label] = "no mapping"
+# ---------------------------------------------------------------------------
+# Target / pool builders
+# ---------------------------------------------------------------------------
+
+
+def build_peak_targets(runners: list[RunnerEntry]) -> dict[str, int]:
+    """Map ``RunnerEntry`` → peak concurrent count via ``OLD_TO_NEW_LABEL``.
+
+    Sums peaks for any old labels that map to the same new runner name.
+    Only includes runners that are schedulable in the topology.
+    """
+    # Local import keeps the workload snapshot a runtime concern — keeps
+    # test fixtures cheap and avoids a top-of-file dependency cycle.
+    from pytorch_workload_data import OLD_TO_NEW_LABEL, PEAK_CONCURRENT
+
+    schedulable_names = {r.name for r in runners if r.schedulable}
+    targets: dict[str, int] = defaultdict(int)
+    for old_label, peak in PEAK_CONCURRENT.items():
+        new_name = OLD_TO_NEW_LABEL.get(old_label)
+        if new_name is None or new_name not in schedulable_names:
             continue
-        new_label = old_to_new[old_label]
-        targets[new_label] = targets.get(new_label, 0) + peak
-    return targets, skipped
+        targets[new_name] += peak
+    return dict(targets)
 
 
-def build_weighted_pool(targets: dict[str, int]) -> list[tuple[str, int]]:
-    """Create (runner_name, weight) tuples for weighted random drawing."""
-    return [(name, weight) for name, weight in targets.items() if weight > 0]
-
-
-def best_fit_place(
-    nodes: list[SimNode],
-    cpu_m: int,
-    mem_mi: int,
-    gpu: int,
-    instance_type: str,
-) -> int | None:
-    """Find matching node with least remaining capacity that fits the runner."""
-    best_idx = None
-    best_remaining = float("inf")
-    for i, node in enumerate(nodes):
-        if node.instance_type != instance_type:
+def build_weighted_pool(targets: dict[str, int]) -> list[str]:
+    """Expand ``{name: weight}`` into a list with each name repeated ``weight`` times."""
+    pool: list[str] = []
+    for name, weight in targets.items():
+        if weight <= 0:
             continue
-        if not node.fits(cpu_m, mem_mi, gpu):
-            continue
-        # Score: remaining resources (lower = tighter fit = preferred)
-        remaining = node.remaining_cpu_m + node.remaining_mem_mi
-        if node.total_gpu > 0:
-            # Scale GPU remaining to be comparable to CPU+mem magnitude
-            gpu_scale = (node.total_cpu_m + node.total_mem_mi) / max(node.total_gpu, 1)
-            remaining += node.remaining_gpu * gpu_scale
-        if remaining < best_remaining:
-            best_remaining = remaining
-            best_idx = i
-    return best_idx
-
-
-def provision_node(
-    instance_type: str,
-    daemonsets: list[DaemonSetOverhead],
-) -> SimNode | None:
-    """Create a new SimNode with allocatable capacity after overhead."""
-    alloc = compute_allocatable(instance_type, daemonsets)
-    if alloc is None:
-        return None
-    return SimNode(
-        instance_type=instance_type,
-        total_cpu_m=alloc["allocatable_cpu_m"],
-        total_mem_mi=alloc["allocatable_mem_mi"],
-        total_gpu=alloc["allocatable_gpu"],
-    )
+        pool.extend([name] * weight)
+    return pool
 
 
 def weighted_mape(deployed: dict[str, int], targets: dict[str, int]) -> float:
-    """Weighted MAPE: sum(|deployed_i - target_i|) / sum(target_i)."""
+    """Weighted MAPE: ``sum(|deployed - target|) / sum(target)``."""
     total_target = sum(targets.values())
     if total_target == 0:
         return 0.0
@@ -125,123 +204,124 @@ def weighted_mape(deployed: dict[str, int], targets: dict[str, int]) -> float:
     return total_error / total_target
 
 
+# ---------------------------------------------------------------------------
+# Simulation loop
+# ---------------------------------------------------------------------------
+
+
+def _stop_condition(deployed: dict[str, int], targets: dict[str, int], threshold: float, max_deploy: int) -> bool:
+    """Stop when MAPE drops to threshold or we hit the safety cap."""
+    total = sum(deployed.values())
+    if total == 0:
+        return False
+    if total >= max_deploy:
+        return True
+    return weighted_mape(deployed, targets) <= threshold
+
+
+def _place_runner_draw(
+    runner: RunnerEntry,
+    workflow_nodes: list[SimNode],
+    runner_nodes: list[SimNode],
+    runner_pool_fleet: str | None,
+    topology_nodepools: list[NodePoolEntry],
+    daemonsets: list[DaemonSetOverhead],
+) -> bool:
+    """Place one runner draw (workflow pod, then runner pod). Returns False when either provisioning fails."""
+    wf_node = best_fit_place_workflow(runner, workflow_nodes)
+    if wf_node is None:
+        wf_node = provision_workflow_node(runner, daemonsets)
+        if wf_node is None:
+            return False
+        workflow_nodes.append(wf_node)
+    wf_node.allocate(*per_workflow_pod_total(runner))
+
+    if runner_pool_fleet is None:
+        # No dedicated runner pool — runner pod placement is skipped, but
+        # the workflow placement above counts as a deployment.
+        return True
+    r_cpu, r_mem, _ = per_runner_pod_total(runner)
+    rn_node = best_fit_place_runner(runner_pool_fleet, r_cpu, r_mem, runner_nodes)
+    if rn_node is None:
+        rn_node = provision_runner_node(runner_pool_fleet, topology_nodepools, daemonsets)
+        if rn_node is None:
+            return False
+        runner_nodes.append(rn_node)
+    rn_node.allocate(r_cpu, r_mem, 0)
+    return True
+
+
 def run_simulation(
-    runner_defs: list[dict],
+    topology: ClusterTopology,
     targets: dict[str, int],
     daemonsets: list[DaemonSetOverhead],
+    *,
     seed: int = 42,
     threshold: float = 0.15,
 ) -> SimResult:
-    """Run Monte Carlo bin-packing: weighted random draw, best-fit place, stop at MAPE <= threshold."""
-    rng = random.Random(seed)  # noqa: S311 — simulation, not crypto
-    runner_by_name = {r["name"]: r for r in runner_defs}
-
-    # Filter targets to runners that have defs
-    active_targets: dict[str, int] = {}
-    skipped: dict[str, str] = {}
-    for name, peak in targets.items():
-        if name in runner_by_name:
-            active_targets[name] = peak
-        else:
-            skipped[name] = "no runner def"
+    """Run the two-phase simulation: workflow pod, then runner pod."""
+    schedulable = {r.name: r for r in topology.runners if r.schedulable}
+    active_targets = {name: count for name, count in targets.items() if name in schedulable}
+    skipped = sorted(name for name in targets if name not in schedulable)
 
     if not active_targets:
-        result = SimResult()
-        result.targets = targets
-        result.skipped_labels = skipped
-        return result
+        return SimResult(targets=active_targets, skipped=skipped)
 
-    pool = build_weighted_pool(active_targets)
-    if not pool:
-        # All targets have zero weight
-        return SimResult(targets=active_targets, skipped_labels=skipped)
+    weighted_pool = build_weighted_pool(active_targets)
+    if not weighted_pool:
+        return SimResult(targets=active_targets, skipped=skipped)
 
-    names = [p[0] for p in pool]
-    weights = [p[1] for p in pool]
-    total_target = sum(active_targets.values())
-    max_deploy = int(total_target * 1.05)
-
-    nodes: list[SimNode] = []
+    workflow_nodes: list[SimNode] = []
+    runner_nodes: list[SimNode] = []
     deployed: dict[str, int] = dict.fromkeys(active_targets, 0)
-    total_deployed = 0
-    failed_types: set[str] = set()  # instance types that can't be provisioned
+    failed: set[str] = set()
+    max_deploy = max(int(sum(active_targets.values()) * 1.05), 1)
+    rng = random.Random(seed)  # noqa: S311 — simulation, not crypto.
 
-    while True:
-        # Check stop conditions
-        if total_deployed > 0:
-            mape = weighted_mape(deployed, active_targets)
-            if mape <= threshold:
-                break
-        if total_deployed >= max_deploy:
+    while not _stop_condition(deployed, active_targets, threshold, max_deploy):
+        eligible = [name for name in weighted_pool if name not in failed]
+        if not eligible:
             break
-
-        # Draw a random runner
-        chosen = rng.choices(names, weights=weights, k=1)[0]
-        runner = runner_by_name[chosen]
-
-        # Skip runners whose instance type can't be provisioned
-        if runner["instance_type"] in failed_types:
-            # Remove from pool to avoid infinite draws of unplaceable runners
-            idx_in_pool = names.index(chosen)
-            names.pop(idx_in_pool)
-            weights.pop(idx_in_pool)
-            if not names:
-                break  # No runners left that can be placed
+        runner_name = rng.choice(eligible)
+        runner = schedulable[runner_name]
+        ok = _place_runner_draw(
+            runner, workflow_nodes, runner_nodes, topology.runner_pool_fleet, topology.nodepools, daemonsets
+        )
+        if not ok:
+            failed.add(runner_name)
             continue
-
-        cpu_m, mem_mi, gpu = per_runner_total(runner)
-
-        # Try best-fit placement
-        idx = best_fit_place(nodes, cpu_m, mem_mi, gpu, runner["instance_type"])
-        if idx is not None:
-            nodes[idx].used_cpu_m += cpu_m
-            nodes[idx].used_mem_mi += mem_mi
-            nodes[idx].used_gpu += gpu
-            nodes[idx].runner_count += 1
-        else:
-            # Provision new node
-            node = provision_node(runner["instance_type"], daemonsets)
-            if node is None:
-                failed_types.add(runner["instance_type"])
-                continue
-            node.used_cpu_m = cpu_m
-            node.used_mem_mi = mem_mi
-            node.used_gpu = gpu
-            node.runner_count = 1
-            nodes.append(node)
-
-        deployed[chosen] = deployed.get(chosen, 0) + 1
-        total_deployed += 1
+        deployed[runner_name] += 1
 
     return SimResult(
-        nodes=nodes,
+        workflow_nodes=workflow_nodes,
+        runner_nodes=runner_nodes,
         deployed=deployed,
         targets=active_targets,
-        skipped_labels=skipped,
+        skipped=skipped,
     )
 
 
-def compute_utilization(result: SimResult) -> dict:
-    """Compute cluster-wide utilization percentages."""
-    total_cpu = sum(n.total_cpu_m for n in result.nodes)
-    used_cpu = sum(n.used_cpu_m for n in result.nodes)
-    total_mem = sum(n.total_mem_mi for n in result.nodes)
-    used_mem = sum(n.used_mem_mi for n in result.nodes)
+# ---------------------------------------------------------------------------
+# Utilization
+# ---------------------------------------------------------------------------
 
-    gpu_nodes = [n for n in result.nodes if n.total_gpu > 0]
-    total_gpu = sum(n.total_gpu for n in gpu_nodes)
-    used_gpu = sum(n.used_gpu for n in gpu_nodes)
 
-    return {
-        "cpu_pct": (used_cpu / total_cpu * 100) if total_cpu > 0 else 0.0,
-        "mem_pct": (used_mem / total_mem * 100) if total_mem > 0 else 0.0,
-        "gpu_pct": (used_gpu / total_gpu * 100) if total_gpu > 0 else 0.0,
-        "total_cpu_m": total_cpu,
-        "used_cpu_m": used_cpu,
-        "total_mem_mi": total_mem,
-        "used_mem_mi": used_mem,
-        "total_gpu": total_gpu,
-        "used_gpu": used_gpu,
-        "total_nodes": len(result.nodes),
-        "gpu_nodes": len(gpu_nodes),
-    }
+def _aggregate(nodes: list[SimNode]) -> PoolUtilization:
+    util = PoolUtilization()
+    for node in nodes:
+        util.nodes += 1
+        util.used_cpu_m += node.used_cpu_m
+        util.total_cpu_m += node.cpu_m
+        util.used_mem_mi += node.used_mem_mi
+        util.total_mem_mi += node.mem_mi
+        util.used_gpu += node.used_gpu
+        util.total_gpu += node.gpu
+    return util
+
+
+def compute_utilization(result: SimResult) -> SimulationUtilization:
+    """Aggregate per-pool utilization from a SimResult."""
+    return SimulationUtilization(
+        workflow=_aggregate(result.workflow_nodes),
+        runner=_aggregate(result.runner_nodes),
+    )

--- a/osdc/scripts/python/simulate_cluster_cli.py
+++ b/osdc/scripts/python/simulate_cluster_cli.py
@@ -3,65 +3,106 @@
 # requires-python = ">=3.12"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-"""CLI for Monte Carlo cluster simulation.
+"""CLI for the split-pool Monte Carlo cluster simulation.
 
-Usage:
-    uv run scripts/python/simulate_cluster_cli.py [--seed 42] [--threshold 0.15]
+Required args:
+    --cluster <id>       — must match a top-level entry in clusters.yaml.
+
+Resolution of repo paths is via env vars set by the just recipe:
+    OSDC_UPSTREAM        — path to the upstream osdc/ tree (default: walk up).
+    OSDC_ROOT            — path to the consumer osdc/ tree (default: upstream).
 """
+
+from __future__ import annotations
 
 import argparse
 import os
 import sys
 from pathlib import Path
 
-from analyze_node_utilization import load_runner_defs
 from cli_colors import BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW
+from cluster_topology import ClusterTopology, resolve_cluster
 from daemonset_overhead import discover_daemonsets
-from pytorch_workload_data import OLD_TO_NEW_LABEL, PEAK_CONCURRENT
 from simulate_cluster import (
-    SimNode,
+    PoolUtilization,
     SimResult,
+    SimulationUtilization,
     build_peak_targets,
     compute_utilization,
     run_simulation,
     weighted_mape,
 )
 
-
-def print_results(result: SimResult, utilization: dict) -> None:
-    """Print simulation results."""
-    print(f"\n{BOLD}{'━' * 80}{NC}")
-    print(f"{BOLD}{CYAN}Cluster Simulation Results{NC}")
-    print(f"{'━' * 80}")
-
-    if result.skipped_labels:
-        print(f"\n{YELLOW}Skipped labels ({len(result.skipped_labels)}):{NC}")
-        for label, reason in sorted(result.skipped_labels.items()):
-            print(f"  {DIM}{label}: {reason}{NC}")
-
-    _print_node_table(result)
-    _print_deployment_accuracy(result)
-    _print_utilization(utilization)
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
 
 
-def _print_node_table(result: SimResult) -> None:
-    by_type: dict[str, list[SimNode]] = {}
-    for node in result.nodes:
-        by_type.setdefault(node.instance_type, []).append(node)
+def _walk_up_for_osdc() -> Path:
+    """Find the nearest ancestor containing ``clusters.yaml`` (the osdc root)."""
+    here = Path(__file__).resolve()
+    for parent in [here.parent, *here.parents]:
+        if (parent / "clusters.yaml").exists():
+            return parent
+    # Fall back to two-up (scripts/python/ → osdc/) which matches the repo layout.
+    return here.parent.parent.parent
 
-    print(f"\n{BOLD}Nodes by instance type:{NC}\n")
-    hdr = f"  {'Instance Type':<22} {'Nodes':>5} {'vCPU Used':>10} {'vCPU Total':>10} {'Mem Used':>10} {'Mem Total':>10} {'GPU':>5}"
-    print(hdr)
-    print(f"  {'─' * 78}")
-    for itype in sorted(by_type):
-        ns = by_type[itype]
-        uc, tc = sum(n.used_cpu_m for n in ns), sum(n.total_cpu_m for n in ns)
-        um, tm = sum(n.used_mem_mi for n in ns), sum(n.total_mem_mi for n in ns)
-        ug, tg = sum(n.used_gpu for n in ns), sum(n.total_gpu for n in ns)
-        gpu_str = f"{ug}/{tg}" if tg > 0 else "-"
-        print(
-            f"  {itype:<22} {len(ns):>5} {uc / 1000:>9.1f}c {tc / 1000:>9.1f}c {um / 1024:>8.1f}Gi {tm / 1024:>8.1f}Gi {gpu_str:>5}"
-        )
+
+def _resolve_roots() -> tuple[Path, Path]:
+    """Resolve (upstream_root, consumer_root) from env vars or filesystem walk."""
+    upstream = Path(os.environ.get("OSDC_UPSTREAM") or _walk_up_for_osdc()).resolve()
+    consumer = Path(os.environ.get("OSDC_ROOT") or upstream).resolve()
+    return upstream, consumer
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def _format_pool(util: PoolUtilization, label: str) -> None:
+    print(f"\n{BOLD}{label}{NC}")
+    if util.nodes == 0:
+        print(f"  {DIM}(no nodes provisioned){NC}")
+        return
+    cpu_color = GREEN if util.cpu_pct >= 80 else YELLOW
+    mem_color = GREEN if util.mem_pct >= 80 else YELLOW
+    print(
+        f"  {cpu_color}vCPU:   {util.cpu_pct:5.1f}%{NC}  "
+        f"({util.used_cpu_m / 1000:.0f} / {util.total_cpu_m / 1000:.0f} cores)"
+    )
+    print(
+        f"  {mem_color}Memory: {util.mem_pct:5.1f}%{NC}  "
+        f"({util.used_mem_mi / 1024:.0f} / {util.total_mem_mi / 1024:.0f} GiB)"
+    )
+    if util.total_gpu > 0:
+        gpu_color = GREEN if util.gpu_pct >= 80 else YELLOW
+        print(f"  {gpu_color}GPU:    {util.gpu_pct:5.1f}%{NC}  ({util.used_gpu} / {util.total_gpu} GPUs)")
+    print(f"  Nodes: {util.nodes}")
+
+
+def _print_node_breakdown(result: SimResult) -> None:
+    """Group nodes by ``(fleet, instance_type, runner_class)`` and print counts."""
+    by_key: dict[tuple[str, str, str | None], list] = {}
+    for node in (*result.workflow_nodes, *result.runner_nodes):
+        key = (node.fleet, node.instance_type, node.runner_class)
+        by_key.setdefault(key, []).append(node)
+
+    if not by_key:
+        return
+    print(f"\n{BOLD}Nodes by fleet / instance / runner-class:{NC}")
+    print(f"  {'Fleet':<14} {'Instance':<22} {'Class':<10} {'Nodes':>5}  {'CPU%':>6}  {'Mem%':>6}  {'GPU%':>6}")
+    print(f"  {'─' * 80}")
+    for key in sorted(by_key):
+        ns = by_key[key]
+        nodes = len(ns)
+        cpu_pct = sum(n.used_cpu_m for n in ns) / max(sum(n.cpu_m for n in ns), 1) * 100
+        mem_pct = sum(n.used_mem_mi for n in ns) / max(sum(n.mem_mi for n in ns), 1) * 100
+        total_gpu = sum(n.gpu for n in ns)
+        gpu_pct = sum(n.used_gpu for n in ns) / total_gpu * 100 if total_gpu > 0 else 0.0
+        rc = key[2] or "-"
+        gpu_str = f"{gpu_pct:5.1f}%" if total_gpu > 0 else "  -   "
+        print(f"  {key[0]:<14} {key[1]:<22} {rc:<10} {nodes:>5}  {cpu_pct:5.1f}%  {mem_pct:5.1f}%  {gpu_str}")
 
 
 def _print_deployment_accuracy(result: SimResult) -> None:
@@ -71,37 +112,58 @@ def _print_deployment_accuracy(result: SimResult) -> None:
     print(f"\n{BOLD}Deployment accuracy:{NC}\n")
     print(f"  Total deployed: {total_deployed} / {total_target} target")
     print(f"  Weighted MAPE: {mape:.1%}")
-    print(f"\n  {'Runner':<35} {'Deployed':>8} {'Target':>8} {'Diff':>8}")
-    print(f"  {'─' * 63}")
+    if not result.targets:
+        return
+    print(f"\n  {'Runner':<35} {'Deployed':>9} {'Target':>8} {'Diff':>8}")
+    print(f"  {'─' * 64}")
     for name in sorted(result.targets):
-        dep, tgt = result.deployed.get(name, 0), result.targets[name]
+        dep = result.deployed.get(name, 0)
+        tgt = result.targets[name]
         diff = dep - tgt
+        # Within 15% of target (or within 1 absolute) counts as green.
         color = GREEN if abs(diff) <= max(1, tgt * 0.15) else YELLOW
-        print(f"  {color}{name:<35} {dep:>8} {tgt:>8} {diff:>+8}{NC}")
+        print(f"  {color}{name:<35} {dep:>9} {tgt:>8} {diff:>+8}{NC}")
 
 
-def _print_utilization(utilization: dict) -> None:
-    print(f"\n{BOLD}Cluster-wide utilization:{NC}\n")
-    _RESOURCE_ROWS = [
-        ("cpu_pct", "vCPU", "used_cpu_m", "total_cpu_m", 1000, "cores"),
-        ("mem_pct", "Memory", "used_mem_mi", "total_mem_mi", 1024, "GiB"),
-    ]
-    for pct_key, label, used_key, total_key, divisor, unit in _RESOURCE_ROWS:
-        color = GREEN if utilization[pct_key] >= 80 else YELLOW
-        print(
-            f"  {color}{label + ':':8s}{utilization[pct_key]:5.1f}%{NC}  ({utilization[used_key] / divisor:.0f} / {utilization[total_key] / divisor:.0f} {unit})"
-        )
-    if utilization["total_gpu"] > 0:
-        color = GREEN if utilization["gpu_pct"] >= 80 else YELLOW
-        print(
-            f"  {color}{'GPU:':8s}{utilization['gpu_pct']:5.1f}%{NC}  ({utilization['used_gpu']} / {utilization['total_gpu']} GPUs across {utilization['gpu_nodes']} nodes)"
-        )
-    print(f"\n  Total nodes: {utilization['total_nodes']}")
+def _print_results(result: SimResult, util: SimulationUtilization) -> None:
+    print(f"\n{BOLD}{'━' * 80}{NC}")
+    print(f"{BOLD}{CYAN}Cluster Simulation Results{NC}")
     print(f"{'━' * 80}")
+    if result.skipped:
+        print(f"\n{YELLOW}Skipped runner targets ({len(result.skipped)}):{NC}")
+        for name in result.skipped:
+            print(f"  {DIM}{name}{NC}")
+    _format_pool(util.workflow, "Workflow Pool")
+    _format_pool(util.runner, "Runner Pool")
+    _print_combined_summary(util)
+    _print_node_breakdown(result)
+    _print_deployment_accuracy(result)
+    print(f"\n{'━' * 80}")
+
+
+def _print_combined_summary(util: SimulationUtilization) -> None:
+    """One-line cluster-wide totals across both pools."""
+    total_nodes = util.workflow.nodes + util.runner.nodes
+    total_cpu_m = util.workflow.total_cpu_m + util.runner.total_cpu_m
+    used_cpu_m = util.workflow.used_cpu_m + util.runner.used_cpu_m
+    total_mem_mi = util.workflow.total_mem_mi + util.runner.total_mem_mi
+    used_mem_mi = util.workflow.used_mem_mi + util.runner.used_mem_mi
+    cpu_pct = (used_cpu_m / total_cpu_m * 100) if total_cpu_m > 0 else 0.0
+    mem_pct = (used_mem_mi / total_mem_mi * 100) if total_mem_mi > 0 else 0.0
+    print(f"\n{BOLD}Cluster-wide totals (both pools):{NC}")
+    print(
+        f"  {total_nodes} nodes  |  "
+        f"vCPU {cpu_pct:.1f}% ({used_cpu_m / 1000:.0f}/{total_cpu_m / 1000:.0f}c)  |  "
+        f"Mem {mem_pct:.1f}% ({used_mem_mi / 1024:.0f}/{total_mem_mi / 1024:.0f} GiB)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-round
+# ---------------------------------------------------------------------------
 
 
 def _percentile(values: list[float], pct: float) -> float:
-    """Return the pct-th percentile (0-100) using nearest-rank."""
     if not values:
         return 0.0
     s = sorted(values)
@@ -110,136 +172,122 @@ def _percentile(values: list[float], pct: float) -> float:
 
 
 def _run_multi(
-    runners: list[dict],
+    topology: ClusterTopology,
     targets: dict[str, int],
-    daemonsets: list,
-    skipped_mapping: dict[str, str],
-    args,
-) -> int:
-    """Run multiple rounds with different seeds, print summary statistics."""
-    utils: list[dict] = []
-    for i in range(args.rounds):
-        seed = args.seed + i
-        result = run_simulation(runners, targets, daemonsets, seed=seed, threshold=args.threshold)
-        utils.append(compute_utilization(result))
-
-    print(f"\n{BOLD}{'━' * 80}{NC}")
-    print(
-        f"{BOLD}{CYAN}Multi-Round Summary ({args.rounds} rounds, seeds {args.seed}..{args.seed + args.rounds - 1}){NC}"
-    )
-    print(f"{'━' * 80}")
-
-    if skipped_mapping:
-        print(f"\n{YELLOW}Unmapped old labels: {len(skipped_mapping)}{NC}")
-
-    _print_multi_summary(utils)
-    return 0
+    daemonsets,
+    *,
+    seed: int,
+    threshold: float,
+    rounds: int,
+) -> list[SimulationUtilization]:
+    out: list[SimulationUtilization] = []
+    for i in range(rounds):
+        result = run_simulation(topology, targets, daemonsets, seed=seed + i, threshold=threshold)
+        out.append(compute_utilization(result))
+    return out
 
 
-def _print_multi_summary(utils: list[dict]) -> None:
-    """Print percentile summary of cluster-wide utilization across rounds."""
-    _ROWS = [("cpu_pct", "vCPU"), ("mem_pct", "Memory")]
-    has_gpu = any(u["total_gpu"] > 0 for u in utils)
+def _summarize(values: list[float]) -> tuple[float, float, float, float]:
+    """Return (avg, p50, p25, worst) — worst = lowest utilization."""
+    if not values:
+        return 0.0, 0.0, 0.0, 0.0
+    avg = sum(values) / len(values)
+    return avg, _percentile(values, 50), _percentile(values, 25), min(values)
 
-    # Header
-    print(f"\n{BOLD}Cluster-wide utilization:{NC}\n")
+
+def _print_pool_multi(label: str, utils: list[PoolUtilization]) -> None:
+    print(f"\n{BOLD}{label}{NC}")
+    if not any(u.nodes for u in utils):
+        print(f"  {DIM}(no nodes provisioned across rounds){NC}")
+        return
     print(f"  {'Resource':<10} {'Avg':>8} {'p50':>8} {'p25':>8} {'Worst':>8}")
     print(f"  {'─' * 42}")
-
-    for pct_key, label in _ROWS:
-        values = [u[pct_key] for u in utils]
-        avg = sum(values) / len(values)
-        p50 = _percentile(values, 50)
-        p25 = _percentile(values, 25)
-        worst = min(values)  # lowest utilization = most wasteful
+    for label_key, getter in (
+        ("vCPU", lambda u: u.cpu_pct),
+        ("Memory", lambda u: u.mem_pct),
+    ):
+        avg, p50, p25, worst = _summarize([getter(u) for u in utils])
         color = GREEN if avg >= 80 else YELLOW
-        print(f"  {color}{label:<10} {avg:>7.1f}% {p50:>7.1f}% {p25:>7.1f}% {worst:>7.1f}%{NC}")
-
-    if has_gpu:
-        values = [u["gpu_pct"] for u in utils]
-        avg = sum(values) / len(values)
-        p50 = _percentile(values, 50)
-        p25 = _percentile(values, 25)
-        worst = min(values)
+        print(f"  {color}{label_key:<10} {avg:>7.1f}% {p50:>7.1f}% {p25:>7.1f}% {worst:>7.1f}%{NC}")
+    if any(u.total_gpu > 0 for u in utils):
+        avg, p50, p25, worst = _summarize([u.gpu_pct for u in utils])
         color = GREEN if avg >= 80 else YELLOW
         print(f"  {color}{'GPU':<10} {avg:>7.1f}% {p50:>7.1f}% {p25:>7.1f}% {worst:>7.1f}%{NC}")
+    node_counts = [u.nodes for u in utils]
+    print(f"  Nodes: avg {sum(node_counts) / len(node_counts):.1f}, min {min(node_counts)}, max {max(node_counts)}")
 
-    # Node count summary
-    node_counts = [u["total_nodes"] for u in utils]
-    avg_nodes = sum(node_counts) / len(node_counts)
-    print(f"\n  Nodes: avg {avg_nodes:.0f}, min {min(node_counts)}, max {max(node_counts)}")
+
+def _print_multi(results: list[SimulationUtilization], *, seed: int, rounds: int) -> None:
+    print(f"\n{BOLD}{'━' * 80}{NC}")
+    print(f"{BOLD}{CYAN}Multi-Round Summary ({rounds} rounds, seeds {seed}..{seed + rounds - 1}){NC}")
     print(f"{'━' * 80}")
+    _print_pool_multi("Workflow Pool", [u.workflow for u in results])
+    _print_pool_multi("Runner Pool", [u.runner for u in results])
+    print(f"\n{'━' * 80}")
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Monte Carlo cluster simulation for PyTorch CI load",
-    )
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Monte Carlo cluster simulation for PyTorch CI load")
+    parser.add_argument("--cluster", required=True, help="Cluster id from clusters.yaml")
     parser.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
     parser.add_argument("--threshold", type=float, default=0.15, help="Weighted MAPE threshold to stop (default: 0.15)")
     parser.add_argument(
-        "--rounds", type=int, default=1, help="Run N rounds with different seeds, print summary statistics"
+        "--rounds", type=int, default=1, help="Run N rounds with different seeds and print summary stats"
     )
-    parser.add_argument("--upstream-dir", type=Path, default=None, help="Path to upstream osdc/ directory")
-    parser.add_argument("--consumer-root", type=Path, default=None, help="Path to consumer osdc/ directory")
-    args = parser.parse_args(argv)
+    return parser.parse_args(argv)
 
-    # Resolve directories
-    script_dir = Path(__file__).resolve().parent
-    upstream_dir = args.upstream_dir or script_dir.parent.parent
-    consumer_root = args.consumer_root
-    if consumer_root is None:
-        env_root = os.environ.get("OSDC_ROOT", "")
-        if env_root and Path(env_root).is_dir():
-            consumer_root = Path(env_root)
-        else:
-            candidate = upstream_dir.parent.parent
-            consumer_root = candidate if (candidate / "clusters.yaml").exists() else upstream_dir
 
-    # Discover DaemonSet overhead
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    upstream_root, consumer_root = _resolve_roots()
+
+    # PEAK_CONCURRENT is a global pytorch/pytorch snapshot — the staging
+    # cluster sees a tiny fraction of that load. Warn so users don't read
+    # the staging numbers as a real capacity assessment.
+    if "staging" in args.cluster:
+        print(
+            f"{YELLOW}WARNING: PEAK_CONCURRENT is a global pytorch/pytorch snapshot — "
+            f"staging numbers will be inflated.{NC}"
+        )
+
     daemonsets = discover_daemonsets(
-        upstream_dir,
-        consumer_root=consumer_root if consumer_root != upstream_dir else None,
+        upstream_root,
+        consumer_root=consumer_root if consumer_root != upstream_root else None,
     )
+    topology = resolve_cluster(args.cluster, upstream_root=upstream_root, consumer_root=consumer_root)
 
-    # Collect runner defs (upstream + consumer modules containing runner YAMLs)
-    runner_dirs = [upstream_dir / "modules" / "arc-runners" / "defs"]
-    if consumer_root != upstream_dir and (consumer_root / "modules").exists():
-        import yaml
-
-        for mod_dir in sorted((consumer_root / "modules").iterdir()):
-            defs = mod_dir / "defs"
-            if not defs.exists():
-                continue
-            if any((d := yaml.safe_load(f.read_text())) and "runner" in d for f in defs.glob("*.yaml")):
-                runner_dirs.append(defs)
-
-    runners = load_runner_defs(runner_dirs)
-    if not runners:
-        print(f"{RED}No runner definitions found{NC}")
+    targets = build_peak_targets(topology.runners)
+    if not targets:
+        print(f"{RED}No schedulable runner targets matched the workload snapshot for cluster '{args.cluster}'{NC}")
         return 1
 
-    print(f"{BOLD}Monte Carlo Cluster Simulation{NC}\n{'━' * 80}")
+    print(f"{BOLD}Monte Carlo Cluster Simulation — {args.cluster}{NC}")
+    print(f"{'━' * 80}")
     print(
-        f"Seed: {args.seed}  |  MAPE threshold: {args.threshold:.0%}  |  Runners: {len(runners)}  |  DaemonSets: {len(daemonsets)}"
+        f"Region: {topology.region or '(unknown)'}  |  "
+        f"Modules: {len(topology.modules)}  |  "
+        f"Runner pool: {topology.runner_pool_fleet or '(none)'}  |  "
+        f"Workflow pools: {len(topology.workflow_pool_fleets)}"
+    )
+    print(
+        f"Seed: {args.seed}  |  MAPE threshold: {args.threshold:.0%}  |  "
+        f"Targets: {len(targets)}  |  DaemonSets: {len(daemonsets)}"
     )
 
-    # Build targets
-    targets, skipped_mapping = build_peak_targets(OLD_TO_NEW_LABEL, PEAK_CONCURRENT)
-    print(f"Peak target runner types: {len(targets)} (mapped from {len(PEAK_CONCURRENT)} old labels)")
-    if skipped_mapping:
-        print(f"{YELLOW}Unmapped old labels: {len(skipped_mapping)}{NC}")
-
     if args.rounds > 1:
-        return _run_multi(runners, targets, daemonsets, skipped_mapping, args)
-
-    # Single run
-    result = run_simulation(runners, targets, daemonsets, seed=args.seed, threshold=args.threshold)
-    for label, reason in skipped_mapping.items():
-        result.skipped_labels[label] = reason
-
-    utilization = compute_utilization(result)
-    print_results(result, utilization)
+        results = _run_multi(
+            topology, targets, daemonsets, seed=args.seed, threshold=args.threshold, rounds=args.rounds
+        )
+        _print_multi(results, seed=args.seed, rounds=args.rounds)
+    else:
+        result = run_simulation(topology, targets, daemonsets, seed=args.seed, threshold=args.threshold)
+        util = compute_utilization(result)
+        _print_results(result, util)
     return 0
 
 

--- a/osdc/scripts/python/test_analyze_node_utilization.py
+++ b/osdc/scripts/python/test_analyze_node_utilization.py
@@ -1,11 +1,15 @@
-"""Tests for analyze_node_utilization module."""
+"""Tests for analyze_node_utilization + utilization_report + packing modules.
 
-from pathlib import Path
+Synthetic ClusterTopology fixtures follow the pattern from test_cluster_topology.py.
+"""
+
+from __future__ import annotations
+
 from unittest.mock import patch
 
-import yaml
 from analyze_node_utilization import (
-    _print_combo,
+    HOOKS_OVERHEAD_CPU_M,
+    HOOKS_OVERHEAD_MEM_MI,
     compute_allocatable,
     compute_daemonset_overhead,
     compute_node_slack,
@@ -13,18 +17,74 @@ from analyze_node_utilization import (
     find_valid_combos,
     format_mem,
     kubelet_reserved,
-    load_nodepool_defs,
-    load_runner_defs,
     main,
+    parse_args,
     parse_memory,
-    per_runner_total,
-    print_node_analysis,
+    per_runner_pod_total,
+    per_workflow_pod_total,
+    print_combo,
+    print_runner_pool_section,
+    print_unschedulable_section,
+    print_workflow_pool_section,
 )
+from cluster_topology import ClusterTopology, NodePoolEntry, RunnerEntry
 from daemonset_overhead import DaemonSetOverhead
+from utilization_report import analyze_pool
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_runner(**overrides) -> RunnerEntry:
+    base = {
+        "name": "r1",
+        "scale_set_name": "c-mt-r1",
+        "instance_type": "c7a.48xlarge",
+        "workflow_fleet": "c7a",
+        "runner_class": None,
+        "runner_pod_cpu_m": 750,
+        "runner_pod_mem_mi": 512,
+        "workflow_pod_cpu_m": 8000,
+        "workflow_pod_mem_mi": 16384,
+        "workflow_pod_gpu": 0,
+        "schedulable": True,
+        "schedulable_reason": None,
+    }
+    base.update(overrides)
+    return RunnerEntry(**base)
+
+
+def _make_pool(**overrides) -> NodePoolEntry:
+    base = {
+        "name": "c7a-48xlarge",
+        "fleet": "c7a",
+        "instance_type": "c7a.48xlarge",
+        "arch": "amd64",
+        "gpu": False,
+        "runner_class": None,
+    }
+    base.update(overrides)
+    return NodePoolEntry(**base)
+
+
+def _make_topology(**overrides) -> ClusterTopology:
+    base = {
+        "cluster_id": "test-cluster",
+        "region": "us-east-2",
+        "modules": ["nodepools", "arc-runners"],
+        "nodepools": [],
+        "runner_pool_fleet": "c7i-runner",
+        "workflow_pool_fleets": {"c7a"},
+        "runners": [],
+    }
+    base.update(overrides)
+    return ClusterTopology(**base)
+
 
 FAKE_DS = [
-    DaemonSetOverhead("kube-proxy", 50, 80, False, "test"),
-    DaemonSetOverhead("gpu-plugin", 100, 256, True, "test"),
+    DaemonSetOverhead("kube-proxy", 50, 80, False, "test", fleet_selector=None),
+    DaemonSetOverhead("gpu-plugin", 100, 256, True, "test", fleet_selector=None),
 ]
 
 
@@ -58,25 +118,46 @@ class TestKubeletReserved:
 
 
 # ---------------------------------------------------------------------------
-# compute_daemonset_overhead
+# compute_daemonset_overhead (signature now takes is_gpu kw + optional fleet_name)
 # ---------------------------------------------------------------------------
 
 
 class TestComputeDaemonsetOverhead:
     def test_cpu_only_node(self):
         cpu, mem = compute_daemonset_overhead(FAKE_DS, is_gpu=False)
-        assert cpu == 50  # only kube-proxy
+        assert cpu == 50
         assert mem == 80
 
     def test_gpu_node(self):
         cpu, mem = compute_daemonset_overhead(FAKE_DS, is_gpu=True)
-        assert cpu == 150  # kube-proxy + gpu-plugin
+        assert cpu == 150
         assert mem == 336
 
     def test_empty_daemonsets(self):
         cpu, mem = compute_daemonset_overhead([], is_gpu=True)
         assert cpu == 0
         assert mem == 0
+
+    def test_fleet_filter_excludes_pinned_to_other(self):
+        ds = [
+            DaemonSetOverhead("a", 10, 32, False, "test", fleet_selector=None),
+            DaemonSetOverhead("b", 20, 64, False, "test", fleet_selector="c7i-runner"),
+            DaemonSetOverhead("c", 30, 128, False, "test", fleet_selector="m8g"),
+        ]
+        cpu, mem = compute_daemonset_overhead(ds, is_gpu=False, fleet_name="c7i-runner")
+        # a (None) + b (c7i-runner) only.
+        assert cpu == 30
+        assert mem == 96
+
+    def test_fleet_none_keeps_all(self):
+        ds = [
+            DaemonSetOverhead("b", 20, 64, False, "test", fleet_selector="c7i-runner"),
+            DaemonSetOverhead("c", 30, 128, False, "test", fleet_selector="m8g"),
+        ]
+        cpu, mem = compute_daemonset_overhead(ds, is_gpu=False, fleet_name=None)
+        # Legacy: no fleet_name => include both.
+        assert cpu == 50
+        assert mem == 192
 
 
 # ---------------------------------------------------------------------------
@@ -121,134 +202,39 @@ class TestFormatMem:
 
 
 # ---------------------------------------------------------------------------
-# per_runner_total
+# per_runner_pod_total / per_workflow_pod_total (RunnerEntry-based)
 # ---------------------------------------------------------------------------
 
 
-class TestPerRunnerTotal:
+class TestPerRunnerPodTotal:
     def test_basic(self):
-        runner = {"vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        cpu, mem, gpu = per_runner_total(runner)
-        # 8*1000 + 750 (sidecar) + 320 (hooks) = 9070
-        assert cpu == 9070
-        # 16384 + 512 (sidecar) + 522 (hooks) = 17418
-        assert mem == 17418
+        r = _make_runner(runner_pod_cpu_m=750, runner_pod_mem_mi=512)
+        assert per_runner_pod_total(r) == (750, 512, 0)
+
+    def test_drops_workflow_fields(self):
+        r = _make_runner(workflow_pod_cpu_m=8000, workflow_pod_mem_mi=16384, workflow_pod_gpu=2)
+        # Runner pod doesn't get workflow CPU/mem/GPU.
+        assert per_runner_pod_total(r) == (r.runner_pod_cpu_m, r.runner_pod_mem_mi, 0)
+
+
+class TestPerWorkflowPodTotal:
+    def test_no_gpu_adds_hooks(self):
+        r = _make_runner(workflow_pod_cpu_m=8000, workflow_pod_mem_mi=16384, workflow_pod_gpu=0)
+        cpu, mem, gpu = per_workflow_pod_total(r)
+        assert cpu == 8000 + HOOKS_OVERHEAD_CPU_M
+        assert mem == 16384 + HOOKS_OVERHEAD_MEM_MI
         assert gpu == 0
 
     def test_with_gpu(self):
-        runner = {"vcpu": 16, "memory_mi": 32768, "gpu": 4}
-        _, _, gpu = per_runner_total(runner)
+        r = _make_runner(workflow_pod_cpu_m=16000, workflow_pod_mem_mi=32768, workflow_pod_gpu=4)
+        cpu, mem, gpu = per_workflow_pod_total(r)
+        assert cpu == 16000 + HOOKS_OVERHEAD_CPU_M
+        assert mem == 32768 + HOOKS_OVERHEAD_MEM_MI
         assert gpu == 4
 
 
 # ---------------------------------------------------------------------------
-# load_runner_defs
-# ---------------------------------------------------------------------------
-
-
-class TestLoadRunnerDefs:
-    def test_loads_runner_yaml(self, tmp_path):
-        runner_def = {
-            "runner": {
-                "name": "test-runner",
-                "instance_type": "c7a.48xlarge",
-                "vcpu": 8,
-                "memory": "16Gi",
-                "gpu": 0,
-            }
-        }
-        (tmp_path / "runner.yaml").write_text(yaml.dump(runner_def))
-        runners = load_runner_defs([tmp_path])
-        assert len(runners) == 1
-        assert runners[0]["name"] == "test-runner"
-        assert runners[0]["vcpu"] == 8
-        assert runners[0]["memory_mi"] == 16384
-
-    def test_skips_non_runner_yaml(self, tmp_path):
-        (tmp_path / "config.yaml").write_text(yaml.dump({"settings": {"key": "value"}}))
-        runners = load_runner_defs([tmp_path])
-        assert len(runners) == 0
-
-    def test_empty_yaml(self, tmp_path):
-        (tmp_path / "empty.yaml").write_text("")
-        runners = load_runner_defs([tmp_path])
-        assert len(runners) == 0
-
-    def test_nonexistent_dir(self):
-        runners = load_runner_defs([Path("/nonexistent")])
-        assert runners == []
-
-    def test_dedup_same_name(self, tmp_path):
-        """Last directory wins for same runner name."""
-        dir1 = tmp_path / "d1"
-        dir2 = tmp_path / "d2"
-        dir1.mkdir()
-        dir2.mkdir()
-        r1 = {"runner": {"name": "r1", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory": "16Gi"}}
-        r2 = {"runner": {"name": "r1", "instance_type": "c7a.48xlarge", "vcpu": 16, "memory": "32Gi"}}
-        (dir1 / "r1.yaml").write_text(yaml.dump(r1))
-        (dir2 / "r1.yaml").write_text(yaml.dump(r2))
-        runners = load_runner_defs([dir1, dir2])
-        assert len(runners) == 1
-        assert runners[0]["vcpu"] == 16
-
-    def test_dedup_same_resolved_path(self, tmp_path):
-        """Duplicate resolved directories are skipped."""
-        runner_def = {
-            "runner": {
-                "name": "test-runner",
-                "instance_type": "c7a.48xlarge",
-                "vcpu": 8,
-                "memory": "16Gi",
-            }
-        }
-        (tmp_path / "r.yaml").write_text(yaml.dump(runner_def))
-        runners = load_runner_defs([tmp_path, tmp_path])
-        assert len(runners) == 1
-
-
-# ---------------------------------------------------------------------------
-# load_nodepool_defs
-# ---------------------------------------------------------------------------
-
-
-class TestLoadNodepoolDefs:
-    def test_loads_nodepool(self, tmp_path):
-        np_def = {
-            "nodepool": {
-                "name": "cpu-pool",
-                "instance_type": "c7a.48xlarge",
-                "gpu": False,
-            }
-        }
-        (tmp_path / "np.yaml").write_text(yaml.dump(np_def))
-        nodepools = load_nodepool_defs([tmp_path])
-        assert "c7a.48xlarge" in nodepools
-        assert nodepools["c7a.48xlarge"]["name"] == "cpu-pool"
-
-    def test_skips_non_nodepool(self, tmp_path):
-        (tmp_path / "other.yaml").write_text(yaml.dump({"runner": {"name": "r"}}))
-        nodepools = load_nodepool_defs([tmp_path])
-        assert nodepools == {}
-
-    def test_nonexistent_dir(self):
-        nodepools = load_nodepool_defs([Path("/nonexistent")])
-        assert nodepools == {}
-
-    def test_dedup_resolved_path(self, tmp_path):
-        np_def = {
-            "nodepool": {
-                "name": "pool",
-                "instance_type": "c7a.48xlarge",
-            }
-        }
-        (tmp_path / "np.yaml").write_text(yaml.dump(np_def))
-        nodepools = load_nodepool_defs([tmp_path, tmp_path])
-        assert len(nodepools) == 1
-
-
-# ---------------------------------------------------------------------------
-# compute_allocatable
+# compute_allocatable (signature gained fleet_name)
 # ---------------------------------------------------------------------------
 
 
@@ -263,8 +249,7 @@ class TestComputeAllocatable:
         assert alloc["is_gpu"] is False
 
     def test_unknown_instance_type(self):
-        alloc = compute_allocatable("z99.nonexistent", [])
-        assert alloc is None
+        assert compute_allocatable("z99.nonexistent", []) is None
 
     def test_gpu_instance(self):
         ds = [DaemonSetOverhead("gpu-ds", 100, 200, True, "test")]
@@ -273,131 +258,93 @@ class TestComputeAllocatable:
         assert alloc["is_gpu"] is True
         assert alloc["allocatable_gpu"] == 1
 
+    def test_fleet_name_filters_ds(self):
+        ds = [
+            DaemonSetOverhead("base", 100, 256, False, "test", fleet_selector=None),
+            DaemonSetOverhead("c7i-only", 50, 128, False, "test", fleet_selector="c7i-runner"),
+            DaemonSetOverhead("m8g-only", 25, 64, False, "test", fleet_selector="m8g"),
+        ]
+        alloc_runner = compute_allocatable("c7a.48xlarge", ds, fleet_name="c7i-runner")
+        alloc_m8g = compute_allocatable("c7a.48xlarge", ds, fleet_name="m8g")
+        assert alloc_runner is not None
+        assert alloc_m8g is not None
+        # Different fleet_name => different DS overhead.
+        assert alloc_runner["ds_cpu_m"] != alloc_m8g["ds_cpu_m"]
+        assert alloc_runner["ds_cpu_m"] == 100 + 50  # base + c7i-only
+        assert alloc_m8g["ds_cpu_m"] == 100 + 25  # base + m8g-only
+
+    def test_legacy_no_fleet_includes_all_ds(self):
+        ds = [
+            DaemonSetOverhead("base", 100, 256, False, "test", fleet_selector=None),
+            DaemonSetOverhead("c7i-only", 50, 128, False, "test", fleet_selector="c7i-runner"),
+        ]
+        alloc = compute_allocatable("c7a.48xlarge", ds)
+        # Legacy path: include everything.
+        assert alloc["ds_cpu_m"] == 150
+
 
 # ---------------------------------------------------------------------------
-# find_valid_combos
+# packing helpers (now take pod_cost tuples + names)
 # ---------------------------------------------------------------------------
 
 
 class TestFindValidCombos:
     def test_single_runner_fits(self):
-        alloc = {
-            "allocatable_cpu_m": 10000,
-            "allocatable_mem_mi": 20000,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": "r1", "vcpu": 2, "memory_mi": 4096, "gpu": 0}]
-        combos = find_valid_combos(runners, alloc, max_pods=5)
+        alloc = {"allocatable_cpu_m": 10000, "allocatable_mem_mi": 20000, "allocatable_gpu": 0}
+        combos = find_valid_combos([(2000, 4096, 0)], ["r1"], alloc, max_pods=5)
         assert len(combos) > 0
         assert all(c["cpu_used_m"] <= 10000 for c in combos)
 
     def test_no_fit(self):
-        alloc = {
-            "allocatable_cpu_m": 100,
-            "allocatable_mem_mi": 100,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": "r1", "vcpu": 8, "memory_mi": 16384, "gpu": 0}]
-        combos = find_valid_combos(runners, alloc, max_pods=5)
-        assert len(combos) == 0
-
-
-# ---------------------------------------------------------------------------
-# find_maximal_combos
-# ---------------------------------------------------------------------------
+        alloc = {"allocatable_cpu_m": 100, "allocatable_mem_mi": 100, "allocatable_gpu": 0}
+        combos = find_valid_combos([(8000, 16384, 0)], ["r1"], alloc, max_pods=5)
+        assert combos == []
 
 
 class TestFindMaximalCombos:
     def test_filters_non_maximal(self):
-        alloc = {
-            "allocatable_cpu_m": 10000,
-            "allocatable_mem_mi": 20000,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": "r1", "vcpu": 2, "memory_mi": 4096, "gpu": 0}]
-        combos = find_valid_combos(runners, alloc, max_pods=5)
-        maximal = find_maximal_combos(combos, alloc, runners)
-        # Only the largest count should remain
+        alloc = {"allocatable_cpu_m": 10000, "allocatable_mem_mi": 20000, "allocatable_gpu": 0}
+        pod_costs = [(2000, 4096, 0)]
+        combos = find_valid_combos(pod_costs, ["r1"], alloc, max_pods=5)
+        maximal = find_maximal_combos(combos, alloc, pod_costs)
         for combo in maximal:
-            # No more runners can fit
-            c, m, _g = per_runner_total(runners[0])
+            c, m, _g = pod_costs[0]
             remaining_cpu = alloc["allocatable_cpu_m"] - combo["cpu_used_m"]
             remaining_mem = alloc["allocatable_mem_mi"] - combo["mem_used_mi"]
             assert remaining_cpu < c or remaining_mem < m
 
 
-# ---------------------------------------------------------------------------
-# compute_node_slack
-# ---------------------------------------------------------------------------
-
-
 class TestComputeNodeSlack:
     def test_homogeneous_only(self):
-        alloc = {
-            "allocatable_cpu_m": 10000,
-            "allocatable_mem_mi": 20000,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": "r1", "vcpu": 2, "memory_mi": 4096, "gpu": 0}]
-        slack = compute_node_slack(alloc, runners, homogeneous_only=True)
+        alloc = {"allocatable_cpu_m": 10000, "allocatable_mem_mi": 20000, "allocatable_gpu": 0}
+        slack = compute_node_slack(alloc, [(2000, 4096, 0)], homogeneous_only=True)
         assert slack is not None
         assert "min_cpu_m" in slack
 
     def test_many_runners_forces_homogeneous(self):
-        """More than 8 runner types forces homogeneous-only path."""
-        alloc = {
-            "allocatable_cpu_m": 100000,
-            "allocatable_mem_mi": 200000,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": f"r{i}", "vcpu": 2, "memory_mi": 4096, "gpu": 0} for i in range(10)]
-        slack = compute_node_slack(alloc, runners)
+        """More than 8 pod costs forces homogeneous-only path."""
+        alloc = {"allocatable_cpu_m": 100000, "allocatable_mem_mi": 200000, "allocatable_gpu": 0}
+        slack = compute_node_slack(alloc, [(2000, 4096, 0)] * 10)
         assert slack is not None
 
     def test_no_valid_combos(self):
-        alloc = {
-            "allocatable_cpu_m": 100,
-            "allocatable_mem_mi": 100,
-            "allocatable_gpu": 0,
-        }
-        runners = [{"name": "r1", "vcpu": 8, "memory_mi": 16384, "gpu": 0}]
-        slack = compute_node_slack(alloc, runners, homogeneous_only=True)
+        alloc = {"allocatable_cpu_m": 100, "allocatable_mem_mi": 100, "allocatable_gpu": 0}
+        slack = compute_node_slack(alloc, [(8000, 16384, 0)], homogeneous_only=True)
         assert slack is None
 
     def test_mixed_combos_path(self):
-        """Few runners triggers the full enumeration path."""
-        alloc = {
-            "allocatable_cpu_m": 20000,
-            "allocatable_mem_mi": 40000,
-            "allocatable_gpu": 0,
-        }
-        runners = [
-            {"name": "r1", "vcpu": 2, "memory_mi": 4096, "gpu": 0},
-            {"name": "r2", "vcpu": 4, "memory_mi": 8192, "gpu": 0},
-        ]
-        slack = compute_node_slack(alloc, runners, homogeneous_only=False)
+        alloc = {"allocatable_cpu_m": 20000, "allocatable_mem_mi": 40000, "allocatable_gpu": 0}
+        slack = compute_node_slack(alloc, [(2000, 4096, 0), (4000, 8192, 0)], homogeneous_only=False)
         assert slack is not None
 
     def test_mixed_no_maximal_returns_none(self):
-        """Mixed path returns None when no maximal combos found (line 329)."""
-        alloc = {
-            "allocatable_cpu_m": 100,
-            "allocatable_mem_mi": 100,
-            "allocatable_gpu": 0,
-        }
-        # Runners too big to fit; find_valid_combos returns empty -> maximal empty
-        runners = [{"name": "r1", "vcpu": 8, "memory_mi": 16384, "gpu": 0}]
-        slack = compute_node_slack(alloc, runners, homogeneous_only=False)
+        alloc = {"allocatable_cpu_m": 100, "allocatable_mem_mi": 100, "allocatable_gpu": 0}
+        slack = compute_node_slack(alloc, [(8000, 16384, 0)], homogeneous_only=False)
         assert slack is None
 
 
 # ---------------------------------------------------------------------------
-# print_node_analysis (smoke test for output, not assertions on content)
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# _print_combo
+# print_combo (smoke output)
 # ---------------------------------------------------------------------------
 
 
@@ -411,10 +358,8 @@ class TestPrintCombo:
             "cpu_waste_m": 1500,
             "mem_waste_mi": 6000,
         }
-        alloc = {"allocatable_gpu": 0}
-        _print_combo(combo, alloc, 90.0, 1)
-        output = capsys.readouterr().out
-        assert "r1" in output
+        print_combo(combo, {"allocatable_gpu": 0}, 90.0, 1)
+        assert "r1" in capsys.readouterr().out
 
     def test_prints_combo_with_gpu(self, capsys):
         combo = {
@@ -425,192 +370,276 @@ class TestPrintCombo:
             "cpu_waste_m": 500,
             "mem_waste_mi": 2000,
         }
-        alloc = {"allocatable_gpu": 4}
-        _print_combo(combo, alloc, 90.0, 1)
-        output = capsys.readouterr().out
-        assert "GPU" in output
-
-    def test_color_green_above_threshold(self, capsys):
-        combo = {
-            "runners": ["r1"],
-            "cpu_util": 95.0,
-            "mem_util": 95.0,
-            "gpu_util": 0.0,
-            "cpu_waste_m": 500,
-            "mem_waste_mi": 1000,
-        }
-        alloc = {"allocatable_gpu": 0}
-        _print_combo(combo, alloc, 90.0, 1)
-        # Just ensure no crash for above-threshold
+        print_combo(combo, {"allocatable_gpu": 4}, 90.0, 1)
+        assert "GPU" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
-# print_node_analysis (smoke test for output, not assertions on content)
+# analyze_pool (per-pool analyzer used by both section printers)
 # ---------------------------------------------------------------------------
 
 
-class TestPrintNodeAnalysis:
-    def test_runs_without_error(self, capsys):
-        ds = [DaemonSetOverhead("ds1", 100, 200, False, "test")]
-        alloc = compute_allocatable("c7a.48xlarge", ds)
+class TestAnalyzePool:
+    def test_runs_workflow_pool(self, capsys):
         runners = [
-            {"name": "r1", "vcpu": 8, "memory_mi": 16384, "gpu": 0},
-            {"name": "r2", "vcpu": 16, "memory_mi": 32768, "gpu": 0},
+            _make_runner(name="r1", workflow_pod_cpu_m=8000, workflow_pod_mem_mi=16384),
+            _make_runner(name="r2", workflow_pod_cpu_m=16000, workflow_pod_mem_mi=32768),
         ]
-        # Just verify it does not raise
-        print_node_analysis("c7a.48xlarge", alloc, runners, 90.0)
-        output = capsys.readouterr().out
-        assert "c7a.48xlarge" in output
+        nodepools = [_make_pool()]
+        below, slacks = analyze_pool(
+            "Test Pool",
+            "c7a",
+            nodepools,
+            runners,
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        out = capsys.readouterr().out
+        assert "Test Pool" in out
+        assert "r1" in out
+        assert "r2" in out
+        assert isinstance(below, int)
+        assert "c7a.48xlarge" in slacks
 
-    def test_gpu_node(self, capsys):
-        ds = [DaemonSetOverhead("gpu-ds", 100, 256, True, "test")]
-        alloc = compute_allocatable("g5.8xlarge", ds)
-        runners = [
-            {"name": "r1", "vcpu": 8, "memory_mi": 16384, "gpu": 1},
-        ]
-        print_node_analysis("g5.8xlarge", alloc, runners, 90.0)
-        output = capsys.readouterr().out
-        assert "GPU" in output
+    def test_runs_runner_pool(self, capsys):
+        runners = [_make_runner(name="r1"), _make_runner(name="r2")]
+        nodepools = [_make_pool(name="c7i-runner-12xl", fleet="c7i-runner", instance_type="c7i.12xlarge")]
+        below, slacks = analyze_pool(
+            "Runner Pool",
+            "c7i-runner",
+            nodepools,
+            runners,
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_runner_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        out = capsys.readouterr().out
+        assert "Runner Pool" in out
+        # Runner pods are tiny → many fit per node.
+        assert "pods" in out
+        assert isinstance(below, int)
+        assert "c7i.12xlarge" in slacks
+
+    def test_no_runners(self, capsys):
+        below, slacks = analyze_pool(
+            "Empty",
+            "c7a",
+            [_make_pool()],
+            [],
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        assert below == 0
+        assert slacks == {}
+        assert "no runners" in capsys.readouterr().out
+
+    def test_no_nodepools(self, capsys):
+        below, slacks = analyze_pool(
+            "NoNP",
+            "c7a",
+            [],
+            [_make_runner()],
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        assert below == 0
+        assert slacks == {}
+        assert "no nodepools" in capsys.readouterr().out
+
+    def test_unknown_instance_type_warning(self, capsys):
+        nodepools = [_make_pool(name="z99-x", fleet="c7a", instance_type="z99.fake")]
+        below, slacks = analyze_pool(
+            "Unknown",
+            "c7a",
+            nodepools,
+            [_make_runner()],
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        assert below == 0
+        assert slacks == {}  # unknown skipped → no slack collected
+        assert "z99.fake" in capsys.readouterr().out
 
     def test_too_many_runners_skips_mixed(self, capsys):
-        """More than 8 runners prints skip message."""
-        ds = [DaemonSetOverhead("ds1", 50, 100, False, "test")]
-        alloc = compute_allocatable("c7a.48xlarge", ds)
-        runners = [{"name": f"r{i}", "vcpu": 2, "memory_mi": 4096, "gpu": 0} for i in range(10)]
-        print_node_analysis("c7a.48xlarge", alloc, runners, 90.0)
-        output = capsys.readouterr().out
-        assert "too many runner types" in output
+        # 10 runners triggers the > 8 path.
+        runners = [_make_runner(name=f"r{i}") for i in range(10)]
+        analyze_pool(
+            "Big",
+            "c7a",
+            [_make_pool()],
+            runners,
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        assert "too many runner types" in capsys.readouterr().out
 
-    def test_no_maximal_combos(self, capsys):
-        """When no maximal combos found, prints skip message (lines 426-427)."""
-        ds = [DaemonSetOverhead("ds1", 50, 100, False, "test")]
-        alloc = compute_allocatable("c7a.48xlarge", ds)
-        # Runners too big to fit at all -> no valid combos -> no maximal combos
+    def test_no_valid_combos_message(self, capsys):
+        # One huge runner that cannot fit on any node.
+        huge = _make_runner(name="huge", workflow_pod_cpu_m=999000, workflow_pod_mem_mi=999000)
+        analyze_pool(
+            "Huge",
+            "c7a",
+            [_make_pool()],
+            [huge],
+            FAKE_DS,
+            threshold=90.0,
+            pod_total_fn=per_workflow_pod_total,
+            compute_allocatable_fn=compute_allocatable,
+        )
+        assert "no valid combos found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Section printers
+# ---------------------------------------------------------------------------
+
+
+class TestPrintWorkflowPoolSection:
+    def test_runs_with_schedulable_runner(self, capsys):
+        runners = [_make_runner(name="r1", workflow_fleet="c7a")]
+        nodepools = [_make_pool()]
+        topo = _make_topology(runners=runners, nodepools=nodepools, workflow_pool_fleets={"c7a"})
+        below, slacks = print_workflow_pool_section(topo, FAKE_DS, threshold=90.0)
+        out = capsys.readouterr().out
+        assert "WORKFLOW POOL PACKING" in out
+        assert "Workflow Pool [c7a]" in out
+        assert isinstance(below, int)
+        assert "c7a/c7a.48xlarge" in slacks
+
+    def test_no_schedulable_runners(self, capsys):
+        topo = _make_topology(runners=[_make_runner(schedulable=False, schedulable_reason="no pool")])
+        below, slacks = print_workflow_pool_section(topo, FAKE_DS, threshold=90.0)
+        assert below == 0
+        assert slacks == {}
+        assert "no schedulable runners" in capsys.readouterr().out
+
+    def test_release_runners_separated(self, capsys):
         runners = [
-            {"name": "huge", "vcpu": 999, "memory_mi": 999999, "gpu": 0},
+            _make_runner(name="r-normal", workflow_fleet="c7a", runner_class=None),
+            _make_runner(name="r-rel", workflow_fleet="c7a", runner_class="release"),
         ]
-        print_node_analysis("c7a.48xlarge", alloc, runners, 90.0)
-        output = capsys.readouterr().out
-        assert "no valid combos found" in output
+        nodepools = [
+            _make_pool(),
+            _make_pool(name="c7a-48xlarge-release", runner_class="release"),
+        ]
+        topo = _make_topology(runners=runners, nodepools=nodepools, workflow_pool_fleets={"c7a"})
+        print_workflow_pool_section(topo, FAKE_DS, threshold=90.0)
+        out = capsys.readouterr().out
+        assert "Workflow Pool [c7a]" in out
+        assert "Workflow Pool [c7a/release]" in out
+
+
+class TestPrintRunnerPoolSection:
+    def test_with_runner_pool(self, capsys):
+        runners = [_make_runner(name="r1", workflow_fleet="c7a")]
+        nodepools = [
+            _make_pool(),
+            _make_pool(name="c7i-runner-12xl", fleet="c7i-runner", instance_type="c7i.12xlarge"),
+        ]
+        topo = _make_topology(
+            runners=runners, nodepools=nodepools, workflow_pool_fleets={"c7a"}, runner_pool_fleet="c7i-runner"
+        )
+        below, slacks = print_runner_pool_section(topo, FAKE_DS, threshold=90.0)
+        out = capsys.readouterr().out
+        assert "RUNNER POOL PACKING" in out
+        assert "Runner Pool [c7i-runner]" in out
+        assert isinstance(below, int)
+        assert "c7i.12xlarge" in slacks
+
+    def test_no_runner_pool_warns(self, capsys):
+        topo = _make_topology(runner_pool_fleet=None)
+        below, slacks = print_runner_pool_section(topo, FAKE_DS, threshold=90.0)
+        assert below == 0
+        assert slacks == {}
+        out = capsys.readouterr().out
+        assert "No c7i-runner pool found" in out
+
+
+class TestPrintUnschedulableSection:
+    def test_lists_unschedulable(self, capsys):
+        runners = [
+            _make_runner(name="ok"),
+            _make_runner(name="bad", schedulable=False, schedulable_reason="missing fleet"),
+        ]
+        topo = _make_topology(runners=runners)
+        print_unschedulable_section(topo)
+        out = capsys.readouterr().out
+        assert "UNSCHEDULABLE RUNNERS" in out
+        assert "bad" in out
+        assert "missing fleet" in out
+        # Schedulable runners should NOT appear in this section.
+        assert "ok " not in out
+
+    def test_all_schedulable(self, capsys):
+        topo = _make_topology(runners=[_make_runner(name="ok")])
+        print_unschedulable_section(topo)
+        out = capsys.readouterr().out
+        assert "all runners are schedulable" in out
 
 
 # ---------------------------------------------------------------------------
-# main
+# parse_args / main
 # ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_required_cluster(self):
+        args = parse_args(["--cluster", "arc-staging"])
+        assert args.cluster == "arc-staging"
+        assert args.threshold == 90.0
+
+    def test_threshold_override(self):
+        args = parse_args(["--cluster", "x", "--threshold", "80"])
+        assert args.threshold == 80.0
 
 
 class TestMain:
-    def test_show_daemonsets(self, capsys):
-        """--show-daemonsets flag prints daemonsets and exits."""
-        # main() resolves __file__ to find upstream_dir, so we run against
-        # the real project tree. --show-daemonsets prints and returns 0.
-        result = main(["--show-daemonsets"])
-        assert result == 0
-        output = capsys.readouterr().out
-        assert "Discovered DaemonSets" in output
-
-    def test_runs_full_analysis(self, capsys):
-        """Full analysis against real project defs (smoke test)."""
-        # This exercises the main() code path against the real tree.
-        # It returns 0 (all good) or 1 (issues found); either is fine.
-        result = main(["--threshold", "99"])
-        assert result in (0, 1)
-        output = capsys.readouterr().out
-        assert "Node Utilization Analysis" in output
-
-    @patch("analyze_node_utilization.load_runner_defs", return_value=[])
-    def test_no_runners_returns_1(self, mock_load, capsys):
-        """main() returns 1 when no runner definitions found (lines 559-560)."""
-        result = main(["--threshold", "90"])
-        assert result == 1
-        output = capsys.readouterr().out
-        assert "No runner definitions found" in output
-
-    @patch("analyze_node_utilization.load_runner_defs")
-    def test_unknown_instance_type_warning(self, mock_load, capsys):
-        """main() warns about unknown instance types (line 570) and skips them (line 577)."""
-        mock_load.return_value = [
-            {"name": "r1", "instance_type": "z99.fake", "vcpu": 4, "memory_mi": 8192, "gpu": 0},
+    @patch("analyze_node_utilization.discover_daemonsets")
+    @patch("analyze_node_utilization.resolve_cluster")
+    def test_runs_with_synthetic_topology(self, mock_resolve, mock_discover, capsys):
+        """main() runs without crashing when topology + daemonsets are stubbed."""
+        runners = [
+            _make_runner(name="r1", workflow_fleet="c7a"),
+            _make_runner(name="bad", schedulable=False, schedulable_reason="fake"),
         ]
-        result = main(["--threshold", "90"])
-        assert result in (0, 1)
-        output = capsys.readouterr().out
-        assert "z99.fake" in output
-
-    @patch("analyze_node_utilization.load_runner_defs")
-    def test_all_good_message(self, mock_load, capsys):
-        """When all runners have good utilization, prints all-good message (line 607)."""
-        # Use controlled runner defs that pack well on their instance type
-        mock_load.return_value = [
-            {"name": "r1", "instance_type": "c7a.xlarge", "vcpu": 2, "memory_mi": 4096, "gpu": 0},
+        nodepools = [
+            _make_pool(),
+            _make_pool(name="c7i-runner-12xl", fleet="c7i-runner", instance_type="c7i.12xlarge"),
         ]
-        result = main(["--threshold", "1"])
-        assert result == 0
-        output = capsys.readouterr().out
-        assert "All runner types achieve" in output
-
-    def test_consumer_runner_defs_discovered(self, tmp_path, monkeypatch, capsys):
-        """main() discovers runner defs from consumer modules/ when OSDC_ROOT is set."""
-        # Create a fake consumer root with a module containing runner defs
-        consumer = tmp_path / "consumer"
-        defs = consumer / "modules" / "custom-runners" / "defs"
-        defs.mkdir(parents=True)
-        (defs / "big-runner.yaml").write_text(
-            yaml.dump(
-                {
-                    "runner": {
-                        "name": "consumer-big",
-                        "instance_type": "c7a.48xlarge",
-                        "vcpu": 96,
-                        "memory": "192Gi",
-                        "gpu": 0,
-                    }
-                }
-            )
+        mock_resolve.return_value = _make_topology(
+            cluster_id="fake-cluster",
+            runners=runners,
+            nodepools=nodepools,
+            workflow_pool_fleets={"c7a"},
+            runner_pool_fleet="c7i-runner",
         )
-        monkeypatch.setenv("OSDC_ROOT", str(consumer))
-        result = main(["--threshold", "1"])
-        assert result in (0, 1)
-        output = capsys.readouterr().out
-        assert str(defs) in output
+        mock_discover.return_value = FAKE_DS
 
-    def test_consumer_nodepool_defs_discovered(self, tmp_path, monkeypatch, capsys):
-        """main() discovers nodepool defs from consumer modules/ when OSDC_ROOT is set."""
-        consumer = tmp_path / "consumer"
-        defs = consumer / "modules" / "custom-nodepools" / "defs"
-        defs.mkdir(parents=True)
-        (defs / "big-pool.yaml").write_text(
-            yaml.dump(
-                {
-                    "nodepool": {
-                        "name": "consumer-pool",
-                        "instance_type": "c7a.48xlarge",
-                    }
-                }
-            )
-        )
-        monkeypatch.setenv("OSDC_ROOT", str(consumer))
-        result = main(["--threshold", "1"])
-        assert result in (0, 1)
-        output = capsys.readouterr().out
-        assert str(defs) in output
+        rc = main(["--cluster", "fake-cluster", "--threshold", "90"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Node Utilization Analysis" in out
+        assert "WORKFLOW POOL PACKING" in out
+        assert "RUNNER POOL PACKING" in out
+        assert "UNSCHEDULABLE RUNNERS" in out
 
-    def test_consumer_module_without_defs_ignored(self, tmp_path, monkeypatch, capsys):
-        """Consumer modules without a defs/ directory are silently skipped."""
-        consumer = tmp_path / "consumer"
-        (consumer / "modules" / "no-defs-module").mkdir(parents=True)
-        monkeypatch.setenv("OSDC_ROOT", str(consumer))
-        result = main(["--threshold", "1"])
-        assert result in (0, 1)
-
-    def test_consumer_module_non_runner_yaml_ignored(self, tmp_path, monkeypatch, capsys):
-        """Consumer module defs with non-runner/nodepool YAMLs are not added."""
-        consumer = tmp_path / "consumer"
-        defs = consumer / "modules" / "other-module" / "defs"
-        defs.mkdir(parents=True)
-        (defs / "config.yaml").write_text(yaml.dump({"something_else": True}))
-        monkeypatch.setenv("OSDC_ROOT", str(consumer))
-        result = main(["--threshold", "1"])
-        assert result in (0, 1)
-        output = capsys.readouterr().out
-        assert str(defs) not in output
+    @patch("analyze_node_utilization.discover_daemonsets")
+    @patch("analyze_node_utilization.resolve_cluster")
+    def test_main_no_runner_pool(self, mock_resolve, mock_discover, capsys):
+        """main() handles topology without c7i-runner gracefully."""
+        mock_resolve.return_value = _make_topology(runner_pool_fleet=None, workflow_pool_fleets={"c7a"})
+        mock_discover.return_value = FAKE_DS
+        rc = main(["--cluster", "x"])
+        assert rc == 0
+        assert "No c7i-runner pool found" in capsys.readouterr().out

--- a/osdc/scripts/python/test_cluster_topology.py
+++ b/osdc/scripts/python/test_cluster_topology.py
@@ -1,0 +1,757 @@
+"""Tests for cluster_topology module.
+
+All tests use synthetic YAML written to ``tmp_path`` — they do NOT touch the
+real ``clusters.yaml`` or ``modules/`` tree.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from cluster_topology import (
+    ClusterTopology,
+    NodePoolEntry,
+    RunnerEntry,
+    _extract_runner_class,
+    _extract_workflow_fleet,
+    _mark_schedulability,
+    derive_fleet_name,
+    fleet_nodepool_name,
+    is_excluded_for_region,
+    load_nodepools,
+    load_runners,
+    parse_cpu,
+    parse_memory,
+    resolve_cluster,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Tiny pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsExcludedForRegion:
+    def test_region_in_list_returns_true(self):
+        assert is_excluded_for_region({"exclude_regions": ["us-west-1"]}, "us-west-1") is True
+
+    def test_region_not_in_list_returns_false(self):
+        assert is_excluded_for_region({"exclude_regions": ["us-west-1"]}, "us-east-2") is False
+
+    def test_no_exclude_regions_key_returns_false(self):
+        assert is_excluded_for_region({"name": "c7i"}, "us-west-1") is False
+
+    def test_none_region_is_noop(self):
+        assert is_excluded_for_region({"exclude_regions": ["us-west-1"]}, None) is False
+
+    def test_empty_region_is_noop(self):
+        assert is_excluded_for_region({"exclude_regions": ["us-west-1"]}, "") is False
+
+    def test_explicit_none_in_list_value(self):
+        assert is_excluded_for_region({"exclude_regions": None}, "us-west-1") is False
+
+
+class TestDeriveFleetName:
+    def test_simple_intel(self):
+        assert derive_fleet_name("c7i.48xlarge") == "c7i"
+
+    def test_graviton(self):
+        assert derive_fleet_name("m8g.24xlarge") == "m8g"
+
+    def test_dashed_family_b200(self):
+        # The dash inside the family must survive — fleet is 'p6-b200', not 'p6'.
+        assert derive_fleet_name("p6-b200.48xlarge") == "p6-b200"
+
+    def test_metal_size_keeps_family(self):
+        assert derive_fleet_name("c7i.metal-24xl") == "c7i"
+
+
+class TestFleetNodepoolName:
+    def test_default_when_fleet_matches_family(self):
+        assert fleet_nodepool_name("c7i", "c7i.48xlarge") == "c7i-48xlarge"
+
+    def test_uses_fleet_prefix_when_overriding(self):
+        # c7i-runner is a name-only clone of c7i; nodepool name keeps the fleet prefix
+        assert fleet_nodepool_name("c7i-runner", "c7i.48xlarge") == "c7i-runner-48xlarge"
+
+    def test_release_suffix(self):
+        assert fleet_nodepool_name("m8g", "m8g.48xlarge", "-release") == "m8g-48xlarge-release"
+
+    def test_dashed_family(self):
+        assert fleet_nodepool_name("p6-b200", "p6-b200.48xlarge") == "p6-b200-48xlarge"
+
+
+class TestParseCpu:
+    def test_milli_string(self):
+        assert parse_cpu("750m") == 750
+
+    def test_whole_number_string(self):
+        assert parse_cpu("6") == 6000
+
+    def test_fractional_string(self):
+        assert parse_cpu("6.5") == 6500
+
+    def test_int_value(self):
+        assert parse_cpu(2) == 2000
+
+    def test_float_value(self):
+        assert parse_cpu(0.5) == 500
+
+
+class TestParseMemory:
+    def test_gib(self):
+        assert parse_memory("29Gi") == 29 * 1024
+
+    def test_mib(self):
+        assert parse_memory("512Mi") == 512
+
+    def test_kib(self):
+        assert parse_memory("2048Ki") == 2
+
+    def test_plain_bytes(self):
+        # Plain numbers are bytes -> MiB
+        assert parse_memory(str(1024 * 1024)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Affinity extractors (workflow_fleet, runner_class)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWorkflowFleet:
+    def test_finds_node_fleet_value(self):
+        spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "weight": 50,
+                            "preference": {
+                                "matchExpressions": [
+                                    {"key": "node-fleet", "operator": "In", "values": ["m8g"]},
+                                    {"key": "workload-type", "operator": "In", "values": ["github-runner"]},
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        assert _extract_workflow_fleet(spec) == "m8g"
+
+    def test_finds_in_second_preference(self):
+        spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {"preference": {"matchExpressions": [{"key": "other", "values": ["x"]}]}},
+                        {"preference": {"matchExpressions": [{"key": "node-fleet", "values": ["p6-b200"]}]}},
+                    ]
+                }
+            }
+        }
+        assert _extract_workflow_fleet(spec) == "p6-b200"
+
+    def test_returns_none_when_missing(self):
+        assert _extract_workflow_fleet({}) is None
+        assert _extract_workflow_fleet({"affinity": {}}) is None
+
+
+class TestExtractRunnerClass:
+    def test_release_runner(self):
+        spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "osdc.io/runner-class",
+                                        "operator": "In",
+                                        "values": ["release"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_runner_class(spec) == "release"
+
+    def test_does_not_exist_returns_none(self):
+        spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {"matchExpressions": [{"key": "osdc.io/runner-class", "operator": "DoesNotExist"}]}
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_runner_class(spec) is None
+
+    def test_missing_returns_none(self):
+        assert _extract_runner_class({}) is None
+
+
+# ---------------------------------------------------------------------------
+# load_nodepools — both schemas, region filter, release expansion
+# ---------------------------------------------------------------------------
+
+
+def _write_nodepools_defs(root: Path, files: dict[str, str]) -> None:
+    defs = root / "modules" / "nodepools" / "defs"
+    defs.mkdir(parents=True, exist_ok=True)
+    for name, content in files.items():
+        (defs / name).write_text(textwrap.dedent(content))
+
+
+def _write_b200_defs(root: Path, files: dict[str, str]) -> None:
+    defs = root / "modules" / "nodepools-b200" / "defs"
+    defs.mkdir(parents=True, exist_ok=True)
+    for name, content in files.items():
+        (defs / name).write_text(textwrap.dedent(content))
+
+
+class TestLoadNodepools:
+    def test_fleet_schema_with_release(self, tmp_path):
+        _write_nodepools_defs(
+            tmp_path,
+            {
+                "m8g.yaml": """
+                    fleet:
+                      name: m8g
+                      arch: arm64
+                      gpu: false
+                      instances:
+                        - type: m8g.48xlarge
+                          weight: 100
+                          node_disk_size: 7000
+                        - type: m8g.24xlarge
+                          weight: 75
+                          node_disk_size: 3500
+                      release:
+                        - type: m8g.48xlarge
+                          weight: 100
+                          node_disk_size: 7000
+                """,
+            },
+        )
+        entries = load_nodepools(["nodepools"], region="us-east-2", upstream_root=tmp_path)
+        names = sorted(e.name for e in entries)
+        assert names == ["m8g-24xlarge", "m8g-48xlarge", "m8g-48xlarge-release"]
+
+        rel = next(e for e in entries if e.runner_class == "release")
+        assert rel.fleet == "m8g"
+        assert rel.instance_type == "m8g.48xlarge"
+        assert rel.arch == "arm64"
+        assert rel.gpu is False
+
+        non_rel = [e for e in entries if e.runner_class is None]
+        assert all(e.fleet == "m8g" for e in non_rel)
+
+    def test_fleets_list_schema(self, tmp_path):
+        # Multi-fleet single file (fleets: list) — synthetic since no current file uses it.
+        _write_nodepools_defs(
+            tmp_path,
+            {
+                "multi.yaml": """
+                    fleets:
+                      - name: c7i
+                        arch: amd64
+                        gpu: false
+                        instances:
+                          - type: c7i.48xlarge
+                            weight: 100
+                            node_disk_size: 100
+                      - name: m8g
+                        arch: arm64
+                        gpu: false
+                        instances:
+                          - type: m8g.24xlarge
+                            weight: 75
+                            node_disk_size: 100
+                """,
+            },
+        )
+        entries = load_nodepools(["nodepools"], region="us-east-2", upstream_root=tmp_path)
+        names = sorted(e.name for e in entries)
+        assert names == ["c7i-48xlarge", "m8g-24xlarge"]
+
+    def test_legacy_nodepool_schema_b200(self, tmp_path):
+        _write_b200_defs(
+            tmp_path,
+            {
+                "p6-b200-48xlarge.yaml": """
+                    nodepool:
+                      name: p6-b200-48xlarge
+                      instance_type: p6-b200.48xlarge
+                      arch: amd64
+                      node_disk_size: 100
+                      gpu: true
+                      has_nvme: true
+                """,
+            },
+        )
+        entries = load_nodepools(["nodepools-b200"], region="us-east-2", upstream_root=tmp_path)
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.name == "p6-b200-48xlarge"
+        # Fleet derives from the instance_type prefix — dash preserved.
+        assert e.fleet == "p6-b200"
+        assert e.instance_type == "p6-b200.48xlarge"
+        assert e.arch == "amd64"
+        assert e.gpu is True
+        assert e.runner_class is None
+
+    def test_region_filter_skips_excluded_fleet(self, tmp_path):
+        _write_nodepools_defs(
+            tmp_path,
+            {
+                "g5.yaml": """
+                    fleet:
+                      name: g5
+                      arch: amd64
+                      gpu: true
+                      exclude_regions:
+                        - us-west-1
+                      instances:
+                        - type: g5.48xlarge
+                          weight: 100
+                          node_disk_size: 600
+                """,
+            },
+        )
+        # In us-west-1 → skipped
+        west = load_nodepools(["nodepools"], region="us-west-1", upstream_root=tmp_path)
+        assert west == []
+        # Elsewhere → included
+        east = load_nodepools(["nodepools"], region="us-east-2", upstream_root=tmp_path)
+        assert len(east) == 1
+        assert east[0].fleet == "g5"
+
+    def test_b200_module_not_enabled_skips_dir(self, tmp_path):
+        # Only nodepools-b200 has defs but the module list omits it.
+        _write_b200_defs(
+            tmp_path,
+            {
+                "p6-b200-48xlarge.yaml": """
+                    nodepool:
+                      name: p6-b200-48xlarge
+                      instance_type: p6-b200.48xlarge
+                      arch: amd64
+                      node_disk_size: 100
+                      gpu: true
+                """,
+            },
+        )
+        entries = load_nodepools(["nodepools"], region="us-east-2", upstream_root=tmp_path)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# load_runners — synthetic generated/ files
+# ---------------------------------------------------------------------------
+
+
+def _runner_helm_doc(*, name: str, scale_set: str, runner_cpu: str, runner_mem: str) -> dict:
+    return {
+        "githubConfigUrl": "https://github.com/foo/bar",
+        "githubConfigSecret": "secret",
+        "runnerScaleSetName": scale_set,
+        "template": {
+            "spec": {
+                "nodeSelector": {"workload-type": "github-runner", "node-fleet": "c7i-runner"},
+                "containers": [
+                    {
+                        "name": "runner",
+                        "resources": {
+                            "requests": {"cpu": runner_cpu, "memory": runner_mem},
+                            "limits": {"cpu": runner_cpu, "memory": runner_mem},
+                        },
+                    }
+                ],
+            }
+        },
+    }
+
+
+def _workflow_pod_yaml(*, fleet: str, cpu: str, mem: str, gpu: int = 0, runner_class: str | None = None) -> str:
+    runner_class_expr: dict
+    if runner_class:
+        runner_class_expr = {
+            "key": "osdc.io/runner-class",
+            "operator": "In",
+            "values": [runner_class],
+        }
+    else:
+        runner_class_expr = {"key": "osdc.io/runner-class", "operator": "DoesNotExist"}
+    requests: dict[str, str | int] = {"cpu": cpu, "memory": mem}
+    if gpu:
+        requests["nvidia.com/gpu"] = gpu
+    pod = {
+        "metadata": {"annotations": {"karpenter.sh/do-not-disrupt": "true"}},
+        "spec": {
+            "serviceAccountName": "arc-workflow",
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [{"matchExpressions": [runner_class_expr]}]
+                    },
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "weight": 50,
+                            "preference": {
+                                "matchExpressions": [
+                                    {"key": "node-fleet", "operator": "In", "values": [fleet]},
+                                    {"key": "workload-type", "operator": "In", "values": ["github-runner"]},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            },
+            "containers": [
+                {
+                    "name": "$job",
+                    "resources": {"requests": requests, "limits": requests},
+                }
+            ],
+        },
+    }
+    return yaml.safe_dump(pod)
+
+
+def _configmap_doc(
+    *, runner_name: str, fleet: str, cpu: str, mem: str, gpu: int = 0, runner_class: str | None = None
+) -> dict:
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": f"arc-runner-hook-{runner_name}", "namespace": "arc-runners"},
+        "data": {
+            "job-pod.yaml": _workflow_pod_yaml(fleet=fleet, cpu=cpu, mem=mem, gpu=gpu, runner_class=runner_class),
+        },
+    }
+
+
+def _write_runner_def(root: Path, *, runner_name: str, instance_type: str, runner_class: str | None = None) -> None:
+    defs = root / "modules" / "arc-runners" / "defs"
+    defs.mkdir(parents=True, exist_ok=True)
+    runner_block: dict = {
+        "name": runner_name,
+        "instance_type": instance_type,
+        "vcpu": 6,
+        "memory": "29Gi",
+        "gpu": 0,
+    }
+    if runner_class:
+        runner_block["runner_class"] = runner_class
+    (defs / f"{runner_name}.yaml").write_text(yaml.safe_dump({"runner": runner_block}))
+
+
+def _write_generated_runner(
+    root: Path,
+    *,
+    runner_name: str,
+    fleet: str,
+    workflow_cpu: str,
+    workflow_mem: str,
+    runner_cpu: str = "750m",
+    runner_mem: str = "512Mi",
+    scale_set: str | None = None,
+    workflow_gpu: int = 0,
+    runner_class: str | None = None,
+) -> None:
+    gen = root / "modules" / "arc-runners" / "generated"
+    gen.mkdir(parents=True, exist_ok=True)
+    helm = _runner_helm_doc(
+        name=runner_name,
+        scale_set=scale_set or f"c-mt-{runner_name}",
+        runner_cpu=runner_cpu,
+        runner_mem=runner_mem,
+    )
+    cm = _configmap_doc(
+        runner_name=runner_name,
+        fleet=fleet,
+        cpu=workflow_cpu,
+        mem=workflow_mem,
+        gpu=workflow_gpu,
+        runner_class=runner_class,
+    )
+    out = yaml.safe_dump(helm) + "---\n" + yaml.safe_dump(cm)
+    (gen / f"{runner_name}.yaml").write_text(out)
+
+
+class TestLoadRunners:
+    def test_extracts_pod_sizes_and_fleet(self, tmp_path):
+        _write_runner_def(tmp_path, runner_name="r1", instance_type="m8g.48xlarge")
+        _write_generated_runner(
+            tmp_path,
+            runner_name="r1",
+            fleet="m8g",
+            workflow_cpu="6",
+            workflow_mem="29Gi",
+        )
+        runners = load_runners(["arc-runners"], upstream_root=tmp_path)
+        assert len(runners) == 1
+        r = runners[0]
+        assert r.name == "r1"
+        assert r.scale_set_name == "c-mt-r1"
+        assert r.instance_type == "m8g.48xlarge"
+        assert r.workflow_fleet == "m8g"
+        assert r.runner_pod_cpu_m == 750
+        assert r.runner_pod_mem_mi == 512
+        assert r.workflow_pod_cpu_m == 6000
+        assert r.workflow_pod_mem_mi == 29 * 1024
+        assert r.workflow_pod_gpu == 0
+        assert r.runner_class is None
+
+    def test_extracts_gpu_and_runner_class(self, tmp_path):
+        _write_runner_def(tmp_path, runner_name="rel-r1", instance_type="m8g.48xlarge", runner_class="release")
+        _write_generated_runner(
+            tmp_path,
+            runner_name="rel-r1",
+            fleet="m8g",
+            workflow_cpu="16",
+            workflow_mem="62Gi",
+            workflow_gpu=2,
+            runner_class="release",
+        )
+        runners = load_runners(["arc-runners"], upstream_root=tmp_path)
+        assert len(runners) == 1
+        r = runners[0]
+        assert r.runner_class == "release"
+        assert r.workflow_pod_gpu == 2
+        assert r.workflow_pod_cpu_m == 16000
+        assert r.workflow_pod_mem_mi == 62 * 1024
+
+    def test_skips_module_when_disabled(self, tmp_path):
+        _write_runner_def(tmp_path, runner_name="r1", instance_type="m8g.48xlarge")
+        _write_generated_runner(tmp_path, runner_name="r1", fleet="m8g", workflow_cpu="6", workflow_mem="29Gi")
+        # arc-runners not in module list → no runners returned.
+        runners = load_runners(["nodepools"], upstream_root=tmp_path)
+        assert runners == []
+
+    def test_falls_back_when_def_missing(self, tmp_path):
+        # Generate without a corresponding def — instance_type falls back.
+        _write_generated_runner(tmp_path, runner_name="orphan", fleet="m8g", workflow_cpu="6", workflow_mem="29Gi")
+        runners = load_runners(["arc-runners"], upstream_root=tmp_path)
+        assert len(runners) == 1
+        # Workflow fleet still parses — instance_type uses synthetic fallback.
+        assert runners[0].workflow_fleet == "m8g"
+        assert runners[0].instance_type.startswith("m8g.")
+
+
+# ---------------------------------------------------------------------------
+# Schedulability
+# ---------------------------------------------------------------------------
+
+
+def _make_runner(**overrides) -> RunnerEntry:
+    base = {
+        "name": "r1",
+        "scale_set_name": "c-mt-r1",
+        "instance_type": "m8g.48xlarge",
+        "workflow_fleet": "m8g",
+        "runner_class": None,
+        "runner_pod_cpu_m": 750,
+        "runner_pod_mem_mi": 512,
+        "workflow_pod_cpu_m": 6000,
+        "workflow_pod_mem_mi": 29 * 1024,
+        "workflow_pod_gpu": 0,
+        "schedulable": True,
+        "schedulable_reason": None,
+    }
+    base.update(overrides)
+    return RunnerEntry(**base)
+
+
+def _make_pool(**overrides) -> NodePoolEntry:
+    base = {
+        "name": "m8g-48xlarge",
+        "fleet": "m8g",
+        "instance_type": "m8g.48xlarge",
+        "arch": "arm64",
+        "gpu": False,
+        "runner_class": None,
+    }
+    base.update(overrides)
+    return NodePoolEntry(**base)
+
+
+class TestSchedulability:
+    def test_all_satisfied(self):
+        runners = [_make_runner()]
+        nodepools = [_make_pool()]
+        _mark_schedulability(runners, nodepools, {"m8g"})
+        assert runners[0].schedulable is True
+        assert runners[0].schedulable_reason is None
+
+    def test_workflow_fleet_missing(self):
+        runners = [_make_runner(workflow_fleet="r7g")]
+        _mark_schedulability(runners, [], {"m8g"})
+        assert runners[0].schedulable is False
+        assert "r7g" in runners[0].schedulable_reason
+        assert "m8g" in runners[0].schedulable_reason
+
+    def test_release_without_release_pool(self):
+        runners = [_make_runner(runner_class="release")]
+        nodepools = [_make_pool()]  # no release variant
+        _mark_schedulability(runners, nodepools, {"m8g"})
+        assert runners[0].schedulable is False
+        assert "release" in runners[0].schedulable_reason
+
+    def test_release_with_release_pool(self):
+        runners = [_make_runner(runner_class="release")]
+        nodepools = [
+            _make_pool(),
+            _make_pool(name="m8g-48xlarge-release", runner_class="release"),
+        ]
+        _mark_schedulability(runners, nodepools, {"m8g"})
+        assert runners[0].schedulable is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_cluster end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _write_clusters_yaml(root: Path, content: dict) -> None:
+    (root / "clusters.yaml").write_text(yaml.safe_dump(content))
+
+
+class TestResolveCluster:
+    def test_full_topology(self, tmp_path, capsys):
+        # Cluster "test-cluster" deploys nodepools + arc-runners in us-east-2.
+        _write_clusters_yaml(
+            tmp_path,
+            {
+                "clusters": {
+                    "test-cluster": {
+                        "region": "us-east-2",
+                        "modules": ["nodepools", "arc-runners"],
+                    }
+                }
+            },
+        )
+        # Two nodepool fleets: c7i-runner (runner pool) + m8g (workflow pool with release).
+        _write_nodepools_defs(
+            tmp_path,
+            {
+                "c7i-runner.yaml": """
+                    fleet:
+                      name: c7i-runner
+                      arch: amd64
+                      gpu: false
+                      instances:
+                        - type: c7i.48xlarge
+                          weight: 100
+                          node_disk_size: 100
+                """,
+                "m8g.yaml": """
+                    fleet:
+                      name: m8g
+                      arch: arm64
+                      gpu: false
+                      instances:
+                        - type: m8g.48xlarge
+                          weight: 100
+                          node_disk_size: 100
+                      release:
+                        - type: m8g.48xlarge
+                          weight: 100
+                          node_disk_size: 100
+                """,
+            },
+        )
+        # Runners: one regular (m8g), one release (m8g release), one orphan (no fleet support).
+        _write_runner_def(tmp_path, runner_name="ok", instance_type="m8g.48xlarge")
+        _write_generated_runner(tmp_path, runner_name="ok", fleet="m8g", workflow_cpu="6", workflow_mem="29Gi")
+        _write_runner_def(tmp_path, runner_name="rel", instance_type="m8g.48xlarge", runner_class="release")
+        _write_generated_runner(
+            tmp_path,
+            runner_name="rel",
+            fleet="m8g",
+            workflow_cpu="16",
+            workflow_mem="62Gi",
+            runner_class="release",
+        )
+        _write_runner_def(tmp_path, runner_name="orphan", instance_type="r7g.48xlarge")
+        _write_generated_runner(
+            tmp_path,
+            runner_name="orphan",
+            fleet="r7g",
+            workflow_cpu="6",
+            workflow_mem="29Gi",
+        )
+
+        topo = resolve_cluster("test-cluster", upstream_root=tmp_path, consumer_root=tmp_path)
+        assert isinstance(topo, ClusterTopology)
+        assert topo.cluster_id == "test-cluster"
+        assert topo.region == "us-east-2"
+        assert topo.modules == ["nodepools", "arc-runners"]
+        assert topo.runner_pool_fleet == "c7i-runner"
+        assert topo.workflow_pool_fleets == {"m8g"}
+
+        by_name = {r.name: r for r in topo.runners}
+        assert by_name["ok"].schedulable is True
+        assert by_name["rel"].schedulable is True
+        assert by_name["orphan"].schedulable is False
+        assert "r7g" in by_name["orphan"].schedulable_reason
+
+        pool_names = sorted(p.name for p in topo.nodepools)
+        assert "c7i-runner-48xlarge" in pool_names
+        assert "m8g-48xlarge" in pool_names
+        assert "m8g-48xlarge-release" in pool_names
+
+    def test_no_runner_pool_warns(self, tmp_path, capsys):
+        _write_clusters_yaml(
+            tmp_path,
+            {
+                "clusters": {
+                    "tiny": {
+                        "region": "us-east-2",
+                        "modules": ["nodepools"],
+                    }
+                }
+            },
+        )
+        _write_nodepools_defs(
+            tmp_path,
+            {
+                "m8g.yaml": """
+                    fleet:
+                      name: m8g
+                      arch: arm64
+                      gpu: false
+                      instances:
+                        - type: m8g.48xlarge
+                          weight: 100
+                          node_disk_size: 100
+                """,
+            },
+        )
+        topo = resolve_cluster("tiny", upstream_root=tmp_path, consumer_root=tmp_path)
+        assert topo.runner_pool_fleet is None
+        assert topo.workflow_pool_fleets == {"m8g"}
+        captured = capsys.readouterr()
+        assert "no 'c7i-runner'" in captured.out
+
+    def test_unknown_cluster_raises(self, tmp_path):
+        _write_clusters_yaml(tmp_path, {"clusters": {"only-one": {"region": "x", "modules": []}}})
+        with pytest.raises(KeyError, match="missing-cluster"):
+            resolve_cluster("missing-cluster", upstream_root=tmp_path, consumer_root=tmp_path)
+
+    def test_missing_clusters_yaml_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            resolve_cluster("foo", upstream_root=tmp_path, consumer_root=tmp_path)

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -5,11 +5,14 @@ from pathlib import Path
 
 import pytest
 import yaml
+from analyze_node_utilization import compute_daemonset_overhead
 from daemonset_overhead import (
     EKS_ADDON_DAEMONSETS,
     HELM_DAEMONSETS,
+    DaemonSetOverhead,
     _discover_from_yaml,
     _extract_container_resources,
+    _extract_fleet_selector,
     _is_gpu_only,
     discover_daemonsets,
     main,
@@ -611,3 +614,423 @@ class TestMainCli:
         assert result == 0
         output = capsys.readouterr().out
         assert "source:" in output
+
+
+# ---------------------------------------------------------------------------
+# _extract_fleet_selector
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFleetSelector:
+    def test_node_selector_node_fleet(self):
+        """node-fleet via nodeSelector returns the value."""
+        pod_spec = {"nodeSelector": {"node-fleet": "c7i-runner"}}
+        assert _extract_fleet_selector(pod_spec) == "c7i-runner"
+
+    def test_node_selector_other_keys_only(self):
+        """nodeSelector without node-fleet returns None."""
+        pod_spec = {"nodeSelector": {"workload-type": "github-runner"}}
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_node_affinity_in_single_value(self):
+        """nodeAffinity matchExpression with In + single value returns that value."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "In",
+                                        "values": ["g4dn"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) == "g4dn"
+
+    def test_node_affinity_in_multiple_values(self):
+        """nodeAffinity matchExpression with In + multiple values returns None."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "In",
+                                        "values": ["c7i-runner", "g4dn"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_node_affinity_not_in_operator(self):
+        """nodeAffinity matchExpression with operator != In returns None."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "NotIn",
+                                        "values": ["c7i-runner"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_node_affinity_exists_operator(self):
+        """nodeAffinity matchExpression with operator=Exists returns None."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "Exists",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_node_affinity_in_zero_values(self):
+        """nodeAffinity matchExpression with In + empty values returns None."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "In",
+                                        "values": [],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_node_affinity_other_key_only(self):
+        """nodeAffinity matchExpression with non-node-fleet key returns None."""
+        pod_spec = {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "workload-type",
+                                        "operator": "In",
+                                        "values": ["github-runner"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        assert _extract_fleet_selector(pod_spec) is None
+
+    def test_no_selector_no_affinity(self):
+        """Empty pod spec returns None."""
+        assert _extract_fleet_selector({}) is None
+
+    def test_empty_node_selector(self):
+        """Empty nodeSelector dict returns None."""
+        assert _extract_fleet_selector({"nodeSelector": {}}) is None
+
+    def test_node_selector_takes_precedence_over_affinity(self):
+        """When both nodeSelector and nodeAffinity have node-fleet, nodeSelector wins."""
+        pod_spec = {
+            "nodeSelector": {"node-fleet": "c7i-runner"},
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-fleet",
+                                        "operator": "In",
+                                        "values": ["different"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+        assert _extract_fleet_selector(pod_spec) == "c7i-runner"
+
+
+# ---------------------------------------------------------------------------
+# fleet_selector parsed via _discover_from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverFromYamlFleetSelector:
+    def test_node_selector_fleet(self, tmp_path):
+        """fleet_selector parsed from spec.template.spec.nodeSelector["node-fleet"]."""
+        manifest = {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {"name": "hooks-warmer"},
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": {"node-fleet": "c7i-runner"},
+                        "containers": [{"name": "main"}],
+                    }
+                }
+            },
+        }
+        (tmp_path / "ds.yaml").write_text(yaml.dump(manifest))
+        results = _discover_from_yaml([tmp_path])
+        assert len(results) == 1
+        assert results[0].fleet_selector == "c7i-runner"
+
+    def test_node_affinity_fleet_single_value(self, tmp_path):
+        """fleet_selector parsed from nodeAffinity matchExpression with In + single value."""
+        manifest = {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {"name": "affinity-pinned"},
+            "spec": {
+                "template": {
+                    "spec": {
+                        "affinity": {
+                            "nodeAffinity": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "nodeSelectorTerms": [
+                                        {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "node-fleet",
+                                                    "operator": "In",
+                                                    "values": ["g4dn"],
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "containers": [{"name": "main"}],
+                    }
+                }
+            },
+        }
+        (tmp_path / "ds.yaml").write_text(yaml.dump(manifest))
+        results = _discover_from_yaml([tmp_path])
+        assert len(results) == 1
+        assert results[0].fleet_selector == "g4dn"
+
+    def test_node_affinity_multiple_values_is_none(self, tmp_path):
+        """fleet_selector is None when matchExpression has multiple values (runs everywhere)."""
+        manifest = {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {"name": "multi-fleet"},
+            "spec": {
+                "template": {
+                    "spec": {
+                        "affinity": {
+                            "nodeAffinity": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "nodeSelectorTerms": [
+                                        {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "node-fleet",
+                                                    "operator": "In",
+                                                    "values": ["c7i-runner", "g4dn"],
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "containers": [{"name": "main"}],
+                    }
+                }
+            },
+        }
+        (tmp_path / "ds.yaml").write_text(yaml.dump(manifest))
+        results = _discover_from_yaml([tmp_path])
+        assert len(results) == 1
+        assert results[0].fleet_selector is None
+
+    def test_no_fleet_selector(self, tmp_path):
+        """fleet_selector is None when no node-fleet anywhere."""
+        manifest = {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {"name": "unpinned"},
+            "spec": {
+                "template": {"spec": {"containers": [{"name": "main"}]}},
+            },
+        }
+        (tmp_path / "ds.yaml").write_text(yaml.dump(manifest))
+        results = _discover_from_yaml([tmp_path])
+        assert len(results) == 1
+        assert results[0].fleet_selector is None
+
+
+# ---------------------------------------------------------------------------
+# fleet_selector for HELM and EKS_ADDON constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstantsFleetSelector:
+    def test_helm_constants_have_none_fleet_selector(self):
+        """All HELM_DAEMONSETS run on every node — fleet_selector must be None."""
+        for ds in HELM_DAEMONSETS:
+            assert ds.fleet_selector is None, f"{ds.name} should have fleet_selector=None"
+
+    def test_eks_addon_constants_have_none_fleet_selector(self):
+        """All EKS_ADDON_DAEMONSETS run on every node — fleet_selector must be None."""
+        for ds in EKS_ADDON_DAEMONSETS:
+            assert ds.fleet_selector is None, f"{ds.name} should have fleet_selector=None"
+
+
+# ---------------------------------------------------------------------------
+# DaemonSetOverhead dataclass field default
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonSetOverheadDefaultFleetSelector:
+    def test_default_fleet_selector_is_none(self):
+        """Constructing without fleet_selector sets it to None (backward-compatible)."""
+        ds = DaemonSetOverhead(
+            name="legacy",
+            cpu_millicores=10,
+            memory_mib=32,
+            gpu_only=False,
+            source="test",
+        )
+        assert ds.fleet_selector is None
+
+    def test_explicit_fleet_selector(self):
+        """Passing fleet_selector keyword stores it."""
+        ds = DaemonSetOverhead(
+            name="pinned",
+            cpu_millicores=10,
+            memory_mib=32,
+            gpu_only=False,
+            source="test",
+            fleet_selector="c7i-runner",
+        )
+        assert ds.fleet_selector == "c7i-runner"
+
+
+# ---------------------------------------------------------------------------
+# compute_daemonset_overhead — fleet-aware filtering
+# ---------------------------------------------------------------------------
+
+
+# Mixed fleet of DaemonSets used by the fleet-aware tests below.
+FLEET_DS = [
+    DaemonSetOverhead("kube-proxy", 50, 80, False, "test", fleet_selector=None),
+    DaemonSetOverhead("gpu-plugin", 100, 256, True, "test", fleet_selector=None),
+    DaemonSetOverhead("hooks-warmer", 10, 32, False, "test", fleet_selector="c7i-runner"),
+    DaemonSetOverhead("g4dn-only-tool", 25, 64, False, "test", fleet_selector="g4dn"),
+]
+
+
+class TestComputeDaemonsetOverheadFleetAware:
+    def test_legacy_no_fleet_includes_all(self):
+        """fleet_name=None (legacy) includes ALL DaemonSets (matching old behavior)."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=False)
+        # kube-proxy (50/80) + hooks-warmer (10/32) + g4dn-only-tool (25/64).
+        # gpu-plugin excluded (is_gpu=False).
+        assert cpu == 50 + 10 + 25
+        assert mem == 80 + 32 + 64
+
+    def test_legacy_no_fleet_includes_all_gpu(self):
+        """fleet_name=None (legacy) on GPU node includes ALL DaemonSets."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=True)
+        # All four.
+        assert cpu == 50 + 100 + 10 + 25
+        assert mem == 80 + 256 + 32 + 64
+
+    def test_c7i_runner_pool_excludes_other_fleets(self):
+        """fleet_name='c7i-runner' includes None-pinned + c7i-runner-pinned only."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=False, fleet_name="c7i-runner")
+        # kube-proxy (None) + hooks-warmer (c7i-runner). g4dn-only-tool excluded.
+        # gpu-plugin excluded (is_gpu=False).
+        assert cpu == 50 + 10
+        assert mem == 80 + 32
+
+    def test_g4dn_pool_with_gpu_includes_gpu_ds(self):
+        """fleet_name='g4dn' on GPU node includes None + g4dn + GPU DaemonSets."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=True, fleet_name="g4dn")
+        # kube-proxy (None) + gpu-plugin (None, gpu) + g4dn-only-tool (g4dn).
+        # hooks-warmer excluded (pinned to c7i-runner).
+        assert cpu == 50 + 100 + 25
+        assert mem == 80 + 256 + 64
+
+    def test_workflow_pool_excludes_runner_only_ds(self):
+        """A pool name not matching any pinned DaemonSet excludes all pinned ones."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=False, fleet_name="workflow")
+        # Only kube-proxy (None) — both hooks-warmer and g4dn-only-tool excluded.
+        assert cpu == 50
+        assert mem == 80
+
+    def test_unknown_fleet_includes_unpinned_only(self):
+        """Pool name with no pinned DS still returns unpinned DaemonSets."""
+        cpu, mem = compute_daemonset_overhead([], is_gpu=False, fleet_name="anything")
+        assert cpu == 0
+        assert mem == 0
+
+    def test_gpu_only_filtered_when_not_gpu_even_with_fleet(self):
+        """gpu_only filtering still applies regardless of fleet."""
+        cpu, mem = compute_daemonset_overhead(FLEET_DS, is_gpu=False, fleet_name="g4dn")
+        # kube-proxy (None) + g4dn-only-tool (g4dn). gpu-plugin excluded (is_gpu=False).
+        assert cpu == 50 + 25
+        assert mem == 80 + 64
+
+    def test_keyword_only_signature(self):
+        """is_gpu and fleet_name are keyword-only — positional call must fail."""
+        with pytest.raises(TypeError):
+            # is_gpu is kw-only after the * marker.
+            compute_daemonset_overhead(FLEET_DS, True)  # type: ignore[misc]

--- a/osdc/scripts/python/test_simulate_cluster.py
+++ b/osdc/scripts/python/test_simulate_cluster.py
@@ -1,14 +1,21 @@
-"""Tests for simulate_cluster module."""
+"""Tests for simulate_cluster module (split-pool model)."""
 
+from __future__ import annotations
+
+from cluster_topology import ClusterTopology, NodePoolEntry, RunnerEntry
 from daemonset_overhead import DaemonSetOverhead
 from simulate_cluster import (
+    PoolUtilization,
     SimNode,
     SimResult,
-    best_fit_place,
+    SimulationUtilization,
+    best_fit_place_runner,
+    best_fit_place_workflow,
     build_peak_targets,
     build_weighted_pool,
     compute_utilization,
-    provision_node,
+    provision_runner_node,
+    provision_workflow_node,
     run_simulation,
     weighted_mape,
 )
@@ -23,287 +30,330 @@ FAKE_DAEMONSETS = [
 ]
 
 
-def make_runner(
+def _make_runner(
     name: str,
+    *,
+    instance_type: str = "c7a.48xlarge",
+    workflow_fleet: str = "c7a",
+    runner_class: str | None = None,
+    runner_pod_cpu_m: int = 750,
+    runner_pod_mem_mi: int = 512,
+    workflow_pod_cpu_m: int = 8000,
+    workflow_pod_mem_mi: int = 16 * 1024,
+    workflow_pod_gpu: int = 0,
+    schedulable: bool = True,
+    schedulable_reason: str | None = None,
+) -> RunnerEntry:
+    return RunnerEntry(
+        name=name,
+        scale_set_name=f"c-mt-{name}",
+        instance_type=instance_type,
+        workflow_fleet=workflow_fleet,
+        runner_class=runner_class,
+        runner_pod_cpu_m=runner_pod_cpu_m,
+        runner_pod_mem_mi=runner_pod_mem_mi,
+        workflow_pod_cpu_m=workflow_pod_cpu_m,
+        workflow_pod_mem_mi=workflow_pod_mem_mi,
+        workflow_pod_gpu=workflow_pod_gpu,
+        schedulable=schedulable,
+        schedulable_reason=schedulable_reason,
+    )
+
+
+def _make_pool(
+    name: str,
+    *,
+    fleet: str,
     instance_type: str,
-    vcpu: int,
-    memory_mi: int,
-    gpu: int = 0,
-) -> dict:
-    return {
-        "name": name,
-        "instance_type": instance_type,
-        "vcpu": vcpu,
-        "memory_mi": memory_mi,
-        "gpu": gpu,
-        "file": f"{name}.yaml",
-    }
+    arch: str = "amd64",
+    gpu: bool = False,
+    runner_class: str | None = None,
+) -> NodePoolEntry:
+    return NodePoolEntry(
+        name=name,
+        fleet=fleet,
+        instance_type=instance_type,
+        arch=arch,
+        gpu=gpu,
+        runner_class=runner_class,
+    )
+
+
+def _make_topology(
+    *,
+    runners: list[RunnerEntry],
+    nodepools: list[NodePoolEntry],
+    runner_pool_fleet: str | None = "c7i-runner",
+    workflow_pool_fleets: set[str] | None = None,
+) -> ClusterTopology:
+    fleets = workflow_pool_fleets or {p.fleet for p in nodepools if p.fleet != runner_pool_fleet}
+    return ClusterTopology(
+        cluster_id="test",
+        region="us-east-2",
+        modules=["nodepools", "arc-runners"],
+        nodepools=nodepools,
+        runner_pool_fleet=runner_pool_fleet,
+        workflow_pool_fleets=fleets,
+        runners=runners,
+    )
 
 
 # ---------------------------------------------------------------------------
-# build_peak_targets
+# build_peak_targets — driven by PEAK_CONCURRENT snapshot
 # ---------------------------------------------------------------------------
 
 
 class TestBuildPeakTargets:
-    def test_collapse_multiple_old_labels(self):
-        old_to_new = {
-            "linux.2xlarge": "l-x86iavx512-8-16",
-            "linux.c7i.2xlarge": "l-x86iavx512-8-16",
-        }
-        peaks = {"linux.2xlarge": 100, "linux.c7i.2xlarge": 50}
-        targets, skipped = build_peak_targets(old_to_new, peaks)
-        assert targets == {"l-x86iavx512-8-16": 150}
-        assert skipped == {}
+    def test_includes_only_schedulable(self):
+        # Use a real runner name from PEAK_CONCURRENT so we actually get a count.
+        good = _make_runner("l-x86iavx512-8-16", workflow_fleet="c7a")
+        bad = _make_runner("l-x86iavx512-46-85", workflow_fleet="c7a", schedulable=False)
+        targets = build_peak_targets([good, bad])
+        assert "l-x86iavx512-8-16" in targets
+        assert targets["l-x86iavx512-8-16"] > 0
+        assert "l-x86iavx512-46-85" not in targets
 
-    def test_skip_unmapped(self):
-        old_to_new = {"linux.2xlarge": "l-x86iavx512-8-16"}
-        peaks = {"linux.2xlarge": 100, "linux.unknown": 50}
-        targets, skipped = build_peak_targets(old_to_new, peaks)
-        assert targets == {"l-x86iavx512-8-16": 100}
-        assert "linux.unknown" in skipped
+    def test_unknown_new_label_skipped(self):
+        runner = _make_runner("totally-unknown-label-not-in-snapshot")
+        assert build_peak_targets([runner]) == {}
 
-    def test_empty_inputs(self):
-        targets, skipped = build_peak_targets({}, {})
-        assert targets == {}
-        assert skipped == {}
+    def test_empty_runners(self):
+        assert build_peak_targets([]) == {}
+
+    def test_collapses_old_labels(self):
+        # linux.2xlarge AND linux.c7i.2xlarge both map to l-x86iavx512-8-16.
+        runner = _make_runner("l-x86iavx512-8-16", workflow_fleet="c7a")
+        targets = build_peak_targets([runner])
+        # Should be the SUM of both old labels' peaks (1473 + 927).
+        assert targets["l-x86iavx512-8-16"] == 1473 + 927
 
 
 # ---------------------------------------------------------------------------
-# build_weighted_pool
+# build_weighted_pool / weighted_mape
 # ---------------------------------------------------------------------------
 
 
 class TestBuildWeightedPool:
-    def test_weights_match_targets(self):
-        targets = {"runner-a": 10, "runner-b": 20}
-        pool = build_weighted_pool(targets)
-        pool_dict = dict(pool)
-        assert pool_dict["runner-a"] == 10
-        assert pool_dict["runner-b"] == 20
+    def test_repeats_each_name_by_weight(self):
+        pool = build_weighted_pool({"a": 2, "b": 3})
+        assert pool.count("a") == 2
+        assert pool.count("b") == 3
 
     def test_zero_weight_excluded(self):
-        targets = {"runner-a": 10, "runner-b": 0}
-        pool = build_weighted_pool(targets)
-        names = [p[0] for p in pool]
-        assert "runner-b" not in names
+        pool = build_weighted_pool({"a": 5, "b": 0})
+        assert "b" not in pool
+        assert pool.count("a") == 5
 
     def test_all_zero_weights(self):
-        targets = {"runner-a": 0, "runner-b": 0}
-        pool = build_weighted_pool(targets)
-        assert pool == []
-
-
-# ---------------------------------------------------------------------------
-# SimNode
-# ---------------------------------------------------------------------------
-
-
-class TestSimNode:
-    def test_fits_when_capacity_available(self):
-        node = SimNode("c7a.48xlarge", 10000, 20000, 0)
-        assert node.fits(5000, 10000, 0) is True
-
-    def test_does_not_fit_cpu(self):
-        node = SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000)
-        assert node.fits(5000, 1000, 0) is False
-
-    def test_does_not_fit_memory(self):
-        node = SimNode("c7a.48xlarge", 10000, 20000, 0, used_mem_mi=18000)
-        assert node.fits(1000, 5000, 0) is False
-
-    def test_does_not_fit_gpu(self):
-        node = SimNode("g5.8xlarge", 10000, 20000, 1, used_gpu=1)
-        assert node.fits(1000, 1000, 1) is False
-
-    def test_remaining_capacity(self):
-        node = SimNode("c7a.48xlarge", 10000, 20000, 4, used_cpu_m=3000, used_mem_mi=5000, used_gpu=1)
-        assert node.remaining_cpu_m == 7000
-        assert node.remaining_mem_mi == 15000
-        assert node.remaining_gpu == 3
-
-
-# ---------------------------------------------------------------------------
-# best_fit_place
-# ---------------------------------------------------------------------------
-
-
-class TestBestFitPlace:
-    def test_prefers_tightest(self):
-        nodes = [
-            SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=2000, used_mem_mi=4000),
-            SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=7000, used_mem_mi=15000),
-        ]
-        # Second node has less remaining → should be preferred
-        idx = best_fit_place(nodes, 2000, 4000, 0, "c7a.48xlarge")
-        assert idx == 1
-
-    def test_returns_none_when_nothing_fits(self):
-        nodes = [
-            SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=9500, used_mem_mi=19000),
-        ]
-        idx = best_fit_place(nodes, 2000, 4000, 0, "c7a.48xlarge")
-        assert idx is None
-
-    def test_only_considers_matching_instance_type(self):
-        nodes = [
-            SimNode("g5.8xlarge", 10000, 20000, 1),
-            SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=16000),
-        ]
-        # First node has more room but wrong type
-        idx = best_fit_place(nodes, 1000, 2000, 0, "c7a.48xlarge")
-        assert idx == 1
-
-    def test_empty_nodes_list(self):
-        idx = best_fit_place([], 1000, 2000, 0, "c7a.48xlarge")
-        assert idx is None
-
-    def test_gpu_scoring_prefers_tighter_gpu_fit(self):
-        """GPU remaining capacity should factor into best-fit scoring."""
-        nodes = [
-            SimNode("g5.8xlarge", 10000, 20000, 4, used_cpu_m=5000, used_mem_mi=10000, used_gpu=1),
-            SimNode("g5.8xlarge", 10000, 20000, 4, used_cpu_m=5000, used_mem_mi=10000, used_gpu=3),
-        ]
-        # Second node has 1 GPU remaining vs first with 3 → second is tighter
-        idx = best_fit_place(nodes, 1000, 1000, 1, "g5.8xlarge")
-        assert idx == 1
-
-
-# ---------------------------------------------------------------------------
-# provision_node
-# ---------------------------------------------------------------------------
-
-
-class TestProvisionNode:
-    def test_known_instance_type(self):
-        node = provision_node("c7a.48xlarge", FAKE_DAEMONSETS)
-        assert node is not None
-        assert node.instance_type == "c7a.48xlarge"
-        assert node.total_cpu_m > 0
-        assert node.total_mem_mi > 0
-        assert node.used_cpu_m == 0
-
-    def test_unknown_instance_type(self):
-        node = provision_node("z99.nonexistent", FAKE_DAEMONSETS)
-        assert node is None
-
-    def test_gpu_instance(self):
-        node = provision_node("g5.8xlarge", FAKE_DAEMONSETS)
-        assert node is not None
-        assert node.total_gpu == 1
-
-
-# ---------------------------------------------------------------------------
-# weighted_mape
-# ---------------------------------------------------------------------------
+        assert build_weighted_pool({"a": 0, "b": 0}) == []
 
 
 class TestWeightedMape:
     def test_exact_match(self):
-        targets = {"a": 10, "b": 20}
-        deployed = {"a": 10, "b": 20}
-        assert weighted_mape(deployed, targets) == 0.0
+        assert weighted_mape({"a": 10, "b": 20}, {"a": 10, "b": 20}) == 0.0
 
     def test_partial_deployment(self):
-        targets = {"a": 100, "b": 100}
-        deployed = {"a": 50, "b": 50}
-        # error = |50-100| + |50-100| = 100, total_target = 200
-        assert weighted_mape(deployed, targets) == 0.5
+        assert weighted_mape({"a": 50, "b": 50}, {"a": 100, "b": 100}) == 0.5
 
     def test_empty_targets(self):
         assert weighted_mape({}, {}) == 0.0
 
     def test_over_deployment(self):
-        targets = {"a": 10}
-        deployed = {"a": 15}
-        # error = 5, total = 10
-        assert weighted_mape(deployed, targets) == 0.5
+        assert weighted_mape({"a": 15}, {"a": 10}) == 0.5
 
     def test_missing_runner_in_deployed(self):
-        targets = {"a": 10, "b": 20}
-        deployed = {"a": 10}
-        # error = |10-10| + |0-20| = 20, total = 30
-        assert abs(weighted_mape(deployed, targets) - 20 / 30) < 1e-9
+        assert abs(weighted_mape({"a": 10}, {"a": 10, "b": 20}) - 20 / 30) < 1e-9
 
 
 # ---------------------------------------------------------------------------
-# run_simulation
+# SimNode capacity checks
 # ---------------------------------------------------------------------------
 
 
-class TestRunSimulation:
-    def test_basic_completion(self):
-        runners = [
-            make_runner("r1", "c7a.48xlarge", 8, 16 * 1024),
-            make_runner("r2", "c7a.48xlarge", 16, 32 * 1024),
+class TestSimNode:
+    def test_can_fit_when_capacity_available(self):
+        node = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0)
+        assert node.can_fit(5000, 10000, 0) is True
+
+    def test_does_not_fit_cpu(self):
+        node = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0, used_cpu_m=8000)
+        assert node.can_fit(5000, 1000, 0) is False
+
+    def test_does_not_fit_memory(self):
+        node = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0, used_mem_mi=18000)
+        assert node.can_fit(1000, 5000, 0) is False
+
+    def test_does_not_fit_gpu(self):
+        node = SimNode("g5.8xlarge", "g5", None, cpu_m=10000, mem_mi=20000, gpu=1, used_gpu=1)
+        assert node.can_fit(1000, 1000, 1) is False
+
+    def test_remaining_capacity(self):
+        node = SimNode(
+            "c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=4,
+            used_cpu_m=3000, used_mem_mi=5000, used_gpu=1,
+        )  # fmt: skip
+        assert node.remaining_cpu_m == 7000
+        assert node.remaining_mem_mi == 15000
+        assert node.remaining_gpu == 3
+
+    def test_allocate_increments_pod_count(self):
+        node = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0)
+        node.allocate(2000, 4000, 0)
+        node.allocate(1000, 2000, 0)
+        assert node.pod_count == 2
+        assert node.used_cpu_m == 3000
+        assert node.used_mem_mi == 6000
+
+
+# ---------------------------------------------------------------------------
+# best_fit_place_workflow
+# ---------------------------------------------------------------------------
+
+
+class TestBestFitPlaceWorkflow:
+    def test_picks_tightest_matching_node(self):
+        runner = _make_runner("r1", workflow_fleet="c7a", workflow_pod_cpu_m=2000, workflow_pod_mem_mi=4096)
+        nodes = [
+            SimNode("c7a.48xlarge", "c7a", None, cpu_m=20000, mem_mi=40000, gpu=0),
+            SimNode("c7a.48xlarge", "c7a", None, cpu_m=20000, mem_mi=40000, gpu=0,
+                    used_cpu_m=15000, used_mem_mi=30000),
+        ]  # fmt: skip
+        pick = best_fit_place_workflow(runner, nodes)
+        assert pick is nodes[1]
+
+    def test_returns_none_when_nothing_fits(self):
+        runner = _make_runner("r1", workflow_fleet="c7a", workflow_pod_cpu_m=10000, workflow_pod_mem_mi=20000)
+        nodes = [SimNode("c7a.48xlarge", "c7a", None, cpu_m=5000, mem_mi=10000, gpu=0)]
+        assert best_fit_place_workflow(runner, nodes) is None
+
+    def test_skips_wrong_fleet(self):
+        runner = _make_runner("r1", workflow_fleet="c7a", workflow_pod_cpu_m=2000, workflow_pod_mem_mi=4096)
+        nodes = [
+            SimNode("m8g.48xlarge", "m8g", None, cpu_m=20000, mem_mi=40000, gpu=0),
+            SimNode("c7a.48xlarge", "c7a", None, cpu_m=20000, mem_mi=40000, gpu=0),
         ]
-        targets = {"r1": 5, "r2": 3}
-        result = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=42)
-        # Should deploy approximately the target counts
-        total_deployed = sum(result.deployed.values())
-        total_target = sum(targets.values())
-        assert total_deployed > 0
-        assert abs(total_deployed - total_target) <= total_target * 0.2
+        pick = best_fit_place_workflow(runner, nodes)
+        assert pick is nodes[1]
 
-    def test_deterministic_with_same_seed(self):
-        runners = [make_runner("r1", "c7a.48xlarge", 8, 16 * 1024)]
-        targets = {"r1": 20}
-        result1 = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=99)
-        result2 = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=99)
-        assert result1.deployed == result2.deployed
-        assert len(result1.nodes) == len(result2.nodes)
-
-    def test_different_seed_different_result(self):
-        runners = [
-            make_runner("r1", "c7a.48xlarge", 8, 16 * 1024),
-            make_runner("r2", "c7a.48xlarge", 16, 32 * 1024),
+    def test_skips_wrong_runner_class(self):
+        runner = _make_runner(
+            "rel", workflow_fleet="m8g", runner_class="release",
+            workflow_pod_cpu_m=2000, workflow_pod_mem_mi=4096,
+        )  # fmt: skip
+        nodes = [
+            SimNode("m8g.48xlarge", "m8g", None, cpu_m=20000, mem_mi=40000, gpu=0),
+            SimNode("m8g.48xlarge", "m8g", "release", cpu_m=20000, mem_mi=40000, gpu=0),
         ]
-        targets = {"r1": 50, "r2": 50}
-        result1 = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=1)
-        result2 = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=2)
-        # Results should differ (deployment order is random)
-        # but both should complete
-        assert sum(result1.deployed.values()) > 0
-        assert sum(result2.deployed.values()) > 0
+        pick = best_fit_place_workflow(runner, nodes)
+        assert pick is nodes[1]
 
-    def test_skips_runners_without_defs(self):
-        runners = [make_runner("r1", "c7a.48xlarge", 8, 16 * 1024)]
-        targets = {"r1": 10, "r_missing": 5}
-        result = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=42)
-        assert "r_missing" in result.skipped_labels
-        assert "r1" in result.deployed
+    def test_empty_node_list(self):
+        runner = _make_runner("r1", workflow_fleet="c7a")
+        assert best_fit_place_workflow(runner, []) is None
 
-    def test_empty_targets(self):
-        runners = [make_runner("r1", "c7a.48xlarge", 8, 16 * 1024)]
-        result = run_simulation(runners, {}, FAKE_DAEMONSETS, seed=42)
-        assert len(result.nodes) == 0
-        assert sum(result.deployed.values()) == 0
+    def test_gpu_scoring_prefers_tighter_gpu_fit(self):
+        runner = _make_runner(
+            "r1", workflow_fleet="g5", instance_type="g5.8xlarge",
+            workflow_pod_cpu_m=1000, workflow_pod_mem_mi=1000, workflow_pod_gpu=1,
+        )  # fmt: skip
+        nodes = [
+            SimNode("g5.8xlarge", "g5", None, cpu_m=10000, mem_mi=20000, gpu=4,
+                    used_cpu_m=5000, used_mem_mi=10000, used_gpu=1),
+            SimNode("g5.8xlarge", "g5", None, cpu_m=10000, mem_mi=20000, gpu=4,
+                    used_cpu_m=5000, used_mem_mi=10000, used_gpu=3),
+        ]  # fmt: skip
+        pick = best_fit_place_workflow(runner, nodes)
+        assert pick is nodes[1]
 
-    def test_unknown_instance_type_does_not_infinite_loop(self):
-        """Runners with unknown instance types are skipped without hanging."""
-        runners = [
-            make_runner("r1", "z99.nonexistent", 8, 16 * 1024),
-            make_runner("r2", "c7a.48xlarge", 8, 16 * 1024),
+
+# ---------------------------------------------------------------------------
+# best_fit_place_runner
+# ---------------------------------------------------------------------------
+
+
+class TestBestFitPlaceRunner:
+    def test_picks_tightest_runner_node(self):
+        nodes = [
+            SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=190000, mem_mi=350000, gpu=0),
+            SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=190000, mem_mi=350000, gpu=0,
+                    used_cpu_m=180000, used_mem_mi=340000),
+        ]  # fmt: skip
+        pick = best_fit_place_runner("c7i-runner", 750, 512, nodes)
+        assert pick is nodes[1]
+
+    def test_returns_none_when_nothing_fits(self):
+        nodes = [
+            SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=1000, mem_mi=1000, gpu=0,
+                    used_cpu_m=900, used_mem_mi=900),
+        ]  # fmt: skip
+        assert best_fit_place_runner("c7i-runner", 750, 512, nodes) is None
+
+    def test_skips_wrong_fleet(self):
+        nodes = [
+            SimNode("m8g.48xlarge", "m8g", None, cpu_m=10000, mem_mi=20000, gpu=0),
+            SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=10000, mem_mi=20000, gpu=0),
         ]
-        targets = {"r1": 10, "r2": 5}
-        # Should complete without hanging — r1 gets skipped after first failure
-        result = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=42)
-        assert result.deployed.get("r2", 0) > 0
+        pick = best_fit_place_runner("c7i-runner", 750, 512, nodes)
+        assert pick is nodes[1]
 
-    def test_all_unknown_instance_types_terminates(self):
-        """Simulation terminates when all runners have unknown instance types."""
-        runners = [make_runner("r1", "z99.nonexistent", 8, 16 * 1024)]
-        targets = {"r1": 10}
-        result = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=42)
-        # Should return without hanging, with zero deployments
-        assert sum(result.deployed.values()) == 0
+    def test_empty_node_list(self):
+        assert best_fit_place_runner("c7i-runner", 750, 512, []) is None
 
-    def test_all_zero_weight_targets(self):
-        """Simulation handles all-zero targets without crashing."""
-        runners = [make_runner("r1", "c7a.48xlarge", 8, 16 * 1024)]
-        targets = {"r1": 0}
-        result = run_simulation(runners, targets, FAKE_DAEMONSETS, seed=42)
-        assert sum(result.deployed.values()) == 0
+
+# ---------------------------------------------------------------------------
+# provision_workflow_node / provision_runner_node
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionWorkflowNode:
+    def test_known_instance_type(self):
+        runner = _make_runner("r1", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        node = provision_workflow_node(runner, FAKE_DAEMONSETS)
+        assert node is not None
+        assert node.instance_type == "c7a.48xlarge"
+        assert node.fleet == "c7a"
+        assert node.runner_class is None
+        assert node.cpu_m > 0
+        assert node.mem_mi > 0
+        assert node.gpu == 0
+
+    def test_unknown_instance_type_returns_none(self):
+        runner = _make_runner("r1", instance_type="z99.nonexistent", workflow_fleet="z99")
+        assert provision_workflow_node(runner, FAKE_DAEMONSETS) is None
+
+    def test_gpu_instance(self):
+        runner = _make_runner("r1", instance_type="g5.8xlarge", workflow_fleet="g5", workflow_pod_gpu=1)
+        node = provision_workflow_node(runner, FAKE_DAEMONSETS)
+        assert node is not None
+        assert node.gpu == 1
+
+    def test_release_runner_class_propagates(self):
+        runner = _make_runner("rel", instance_type="m8g.48xlarge", workflow_fleet="m8g", runner_class="release")
+        node = provision_workflow_node(runner, FAKE_DAEMONSETS)
+        assert node is not None
+        assert node.runner_class == "release"
+
+
+class TestProvisionRunnerNode:
+    def test_picks_largest_instance(self):
+        nodepools = [
+            _make_pool("c7i-runner-24xlarge", fleet="c7i-runner", instance_type="c7i.24xlarge"),
+            _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+        ]
+        node = provision_runner_node("c7i-runner", nodepools, FAKE_DAEMONSETS)
+        assert node is not None
+        assert node.instance_type == "c7i.48xlarge"
+        assert node.fleet == "c7i-runner"
+        assert node.runner_class is None
+        assert node.gpu == 0
+
+    def test_no_matching_fleet_returns_none(self):
+        nodepools = [_make_pool("m8g-48xlarge", fleet="m8g", instance_type="m8g.48xlarge")]
+        assert provision_runner_node("c7i-runner", nodepools, FAKE_DAEMONSETS) is None
+
+    def test_unknown_instance_type_returns_none(self):
+        nodepools = [_make_pool("bogus", fleet="c7i-runner", instance_type="z99.nonexistent")]
+        assert provision_runner_node("c7i-runner", nodepools, FAKE_DAEMONSETS) is None
 
 
 # ---------------------------------------------------------------------------
@@ -312,50 +362,163 @@ class TestRunSimulation:
 
 
 class TestComputeUtilization:
-    def test_single_node(self):
-        node = SimNode(
-            "c7a.48xlarge",
-            total_cpu_m=10000,
-            total_mem_mi=20000,
-            total_gpu=0,
-            used_cpu_m=8000,
-            used_mem_mi=15000,
-        )
-        result = SimResult(nodes=[node], deployed={"r1": 5}, targets={"r1": 5})
+    def test_workflow_only(self):
+        wf = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0,
+                     used_cpu_m=8000, used_mem_mi=15000)  # fmt: skip
+        result = SimResult(workflow_nodes=[wf], runner_nodes=[], deployed={"r1": 1}, targets={"r1": 1})
         util = compute_utilization(result)
-        assert util["cpu_pct"] == 80.0
-        assert util["mem_pct"] == 75.0
-        assert util["total_nodes"] == 1
-        assert util["gpu_nodes"] == 0
+        assert isinstance(util, SimulationUtilization)
+        assert util.workflow.cpu_pct == 80.0
+        assert util.workflow.mem_pct == 75.0
+        assert util.workflow.nodes == 1
+        assert util.runner.nodes == 0
 
-    def test_gpu_only_counts_gpu_nodes(self):
-        cpu_node = SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=5000, used_mem_mi=10000)
-        gpu_node = SimNode("g5.8xlarge", 10000, 20000, 1, used_cpu_m=5000, used_mem_mi=10000, used_gpu=1)
-        result = SimResult(
-            nodes=[cpu_node, gpu_node],
-            deployed={"r1": 2},
-            targets={"r1": 2},
-        )
+    def test_both_pools(self):
+        wf = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0,
+                     used_cpu_m=5000, used_mem_mi=10000)  # fmt: skip
+        rn = SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=10000, mem_mi=20000, gpu=0,
+                     used_cpu_m=2500, used_mem_mi=5000)  # fmt: skip
+        result = SimResult(workflow_nodes=[wf], runner_nodes=[rn], deployed={"r1": 1}, targets={"r1": 1})
         util = compute_utilization(result)
-        assert util["gpu_pct"] == 100.0
-        assert util["gpu_nodes"] == 1
-        assert util["total_gpu"] == 1
+        assert util.workflow.nodes == 1
+        assert util.runner.nodes == 1
+        assert util.workflow.cpu_pct == 50.0
+        assert util.runner.cpu_pct == 25.0
+
+    def test_gpu_pool(self):
+        wf = SimNode("g5.8xlarge", "g5", None, cpu_m=10000, mem_mi=20000, gpu=1, used_gpu=1)
+        result = SimResult(workflow_nodes=[wf], runner_nodes=[], deployed={"r1": 1}, targets={"r1": 1})
+        util = compute_utilization(result)
+        assert util.workflow.gpu_pct == 100.0
+        assert util.workflow.total_gpu == 1
 
     def test_empty_result(self):
-        result = SimResult()
-        util = compute_utilization(result)
-        assert util["cpu_pct"] == 0.0
-        assert util["mem_pct"] == 0.0
-        assert util["gpu_pct"] == 0.0
-        assert util["total_nodes"] == 0
+        util = compute_utilization(SimResult())
+        assert util.workflow.nodes == 0
+        assert util.runner.nodes == 0
+        assert util.workflow.cpu_pct == 0.0
+        assert util.runner.cpu_pct == 0.0
 
-    def test_multiple_gpu_nodes(self):
-        nodes = [
-            SimNode("g5.8xlarge", 10000, 20000, 1, used_gpu=1),
-            SimNode("g5.8xlarge", 10000, 20000, 1, used_gpu=0),
+
+class TestPoolUtilizationProperties:
+    def test_zero_total_returns_zero_pct(self):
+        empty = PoolUtilization()
+        assert empty.cpu_pct == 0.0
+        assert empty.mem_pct == 0.0
+        assert empty.gpu_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# run_simulation
+# ---------------------------------------------------------------------------
+
+
+def _topology_one_runner(name: str, *, instance_type: str, workflow_fleet: str) -> ClusterTopology:
+    runner = _make_runner(name, instance_type=instance_type, workflow_fleet=workflow_fleet)
+    nodepools = [
+        _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+        _make_pool(f"{workflow_fleet}-48xlarge", fleet=workflow_fleet, instance_type=instance_type),
+    ]
+    return _make_topology(runners=[runner], nodepools=nodepools)
+
+
+class TestRunSimulation:
+    def test_basic_completion_two_phase(self):
+        topo = _topology_one_runner("l-x86iavx512-8-16", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        targets = {"l-x86iavx512-8-16": 10}
+        result = run_simulation(topo, targets, FAKE_DAEMONSETS, seed=42)
+        assert sum(result.deployed.values()) > 0
+        # Both pools should have nodes when runner_pool_fleet is set.
+        assert len(result.workflow_nodes) > 0
+        assert len(result.runner_nodes) > 0
+        # Workflow nodes use the runner's workflow_fleet.
+        assert all(n.fleet == "c7a" for n in result.workflow_nodes)
+        # Runner nodes use the topology's runner pool.
+        assert all(n.fleet == "c7i-runner" for n in result.runner_nodes)
+
+    def test_no_runner_pool_skips_runner_phase(self):
+        runner = _make_runner("r1", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        nodepools = [_make_pool("c7a-48xlarge", fleet="c7a", instance_type="c7a.48xlarge")]
+        topo = _make_topology(runners=[runner], nodepools=nodepools, runner_pool_fleet=None)
+        result = run_simulation(topo, {"r1": 5}, FAKE_DAEMONSETS, seed=42)
+        # Without a runner pool, only workflow nodes get provisioned.
+        assert len(result.workflow_nodes) > 0
+        assert result.runner_nodes == []
+        assert sum(result.deployed.values()) > 0
+
+    def test_deterministic_with_same_seed(self):
+        topo = _topology_one_runner("l-x86iavx512-8-16", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        targets = {"l-x86iavx512-8-16": 20}
+        r1 = run_simulation(topo, targets, FAKE_DAEMONSETS, seed=99)
+        r2 = run_simulation(topo, targets, FAKE_DAEMONSETS, seed=99)
+        assert r1.deployed == r2.deployed
+        assert len(r1.workflow_nodes) == len(r2.workflow_nodes)
+        assert len(r1.runner_nodes) == len(r2.runner_nodes)
+
+    def test_unschedulable_runner_is_skipped(self):
+        good = _make_runner("good", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        bad = _make_runner(
+            "bad", instance_type="c7a.48xlarge", workflow_fleet="c7a",
+            schedulable=False, schedulable_reason="no fleet",
+        )  # fmt: skip
+        nodepools = [
+            _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+            _make_pool("c7a-48xlarge", fleet="c7a", instance_type="c7a.48xlarge"),
         ]
-        result = SimResult(nodes=nodes, deployed={}, targets={})
-        util = compute_utilization(result)
-        assert util["gpu_pct"] == 50.0
-        assert util["total_gpu"] == 2
-        assert util["used_gpu"] == 1
+        topo = _make_topology(runners=[good, bad], nodepools=nodepools)
+        result = run_simulation(topo, {"good": 5, "bad": 5}, FAKE_DAEMONSETS, seed=42)
+        assert "bad" in result.skipped
+        assert "bad" not in result.deployed
+        assert result.deployed.get("good", 0) > 0
+
+    def test_unknown_instance_type_does_not_infinite_loop(self):
+        # One runner with a bogus instance type, one with a real type.
+        good = _make_runner("good", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        bad = _make_runner("bad", instance_type="z99.nonexistent", workflow_fleet="c7a")
+        nodepools = [
+            _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+            _make_pool("c7a-48xlarge", fleet="c7a", instance_type="c7a.48xlarge"),
+        ]
+        topo = _make_topology(runners=[good, bad], nodepools=nodepools)
+        # Should complete without hanging — bad gets marked as failed after first attempt.
+        result = run_simulation(topo, {"good": 5, "bad": 5}, FAKE_DAEMONSETS, seed=42)
+        assert result.deployed.get("good", 0) > 0
+
+    def test_all_unknown_instance_types_terminates(self):
+        bad = _make_runner("bad", instance_type="z99.nonexistent", workflow_fleet="c7a")
+        nodepools = [
+            _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+            _make_pool("c7a-48xlarge", fleet="c7a", instance_type="c7a.48xlarge"),
+        ]
+        topo = _make_topology(runners=[bad], nodepools=nodepools)
+        result = run_simulation(topo, {"bad": 10}, FAKE_DAEMONSETS, seed=42)
+        # Loop must terminate even when no runner ever places.
+        assert result.deployed.get("bad", 0) == 0
+
+    def test_empty_targets(self):
+        topo = _topology_one_runner("r1", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        result = run_simulation(topo, {}, FAKE_DAEMONSETS, seed=42)
+        assert result.workflow_nodes == []
+        assert result.runner_nodes == []
+
+    def test_zero_weight_targets(self):
+        topo = _topology_one_runner("r1", instance_type="c7a.48xlarge", workflow_fleet="c7a")
+        result = run_simulation(topo, {"r1": 0}, FAKE_DAEMONSETS, seed=42)
+        assert sum(result.deployed.values()) == 0
+
+    def test_release_workflow_node_runner_class_propagates(self):
+        # Release runner — workflow nodes must carry runner_class="release".
+        rel = _make_runner(
+            "rel", instance_type="m8g.48xlarge", workflow_fleet="m8g",
+            runner_class="release",
+        )  # fmt: skip
+        nodepools = [
+            _make_pool("c7i-runner-48xlarge", fleet="c7i-runner", instance_type="c7i.48xlarge"),
+            _make_pool("m8g-48xlarge-release", fleet="m8g", instance_type="m8g.48xlarge", runner_class="release"),
+        ]
+        topo = _make_topology(runners=[rel], nodepools=nodepools)
+        result = run_simulation(topo, {"rel": 3}, FAKE_DAEMONSETS, seed=42)
+        # All workflow nodes belong to the release class.
+        assert all(n.runner_class == "release" for n in result.workflow_nodes)
+        # Runner nodes never carry a runner_class — runner pool is shared.
+        assert all(n.runner_class is None for n in result.runner_nodes)

--- a/osdc/scripts/python/test_simulate_cluster_cli.py
+++ b/osdc/scripts/python/test_simulate_cluster_cli.py
@@ -1,66 +1,131 @@
-"""Tests for simulate_cluster_cli module."""
+"""Tests for simulate_cluster_cli module (split-pool model)."""
 
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
 
+from unittest.mock import patch
+
+from cluster_topology import ClusterTopology, NodePoolEntry, RunnerEntry
 from daemonset_overhead import DaemonSetOverhead
-from simulate_cluster import SimNode, SimResult
+from simulate_cluster import (
+    PoolUtilization,
+    SimNode,
+    SimResult,
+    SimulationUtilization,
+)
 from simulate_cluster_cli import (
+    _format_pool,
     _percentile,
     _print_deployment_accuracy,
-    _print_multi_summary,
-    _print_node_table,
-    _print_utilization,
-    _run_multi,
+    _print_multi,
+    _print_node_breakdown,
+    _print_results,
+    _resolve_roots,
     main,
-    print_results,
+    parse_args,
 )
 
-FAKE_DS = [
-    DaemonSetOverhead("kube-proxy", 50, 80, False, "test"),
-]
+FAKE_DS = [DaemonSetOverhead("kube-proxy", 50, 80, False, "test")]
 
 
-def _make_result():
-    """Create a minimal SimResult for testing output functions."""
-    node = SimNode(
-        "c7a.48xlarge",
-        total_cpu_m=10000,
-        total_mem_mi=20000,
-        total_gpu=0,
-        used_cpu_m=8000,
-        used_mem_mi=15000,
-    )
-    gpu_node = SimNode(
-        "g5.8xlarge",
-        total_cpu_m=10000,
-        total_mem_mi=20000,
-        total_gpu=1,
-        used_cpu_m=5000,
-        used_mem_mi=10000,
-        used_gpu=1,
-    )
-    return SimResult(
-        nodes=[node, gpu_node],
-        deployed={"r1": 5, "r2": 3},
-        targets={"r1": 5, "r2": 4},
-        skipped_labels={"old-label": "no mapping"},
-    )
-
-
-def _make_utilization():
-    return {
-        "cpu_pct": 65.0,
-        "mem_pct": 62.5,
-        "gpu_pct": 100.0,
-        "total_cpu_m": 20000,
-        "used_cpu_m": 13000,
-        "total_mem_mi": 40000,
-        "used_mem_mi": 25000,
-        "total_gpu": 1,
-        "used_gpu": 1,
-        "total_nodes": 2,
-        "gpu_nodes": 1,
+def _runner(name: str = "r1", **overrides) -> RunnerEntry:
+    base = {
+        "name": name,
+        "scale_set_name": f"c-mt-{name}",
+        "instance_type": "c7a.48xlarge",
+        "workflow_fleet": "c7a",
+        "runner_class": None,
+        "runner_pod_cpu_m": 750,
+        "runner_pod_mem_mi": 512,
+        "workflow_pod_cpu_m": 8000,
+        "workflow_pod_mem_mi": 16 * 1024,
+        "workflow_pod_gpu": 0,
+        "schedulable": True,
+        "schedulable_reason": None,
     }
+    base.update(overrides)
+    return RunnerEntry(**base)
+
+
+def _topology(*, runner_pool_fleet: str | None = "c7i-runner") -> ClusterTopology:
+    runners = [_runner("r1")]
+    nodepools = [
+        NodePoolEntry("c7i-runner-48xlarge", "c7i-runner", "c7i.48xlarge", "amd64", False, None),
+        NodePoolEntry("c7a-48xlarge", "c7a", "c7a.48xlarge", "amd64", False, None),
+    ]
+    workflow_fleets = {"c7a"}
+    return ClusterTopology(
+        cluster_id="test",
+        region="us-east-2",
+        modules=["nodepools", "arc-runners"],
+        nodepools=nodepools,
+        runner_pool_fleet=runner_pool_fleet,
+        workflow_pool_fleets=workflow_fleets,
+        runners=runners,
+    )
+
+
+def _make_result() -> SimResult:
+    wf = SimNode("c7a.48xlarge", "c7a", None, cpu_m=10000, mem_mi=20000, gpu=0,
+                 used_cpu_m=8000, used_mem_mi=15000, pod_count=2)  # fmt: skip
+    rn = SimNode("c7i.48xlarge", "c7i-runner", None, cpu_m=10000, mem_mi=20000, gpu=0,
+                 used_cpu_m=2000, used_mem_mi=3000, pod_count=2)  # fmt: skip
+    return SimResult(
+        workflow_nodes=[wf],
+        runner_nodes=[rn],
+        deployed={"r1": 2},
+        targets={"r1": 2},
+        skipped=["legacy-name"],
+    )
+
+
+def _make_util() -> SimulationUtilization:
+    wf = PoolUtilization(nodes=1, used_cpu_m=8000, total_cpu_m=10000,
+                         used_mem_mi=15000, total_mem_mi=20000)  # fmt: skip
+    rn = PoolUtilization(nodes=1, used_cpu_m=2000, total_cpu_m=10000,
+                         used_mem_mi=3000, total_mem_mi=20000)  # fmt: skip
+    return SimulationUtilization(workflow=wf, runner=rn)
+
+
+# ---------------------------------------------------------------------------
+# parse_args / _resolve_roots
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_required_cluster(self):
+        args = parse_args(["--cluster", "arc-staging"])
+        assert args.cluster == "arc-staging"
+        assert args.seed == 42
+        assert args.threshold == 0.15
+        assert args.rounds == 1
+
+    def test_overrides(self):
+        args = parse_args(["--cluster", "x", "--seed", "7", "--threshold", "0.05", "--rounds", "5"])
+        assert args.seed == 7
+        assert args.threshold == 0.05
+        assert args.rounds == 5
+
+    def test_missing_cluster_errors(self):
+        import pytest
+
+        with pytest.raises(SystemExit):
+            parse_args([])
+
+
+class TestResolveRoots:
+    def test_env_vars_take_precedence(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        upstream, consumer = _resolve_roots()
+        assert upstream == tmp_path.resolve()
+        assert consumer == tmp_path.resolve()
+
+    def test_root_falls_back_to_upstream(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
+        monkeypatch.delenv("OSDC_ROOT", raising=False)
+        upstream, consumer = _resolve_roots()
+        assert upstream == tmp_path.resolve()
+        assert consumer == tmp_path.resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -86,364 +151,194 @@ class TestPercentile:
 
 
 # ---------------------------------------------------------------------------
-# Output formatting functions (smoke tests)
+# Output formatters
 # ---------------------------------------------------------------------------
 
 
-class TestPrintResults:
-    def test_prints_without_error(self, capsys):
-        result = _make_result()
-        utilization = _make_utilization()
-        print_results(result, utilization)
-        output = capsys.readouterr().out
-        assert "Simulation Results" in output
-        assert "r1" in output
+class TestFormatPool:
+    def test_renders_pool_with_nodes(self, capsys):
+        util = PoolUtilization(nodes=2, used_cpu_m=8000, total_cpu_m=10000,
+                               used_mem_mi=15000, total_mem_mi=20000,
+                               used_gpu=1, total_gpu=2)  # fmt: skip
+        _format_pool(util, "Workflow Pool")
+        out = capsys.readouterr().out
+        assert "Workflow Pool" in out
+        assert "vCPU" in out
+        assert "Memory" in out
+        assert "GPU" in out
 
-    def test_no_skipped_labels(self, capsys):
-        result = _make_result()
-        result.skipped_labels = {}
-        utilization = _make_utilization()
-        print_results(result, utilization)
-        output = capsys.readouterr().out
-        assert "Skipped labels" not in output
+    def test_no_nodes_renders_placeholder(self, capsys):
+        _format_pool(PoolUtilization(), "Runner Pool")
+        out = capsys.readouterr().out
+        assert "Runner Pool" in out
+        assert "no nodes provisioned" in out
+
+    def test_no_gpu_section_when_total_gpu_zero(self, capsys):
+        util = PoolUtilization(nodes=1, used_cpu_m=5000, total_cpu_m=10000,
+                               used_mem_mi=5000, total_mem_mi=10000)  # fmt: skip
+        _format_pool(util, "Workflow Pool")
+        out = capsys.readouterr().out
+        assert "GPU:" not in out
 
 
-class TestPrintNodeTable:
-    def test_shows_instance_types(self, capsys):
+class TestPrintNodeBreakdown:
+    def test_groups_by_fleet(self, capsys):
         result = _make_result()
-        _print_node_table(result)
-        output = capsys.readouterr().out
-        assert "c7a.48xlarge" in output
-        assert "g5.8xlarge" in output
+        _print_node_breakdown(result)
+        out = capsys.readouterr().out
+        assert "c7a" in out
+        assert "c7i-runner" in out
+
+    def test_empty_result_prints_nothing_extra(self, capsys):
+        empty = SimResult()
+        _print_node_breakdown(empty)
+        out = capsys.readouterr().out
+        # Should produce no output when there are no nodes.
+        assert "Nodes by fleet" not in out
 
 
 class TestPrintDeploymentAccuracy:
     def test_shows_deployed_vs_target(self, capsys):
+        _print_deployment_accuracy(_make_result())
+        out = capsys.readouterr().out
+        assert "Deployment accuracy" in out
+        assert "r1" in out
+
+    def test_zero_targets_skips_breakdown(self, capsys):
+        _print_deployment_accuracy(SimResult())
+        out = capsys.readouterr().out
+        assert "Deployment accuracy" in out
+        # No per-runner table when targets is empty.
+        assert "Runner" not in out.split("Total deployed")[1]
+
+
+class TestPrintResults:
+    def test_renders_complete_summary(self, capsys):
+        _print_results(_make_result(), _make_util())
+        out = capsys.readouterr().out
+        assert "Cluster Simulation Results" in out
+        assert "Workflow Pool" in out
+        assert "Runner Pool" in out
+        assert "Skipped runner targets" in out
+        assert "legacy-name" in out
+
+    def test_no_skipped_section_when_empty(self, capsys):
         result = _make_result()
-        _print_deployment_accuracy(result)
-        output = capsys.readouterr().out
-        assert "Deployment accuracy" in output
-        assert "r1" in output
-        assert "r2" in output
+        result.skipped = []
+        _print_results(result, _make_util())
+        out = capsys.readouterr().out
+        assert "Skipped runner targets" not in out
 
 
-class TestPrintUtilization:
-    def test_shows_cpu_and_mem(self, capsys):
-        utilization = _make_utilization()
-        _print_utilization(utilization)
-        output = capsys.readouterr().out
-        assert "vCPU" in output
-        assert "Memory" in output
-        assert "GPU" in output
+class TestPrintMulti:
+    def test_renders_multi_round_summary(self, capsys):
+        utils = [_make_util(), _make_util()]
+        _print_multi(utils, seed=42, rounds=2)
+        out = capsys.readouterr().out
+        assert "Multi-Round Summary" in out
+        assert "Workflow Pool" in out
+        assert "Runner Pool" in out
 
-    def test_no_gpu(self, capsys):
-        utilization = _make_utilization()
-        utilization["total_gpu"] = 0
-        _print_utilization(utilization)
-        output = capsys.readouterr().out
-        assert "GPU:" not in output
-
-
-class TestPrintMultiSummary:
-    def test_prints_summary(self, capsys):
-        utils = [
-            {
-                "cpu_pct": 80.0,
-                "mem_pct": 75.0,
-                "gpu_pct": 100.0,
-                "total_gpu": 1,
-                "total_nodes": 10,
-            },
-            {
-                "cpu_pct": 85.0,
-                "mem_pct": 78.0,
-                "gpu_pct": 90.0,
-                "total_gpu": 1,
-                "total_nodes": 11,
-            },
-        ]
-        _print_multi_summary(utils)
-        output = capsys.readouterr().out
-        assert "vCPU" in output
-        assert "Nodes" in output
-
-    def test_no_gpu_nodes(self, capsys):
-        utils = [
-            {
-                "cpu_pct": 80.0,
-                "mem_pct": 75.0,
-                "gpu_pct": 0.0,
-                "total_gpu": 0,
-                "total_nodes": 5,
-            },
-        ]
-        _print_multi_summary(utils)
-        output = capsys.readouterr().out
-        assert "GPU" not in output
+    def test_no_nodes_message(self, capsys):
+        empty_pool = PoolUtilization()
+        utils = [SimulationUtilization(workflow=empty_pool, runner=empty_pool)]
+        _print_multi(utils, seed=42, rounds=1)
+        out = capsys.readouterr().out
+        assert "no nodes provisioned across rounds" in out
 
 
 # ---------------------------------------------------------------------------
-# _run_multi
+# main — smoke test with mocked resolve_cluster + discover_daemonsets
 # ---------------------------------------------------------------------------
 
 
-class TestRunMulti:
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    def test_runs_multiple_rounds(self, mock_util, mock_sim, capsys):
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"r1": 5},
-            targets={"r1": 5},
-        )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_gpu": 0,
-            "total_nodes": 1,
-        }
-        runners = [{"name": "r1", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}]
-        args = MagicMock(seed=42, rounds=3, threshold=0.15)
-        result = _run_multi(runners, {"r1": 5}, FAKE_DS, {}, args)
-        assert result == 0
-        assert mock_sim.call_count == 3
-
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    def test_run_multi_with_skipped_mapping(self, mock_util, mock_sim, capsys):
-        """_run_multi prints skipped mapping when non-empty (line 133)."""
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"r1": 5},
-            targets={"r1": 5},
-        )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_gpu": 0,
-            "total_nodes": 1,
-        }
-        runners = [{"name": "r1", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}]
-        args = MagicMock(seed=42, rounds=2, threshold=0.15)
-        skipped = {"old-label": "no mapping found"}
-        result = _run_multi(runners, {"r1": 5}, FAKE_DS, skipped, args)
-        assert result == 0
-        output = capsys.readouterr().out
-        assert "Unmapped old labels" in output
-
-
-# ---------------------------------------------------------------------------
-# main
-# ---------------------------------------------------------------------------
-
-
-class TestMain:
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    @patch("simulate_cluster_cli.load_runner_defs")
+class TestMainSmoke:
+    @patch("simulate_cluster_cli.resolve_cluster")
     @patch("simulate_cluster_cli.discover_daemonsets")
-    def test_single_run(self, mock_ds, mock_runners, mock_util, mock_sim, capsys, tmp_path):
+    def test_single_run(self, mock_ds, mock_resolve, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
         mock_ds.return_value = FAKE_DS
-        mock_runners.return_value = [
-            {"name": "l-x86iavx512-8-16", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        ]
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"l-x86iavx512-8-16": 10},
-            targets={"l-x86iavx512-8-16": 10},
-            skipped_labels={},
+        # Use a runner whose new label matches a real PEAK_CONCURRENT entry.
+        mock_resolve.return_value = ClusterTopology(
+            cluster_id="test",
+            region="us-east-2",
+            modules=["nodepools", "arc-runners"],
+            nodepools=[
+                NodePoolEntry("c7i-runner-48xlarge", "c7i-runner", "c7i.48xlarge", "amd64", False, None),
+                NodePoolEntry("c7a-48xlarge", "c7a", "c7a.48xlarge", "amd64", False, None),
+            ],
+            runner_pool_fleet="c7i-runner",
+            workflow_pool_fleets={"c7a"},
+            runners=[_runner("l-x86iavx512-8-16", workflow_fleet="c7a")],
         )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_cpu_m": 10000,
-            "used_cpu_m": 8000,
-            "total_mem_mi": 20000,
-            "used_mem_mi": 15000,
-            "total_gpu": 0,
-            "used_gpu": 0,
-            "total_nodes": 1,
-            "gpu_nodes": 0,
-        }
-        result = main(
-            [
-                "--upstream-dir",
-                str(tmp_path),
-                "--consumer-root",
-                str(tmp_path),
-                "--seed",
-                "42",
-            ]
-        )
+        result = main(["--cluster", "test"])
         assert result == 0
+        out = capsys.readouterr().out
+        assert "Cluster Simulation Results" in out
 
-    @patch("simulate_cluster_cli.load_runner_defs", return_value=[])
-    @patch("simulate_cluster_cli.discover_daemonsets", return_value=FAKE_DS)
-    def test_no_runners_returns_1(self, mock_ds, mock_runners, capsys, tmp_path):
-        result = main(
-            [
-                "--upstream-dir",
-                str(tmp_path),
-                "--consumer-root",
-                str(tmp_path),
-            ]
+    @patch("simulate_cluster_cli.resolve_cluster")
+    @patch("simulate_cluster_cli.discover_daemonsets")
+    def test_multi_round(self, mock_ds, mock_resolve, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        mock_ds.return_value = FAKE_DS
+        mock_resolve.return_value = ClusterTopology(
+            cluster_id="test",
+            region="us-east-2",
+            modules=["nodepools", "arc-runners"],
+            nodepools=[
+                NodePoolEntry("c7i-runner-48xlarge", "c7i-runner", "c7i.48xlarge", "amd64", False, None),
+                NodePoolEntry("c7a-48xlarge", "c7a", "c7a.48xlarge", "amd64", False, None),
+            ],
+            runner_pool_fleet="c7i-runner",
+            workflow_pool_fleets={"c7a"},
+            runners=[_runner("l-x86iavx512-8-16", workflow_fleet="c7a")],
         )
+        result = main(["--cluster", "test", "--rounds", "2"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Multi-Round Summary" in out
+
+    @patch("simulate_cluster_cli.resolve_cluster")
+    @patch("simulate_cluster_cli.discover_daemonsets")
+    def test_no_targets_returns_1(self, mock_ds, mock_resolve, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        mock_ds.return_value = FAKE_DS
+        # Topology with no runners → no targets → return 1.
+        mock_resolve.return_value = ClusterTopology(
+            cluster_id="test",
+            region="us-east-2",
+            modules=["nodepools"],
+            nodepools=[],
+            runner_pool_fleet=None,
+            workflow_pool_fleets=set(),
+            runners=[],
+        )
+        result = main(["--cluster", "test"])
         assert result == 1
 
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    @patch("simulate_cluster_cli.load_runner_defs")
+    @patch("simulate_cluster_cli.resolve_cluster")
     @patch("simulate_cluster_cli.discover_daemonsets")
-    def test_multi_round(self, mock_ds, mock_runners, mock_util, mock_sim, capsys, tmp_path):
-        mock_ds.return_value = FAKE_DS
-        mock_runners.return_value = [
-            {"name": "l-x86iavx512-8-16", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        ]
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"l-x86iavx512-8-16": 10},
-            targets={"l-x86iavx512-8-16": 10},
-        )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_gpu": 0,
-            "total_nodes": 1,
-        }
-        result = main(
-            [
-                "--upstream-dir",
-                str(tmp_path),
-                "--consumer-root",
-                str(tmp_path),
-                "--rounds",
-                "3",
-            ]
-        )
-        assert result == 0
-
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    @patch("simulate_cluster_cli.load_runner_defs")
-    @patch("simulate_cluster_cli.discover_daemonsets")
-    def test_env_osdc_root(self, mock_ds, mock_runners, mock_util, mock_sim, capsys, tmp_path, monkeypatch):
-        """Tests the OSDC_ROOT env var path."""
-        mock_ds.return_value = FAKE_DS
-        mock_runners.return_value = [
-            {"name": "l-x86iavx512-8-16", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        ]
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"l-x86iavx512-8-16": 10},
-            targets={"l-x86iavx512-8-16": 10},
-            skipped_labels={},
-        )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_cpu_m": 10000,
-            "used_cpu_m": 8000,
-            "total_mem_mi": 20000,
-            "used_mem_mi": 15000,
-            "total_gpu": 0,
-            "used_gpu": 0,
-            "total_nodes": 1,
-            "gpu_nodes": 0,
-        }
+    def test_staging_warning(self, mock_ds, mock_resolve, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", str(tmp_path))
         monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
-        result = main(["--upstream-dir", str(tmp_path)])
-        assert result == 0
-
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    @patch("simulate_cluster_cli.load_runner_defs")
-    @patch("simulate_cluster_cli.discover_daemonsets")
-    def test_candidate_fallback_no_clusters_yaml(
-        self, mock_ds, mock_runners, mock_util, mock_sim, capsys, tmp_path, monkeypatch
-    ):
-        """When OSDC_ROOT unset and candidate has no clusters.yaml, falls back to upstream (lines 196-197)."""
         mock_ds.return_value = FAKE_DS
-        mock_runners.return_value = [
-            {"name": "r1", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        ]
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"r1": 10},
-            targets={"r1": 10},
-            skipped_labels={},
+        mock_resolve.return_value = ClusterTopology(
+            cluster_id="arc-staging",
+            region="us-west-1",
+            modules=["nodepools", "arc-runners"],
+            nodepools=[
+                NodePoolEntry("c7i-runner-48xlarge", "c7i-runner", "c7i.48xlarge", "amd64", False, None),
+                NodePoolEntry("c7a-48xlarge", "c7a", "c7a.48xlarge", "amd64", False, None),
+            ],
+            runner_pool_fleet="c7i-runner",
+            workflow_pool_fleets={"c7a"},
+            runners=[_runner("l-x86iavx512-8-16", workflow_fleet="c7a")],
         )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_cpu_m": 10000,
-            "used_cpu_m": 8000,
-            "total_mem_mi": 20000,
-            "used_mem_mi": 15000,
-            "total_gpu": 0,
-            "used_gpu": 0,
-            "total_nodes": 1,
-            "gpu_nodes": 0,
-        }
-        monkeypatch.delenv("OSDC_ROOT", raising=False)
-        # Use a deep tmp_path so candidate.parent.parent won't have clusters.yaml
-        upstream = tmp_path / "a" / "b" / "upstream"
-        upstream.mkdir(parents=True)
-        result = main(["--upstream-dir", str(upstream)])
+        result = main(["--cluster", "arc-staging"])
         assert result == 0
-
-    @patch("simulate_cluster_cli.run_simulation")
-    @patch("simulate_cluster_cli.compute_utilization")
-    @patch("simulate_cluster_cli.load_runner_defs")
-    @patch("simulate_cluster_cli.discover_daemonsets")
-    def test_consumer_with_runner_modules(self, mock_ds, mock_runners, mock_util, mock_sim, capsys, tmp_path):
-        """Tests consumer_root != upstream with runner modules."""
-        consumer = tmp_path / "consumer"
-        upstream = tmp_path / "upstream"
-        consumer.mkdir()
-        upstream.mkdir()
-        mod = consumer / "modules" / "custom-runners" / "defs"
-        mod.mkdir(parents=True)
-        # Write a runner def that will be found by the iterdir scanning
-        import yaml
-
-        runner_def = {"runner": {"name": "custom-r", "instance_type": "c7a.48xlarge", "vcpu": 4, "memory": "8Gi"}}
-        (mod / "custom.yaml").write_text(yaml.dump(runner_def))
-
-        mock_ds.return_value = FAKE_DS
-        mock_runners.return_value = [
-            {"name": "l-x86iavx512-8-16", "instance_type": "c7a.48xlarge", "vcpu": 8, "memory_mi": 16384, "gpu": 0}
-        ]
-        mock_sim.return_value = SimResult(
-            nodes=[SimNode("c7a.48xlarge", 10000, 20000, 0, used_cpu_m=8000, used_mem_mi=15000)],
-            deployed={"l-x86iavx512-8-16": 10},
-            targets={"l-x86iavx512-8-16": 10},
-            skipped_labels={},
-        )
-        mock_util.return_value = {
-            "cpu_pct": 80.0,
-            "mem_pct": 75.0,
-            "gpu_pct": 0.0,
-            "total_cpu_m": 10000,
-            "used_cpu_m": 8000,
-            "total_mem_mi": 20000,
-            "used_mem_mi": 15000,
-            "total_gpu": 0,
-            "used_gpu": 0,
-            "total_nodes": 1,
-            "gpu_nodes": 0,
-        }
-        result = main(
-            [
-                "--upstream-dir",
-                str(upstream),
-                "--consumer-root",
-                str(consumer),
-            ]
-        )
-        assert result == 0
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "PEAK_CONCURRENT" in out

--- a/osdc/scripts/python/utilization_report.py
+++ b/osdc/scripts/python/utilization_report.py
@@ -1,0 +1,230 @@
+"""Per-pool packing analyzer + pod-cost helpers for ``analyze_node_utilization``.
+
+Splits the per-pool printing logic out of the CLI driver so:
+  * The runner-pool and workflow-pool sections can share one analyzer.
+  * The CLI driver stays small and focused on orchestration.
+
+Public API:
+  * ``per_runner_pod_total(runner)`` — pod cost on the runner pool (no GPU).
+  * ``per_workflow_pod_total(runner)`` — pod cost on the workflow pool, including
+    runner-container-hooks overhead and any GPU request.
+  * ``analyze_pool(...)`` — analyze one pool of (NodePoolEntry, RunnerEntry)
+    against the provided DaemonSet set + threshold; returns a count of
+    below-threshold runners and per-instance slack stats.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from cli_colors import BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW
+from instance_specs import INSTANCE_SPECS
+from packing import compute_node_slack, find_maximal_combos, find_valid_combos, print_combo
+
+if TYPE_CHECKING:
+    from cluster_topology import NodePoolEntry, RunnerEntry
+    from daemonset_overhead import DaemonSetOverhead
+
+# Re-imported here so per_workflow_pod_total stays in one module. Kept in sync
+# with analyze_node_utilization manually — see docstring there.
+HOOKS_OVERHEAD_CPU_M = 320
+HOOKS_OVERHEAD_MEM_MI = 522
+
+PodCost = tuple[int, int, int]
+PodCostFn = Callable[["RunnerEntry"], PodCost]
+AllocFn = Callable[..., dict | None]
+
+
+def per_runner_pod_total(runner: RunnerEntry) -> PodCost:
+    """Resources required by ONE runner pod on the runner pool (no GPU)."""
+    return (runner.runner_pod_cpu_m, runner.runner_pod_mem_mi, 0)
+
+
+def per_workflow_pod_total(runner: RunnerEntry) -> PodCost:
+    """Resources required by ONE workflow pod on the workflow pool (GPU if any).
+
+    Adds HOOKS_OVERHEAD_* to account for runner-container-hooks injecting
+    helper containers into the workflow pod at runtime.
+    """
+    return (
+        runner.workflow_pod_cpu_m + HOOKS_OVERHEAD_CPU_M,
+        runner.workflow_pod_mem_mi + HOOKS_OVERHEAD_MEM_MI,
+        runner.workflow_pod_gpu,
+    )
+
+
+def _format_mem(mi: int) -> str:
+    if abs(mi) >= 1024:
+        return f"{mi / 1024:.1f}Gi"
+    return f"{mi}Mi"
+
+
+def _summarize_pod(runner: RunnerEntry, pod_total_fn: PodCostFn) -> str:
+    cpu, mem, gpu = pod_total_fn(runner)
+    gpu_note = f", {gpu} GPU" if gpu > 0 else ""
+    if pod_total_fn is per_workflow_pod_total:
+        return (
+            f"{cpu}m CPU, {_format_mem(mem)} RAM{gpu_note} "
+            f"(job: {runner.workflow_pod_cpu_m}m+{_format_mem(runner.workflow_pod_mem_mi)},"
+            f" hooks: {HOOKS_OVERHEAD_CPU_M}m+{HOOKS_OVERHEAD_MEM_MI}Mi)"
+        )
+    return f"{cpu}m CPU, {_format_mem(mem)} RAM{gpu_note}"
+
+
+def _print_alloc_header(instance_type: str, alloc: dict, fleet_name: str) -> None:
+    spec = INSTANCE_SPECS[instance_type]
+    print(f"\n{'━' * 80}")
+    print(f"{BOLD}{CYAN}Node Type: {instance_type} (fleet={fleet_name}){NC}")
+    print(
+        f"  Total: {spec['vcpu']} vCPU, {spec['memory_gib']}Gi advertised"
+        f" ({_format_mem(spec['memory_mi'])} actual)" + (f", {spec['gpu']} GPU" if spec["gpu"] > 0 else "")
+    )
+    print(f"  Kubelet reserved: {alloc['kube_reserved_cpu_m']}m CPU, {_format_mem(alloc['kube_reserved_mem_mi'])} RAM")
+    print(f"  DaemonSet overhead: {alloc['ds_cpu_m']}m CPU, {_format_mem(alloc['ds_mem_mi'])} RAM")
+    print(
+        f"  {GREEN}Allocatable: "
+        f"{alloc['allocatable_cpu_m']}m CPU ({alloc['allocatable_cpu_m'] / 1000:.1f} cores), "
+        f"{_format_mem(alloc['allocatable_mem_mi'])} RAM"
+        + (f", {alloc['allocatable_gpu']} GPU" if alloc["allocatable_gpu"] > 0 else "")
+        + f"{NC}"
+    )
+
+
+def _print_homogeneous(
+    runners: list[RunnerEntry],
+    alloc: dict,
+    threshold: float,
+    pod_total_fn: PodCostFn,
+) -> int:
+    """One line per runner type with single-type packing stats. Returns below-threshold count."""
+    below = 0
+    print(f"\n  {BOLD}Homogeneous packing (single runner type fills the node):{NC}")
+    for r in runners:
+        c, m, g = pod_total_fn(r)
+        max_by_cpu = alloc["allocatable_cpu_m"] // c if c > 0 else 999
+        max_by_mem = alloc["allocatable_mem_mi"] // m if m > 0 else 999
+        max_by_gpu = alloc["allocatable_gpu"] // g if g > 0 else 999
+        max_pods = min(max_by_cpu, max_by_mem, max_by_gpu)
+        used_cpu, used_mem, used_gpu = max_pods * c, max_pods * m, max_pods * g
+
+        cpu_pct = used_cpu / alloc["allocatable_cpu_m"] * 100 if alloc["allocatable_cpu_m"] > 0 else 0
+        mem_pct = used_mem / alloc["allocatable_mem_mi"] * 100 if alloc["allocatable_mem_mi"] > 0 else 0
+        gpu_pct = used_gpu / alloc["allocatable_gpu"] * 100 if alloc["allocatable_gpu"] > 0 else 100
+
+        if max_by_cpu <= max_by_mem and max_by_cpu <= max_by_gpu:
+            bottleneck = "CPU"
+        elif max_by_mem <= max_by_gpu:
+            bottleneck = "MEM"
+        else:
+            bottleneck = "GPU"
+
+        worst = min(cpu_pct, mem_pct)
+        color = GREEN if worst >= threshold else (YELLOW if worst >= threshold * 0.9 else RED)
+        if worst < threshold:
+            below += 1
+        waste_cpu = alloc["allocatable_cpu_m"] - used_cpu
+        waste_mem = alloc["allocatable_mem_mi"] - used_mem
+
+        print(f"    {color}{r.name}{NC}: {max_pods} pods")
+        print(
+            f"      CPU: {cpu_pct:5.1f}% ({used_cpu}m / {alloc['allocatable_cpu_m']}m) "
+            f"waste: {waste_cpu}m ({waste_cpu / 1000:.1f} cores)"
+        )
+        print(
+            f"      MEM: {mem_pct:5.1f}% ({_format_mem(used_mem)} / {_format_mem(alloc['allocatable_mem_mi'])}) "
+            f"waste: {_format_mem(waste_mem)}"
+        )
+        if alloc["allocatable_gpu"] > 0:
+            print(f"      GPU: {gpu_pct:5.1f}% ({used_gpu} / {alloc['allocatable_gpu']})")
+        print(f"      Bottleneck: {bottleneck}")
+    return below
+
+
+def _print_mixed_combos(
+    runners: list[RunnerEntry],
+    alloc: dict,
+    threshold: float,
+    pod_total_fn: PodCostFn,
+) -> None:
+    """Enumerate maximal mixed combos when there aren't too many runner types."""
+    if len(runners) > 8:
+        print(f"\n  {DIM}(too many runner types ({len(runners)}) to enumerate mixed combos){NC}")
+        return
+    print(f"\n  {BOLD}Maximal mixed combos (node fully packed, no room for another pod):{NC}")
+    pod_costs = [pod_total_fn(r) for r in runners]
+    runner_names = [r.name for r in runners]
+    all_combos = find_valid_combos(pod_costs, runner_names, alloc)
+    maximal = find_maximal_combos(all_combos, alloc, pod_costs)
+    if not maximal:
+        print(f"    {DIM}(no valid combos found){NC}")
+        return
+
+    maximal.sort(key=lambda c: min(c["cpu_util"], c["mem_util"]), reverse=True)
+    best = maximal[:5]
+    worst = maximal[-5:] if len(maximal) > 5 else []
+
+    print(f"    Total maximal combos: {len(maximal)}")
+    print()
+    print(f"    {GREEN}Top {len(best)} most efficient:{NC}")
+    for i, combo in enumerate(best):
+        print_combo(combo, alloc, threshold, i + 1)
+    if worst:
+        seen = {tuple(sorted(b["runners"])) for b in best}
+        worst = [w for w in worst if tuple(sorted(w["runners"])) not in seen]
+        if worst:
+            print(f"\n    {RED}Bottom {len(worst)} least efficient (money on the table):{NC}")
+            for i, combo in enumerate(worst):
+                print_combo(combo, alloc, threshold, i + 1)
+
+
+def analyze_pool(
+    pool_label: str,
+    fleet_name: str,
+    nodepools: list[NodePoolEntry],
+    runners: list[RunnerEntry],
+    daemonsets: list[DaemonSetOverhead],
+    *,
+    threshold: float,
+    pod_total_fn: PodCostFn,
+    compute_allocatable_fn: AllocFn,
+) -> tuple[int, dict[str, dict]]:
+    """Analyze packing for one pool. Returns (below_threshold_count, slack_per_instance)."""
+    print(f"\n{BOLD}{'═' * 80}{NC}")
+    print(f"{BOLD}{pool_label}{NC} (fleet={fleet_name}, runners={len(runners)})")
+    print(f"{BOLD}{'═' * 80}{NC}")
+
+    if not runners:
+        print(f"  {DIM}(no runners target this pool){NC}")
+        return 0, {}
+    if not nodepools:
+        print(f"  {YELLOW}WARN: no nodepools deployed for fleet '{fleet_name}'{NC}")
+        return 0, {}
+
+    by_instance: dict[str, list[NodePoolEntry]] = {}
+    for np in nodepools:
+        by_instance.setdefault(np.instance_type, []).append(np)
+    unknown = [it for it in by_instance if it not in INSTANCE_SPECS]
+    if unknown:
+        print(f"  {RED}Unknown instance types (add to INSTANCE_SPECS): {unknown}{NC}")
+
+    below_total = 0
+    slacks: dict[str, dict] = {}
+    for instance_type in sorted(by_instance):
+        if instance_type not in INSTANCE_SPECS:
+            continue
+        alloc = compute_allocatable_fn(instance_type, daemonsets, fleet_name=fleet_name)
+        _print_alloc_header(instance_type, alloc, fleet_name)
+        print()
+        print(f"  {BOLD}Runners targeting this pool:{NC}")
+        for r in runners:
+            print(f"    - {r.name}: {_summarize_pod(r, pod_total_fn)}")
+
+        below_total += _print_homogeneous(runners, alloc, threshold, pod_total_fn)
+        _print_mixed_combos(runners, alloc, threshold, pod_total_fn)
+
+        pod_costs = [pod_total_fn(r) for r in runners]
+        slack = compute_node_slack(alloc, pod_costs, homogeneous_only=True)
+        if slack:
+            slacks[instance_type] = slack
+    return below_total, slacks


### PR DESCRIPTION
**Impact:** All ARC runner scale sets across all clusters — caps how many placeholder pod pairs the capacity monitor can create per reconcile cycle
**Risk:** medium

## What
Adds a new `max_burst_capacity` field to every runner definition, wired through the generation pipeline as `CAPACITY_AWARE_MAX_BURST_CAPACITY` on listener pods. This caps the total number of placeholder pairs (running + pending) the provisioner will create, preventing burst node provisioning from overwhelming downstream services.

## Why
The ARC fork's capacity monitor creates placeholder pod pairs to pre-warm nodes ahead of demand. Without a ceiling, a sudden spike in queued jobs (or a proactive capacity miscalculation) can trigger hundreds of simultaneous node provisions — saturating git-cache, Harbor, and pypi-cache and causing cascading timeouts. Additionally, the fork had a bug where placeholder creation did not properly clamp against `maxRunners` headroom (real runners weren't subtracted from the cap), effectively doubling the intended maximum. The `max_burst_capacity` field provides an independent, operator-tunable safety valve on the OSDC side.

## How
- `max_burst_capacity` defaults to `0` (unlimited/uncapped) for backward compatibility — runners without the field behave exactly as before
- Values are tiered by runner size to match infrastructure capacity:
  - Small runners (proactive_capacity=30): `max_burst_capacity=2000`
  - Medium runners (proactive_capacity=10): `max_burst_capacity=250`
  - Large/GPU runners (proactive_capacity=5): `max_burst_capacity=30`
- Generator validates the field is a non-negative integer and warns (but does not fail) when `max_burst_capacity < proactive_capacity`, since that configuration would prevent the listener from ever reaching its proactive baseline
- The cap is applied in the fork's provisioner after the MaxRunners headroom clamp, so whichever limit is tighter wins

## Changes
- **Runner defs** (`defs/*.yaml`): Added `max_burst_capacity` to all 38 runner definitions with size-appropriate values
- **Generator** (`generate_runners.py`):
  - Reads `max_burst_capacity` from def files (default `0`)
  - Validates it's a non-negative integer
  - Warns when `max_burst_capacity < proactive_capacity`
  - Substitutes `{{MAX_BURST_CAPACITY}}` into the template
  - Added `log_warning()` helper and `YELLOW` ANSI color
- **Template** (`runner.yaml.tpl`): Added `CAPACITY_AWARE_MAX_BURST_CAPACITY` env var to the listener container
- **Unit tests** (`test_generate_runners.py`): 8 new test cases covering default-zero, explicit values, invalid inputs (negative, non-int), zero-allowed, and warning/no-warning edge cases
- **Smoke tests** (`tests/smoke/test_runners.py`): New `TestListenerCapacityAwareEnvVars` class verifies all 16 `CAPACITY_AWARE_*` env vars (including `MAX_BURST_CAPACITY`) are present and populated on live listener pods
- **Docs** (`docs/arc-fork-build-deploy.md`): Documented `CAPACITY_AWARE_MAX_BURST_CAPACITY` in the capacity monitor config table

## Notes
- This PR covers the OSDC (config/generation) side only. The fork-side Go code that reads `CAPACITY_AWARE_MAX_BURST_CAPACITY` and applies the clamp lives in `actions-runner-controller` and includes the MaxRunners headroom bug fix (placeholder creation now subtracts running+pending real runners from the cap instead of ignoring them).
- `force_proactive_capacity_zero` (used by staging clusters) does NOT zero out `max_burst_capacity` — staging clusters will still have the configured cap, which is harmless since proactive capacity is already disabled there.

## Testing
- `just test` — all unit tests pass, including 8 new `max_burst_capacity` test cases
- `just lint` — all 13 linters pass
- Smoke tests (`TestListenerCapacityAwareEnvVars`) will validate live listener pods have the env var after deploy
- Manual verification: after deploy, confirm listener pods show `CAPACITY_AWARE_MAX_BURST_CAPACITY` in their env (`kubectl get pod -n arc-systems -l app.kubernetes.io/component=runner-scale-set-listener -o jsonpath='{.items[0].spec.containers[?(@.name=="listener")].env}'`)