### PR TITLE
Add max_burst_capacity to ARC runners

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -193,7 +193,7 @@ clusters:
       github_secret_name: pytorch-arc-cbr-production
       runner_name_prefix: "mt-"
     pypi_cache:
-      replicas: 4
+      replicas: 5
     modules:
       - karpenter
       - arc

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -49,7 +49,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.5"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.7"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 2
     log_level: info

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -52,7 +52,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.8"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.9"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 2
     log_level: info

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -52,7 +52,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.7"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.8"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 2
     log_level: info

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -154,6 +154,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 |---------|---------|-------------|
 | `CAPACITY_AWARE_ENABLED` | `true` | Enable the capacity monitor goroutine |
 | `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | Number of placeholder pairs to maintain ahead of demand |
+| `CAPACITY_AWARE_MAX_BURST_CAPACITY` | `0` | Caps the maximum total placeholder pairs (running + pending) the provisioner will create per cycle. `0` means unlimited. Used to prevent burst node provisioning from overloading downstream services (git-cache, Harbor, pypi-cache) |
 | `CAPACITY_AWARE_RECALCULATE_INTERVAL` | `30s` | Fallback reconciliation interval (event-driven is primary) |
 | `CAPACITY_AWARE_PLACEHOLDER_TIMEOUT` | `20m` | How long a placeholder can stay Pending before being deleted |
 | `CAPACITY_AWARE_WORKFLOW_CPU` | _(from runner def)_ | Workflow placeholder CPU request (template: `{{VCPU}}`) |

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -17,8 +17,8 @@
 Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image and publishes the chart to GHCR.
 
 - **OCI registry**: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.7`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
-- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.7` to match the chart)
+- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.8`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
+- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.8` to match the chart)
 
 To publish a new chart version, trigger `gha-publish-chart.yaml` from the fork's GitHub Actions UI with `publish_gha_runner_scale_set_controller_chart: true`.
 
@@ -129,14 +129,14 @@ This runs `modules/arc/deploy.sh`, which:
 3. **Applies RBAC** from `modules/arc/kubernetes/capacity-monitor-rbac.yaml`
 4. **Helm upgrade** of the fork chart:
    - Chart: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.7`)
+   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.8`)
    - Image: defaults to `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<chart_version>`. Override with `arc.image_repository` / `arc.image_tag` in `clusters.yaml` for local Harbor builds.
 
 Other deploy.sh config knobs (all from `clusters.yaml`):
 
 | Key | Default | What |
 |-----|---------|------|
-| `arc.chart_version` | `0.14.1-jeanschmidt.7` | Helm chart version (fork) |
+| `arc.chart_version` | `0.14.1-jeanschmidt.8` | Helm chart version (fork) |
 | `arc.image_repository` | `ghcr.io/jeanschmidt/gha-runner-scale-set-controller` | Controller image repo (override for local Harbor builds) |
 | `arc.image_tag` | _(chart_version)_ | Controller image tag (override for local Harbor builds) |
 | `arc.replica_count` | `2` | Controller replicas |

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -17,8 +17,8 @@
 Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image and publishes the chart to GHCR.
 
 - **OCI registry**: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.5`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
-- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.5` to match the chart)
+- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.7`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
+- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.7` to match the chart)
 
 To publish a new chart version, trigger `gha-publish-chart.yaml` from the fork's GitHub Actions UI with `publish_gha_runner_scale_set_controller_chart: true`.
 
@@ -129,14 +129,14 @@ This runs `modules/arc/deploy.sh`, which:
 3. **Applies RBAC** from `modules/arc/kubernetes/capacity-monitor-rbac.yaml`
 4. **Helm upgrade** of the fork chart:
    - Chart: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.5`)
