### PR TITLE
Add H100 (p5.48xlarge) GPU nodepool with 1/2/4/8x splits

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -196,8 +196,10 @@ clusters:
       - arc
       - nodepools
       - nodepools-b200
+      - nodepools-h100
       - arc-runners
       - arc-runners-b200
+      - arc-runners-h100
       - buildkit
       - pypi-cache
       - cache-enforcer

--- a/osdc/modules/arc-runners-h100/defs/l-bx86iamx-176-1800-h100-8.yaml
+++ b/osdc/modules/arc-runners-h100/defs/l-bx86iamx-176-1800-h100-8.yaml
@@ -1,0 +1,11 @@
+# ARC runner definition: l-bx86iamx-176-1800-h100-8 (8x NVIDIA H100, full node)
+# Scheduled on NodePool: p5-48xlarge (from nodepools-h100 module)
+runner:
+  name: l-bx86iamx-176-1800-h100-8
+  instance_type: p5.48xlarge
+  disk_size: 200
+  vcpu: 176
+  memory: 1800Gi
+  gpu: 8
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 8 GPUs per runner = 1 concurrent runner.
+  max_runners: 1

--- a/osdc/modules/arc-runners-h100/defs/l-x86iamx-22-225-h100.yaml
+++ b/osdc/modules/arc-runners-h100/defs/l-x86iamx-22-225-h100.yaml
@@ -1,0 +1,12 @@
+# ARC runner definition: l-x86iamx-22-225-h100 (1x NVIDIA H100)
+# Scheduled on NodePool: p5-48xlarge (from nodepools-h100 module)
+# Resource math: 176 usable vCPU / 8 GPUs = 22 vCPU/GPU, 1800 GiB / 8 = 225 GiB/GPU
+runner:
+  name: l-x86iamx-22-225-h100
+  instance_type: p5.48xlarge
+  disk_size: 200
+  vcpu: 22
+  memory: 225Gi
+  gpu: 1
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 1 GPU per runner = 8 concurrent runners.
+  max_runners: 8

--- a/osdc/modules/arc-runners-h100/defs/l-x86iamx-44-450-h100-2.yaml
+++ b/osdc/modules/arc-runners-h100/defs/l-x86iamx-44-450-h100-2.yaml
@@ -1,0 +1,11 @@
+# ARC runner definition: l-x86iamx-44-450-h100-2 (2x NVIDIA H100)
+# Scheduled on NodePool: p5-48xlarge (from nodepools-h100 module)
+runner:
+  name: l-x86iamx-44-450-h100-2
+  instance_type: p5.48xlarge
+  disk_size: 200
+  vcpu: 44
+  memory: 450Gi
+  gpu: 2
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 2 GPUs per runner = 4 concurrent runners.
+  max_runners: 4

--- a/osdc/modules/arc-runners-h100/defs/l-x86iamx-88-900-h100-4.yaml
+++ b/osdc/modules/arc-runners-h100/defs/l-x86iamx-88-900-h100-4.yaml
@@ -1,0 +1,11 @@
+# ARC runner definition: l-x86iamx-88-900-h100-4 (4x NVIDIA H100)
+# Scheduled on NodePool: p5-48xlarge (from nodepools-h100 module)
+runner:
+  name: l-x86iamx-88-900-h100-4
+  instance_type: p5.48xlarge
+  disk_size: 200
+  vcpu: 88
+  memory: 900Gi
+  gpu: 4
+  # Fixed-capacity cap: 1 reserved 8-GPU node / 4 GPUs per runner = 2 concurrent runners.
+  max_runners: 2

--- a/osdc/modules/arc-runners-h100/deploy.sh
+++ b/osdc/modules/arc-runners-h100/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# H100 GPU ARC Runners — delegates to upstream deploy with local definitions.
+# Called by: just deploy-module <cluster> arc-runners-h100
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$(cd "$MODULE_DIR/../.." && pwd)}"
+
+export ARC_RUNNERS_DEFS_DIR="$MODULE_DIR/defs"
+export ARC_RUNNERS_OUTPUT_DIR="$MODULE_DIR/generated"
+export ARC_RUNNERS_MODULE_NAME="arc-runners-h100"
+exec "$UPSTREAM_ROOT/modules/arc-runners/deploy.sh" "$@"

--- a/osdc/modules/nodepools-h100/defs/p5-48xlarge.yaml
+++ b/osdc/modules/nodepools-h100/defs/p5-48xlarge.yaml
@@ -1,0 +1,18 @@
+# Karpenter NodePool definition: p5.48xlarge (GPU compute, 8x NVIDIA H100 80GB SXM5)
+# Used by: l-x86iamx-22-225-h100, l-x86iamx-44-450-h100-2, l-x86iamx-88-900-h100-4, l-bx86iamx-176-1800-h100-8
+# Capacity: AWS Capacity Blocks (reserved)
+# Node disk: 100Gi OS only — NVMe instance storage (8x3840GB) handles container data
+nodepool:
+  name: p5-48xlarge
+  instance_type: p5.48xlarge
+  arch: amd64
+  node_disk_size: 100
+  gpu: true
+  has_nvme: true
+  topology_manager_policy: single-numa-node
+  topology_manager_scope: pod
+  capacity_type: reserved
+  capacity_reservation_ids:
+    - cr-0fea9e9472d5e76c6
+  baremetal: true
+  user_data_script: scripts/h100-node-setup.sh