+   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.7`)
    - Image: defaults to `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<chart_version>`. Override with `arc.image_repository` / `arc.image_tag` in `clusters.yaml` for local Harbor builds.
 
 Other deploy.sh config knobs (all from `clusters.yaml`):
 
 | Key | Default | What |
 |-----|---------|------|
-| `arc.chart_version` | `0.14.1-jeanschmidt.5` | Helm chart version (fork) |
+| `arc.chart_version` | `0.14.1-jeanschmidt.7` | Helm chart version (fork) |
 | `arc.image_repository` | `ghcr.io/jeanschmidt/gha-runner-scale-set-controller` | Controller image repo (override for local Harbor builds) |
 | `arc.image_tag` | _(chart_version)_ | Controller image tag (override for local Harbor builds) |
 | `arc.replica_count` | `2` | Controller replicas |

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1239,6 +1239,57 @@ analyze-utilization *args:
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \
     uv run {{SCRIPTS}}/python/analyze_node_utilization.py {{args}}
 
+# Generate ARC runner scale set YAMLs for a cluster (no validation, no apply).
+# Mirrors Step 1 of modules/arc-runners/deploy.sh — generation only. Used by
+# smoke tests to obtain post-override YAMLs (e.g. force_proactive_capacity_zero
+# on staging) without touching the cluster.
+generate-arc-runners cluster:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export OSDC_ROOT="{{ROOT}}"
+    export OSDC_UPSTREAM="{{UPSTREAM}}"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    SECONDS=0
+
+    # Agent mode: suppress output on success, show only on failure
+    _AGENT="${AGENT_ENVIRONMENT:-false}"
+    _agent_out=""
+    if [[ "$_AGENT" == "true" ]]; then
+        _agent_out=$(mktemp)
+        exec 3>&1 4>&2
+        exec > "$_agent_out" 2>&1
+    fi
+    trap '[[ -n "$_agent_out" ]] && rm -f "$_agent_out"' EXIT
+
+    # Resolve module-relative defaults (mirrors deploy.sh).
+    MODULE_DIR="{{UPSTREAM}}/modules/arc-runners"
+    DEFS_DIR="${ARC_RUNNERS_DEFS_DIR:-$MODULE_DIR/defs}"
+    OUTPUT_DIR="${ARC_RUNNERS_OUTPUT_DIR:-$MODULE_DIR/generated}"
+    TEMPLATE="${ARC_RUNNERS_TEMPLATE:-$MODULE_DIR/templates/runner.yaml.tpl}"
+    MODULE_NAME="${ARC_RUNNERS_MODULE_NAME:-arc-runners}"
+
+    ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
+        ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \
+        ARC_RUNNERS_TEMPLATE="$TEMPLATE" \
+        ARC_RUNNERS_MODULE_NAME="$MODULE_NAME" \
+        uv run "$MODULE_DIR/scripts/python/generate_runners.py" "$CLUSTER" \
+        && rc=0 || rc=$?
+
+    if (( SECONDS < 60 )); then elapsed="${SECONDS}s"; else elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"; fi
+    if [[ "$_AGENT" == "true" ]]; then
+        exec 1>&3 2>&4
+        if [[ $rc -eq 0 ]]; then echo "OK (${elapsed})"; else cat "$_agent_out"; fi
+        rm -f "$_agent_out"
+        exit $rc
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo "Generation FAILED. (${elapsed})"
+        exit $rc
+    fi
+    echo "Generated ARC runner configs in ${OUTPUT_DIR} (${elapsed})"
+
 # Monte Carlo cluster simulation for PyTorch CI load
 simulate-cluster *args:
     @export OSDC_ROOT="{{ROOT}}"; \

--- a/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 29Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 62Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 463Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 62Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 226Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 167Gi
   gpu: 0
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 344Gi
   gpu: 8
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 704Gi
   gpu: 8
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 113Gi
   gpu: 1
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 113Gi
   gpu: 1
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 167Gi
   gpu: 4
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 172Gi
   gpu: 4
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 463Gi
   gpu: 0
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 27Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 128Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 41Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 128Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 84Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 16Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 32Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 64Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 160Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 32Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 128Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 32Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 4Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -11,3 +11,4 @@ runner:
   memory: 115Gi
   gpu: 1
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 256Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 68Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 172Gi
   gpu: 4
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 85Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 384Gi
   gpu: 0
   proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 16Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 64Gi
   gpu: 0
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
@@ -9,3 +9,4 @@ runner:
   memory: 189Gi
   gpu: 0
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
@@ -8,3 +8,4 @@ runner:
   memory: 740Gi
   gpu: 0
   proactive_capacity: 5
+  max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
@@ -11,3 +11,4 @@ runner:
   runner_group: release-runners
   runner_class: release
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
@@ -11,3 +11,4 @@ runner:
   runner_group: release-runners
   runner_class: release
   proactive_capacity: 30
+  max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -32,12 +32,17 @@ if _scripts_python not in sys.path:
 
 # ANSI colors
 GREEN = "\033[0;32m"
+YELLOW = "\033[0;33m"
 RED = "\033[0;31m"
 NC = "\033[0m"
 
 
 def log_info(msg):
     print(f"{GREEN}\u2192{NC} {msg}")
+
+
+def log_warning(msg):
+    print(f"{YELLOW}\u26a0{NC} {msg}", file=sys.stderr)
 
 
 def log_error(msg):
@@ -146,6 +151,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     # that can scale out on demand.
     max_runners = runner.get("max_runners")
     proactive_capacity = runner.get("proactive_capacity", 0)
+    max_burst_capacity = runner.get("max_burst_capacity", 0)
     if cluster_config.get("force_proactive_capacity_zero"):
         proactive_capacity = 0
 
@@ -156,6 +162,20 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     if max_runners is not None and (not isinstance(max_runners, int) or max_runners < 1):
         log_error(f"Invalid definition file {def_file}: max_runners must be a positive integer, got {max_runners!r}")
         return False
+
+    if max_burst_capacity is not None and (not isinstance(max_burst_capacity, int) or max_burst_capacity < 0):
+        log_error(
+            f"Invalid definition file {def_file}: max_burst_capacity must be a non-negative integer, "
+            f"got {max_burst_capacity!r}"
+        )
+        return False
+
+    if max_burst_capacity > 0 and proactive_capacity > 0 and max_burst_capacity < proactive_capacity:
+        log_warning(
+            f"In {def_file}: max_burst_capacity ({max_burst_capacity}) < proactive_capacity ({proactive_capacity}); "
+            f"the cap will prevent the listener from reaching its proactive baseline. "
+            f"Consider raising max_burst_capacity."
+        )
 
     node_fleet = derive_fleet_name(instance_type)
 
@@ -255,6 +275,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
         "{{GPU_COUNT}}": str(gpu),
         "{{RUNNER_CLASS}}": runner_class,
         "{{PROACTIVE_CAPACITY}}": str(proactive_capacity),
+        "{{MAX_BURST_CAPACITY}}": str(max_burst_capacity),
     }
 
     for placeholder, value in replacements.items():

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -42,6 +42,8 @@ MINIMAL_TEMPLATE = textwrap.dedent("""\
             env:
               - name: CAPACITY_AWARE_PROACTIVE_CAPACITY
                 value: "{{PROACTIVE_CAPACITY}}"
+              - name: CAPACITY_AWARE_MAX_BURST_CAPACITY
+                value: "{{MAX_BURST_CAPACITY}}"
     template:
       spec:
         containers:
@@ -197,6 +199,7 @@ def make_def_file(
     runner_class=None,
     max_runners=None,
     proactive_capacity=None,
+    max_burst_capacity=None,
 ):
     """Write a runner def YAML and return the path."""
     runner = {
@@ -215,6 +218,8 @@ def make_def_file(
         runner["max_runners"] = max_runners
     if proactive_capacity is not None:
         runner["proactive_capacity"] = proactive_capacity
+    if max_burst_capacity is not None:
+        runner["max_burst_capacity"] = max_burst_capacity
     content = {"runner": runner}
     p = tmp_path / f"{name}.yaml"
     p.write_text(yaml.dump(content, default_flow_style=False))
@@ -676,6 +681,156 @@ class TestGenerateRunner:
         docs = list(yaml.safe_load_all((output_dir / "kept-runner.yaml").read_text()))
         listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
         assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "10"
+
+    def test_max_burst_capacity_default_zero(self, tmp_path):
+        """max_burst_capacity defaults to 0 when not in the runner def."""
+        def_file = make_def_file(tmp_path, "burst-runner", "c7i.24xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "burst-runner.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_MAX_BURST_CAPACITY"] == "0"
+
+    def test_max_burst_capacity_nonzero(self, tmp_path):
+        """max_burst_capacity: 50 renders as "50" in the listener env."""
+        def_file = make_def_file(tmp_path, "capped-runner", "c7i.24xlarge", 4, 16, max_burst_capacity=50)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "capped-runner.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_MAX_BURST_CAPACITY"] == "50"
+
+    def test_invalid_max_burst_capacity_negative(self, tmp_path):
+        """max_burst_capacity must be a non-negative integer; -1 is rejected."""
+        def_file = make_def_file(tmp_path, "bad-burst", "c7i.24xlarge", 4, 16, max_burst_capacity=-1)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+
+    def test_invalid_max_burst_capacity_non_int(self, tmp_path):
+        """max_burst_capacity must be an int, not a string."""
+        def_file = make_def_file(tmp_path, "bad-burst2", "c7i.24xlarge", 4, 16, max_burst_capacity="50")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+
+    def test_max_burst_capacity_zero_allowed(self, tmp_path):
+        """max_burst_capacity: 0 is valid (means uncapped / disabled)."""
+        def_file = make_def_file(tmp_path, "zero-burst", "c7i.24xlarge", 4, 16, max_burst_capacity=0)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "zero-burst.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_MAX_BURST_CAPACITY"] == "0"
+
+    def test_max_burst_capacity_warning_when_below_proactive(self, tmp_path, capsys):
+        """Warn when max_burst_capacity (>0) is less than proactive_capacity — the cap
+        would prevent the listener from reaching its proactive baseline.
+        """
+        def_file = make_def_file(
+            tmp_path, "misconfig-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30, max_burst_capacity=10
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "max_burst_capacity" in combined
+        assert "proactive_capacity" in combined
+        assert "10" in combined
+        assert "30" in combined
+
+    def test_max_burst_capacity_no_warning_when_above_proactive(self, tmp_path, capsys):
+        """No warning when max_burst_capacity >= proactive_capacity."""
+        def_file = make_def_file(
+            tmp_path, "ok-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30, max_burst_capacity=100
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # The warning text mentions both fields together — plain mentions in "Generating ..."
+        # don't trigger this assertion since neither field name appears in info logs.
+        assert "max_burst_capacity" not in combined
+
+    def test_max_burst_capacity_no_warning_when_proactive_zero(self, tmp_path, capsys):
+        """No warning when proactive_capacity is 0, regardless of max_burst_capacity."""
+        def_file = make_def_file(
+            tmp_path, "noproactive-runner", "c7i.24xlarge", 4, 16, proactive_capacity=0, max_burst_capacity=5
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "max_burst_capacity" not in combined
+
+    def test_max_burst_capacity_no_warning_when_burst_zero(self, tmp_path, capsys):
+        """No warning when max_burst_capacity is 0 (uncapped), regardless of proactive."""
+        def_file = make_def_file(
+            tmp_path, "uncapped-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30, max_burst_capacity=0
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "max_burst_capacity" not in combined
 
     def test_resource_values_match_def(self, tmp_path):
         def_file = make_def_file(tmp_path, "res-test", "c7i.24xlarge", 48, 96, disk_size=200)

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -90,6 +90,8 @@ listenerTemplate:
             value: "true"
           - name: CAPACITY_AWARE_PROACTIVE_CAPACITY
             value: "{{PROACTIVE_CAPACITY}}"
+          - name: CAPACITY_AWARE_MAX_BURST_CAPACITY
+            value: "{{MAX_BURST_CAPACITY}}"
           - name: CAPACITY_AWARE_RECALCULATE_INTERVAL
             value: "30s"
           - name: CAPACITY_AWARE_PLACEHOLDER_TIMEOUT

--- a/osdc/modules/arc-runners/tests/smoke/conftest.py
+++ b/osdc/modules/arc-runners/tests/smoke/conftest.py
@@ -1,1 +1,60 @@
+"""arc-runners smoke test fixtures.
+
+Reuses the shared smoke fixtures via star-import, then layers on arc-runners
+specific fixtures (currently: regenerated runner YAMLs for the cluster under
+test).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
 from smoke_conftest import *  # noqa: F403
+
+
+@pytest.fixture(scope="session")
+def generated_arc_runners(cluster_id: str, upstream_dir: Path) -> dict[str, dict]:
+    """Regenerate ARC runner YAMLs for the cluster and return them parsed.
+
+    Runs ``just generate-arc-runners <cluster>`` exactly once per pytest
+    session (session scope) so the on-disk generated YAMLs match the cluster
+    under test before any test reads them. This is the only legitimate way to
+    get post-override values (e.g. ``force_proactive_capacity_zero`` flips
+    ``CAPACITY_AWARE_PROACTIVE_CAPACITY`` to ``"0"`` on staging).
+
+    Returns:
+        Mapping ``def_name -> parsed first YAML document`` (the chart values
+        block, which contains ``listenerTemplate``). The second YAML doc (the
+        ConfigMap) is intentionally dropped — coherence tests only need the
+        listener env block.
+    """
+    result = subprocess.run(
+        ["just", "generate-arc-runners", cluster_id],
+        cwd=str(upstream_dir),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"`just generate-arc-runners {cluster_id}` failed (rc={result.returncode}):\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+    generated_dir = upstream_dir / "modules" / "arc-runners" / "generated"
+    out: dict[str, dict] = {}
+    for yaml_file in sorted(generated_dir.glob("*.yaml")):
+        # Each generated YAML is a multi-doc file: doc 1 = chart values (with
+        # listenerTemplate), doc 2 = job-pod hook ConfigMap. Coherence tests
+        # only consume doc 1; keep just that.
+        docs = list(yaml.safe_load_all(yaml_file.read_text()))
+        if not docs or not isinstance(docs[0], dict):
+            pytest.fail(f"Generated YAML {yaml_file} has no parseable first document")
+        out[yaml_file.stem] = docs[0]
+    if not out:
+        pytest.fail(f"No generated YAMLs found in {generated_dir} after running the recipe")
+    return out

--- a/osdc/modules/arc-runners/tests/smoke/runner_defs.py
+++ b/osdc/modules/arc-runners/tests/smoke/runner_defs.py
@@ -1,0 +1,78 @@
+"""Helpers for loading ARC runner definitions and mapping live pods to defs.
+
+These helpers are shared between the listener env-var coherence test and the
+placeholder ↔ workflow scheduling parity test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+# Label that ARC sets on listener pods. Value = AutoscalingRunnerSet's name,
+# which is the chart's `runnerScaleSetName` = `<runner_name_prefix><def_name>`.
+SCALE_SET_NAME_LABEL = "actions.github.com/scale-set-name"
+
+
+def defs_dir(upstream_dir: Path) -> Path:
+    """Resolve the runner definitions directory, respecting env override."""
+    override = os.environ.get("ARC_RUNNERS_DEFS_DIR")
+    if override:
+        return Path(override)
+    return upstream_dir / "modules" / "arc-runners" / "defs"
+
+
+def load_runner_defs(upstream_dir: Path) -> list[dict]:
+    """Load all runner definition YAML files; return the inner `runner` dicts."""
+    out: list[dict] = []
+    for f in sorted(defs_dir(upstream_dir).glob("*.yaml")):
+        data = yaml.safe_load(f.read_text())
+        if data and "runner" in data:
+            out.append(data["runner"])
+    return out
+
+
+def load_defs_by_name(upstream_dir: Path) -> dict[str, dict]:
+    """Index runner defs by `name` for fast lookup."""
+    return {d["name"]: d for d in load_runner_defs(upstream_dir)}
+
+
+def def_name_from_scale_set(scale_set_name: str, runner_name_prefix: str) -> str | None:
+    """Strip the cluster's runner_name_prefix from a scale-set name.
+
+    Returns None if the name does not start with the prefix (which would
+    indicate a stale scale-set or a misconfigured cluster — surface that
+    rather than silently returning the unstripped name).
+
+    Example:
+        scale_set_name = "c-mt-l-arm64g2-6-32"
+        runner_name_prefix = "c-mt-"
+        returns: "l-arm64g2-6-32"
+
+    An empty prefix is allowed — the scale-set name is the def name as-is.
+    """
+    if runner_name_prefix and not scale_set_name.startswith(runner_name_prefix):
+        return None
+    return scale_set_name[len(runner_name_prefix) :]
+
+
+def def_for_listener_pod(
+    pod: dict,
+    defs_by_name: dict[str, dict],
+    runner_name_prefix: str,
+) -> tuple[str | None, dict | None]:
+    """Map a listener pod to its runner def via the scale-set-name label.
+
+    Returns ``(def_name, def_dict)`` or ``(None, None)`` if no mapping.
+    The def_name is returned even when the def is missing (for diagnostics).
+    """
+    labels = pod.get("metadata", {}).get("labels", {})
+    scale_set = labels.get(SCALE_SET_NAME_LABEL)
+    if not scale_set:
+        return None, None
+    def_name = def_name_from_scale_set(scale_set, runner_name_prefix)
+    if def_name is None:
+        return None, None
+    return def_name, defs_by_name.get(def_name)

--- a/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
@@ -1,0 +1,319 @@
+"""Smoke test: placeholder pods must be schedulable wherever the workflow pod is.
+
+The capacity-aware listener pre-creates placeholder pods to reserve capacity
+for incoming workflow pods. This file validates that each LIVE placeholder
+pod's scheduling envelope (required nodeAffinity + tolerations) is COMPATIBLE
+with the workflow pod template it is supposed to reserve capacity for.
+
+# Subset semantics
+
+We want: "anywhere the placeholder fits, the workflow pod also fits".
+This requires:
+
+  - Required nodeAffinity terms — placeholder MUST have AT LEAST every
+    required term the workflow pod has. More required terms = stricter
+    selection. Placeholder can be stricter (set ⊇ workflow required terms).
+
+  - Tolerations — placeholder MUST tolerate AT MOST what the workflow pod
+    tolerates. A toleration relaxes the schedulable set. If the placeholder
+    tolerated a taint the workflow pod doesn't, the placeholder could land
+    on a node the workflow pod cannot use (workflow won't take over that
+    reserved capacity). Placeholder tolerations ⊆ workflow tolerations.
+
+If parity fails: placeholders pre-warm capacity that workflow pods cannot
+actually claim. Capacity reservation silently degrades.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from helpers import filter_pods, run_kubectl
+from runner_defs import def_for_listener_pod, load_defs_by_name
+
+pytestmark = [pytest.mark.live]
+
+NAMESPACE = "arc-runners"
+
+# Labels set by the listener's PlaceholderManager (see
+# /actions-runner-controller/cmd/ghalistener/capacity/placeholder.go).
+LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
+LABEL_ROLE = "capacity.actions.github.com/role"
+LABEL_SCALE_SET = "actions.github.com/scale-set-name"
+ROLE_PLACEHOLDER_WORKFLOW = "placeholder-workflow"
+MANAGED_BY_VALUE = "capacity-monitor"
+
+WORKFLOW_PLACEHOLDER_LABELS = {
+    LABEL_MANAGED_BY: MANAGED_BY_VALUE,
+    LABEL_ROLE: ROLE_PLACEHOLDER_WORKFLOW,
+}
+
+
+def _normalize_name(name: str) -> str:
+    return name.replace(".", "-").replace("_", "-")
+
+
+def _proactive_capacity_from_generated(generated_doc: dict) -> int:
+    """Return the CAPACITY_AWARE_PROACTIVE_CAPACITY env value from a generated YAML.
+
+    Returns 0 if the env var is missing, has no literal value, or the value
+    cannot be parsed as int — defensive default that excludes the def from
+    the parity check rather than crashing.
+    """
+    containers = generated_doc.get("listenerTemplate", {}).get("spec", {}).get("containers", []) or []
+    if not containers:
+        return 0
+    for entry in containers[0].get("env", []) or []:
+        if entry.get("name") == "CAPACITY_AWARE_PROACTIVE_CAPACITY":
+            raw = entry.get("value", "")
+            try:
+                return int(raw)
+            except (TypeError, ValueError):
+                return 0
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Workflow pod-template loading (lenient)
+# ---------------------------------------------------------------------------
+
+
+def _load_workflow_pod_template(runner_name: str) -> dict[str, Any] | None:
+    """Load the workflow pod template from the hook ConfigMap.
+
+    The ConfigMap's job-pod.yaml uses ``$job`` as the container name (a hook
+    DSL placeholder), so we cannot validate it as a Pod object — just navigate
+    the dict with yaml.safe_load. Returns the parsed dict's ``spec`` (the
+    fields we care about: nodeSelector / tolerations / affinity) or None when
+    the ConfigMap is missing or malformed.
+
+    Contract: ``None`` means "ConfigMap absent / no usable template" — the
+    caller treats that as a failure with a clear message. Other failures
+    (timeouts, network issues, malformed JSON from kubectl) propagate so the
+    test fails loudly instead of silently degrading to a misleading None.
+    """
+    cm_name = f"arc-runner-hook-{_normalize_name(runner_name)}"
+    try:
+        cm = run_kubectl(["get", "configmap", cm_name], namespace=NAMESPACE)
+    except subprocess.CalledProcessError:
+        # kubectl returns non-zero when the ConfigMap doesn't exist — surface
+        # that as None so the caller can emit a clear "missing template"
+        # failure. Other exception classes (TimeoutExpired, JSONDecodeError,
+        # OSError) propagate intentionally.
+        return None
+    raw = cm.get("data", {}).get("job-pod.yaml", "")
+    if not raw:
+        return None
+    parsed = yaml.safe_load(raw)
+    if not isinstance(parsed, dict):
+        return None
+    return parsed.get("spec", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# Affinity / toleration extraction + subset semantics
+# ---------------------------------------------------------------------------
+
+
+def _required_terms(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the list of required matchExpressions terms from a pod spec.
+
+    Each entry in the returned list is a single matchExpression dict with
+    keys ``key`` / ``operator`` / ``values`` (values may be missing for
+    Exists / DoesNotExist).
+
+    A pod has no required nodeAffinity by default — return [].
+    """
+    affinity = spec.get("affinity") or {}
+    node_aff = affinity.get("nodeAffinity") or {}
+    required = node_aff.get("requiredDuringSchedulingIgnoredDuringExecution") or {}
+    if not required:
+        return []
+    out: list[dict[str, Any]] = []
+    for term in required.get("nodeSelectorTerms", []) or []:
+        for me in term.get("matchExpressions", []) or []:
+            out.append(me)
+    return out
+
+
+def _term_compatible(placeholder: dict, workflow: dict) -> bool:
+    """True if the placeholder term is at least as restrictive as workflow's.
+
+    Same key + same operator. For value-bearing operators (In / NotIn),
+    placeholder values must be a SUBSET of workflow values (placeholder
+    matches a strict subset of nodes). For Exists / DoesNotExist (no values),
+    a key+operator match is sufficient.
+    """
+    if placeholder.get("key") != workflow.get("key"):
+        return False
+    if placeholder.get("operator") != workflow.get("operator"):
+        return False
+    op = placeholder.get("operator")
+    if op in ("In", "NotIn"):
+        ph_vals = set(placeholder.get("values", []) or [])
+        wf_vals = set(workflow.get("values", []) or [])
+        return ph_vals.issubset(wf_vals)
+    return True
+
+
+def _missing_required_terms(placeholder_spec: dict, workflow_spec: dict) -> list[dict]:
+    """Return workflow required terms NOT covered by any placeholder term.
+
+    For parity, the placeholder must have a compatible counterpart for every
+    workflow required term (placeholder ⊇ workflow on required affinity).
+
+    GPU asymmetry note: workflow pods declare the GPU node-selector only in
+    ``preferredDuringSchedulingIgnoredDuringExecution``, while placeholders
+    declare it in ``requiredDuringSchedulingIgnoredDuringExecution``. The
+    placeholder is intentionally stricter — it MUST land on a GPU node to
+    reserve capacity. Workflow uses preferred because the GPU NodePool's
+    selector + tolerations already guarantee GPU node placement. This
+    asymmetry is fine under our subset semantics: stricter placeholder
+    affinity is allowed (placeholder ⊇ workflow required terms).
+    """
+    ph_terms = _required_terms(placeholder_spec)
+    missing = []
+    for wf_term in _required_terms(workflow_spec):
+        if not any(_term_compatible(ph, wf_term) for ph in ph_terms):
+            missing.append(wf_term)
+    return missing
+
+
+def _toleration_key(t: dict[str, Any]) -> tuple:
+    """Hashable identity for a toleration — key + operator + value + effect."""
+    return (t.get("key"), t.get("operator"), t.get("value"), t.get("effect"))
+
+
+def _excess_tolerations(placeholder_spec: dict, workflow_spec: dict) -> list[dict]:
+    """Return placeholder tolerations NOT present on the workflow pod.
+
+    Excess tolerations relax scheduling for the placeholder beyond what the
+    workflow pod allows — the placeholder could land somewhere the workflow
+    pod cannot. Returns [] when placeholder ⊆ workflow.
+    """
+    wf = {_toleration_key(t) for t in (workflow_spec.get("tolerations") or [])}
+    return [t for t in (placeholder_spec.get("tolerations") or []) if _toleration_key(t) not in wf]
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderSchedulingParity:
+    """Parity check between live placeholder pods and the workflow pod template.
+
+    Placeholder pods reserve capacity for workflow pods. To be useful, the
+    placeholder's scheduling envelope must be COMPATIBLE with the workflow
+    pod's: required affinity ⊇ workflow's, tolerations ⊆ workflow's.
+    See module docstring for the full subset rationale.
+    """
+
+    def test_workflow_placeholder_parity(
+        self,
+        all_pods: dict,
+        upstream_dir: Path,
+        enabled_modules: list[str],
+        resolve_config,
+        generated_arc_runners: dict[str, dict],
+    ) -> None:
+        if "arc-runners" not in enabled_modules:
+            pytest.skip("arc-runners module not enabled")
+
+        defs_by_name = load_defs_by_name(upstream_dir)
+        # Only scale sets that opted into proactive capacity will have
+        # placeholders running. Use the GENERATED YAML's
+        # CAPACITY_AWARE_PROACTIVE_CAPACITY env value (post-override) — not
+        # the raw def — so cluster-specific overrides like
+        # `force_proactive_capacity_zero` on staging correctly skip all defs.
+        proactive_defs = {
+            name: d
+            for name, d in defs_by_name.items()
+            if name in generated_arc_runners and _proactive_capacity_from_generated(generated_arc_runners[name]) > 0
+        }
+        if not proactive_defs:
+            pytest.skip("no scale sets with proactive_capacity > 0")
+
+        # Per-cluster prefix that ARC strips off the scale-set-name label
+        # (e.g. "c-mt-" → label "c-mt-l-arm64g4-16-62" maps to def
+        # "l-arm64g4-16-62"). We MUST use exact match against the stripped
+        # name — endswith() collides on rel-* defs whose names share a
+        # suffix with their non-rel siblings (rel-l-arm64g4-16-62 ↔
+        # l-arm64g4-16-62), causing placeholders to be attributed to the
+        # wrong def and silently breaking parity attribution.
+        runner_name_prefix = resolve_config("arc-runners.runner_name_prefix", "")
+
+        # Group live placeholder pods by their owning runner def via the
+        # scale-set-name label + exact-match lookup (not suffix-match).
+        all_ph_pods = filter_pods(all_pods, namespace=NAMESPACE, labels=WORKFLOW_PLACEHOLDER_LABELS)
+        ph_pods_by_def: dict[str, list[dict]] = {name: [] for name in proactive_defs}
+        unattributed: list[str] = []
+        for pod in all_ph_pods:
+            def_name, _runner = def_for_listener_pod(pod, defs_by_name, runner_name_prefix)
+            pod_name = pod.get("metadata", {}).get("name", "?")
+            if def_name is None:
+                # Missing/invalid scale-set-name label or wrong cluster prefix.
+                label_val = pod.get("metadata", {}).get("labels", {}).get(LABEL_SCALE_SET, "<missing>")
+                unattributed.append(
+                    f"{pod_name}: cannot map placeholder to def "
+                    f"({LABEL_SCALE_SET}={label_val!r}, prefix={runner_name_prefix!r})"
+                )
+                continue
+            if def_name not in proactive_defs:
+                # Placeholder exists but its def doesn't have proactive_capacity > 0
+                # locally — likely a stale scale-set or a def removed without
+                # the corresponding placeholders being cleaned up. Skip silently;
+                # the env-var coherence test in test_runners.py catches stale
+                # scale-sets directly.
+                continue
+            ph_pods_by_def[def_name].append(pod)
+
+        problems: list[str] = list(unattributed)
+        info: list[str] = []
+
+        for runner_name, _runner in proactive_defs.items():
+            ph_pods = ph_pods_by_def[runner_name]
+            if not ph_pods:
+                # Informational, not a failure — placeholders may be in
+                # between cycles or all preempted/Pending right now. Report
+                # the effective (post-override) proactive_capacity from the
+                # generated YAML, not the raw def value.
+                effective = _proactive_capacity_from_generated(generated_arc_runners[runner_name])
+                info.append(f"{runner_name}: no live workflow placeholders (proactive={effective})")
+                continue
+
+            workflow_spec = _load_workflow_pod_template(runner_name)
+            if workflow_spec is None:
+                problems.append(f"{runner_name}: workflow pod template (hook ConfigMap) missing or empty")
+                continue
+
+            for pod in ph_pods:
+                pod_name = pod["metadata"]["name"]
+                ph_spec = pod.get("spec", {})
+
+                missing = _missing_required_terms(ph_spec, workflow_spec)
+                for term in missing:
+                    problems.append(
+                        f"[{runner_name}] {pod_name}: workflow requires affinity term not present on "
+                        f"placeholder — expected {term}"
+                    )
+
+                excess = _excess_tolerations(ph_spec, workflow_spec)
+                for tol in excess:
+                    problems.append(
+                        f"[{runner_name}] {pod_name}: placeholder tolerates {tol} which the workflow "
+                        f"pod does not — placeholder could land where workflow cannot"
+                    )
+
+        if info:
+            # Surface skip-style notices through the test report (they don't
+            # fail the test, but they're worth seeing in CI output).
+            print("\nPlaceholder parity informational notes:")
+            for line in info:
+                print(f"  - {line}")
+
+        assert not problems, "Workflow placeholder ↔ workflow pod parity failures:\n" + "\n".join(problems)

--- a/osdc/modules/arc-runners/tests/smoke/test_runner_defs.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runner_defs.py
@@ -1,0 +1,165 @@
+"""Unit tests for runner_defs helper functions and generated-YAML readers.
+
+Pure-Python tests with no live cluster dependency — runnable from this dir
+via `pytest test_runner_defs.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from runner_defs import def_for_listener_pod, def_name_from_scale_set
+from test_capacity_parity import _proactive_capacity_from_generated
+from test_runners import _capacity_aware_env, _listener_env_from_generated_yaml
+
+
+class TestDefNameFromScaleSet:
+    def test_strips_prefix(self):
+        assert def_name_from_scale_set("c-mt-l-arm64g2-6-32", "c-mt-") == "l-arm64g2-6-32"
+
+    def test_empty_prefix_returns_input(self):
+        assert def_name_from_scale_set("l-arm64g2-6-32", "") == "l-arm64g2-6-32"
+
+    def test_short_prefix(self):
+        assert def_name_from_scale_set("mt-l-arm64g2-6-32", "mt-") == "l-arm64g2-6-32"
+
+    def test_returns_none_when_prefix_missing(self):
+        assert def_name_from_scale_set("c-mt-l-arm64g2-6-32", "other-") is None
+
+    def test_returns_empty_when_name_equals_prefix(self):
+        assert def_name_from_scale_set("c-mt-", "c-mt-") == ""
+
+
+class TestDefForListenerPod:
+    def test_finds_def_via_label(self):
+        pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "c-mt-runner-1"}}}
+        defs = {"runner-1": {"name": "runner-1", "vcpu": 4}}
+        name, d = def_for_listener_pod(pod, defs, "c-mt-")
+        assert name == "runner-1"
+        assert d == defs["runner-1"]
+
+    def test_returns_def_name_when_def_missing(self):
+        pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "c-mt-runner-1"}}}
+        defs: dict = {}
+        name, d = def_for_listener_pod(pod, defs, "c-mt-")
+        assert name == "runner-1"
+        assert d is None
+
+    def test_returns_none_when_label_missing(self):
+        pod = {"metadata": {"labels": {}}}
+        name, d = def_for_listener_pod(pod, {}, "c-mt-")
+        assert name is None
+        assert d is None
+
+    def test_returns_none_when_prefix_does_not_match(self):
+        pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "rogue-runner-1"}}}
+        defs = {"runner-1": {"name": "runner-1"}}
+        name, d = def_for_listener_pod(pod, defs, "c-mt-")
+        assert name is None
+        assert d is None
+
+    def test_disambiguates_rel_vs_non_rel_suffix_collision(self):
+        """rel-* defs share suffixes with their non-rel siblings.
+
+        e.g. rel-l-arm64g4-16-62 ends with l-arm64g4-16-62. A naive
+        endswith() lookup grabs the wrong def when both have placeholders;
+        exact-match against the prefix-stripped scale-set name must NOT.
+        """
+        defs = {
+            "l-arm64g4-16-62": {"name": "l-arm64g4-16-62", "proactive_capacity": 30},
+            "rel-l-arm64g4-16-62": {"name": "rel-l-arm64g4-16-62", "proactive_capacity": 30},
+        }
+
+        rel_pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "c-mt-rel-l-arm64g4-16-62"}}}
+        rel_name, rel_def = def_for_listener_pod(rel_pod, defs, "c-mt-")
+        assert rel_name == "rel-l-arm64g4-16-62"
+        assert rel_def is defs["rel-l-arm64g4-16-62"]
+
+        non_rel_pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "c-mt-l-arm64g4-16-62"}}}
+        non_rel_name, non_rel_def = def_for_listener_pod(non_rel_pod, defs, "c-mt-")
+        assert non_rel_name == "l-arm64g4-16-62"
+        assert non_rel_def is defs["l-arm64g4-16-62"]
+
+
+class TestListenerEnvFromGeneratedYaml:
+    """Unit tests for the generated-YAML env reader used by the coherence test."""
+
+    def test_extracts_env_from_first_container(self):
+        doc = {
+            "listenerTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "listener",
+                            "env": [
+                                {"name": "CAPACITY_AWARE_PROACTIVE_CAPACITY", "value": "30"},
+                                {"name": "CAPACITY_AWARE_NODE_FLEET", "value": "m8g"},
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+        env = _listener_env_from_generated_yaml(doc)
+        assert env["CAPACITY_AWARE_PROACTIVE_CAPACITY"]["value"] == "30"
+        assert env["CAPACITY_AWARE_NODE_FLEET"]["value"] == "m8g"
+
+    def test_returns_empty_when_containers_missing(self):
+        assert _listener_env_from_generated_yaml({}) == {}
+        assert _listener_env_from_generated_yaml({"listenerTemplate": {}}) == {}
+        assert _listener_env_from_generated_yaml({"listenerTemplate": {"spec": {"containers": []}}}) == {}
+
+    def test_returns_empty_when_env_missing(self):
+        doc = {"listenerTemplate": {"spec": {"containers": [{"name": "listener"}]}}}
+        assert _listener_env_from_generated_yaml(doc) == {}
+
+    def test_filter_capacity_aware(self):
+        env = {
+            "CAPACITY_AWARE_PROACTIVE_CAPACITY": {"value": "0"},
+            "CAPACITY_AWARE_NODE_FLEET": {"value": "g4dn"},
+            "OTHER_VAR": {"value": "ignored"},
+        }
+        out = _capacity_aware_env(env)
+        assert "CAPACITY_AWARE_PROACTIVE_CAPACITY" in out
+        assert "CAPACITY_AWARE_NODE_FLEET" in out
+        assert "OTHER_VAR" not in out
+
+
+class TestProactiveCapacityFromGenerated:
+    """Unit tests for the parity test's proactive-capacity extractor."""
+
+    def _doc(self, value):
+        return {
+            "listenerTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "env": [
+                                {"name": "CAPACITY_AWARE_PROACTIVE_CAPACITY", "value": value},
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_parses_positive_int(self):
+        assert _proactive_capacity_from_generated(self._doc("30")) == 30
+
+    def test_parses_zero(self):
+        assert _proactive_capacity_from_generated(self._doc("0")) == 0
+
+    def test_returns_zero_when_env_missing(self):
+        doc = {"listenerTemplate": {"spec": {"containers": [{"env": []}]}}}
+        assert _proactive_capacity_from_generated(doc) == 0
+
+    def test_returns_zero_when_containers_missing(self):
+        assert _proactive_capacity_from_generated({}) == 0
+        assert _proactive_capacity_from_generated({"listenerTemplate": {"spec": {"containers": []}}}) == 0
+
+    def test_returns_zero_when_value_unparseable(self):
+        assert _proactive_capacity_from_generated(self._doc("not-an-int")) == 0
+        assert _proactive_capacity_from_generated(self._doc(None)) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import assert_daemonset_healthy, filter_daemonsets, find_helm_release, run_kubectl
+from helpers import assert_daemonset_healthy, filter_daemonsets, filter_pods, find_helm_release, run_kubectl
 
 pytestmark = [pytest.mark.live]
 
@@ -20,6 +20,9 @@ pytestmark = [pytest.mark.live]
 # ---------------------------------------------------------------------------
 
 NAMESPACE = "arc-runners"
+LISTENER_NAMESPACE = "arc-systems"
+LISTENER_LABELS = {"app.kubernetes.io/component": "runner-scale-set-listener"}
+LISTENER_CONTAINER_NAME = "listener"
 MODULE_LABEL = "osdc.io/module=arc-runners"
 REQUIRED_FIELDS = {"name", "instance_type", "disk_size", "vcpu", "memory"}
 
@@ -242,6 +245,78 @@ class TestArcRunnersNamespace:
         assert labels.get("app.kubernetes.io/part-of") == "osdc-arc-runners", (
             f"Namespace missing label app.kubernetes.io/part-of=osdc-arc-runners, got: {labels}"
         )
+
+
+# ============================================================================
+# Live: Listener Pod Capacity-Aware Env Vars
+# ============================================================================
+
+
+class TestListenerCapacityAwareEnvVars:
+    """Verify ARC listener pods have all CAPACITY_AWARE_* env vars set.
+
+    These env vars drive the proactive-capacity placeholder controller in the
+    listener. If any are missing, capacity-aware behaviour silently degrades.
+    """
+
+    REQUIRED_ENV_VARS: frozenset[str] = frozenset(
+        {
+            "CAPACITY_AWARE_ENABLED",
+            "CAPACITY_AWARE_PROACTIVE_CAPACITY",
+            "CAPACITY_AWARE_MAX_BURST_CAPACITY",
+            "CAPACITY_AWARE_RECALCULATE_INTERVAL",
+            "CAPACITY_AWARE_PLACEHOLDER_TIMEOUT",
+            "CAPACITY_AWARE_WORKFLOW_CPU",
+            "CAPACITY_AWARE_WORKFLOW_MEMORY",
+            "CAPACITY_AWARE_WORKFLOW_GPU",
+            "CAPACITY_AWARE_WORKFLOW_DISK",
+            "CAPACITY_AWARE_RUNNER_CPU",
+            "CAPACITY_AWARE_RUNNER_MEMORY",
+            "CAPACITY_AWARE_NODE_FLEET",
+            "CAPACITY_AWARE_RUNNER_NODE_FLEET",
+            "CAPACITY_AWARE_RUNNER_CLASS",
+            "CAPACITY_AWARE_HUD_API_URL",
+            "CAPACITY_AWARE_HUD_API_TOKEN",
+        }
+    )
+
+    @staticmethod
+    def _env_has_value(env: dict) -> bool:
+        """Return True if the env entry has either a non-empty value or a valueFrom."""
+        if env.get("value") not in (None, ""):
+            return True
+        return bool(env.get("valueFrom"))
+
+    def test_listener_pods_have_capacity_aware_env_vars(self, all_pods: dict, enabled_modules: list[str]) -> None:
+        """Each listener pod's listener container has all CAPACITY_AWARE_* env vars set."""
+        if "arc-runners" not in enabled_modules:
+            pytest.skip("arc-runners module not enabled")
+
+        listener_pods = filter_pods(all_pods, namespace=LISTENER_NAMESPACE, labels=LISTENER_LABELS)
+        assert len(listener_pods) >= 1, (
+            f"No listener pods found in '{LISTENER_NAMESPACE}' with labels {LISTENER_LABELS}"
+        )
+
+        problems: list[str] = []
+        for pod in listener_pods:
+            pod_name = pod["metadata"]["name"]
+            containers = pod.get("spec", {}).get("containers", [])
+            listener = next((c for c in containers if c.get("name") == LISTENER_CONTAINER_NAME), None)
+            if listener is None:
+                problems.append(f"{pod_name}: no '{LISTENER_CONTAINER_NAME}' container")
+                continue
+
+            env_by_name = {e["name"]: e for e in listener.get("env", [])}
+            missing = self.REQUIRED_ENV_VARS - env_by_name.keys()
+            if missing:
+                problems.append(f"{pod_name}: missing env vars {sorted(missing)}")
+                continue
+
+            empty = sorted(name for name in self.REQUIRED_ENV_VARS if not self._env_has_value(env_by_name[name]))
+            if empty:
+                problems.append(f"{pod_name}: env vars present but with no value/valueFrom: {empty}")
+
+        assert not problems, "Listener pods with missing CAPACITY_AWARE_* env vars:\n" + "\n".join(problems)
 
 
 # ============================================================================

--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -6,12 +6,13 @@ ConfigMaps + Helm releases exist in the cluster for each definition.
 
 from __future__ import annotations
 
-import os
+import json
 from pathlib import Path
 
 import pytest
 import yaml
 from helpers import assert_daemonset_healthy, filter_daemonsets, filter_pods, find_helm_release, run_kubectl
+from runner_defs import def_for_listener_pod, load_defs_by_name, load_runner_defs
 
 pytestmark = [pytest.mark.live]
 
@@ -31,28 +32,11 @@ def _normalize_name(name: str) -> str:
     return name.replace(".", "-").replace("_", "-")
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _defs_dir(upstream_dir: Path) -> Path:
-    """Resolve the runner definitions directory, respecting env override."""
-    override = os.environ.get("ARC_RUNNERS_DEFS_DIR")
-    if override:
-        return Path(override)
-    return upstream_dir / "modules" / "arc-runners" / "defs"
-
-
+# Backwards-compatible local alias — tests below pass `upstream_dir` and the
+# runner-def loader lives in runner_defs.py. Keep this thin shim so the call
+# sites here read naturally.
 def _load_all_defs(upstream_dir: Path) -> list[dict]:
-    """Load all runner definition YAML files and return the runner dicts."""
-    defs_path = _defs_dir(upstream_dir)
-    defs = []
-    for f in sorted(defs_path.glob("*.yaml")):
-        data = yaml.safe_load(f.read_text())
-        if data and "runner" in data:
-            defs.append(data["runner"])
-    return defs
+    return load_runner_defs(upstream_dir)
 
 
 # ============================================================================
@@ -252,43 +236,69 @@ class TestArcRunnersNamespace:
 # ============================================================================
 
 
-class TestListenerCapacityAwareEnvVars:
-    """Verify ARC listener pods have all CAPACITY_AWARE_* env vars set.
+def _listener_env_from_generated_yaml(generated_doc: dict) -> dict[str, dict]:
+    """Extract the listener container's env list (as a {name: env_entry} map).
 
-    These env vars drive the proactive-capacity placeholder controller in the
-    listener. If any are missing, capacity-aware behaviour silently degrades.
+    Looks up ``listenerTemplate.spec.containers[0].env`` from a parsed
+    generated YAML. Uses ``[0]`` because the chart values define exactly one
+    container under ``listenerTemplate``; a missing/empty env list returns ``{}``
+    so callers see "expected env vars missing" rather than a KeyError.
+    """
+    containers = generated_doc.get("listenerTemplate", {}).get("spec", {}).get("containers", []) or []
+    if not containers:
+        return {}
+    return {e["name"]: e for e in containers[0].get("env", []) or []}
+
+
+def _capacity_aware_env(env_by_name: dict[str, dict]) -> dict[str, dict]:
+    """Filter an env-by-name map down to CAPACITY_AWARE_* entries."""
+    return {name: entry for name, entry in env_by_name.items() if name.startswith("CAPACITY_AWARE_")}
+
+
+class TestListenerCapacityAwareEnvVars:
+    """Verify ARC listener pods have CAPACITY_AWARE_* env vars matching the
+    GENERATED runner YAML (post-override, post-template-substitution).
+
+    The generated YAML is the single source of truth for what should be
+    deployed: it already accounts for cluster-specific overrides such as
+    ``force_proactive_capacity_zero`` (staging) and any future generator
+    transformations. Comparing the deployed listener directly against the
+    runner def would re-introduce knowledge of those overrides into the test.
     """
 
-    REQUIRED_ENV_VARS: frozenset[str] = frozenset(
-        {
-            "CAPACITY_AWARE_ENABLED",
-            "CAPACITY_AWARE_PROACTIVE_CAPACITY",
-            "CAPACITY_AWARE_MAX_BURST_CAPACITY",
-            "CAPACITY_AWARE_RECALCULATE_INTERVAL",
-            "CAPACITY_AWARE_PLACEHOLDER_TIMEOUT",
-            "CAPACITY_AWARE_WORKFLOW_CPU",
-            "CAPACITY_AWARE_WORKFLOW_MEMORY",
-            "CAPACITY_AWARE_WORKFLOW_GPU",
-            "CAPACITY_AWARE_WORKFLOW_DISK",
-            "CAPACITY_AWARE_RUNNER_CPU",
-            "CAPACITY_AWARE_RUNNER_MEMORY",
-            "CAPACITY_AWARE_NODE_FLEET",
-            "CAPACITY_AWARE_RUNNER_NODE_FLEET",
-            "CAPACITY_AWARE_RUNNER_CLASS",
-            "CAPACITY_AWARE_HUD_API_URL",
-            "CAPACITY_AWARE_HUD_API_TOKEN",
-        }
-    )
-
     @staticmethod
-    def _env_has_value(env: dict) -> bool:
-        """Return True if the env entry has either a non-empty value or a valueFrom."""
-        if env.get("value") not in (None, ""):
-            return True
-        return bool(env.get("valueFrom"))
+    def _env_value_signature(entry: dict) -> tuple:
+        """Hashable signature for an env entry's value source.
 
-    def test_listener_pods_have_capacity_aware_env_vars(self, all_pods: dict, enabled_modules: list[str]) -> None:
-        """Each listener pod's listener container has all CAPACITY_AWARE_* env vars set."""
+        For literal-value entries, returns ``("value", <str>)``. For
+        ``valueFrom`` entries, returns ``("valueFrom", <normalized dict>)``
+        so secret/configmap references compare structurally without trying
+        to read the actual secret.
+        """
+        if "valueFrom" in entry and entry["valueFrom"] is not None:
+            # Sort keys for deterministic comparison; valueFrom blocks are
+            # small dicts (e.g. {"secretKeyRef": {...}}) — JSON-style sort is
+            # cheap and stable.
+            return ("valueFrom", json.dumps(entry["valueFrom"], sort_keys=True))
+        # Treat missing value as empty string (matches K8s behavior).
+        return ("value", entry.get("value", "") or "")
+
+    def test_listener_env_vars_match_generated_yaml(
+        self,
+        all_pods: dict,
+        upstream_dir: Path,
+        enabled_modules: list[str],
+        resolve_config,
+        generated_arc_runners: dict[str, dict],
+    ) -> None:
+        """Each listener pod's CAPACITY_AWARE_* env vars match its generated YAML.
+
+        For each CAPACITY_AWARE_* env var present in the generated YAML's
+        listener container, the deployed pod must have an entry with the
+        same value (literal) or the same valueFrom (secret/configmap ref).
+        Also catches deployed env vars that exist in the pod but are absent
+        from the generated YAML — surfaces drift from a stale chart install.
+        """
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
@@ -296,6 +306,11 @@ class TestListenerCapacityAwareEnvVars:
         assert len(listener_pods) >= 1, (
             f"No listener pods found in '{LISTENER_NAMESPACE}' with labels {LISTENER_LABELS}"
         )
+
+        runner_name_prefix = resolve_config("arc-runners.runner_name_prefix", "")
+        # Reuse load_defs_by_name only for the listener→def mapping helper —
+        # value comparisons go through generated_arc_runners.
+        defs_by_name = load_defs_by_name(upstream_dir)
 
         problems: list[str] = []
         for pod in listener_pods:
@@ -306,17 +321,52 @@ class TestListenerCapacityAwareEnvVars:
                 problems.append(f"{pod_name}: no '{LISTENER_CONTAINER_NAME}' container")
                 continue
 
-            env_by_name = {e["name"]: e for e in listener.get("env", [])}
-            missing = self.REQUIRED_ENV_VARS - env_by_name.keys()
-            if missing:
-                problems.append(f"{pod_name}: missing env vars {sorted(missing)}")
+            def_name, _runner = def_for_listener_pod(pod, defs_by_name, runner_name_prefix)
+            if def_name is None:
+                problems.append(
+                    f"{pod_name}: missing/invalid 'actions.github.com/scale-set-name' label "
+                    f"(prefix={runner_name_prefix!r})"
+                )
                 continue
 
-            empty = sorted(name for name in self.REQUIRED_ENV_VARS if not self._env_has_value(env_by_name[name]))
-            if empty:
-                problems.append(f"{pod_name}: env vars present but with no value/valueFrom: {empty}")
+            generated = generated_arc_runners.get(def_name)
+            if generated is None:
+                problems.append(f"{pod_name}: no generated YAML found for def {def_name!r} (stale scale-set?)")
+                continue
 
-        assert not problems, "Listener pods with missing CAPACITY_AWARE_* env vars:\n" + "\n".join(problems)
+            generated_env = _capacity_aware_env(_listener_env_from_generated_yaml(generated))
+            if not generated_env:
+                problems.append(
+                    f"{pod_name} (def={def_name}): generated YAML has no CAPACITY_AWARE_* env vars in "
+                    f"listenerTemplate — template/generator regression?"
+                )
+                continue
+
+            deployed_env = _capacity_aware_env({e["name"]: e for e in listener.get("env", []) or []})
+
+            # Every CAPACITY_AWARE_* env var in the generated YAML must be in
+            # the deployed pod with an identical value/valueFrom shape.
+            for var, want_entry in generated_env.items():
+                got_entry = deployed_env.get(var)
+                if got_entry is None:
+                    problems.append(f"{pod_name} (def={def_name}): missing env var {var!r}")
+                    continue
+                want_sig = self._env_value_signature(want_entry)
+                got_sig = self._env_value_signature(got_entry)
+                if want_sig != got_sig:
+                    problems.append(
+                        f"{pod_name} (def={def_name}): {var} mismatch — generated {want_sig!r}, deployed {got_sig!r}"
+                    )
+
+            # Catch the reverse: env vars deployed but no longer in the
+            # generated YAML (chart out of sync with the latest generator).
+            extra = sorted(deployed_env.keys() - generated_env.keys())
+            if extra:
+                problems.append(
+                    f"{pod_name} (def={def_name}): unexpected CAPACITY_AWARE_* env vars not in generated YAML: {extra}"
+                )
+
+        assert not problems, "Listener CAPACITY_AWARE_* env-var coherence failures:\n" + "\n".join(problems)
 
 
 # ============================================================================


### PR DESCRIPTION
**Impact:** All ARC runner scale sets across all clusters — caps how many placeholder pod pairs the capacity monitor can create per reconcile cycle
**Risk:** medium

## What
Adds a new `max_burst_capacity` field to every runner definition, wired through the generation pipeline as `CAPACITY_AWARE_MAX_BURST_CAPACITY` on listener pods. This caps the total number of placeholder pairs (running + pending) the provisioner will create, preventing burst node provisioning from overwhelming downstream services.

## Why
The ARC fork's capacity monitor creates placeholder pod pairs to pre-warm nodes ahead of demand. Without a ceiling, a sudden spike in queued jobs (or a proactive capacity miscalculation) can trigger hundreds of simultaneous node provisions — saturating git-cache, Harbor, and pypi-cache and causing cascading timeouts. Additionally, the fork had a bug where placeholder creation did not properly clamp against `maxRunners` headroom (real runners weren't subtracted from the cap), effectively doubling the intended maximum. The `max_burst_capacity` field provides an independent, operator-tunable safety valve on the OSDC side.

## How
- `max_burst_capacity` defaults to `0` (unlimited/uncapped) for backward compatibility — runners without the field behave exactly as before
- Values are tiered by runner size to match infrastructure capacity:
  - Small runners (proactive_capacity=30): `max_burst_capacity=2000`
  - Medium runners (proactive_capacity=10): `max_burst_capacity=250`
  - Large/GPU runners (proactive_capacity=5): `max_burst_capacity=30`
- Generator validates the field is a non-negative integer and warns (but does not fail) when `max_burst_capacity < proactive_capacity`, since that configuration would prevent the listener from ever reaching its proactive baseline
- The cap is applied in the fork's provisioner after the MaxRunners headroom clamp, so whichever limit is tighter wins

## Changes
- **Runner defs** (`defs/*.yaml`): Added `max_burst_capacity` to all 38 runner definitions with size-appropriate values
- **Generator** (`generate_runners.py`):
  - Reads `max_burst_capacity` from def files (default `0`)
  - Validates it's a non-negative integer
  - Warns when `max_burst_capacity < proactive_capacity`
  - Substitutes `{{MAX_BURST_CAPACITY}}` into the template
  - Added `log_warning()` helper and `YELLOW` ANSI color
- **Template** (`runner.yaml.tpl`): Added `CAPACITY_AWARE_MAX_BURST_CAPACITY` env var to the listener container
- **Unit tests** (`test_generate_runners.py`): 8 new test cases covering default-zero, explicit values, invalid inputs (negative, non-int), zero-allowed, and warning/no-warning edge cases
- **Smoke tests** (`tests/smoke/test_runners.py`): New `TestListenerCapacityAwareEnvVars` class verifies all 16 `CAPACITY_AWARE_*` env vars (including `MAX_BURST_CAPACITY`) are present and populated on live listener pods
- **Docs** (`docs/arc-fork-build-deploy.md`): Documented `CAPACITY_AWARE_MAX_BURST_CAPACITY` in the capacity monitor config table

## Notes
- This PR covers the OSDC (config/generation) side only. The fork-side Go code that reads `CAPACITY_AWARE_MAX_BURST_CAPACITY` and applies the clamp lives in `actions-runner-controller` and includes the MaxRunners headroom bug fix (placeholder creation now subtracts running+pending real runners from the cap instead of ignoring them).
- `force_proactive_capacity_zero` (used by staging clusters) does NOT zero out `max_burst_capacity` — staging clusters will still have the configured cap, which is harmless since proactive capacity is already disabled there.

## Testing
- `just test` — all unit tests pass, including 8 new `max_burst_capacity` test cases
- `just lint` — all 13 linters pass
- Smoke tests (`TestListenerCapacityAwareEnvVars`) will validate live listener pods have the env var after deploy
- Manual verification: after deploy, confirm listener pods show `CAPACITY_AWARE_MAX_BURST_CAPACITY` in their env (`kubectl get pod -n arc-systems -l app.kubernetes.io/component=runner-scale-set-listener -o jsonpath='{.items[0].spec.containers[?(@.name=="listener")].env}'`)