--- a/osdc/modules/nodepools-h100/deploy.sh
+++ b/osdc/modules/nodepools-h100/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# H100 GPU NodePools — delegates to upstream deploy with local definitions.
+# Called by: just deploy-module <cluster> nodepools-h100
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$(cd "$MODULE_DIR/../.." && pwd)}"
+
+export NODEPOOLS_DEFS_DIR="$MODULE_DIR/defs"
+export NODEPOOLS_OUTPUT_DIR="$MODULE_DIR/generated"
+export NODEPOOLS_MODULE_NAME="nodepools-h100"
+exec "$UPSTREAM_ROOT/modules/nodepools/deploy.sh" "$@"

--- a/osdc/modules/nodepools-h100/scripts/h100-node-setup.sh
+++ b/osdc/modules/nodepools-h100/scripts/h100-node-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+# ---- Registry mirror configuration (Harbor pull-through cache) ----
+echo "Post-bootstrap: Configuring registry mirrors..."
+HARBOR_PORT=30002
+
+for registry_project in \
+  "docker.io dockerhub-cache https://docker.io" \
+  "ghcr.io ghcr-cache https://ghcr.io" \
+  "public.ecr.aws ecr-public-cache https://public.ecr.aws" \
+  "nvcr.io nvcr-cache https://nvcr.io" \
+  "registry.k8s.io k8s-cache https://registry.k8s.io" \
+  "quay.io quay-cache https://quay.io"; do
+  # shellcheck disable=SC2086  # Intentional word-splitting
+  set -- $registry_project
+  registry=$1
+  project=$2
+  upstream=$3
+  mkdir -p "/etc/containerd/certs.d/$registry"
+  cat >"/etc/containerd/certs.d/$registry/hosts.toml" <<MIRRORS
+server = "$upstream"
+
+[host."http://localhost:$HARBOR_PORT/v2/$project"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+  override_path = true
+
+[host."$upstream"]
+  capabilities = ["pull", "resolve"]
+MIRRORS
+done
+echo "Registry mirrors configured for 6 registries"
+
+# ---- CPU performance tuning ----
+echo "Post-bootstrap: Configuring performance settings for p5.48xlarge..."
+
+for cpu_governor in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+  if [ -f "$cpu_governor" ]; then
+    echo "performance" >"$cpu_governor" || true
+  fi
+done
+
+cat >/etc/systemd/system/cpu-performance.service <<'EOFS'
+[Unit]
+Description=Set CPU governor to performance mode
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c \
+  'for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; \
+  do echo performance > $gov 2>/dev/null || true; done'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOFS
+
+# daemon-reload + enable only — do NOT 'systemctl start' here.
+# This script runs inside cloud-init (cloud-final.service), and the service
+# unit has After=multi-user.target, creating a systemd deadlock:
+#   cloud-final waits for this script → script waits for systemctl start →
+#   systemd waits for multi-user.target → multi-user.target waits for cloud-final.
+# The CPU governors are already set directly above; the service is only
+# needed for persistence across reboots.
+systemctl daemon-reload
+systemctl enable cpu-performance.service
+
+# Enable GPU persistence mode for consistent performance
+nvidia-smi -pm 1 || true
+echo "Performance configuration complete for p5.48xlarge"

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -92,6 +92,7 @@ INSTANCE_SPECS: dict[str, dict] = {
     "g4dn.metal": {"vcpu": 96, "memory_gib": 384, "memory_mi": 363724, "gpu": 8, "arch": "amd64"},
     "g5.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
     "g6.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
+    "p5.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     "p6-b200.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     # pypi-cache instances
     "r7i.2xlarge": {"vcpu": 8, "memory_gib": 64, "memory_mi": 60620, "gpu": 0, "arch": "amd64"},
@@ -172,6 +173,7 @@ ENI_MAX_PODS: dict[str, int] = {
     "g6.12xlarge": 234,
     "g6.24xlarge": 234,
     "g6.48xlarge": 737,
+    "p5.48xlarge": 198,
     "p6-b200.48xlarge": 198,
     # pypi-cache instance types
     "r7i.2xlarge": 56,  # 4 ENIs x 15 IPs - 4

--- a/osdc/scripts/python/pytorch_workload_data.py
+++ b/osdc/scripts/python/pytorch_workload_data.py
@@ -58,6 +58,11 @@ OLD_TO_NEW_LABEL: dict[str, str] = {
     "a.linux.b200.2": "l-x86iamx-44-450-b200-2",
     "a.linux.b200.4": "l-x86iamx-88-900-b200-4",
     "a.linux.b200.8": "l-bx86iamx-176-1800-b200-8",
+    # x86 GPU — H100 (p5)
+    "a.linux.h100": "l-x86iamx-22-225-h100",
+    "a.linux.h100.2": "l-x86iamx-44-450-h100-2",
+    "a.linux.h100.4": "l-x86iamx-88-900-h100-4",
+    "a.linux.h100.8": "l-bx86iamx-176-1800-h100-8",
     # ARM64
     "linux.arm64.2xlarge": "l-arm64g2-6-32",
     "linux.arm64.2xlarge.ephemeral": "l-arm64g2-6-32",


### PR DESCRIPTION
Introduces nodepools-h100 and arc-runners-h100 modules for the new p5.48xlarge capacity reservation cr-0fea9e9472d5e76c6 in arc-cbr-production (us-east-2), mirroring the existing B200 pattern. p5.48xlarge has the same 192 vCPU / 2048 GiB / 8 GPU form factor as p6-b200.48xlarge, so the same 22/44/88/176 vCPU and 225/450/900/1800 GiB per-runner split applies.

### Testing

```
just plan arc-cbr-production
```