### PR TITLE
Fix analyze_node_utilization to discover peer modules in single-repo layout

### DIFF
--- a/osdc/scripts/python/analyze_node_utilization.py
+++ b/osdc/scripts/python/analyze_node_utilization.py
@@ -515,41 +515,33 @@ def main(argv: list[str] | None = None) -> int:
             print(f"    {DIM}source: {ds.source}{NC}")
         return 0
 
-    # Collect runner defs from upstream + consumer
+    # Collect runner + nodepool defs from upstream and any peer/consumer modules.
+    # The walk also fires when consumer_root == upstream_dir (single-repo OSDC
+    # layout), which lets us discover sibling fixed-capacity modules like
+    # arc-runners-b200 / nodepools-b200 that live next to the upstream defaults.
+    # load_runner_defs / load_nodepool_defs dedupe by resolved path, so the
+    # explicit upstream entries are safe even when the walk re-yields them.
     runner_dirs = [
         upstream_dir / "modules" / "arc-runners" / "defs",
     ]
-    # Add consumer runner def dirs
-    if consumer_root != upstream_dir:
-        consumer_modules = consumer_root / "modules"
-        if consumer_modules.exists():
-            for mod_dir in sorted(consumer_modules.iterdir()):
-                defs = mod_dir / "defs"
-                if defs.exists() and any(defs.glob("*.yaml")):
-                    # Check if any def has runner key
-                    for f in defs.glob("*.yaml"):
-                        with open(f) as fh:
-                            d = yaml.safe_load(fh)
-                        if d and "runner" in d:
-                            runner_dirs.append(defs)
-                            break
-
-    # Collect nodepool defs
     nodepool_dirs = [
         upstream_dir / "modules" / "nodepools" / "defs",
     ]
-    if consumer_root != upstream_dir:
-        consumer_modules = consumer_root / "modules"
-        if consumer_modules.exists():
-            for mod_dir in sorted(consumer_modules.iterdir()):
-                defs = mod_dir / "defs"
-                if defs.exists() and any(defs.glob("*.yaml")):
-                    for f in defs.glob("*.yaml"):
-                        with open(f) as fh:
-                            d = yaml.safe_load(fh)
-                        if d and "nodepool" in d:
-                            nodepool_dirs.append(defs)
-                            break
+    consumer_modules = consumer_root / "modules"
+    if consumer_modules.exists():
+        for mod_dir in sorted(consumer_modules.iterdir()):
+            defs = mod_dir / "defs"
+            if not (defs.exists() and any(defs.glob("*.yaml"))):
+                continue
+            for f in defs.glob("*.yaml"):
+                with open(f) as fh:
+                    d = yaml.safe_load(fh)
+                if not d:
+                    continue
+                if "runner" in d and defs not in runner_dirs:
+                    runner_dirs.append(defs)
+                if "nodepool" in d and defs not in nodepool_dirs:
+                    nodepool_dirs.append(defs)
 
     print(f"{BOLD}Node Utilization Analysis{NC}")
     print(f"{'━' * 80}")

--- a/osdc/scripts/python/test_analyze_node_utilization.py
+++ b/osdc/scripts/python/test_analyze_node_utilization.py
@@ -616,3 +616,17 @@ class TestMain:
         assert result in (0, 1)
         output = capsys.readouterr().out
         assert str(defs) not in output
+
+    def test_single_repo_layout_discovers_peer_modules(self, capsys):
+        """Single-repo layout (consumer_root == upstream_dir) still walks peer modules.
+
+        Regression for the case where arc-runners-b200 / nodepools-b200 (and any
+        future fixed-capacity GPU module) live next to the upstream defs in the
+        same repo and were silently dropped by an earlier consumer_root guard.
+        """
+        result = main(["--threshold", "1"])
+        assert result in (0, 1)
+        output = capsys.readouterr().out
+        assert "arc-runners-b200/defs" in output
+        assert "nodepools-b200/defs" in output
+        assert "p6-b200.48xlarge" in output


### PR DESCRIPTION
The consumer-walk that picks up runner/nodepool defs from peer modules (arc-runners-b200, nodepools-b200, etc.) was guarded by consumer_root != upstream_dir, so it never fired in the in-tree OSDC layout where both resolve to the same path. As a result, B200 (and other fixed- capacity GPU modules) were silently missing from `uv run scripts/python/analyze_node_utilization.py` output. Drop the guard and rely on the existing resolved-path dedupe in load_runner_defs / load_nodepool_defs to keep upstream defs from being counted twice.

### Testing

B200 `p6-b200.48xlarge` now shows up:

```
Node Utilization Analysis
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Runner def dirs: /Users/huydo/Storage/mine/ci-infra/osdc/modules/arc-runners/defs, /Users/huydo/Storage/mine/ci-infra/osdc/modules/arc-runners-b200/defs
NodePool def dirs: /Users/huydo/Storage/mine/ci-infra/osdc/modules/nodepools/defs, /Users/huydo/Storage/mine/ci-infra/osdc/modules/nodepools-b200/defs
Utilization threshold: 90.0%

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: c7a.48xlarge
  Total: 192 vCPU, 384Gi advertised (355.2Gi actual)
  Kubelet reserved: 550m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 191035m CPU (191.0 cores), 346.0Gi RAM

  Runners targeting this node:
    - l-x86iavx512-16-32: 16320m CPU, 32.5Gi RAM (job: 16c+32.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-2-4: 2320m CPU, 4.5Gi RAM (job: 2c+4.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-37-68: 37320m CPU, 68.5Gi RAM (job: 37c+68.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-46-85: 46320m CPU, 85.5Gi RAM (job: 46c+85.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-8-16: 8320m CPU, 16.5Gi RAM (job: 8c+16.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-94-192: 94320m CPU, 189.5Gi RAM (job: 94c+189.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iavx512-16-32: 10 pods
      CPU:  85.4% (163200m / 191035m) waste: 27835m (27.8 cores)
      MEM:  94.0% (325.1Gi / 346.0Gi) waste: 20.9Gi
      Bottleneck: MEM
    l-x86iavx512-2-4: 76 pods
      CPU:  92.3% (176320m / 191035m) waste: 14715m (14.7 cores)
      MEM:  99.1% (342.7Gi / 346.0Gi) waste: 3.2Gi
      Bottleneck: MEM
    l-x86iavx512-37-68: 5 pods
      CPU:  97.7% (186600m / 191035m) waste: 4435m (4.4 cores)
      MEM:  99.0% (342.5Gi / 346.0Gi) waste: 3.4Gi
      Bottleneck: CPU
    l-x86iavx512-46-85: 4 pods
      CPU:  97.0% (185280m / 191035m) waste: 5755m (5.8 cores)
      MEM:  98.9% (342.0Gi / 346.0Gi) waste: 3.9Gi
      Bottleneck: CPU
    l-x86iavx512-8-16: 20 pods
      CPU:  87.1% (166400m / 191035m) waste: 24635m (24.6 cores)
      MEM:  95.4% (330.2Gi / 346.0Gi) waste: 15.8Gi
      Bottleneck: MEM
    l-x86iavx512-94-192: 1 pods
      CPU:  49.4% (94320m / 191035m) waste: 96715m (96.7 cores)
      MEM:  54.8% (189.5Gi / 346.0Gi) waste: 156.5Gi
      Bottleneck: MEM

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 236

    Top 5 most efficient:
      #1 [5xl-x86iavx512-37-68]
         CPU:  97.7%  MEM:  99.0%  waste: 4.4c + 3.4Gi
      #2 [1xl-x86iavx512-2-4, 2xl-x86iavx512-37-68, 2xl-x86iavx512-46-85, 2xl-x86iavx512-8-16]
         CPU:  97.5%  MEM:  99.9%  waste: 4.8c + 406Mi
      #3 [12xl-x86iavx512-2-4, 3xl-x86iavx512-37-68, 1xl-x86iavx512-46-85]
         CPU:  97.4%  MEM:  99.8%  waste: 4.9c + 828Mi
      #4 [1xl-x86iavx512-16-32, 1xl-x86iavx512-2-4, 2xl-x86iavx512-37-68, 2xl-x86iavx512-46-85]
         CPU:  97.3%  MEM:  99.7%  waste: 5.1c + 928Mi
      #5 [8xl-x86iavx512-2-4, 2xl-x86iavx512-37-68, 2xl-x86iavx512-46-85]
         CPU:  97.3%  MEM:  99.5%  waste: 5.2c + 1.8Gi

    Bottom 5 least efficient (money on the table):
      #1 [1xl-x86iavx512-2-4, 9xl-x86iavx512-8-16, 1xl-x86iavx512-94-192]
         CPU:  89.8%  MEM:  99.0%  waste: 19.5c + 3.4Gi
      #2 [2xl-x86iavx512-16-32, 12xl-x86iavx512-2-4, 2xl-x86iavx512-8-16, 1xl-x86iavx512-94-192]
         CPU:  89.7%  MEM:  98.8%  waste: 19.6c + 4.3Gi
      #3 [4xl-x86iavx512-16-32, 5xl-x86iavx512-2-4, 1xl-x86iavx512-94-192]
         CPU:  89.6%  MEM:  98.9%  waste: 19.8c + 3.9Gi
      #4 [1xl-x86iavx512-16-32, 1xl-x86iavx512-2-4, 7xl-x86iavx512-8-16, 1xl-x86iavx512-94-192]
         CPU:  89.6%  MEM:  98.9%  waste: 19.8c + 3.9Gi
      #5 [2xl-x86iavx512-16-32, 1xl-x86iavx512-2-4, 5xl-x86iavx512-8-16, 1xl-x86iavx512-94-192]
         CPU:  89.4%  MEM:  98.7%  waste: 20.2c + 4.4Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: c7i.12xlarge
  Total: 48 vCPU, 96Gi advertised (88.8Gi actual)
  Kubelet reserved: 190m CPU, 2.9Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 47395m CPU (47.4 cores), 85.0Gi RAM

  Runners targeting this node:
    - l-x86iamx-14-27: 14320m CPU, 27.5Gi RAM (job: 14c+27.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-22-41: 22320m CPU, 41.5Gi RAM (job: 22c+41.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-46-84: 46320m CPU, 84.5Gi RAM (job: 46c+84.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-8-16: 8320m CPU, 16.5Gi RAM (job: 8c+16.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iamx-14-27: 3 pods
      CPU:  90.6% (42960m / 47395m) waste: 4435m (4.4 cores)
      MEM:  97.1% (82.5Gi / 85.0Gi) waste: 2.4Gi
      Bottleneck: CPU
    l-x86iamx-22-41: 2 pods
      CPU:  94.2% (44640m / 47395m) waste: 2755m (2.8 cores)
      MEM:  97.7% (83.0Gi / 85.0Gi) waste: 1.9Gi
      Bottleneck: CPU
    l-x86iamx-46-84: 1 pods
      CPU:  97.7% (46320m / 47395m) waste: 1075m (1.1 cores)
      MEM:  99.5% (84.5Gi / 85.0Gi) waste: 470Mi
      Bottleneck: CPU
    l-x86iamx-8-16: 5 pods
      CPU:  87.8% (41600m / 47395m) waste: 5795m (5.8 cores)
      MEM:  97.2% (82.5Gi / 85.0Gi) waste: 2.4Gi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 8

    Top 5 most efficient:
      #1 [1xl-x86iamx-46-84]
         CPU:  97.7%  MEM:  99.5%  waste: 1.1c + 470Mi
      #2 [2xl-x86iamx-22-41]
         CPU:  94.2%  MEM:  97.7%  waste: 2.8c + 1.9Gi
      #3 [3xl-x86iamx-14-27]
         CPU:  90.6%  MEM:  97.1%  waste: 4.4c + 2.4Gi
      #4 [5xl-x86iamx-8-16]
         CPU:  87.8%  MEM:  97.2%  waste: 5.8c + 2.4Gi
      #5 [1xl-x86iamx-14-27, 3xl-x86iamx-8-16]
         CPU:  82.9%  MEM:  90.7%  waste: 8.1c + 7.9Gi

    Bottom 3 least efficient (money on the table):
      #1 [1xl-x86iamx-22-41, 2xl-x86iamx-8-16]
         CPU:  82.2%  MEM:  87.7%  waste: 8.4c + 10.4Gi
      #2 [2xl-x86iamx-14-27, 1xl-x86iamx-8-16]
         CPU:  78.0%  MEM:  84.2%  waste: 10.4c + 13.4Gi
      #3 [1xl-x86iamx-14-27, 1xl-x86iamx-22-41]
         CPU:  77.3%  MEM:  81.2%  waste: 10.8c + 15.9Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: c7i.metal-24xl
  Total: 96 vCPU, 192Gi advertised (177.6Gi actual)
  Kubelet reserved: 310m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 95275m CPU (95.3 cores), 168.4Gi RAM

  Runners targeting this node:
    - l-bx86iamx-92-167: 92320m CPU, 167.5Gi RAM (job: 92c+167.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-bx86iamx-92-167: 1 pods
      CPU:  96.9% (92320m / 95275m) waste: 2955m (3.0 cores)
      MEM:  99.5% (167.5Gi / 168.4Gi) waste: 876Mi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-bx86iamx-92-167]
         CPU:  96.9%  MEM:  99.5%  waste: 3.0c + 876Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g4dn.12xlarge
  Total: 48 vCPU, 192Gi advertised (177.6Gi actual), 4 GPU
  Kubelet reserved: 190m CPU, 2.9Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 47295m CPU (47.3 cores), 173.5Gi RAM, 4 GPU

  Runners targeting this node:
    - l-x86iavx512-45-172-t4-4: 45320m CPU, 172.5Gi RAM, 4 GPU (job: 45c+172.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iavx512-45-172-t4-4: 1 pods
      CPU:  95.8% (45320m / 47295m) waste: 1975m (2.0 cores)
      MEM:  99.4% (172.5Gi / 173.5Gi) waste: 1.0Gi
      GPU: 100.0% (4 / 4)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86iavx512-45-172-t4-4]
         CPU:  95.8%  MEM:  99.4%  GPU: 100.0%  waste: 2.0c + 1.0Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g4dn.8xlarge
  Total: 32 vCPU, 128Gi advertised (118.4Gi actual), 1 GPU
  Kubelet reserved: 150m CPU, 993Mi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 31335m CPU (31.3 cores), 116.2Gi RAM, 1 GPU

  Runners targeting this node:
    - l-x86iavx512-29-115-t4: 29320m CPU, 115.5Gi RAM, 1 GPU (job: 29c+115.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iavx512-29-115-t4: 1 pods
      CPU:  93.6% (29320m / 31335m) waste: 2015m (2.0 cores)
      MEM:  99.4% (115.5Gi / 116.2Gi) waste: 716Mi
      GPU: 100.0% (1 / 1)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86iavx512-29-115-t4]
         CPU:  93.6%  MEM:  99.4%  GPU: 100.0%  waste: 2.0c + 716Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g4dn.metal
  Total: 96 vCPU, 384Gi advertised (355.2Gi actual), 8 GPU
  Kubelet reserved: 310m CPU, 8.3Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 95175m CPU (95.2 cores), 345.7Gi RAM, 8 GPU

  Runners targeting this node:
    - l-bx86iavx512-94-344-t4-8: 94320m CPU, 344.5Gi RAM, 8 GPU (job: 94c+344.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-bx86iavx512-94-344-t4-8: 1 pods
      CPU:  99.1% (94320m / 95175m) waste: 855m (0.9 cores)
      MEM:  99.7% (344.5Gi / 345.7Gi) waste: 1.2Gi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-bx86iavx512-94-344-t4-8]
         CPU:  99.1%  MEM:  99.7%  GPU: 100.0%  waste: 0.9c + 1.2Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g5.12xlarge
  Total: 48 vCPU, 192Gi advertised (177.6Gi actual), 4 GPU
  Kubelet reserved: 190m CPU, 8.3Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 47295m CPU (47.3 cores), 168.1Gi RAM, 4 GPU

  Runners targeting this node:
    - l-x86aavx2-45-167-a10g-4: 45320m CPU, 167.5Gi RAM, 4 GPU (job: 45c+167.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx2-45-167-a10g-4: 1 pods
      CPU:  95.8% (45320m / 47295m) waste: 1975m (2.0 cores)
      MEM:  99.6% (167.5Gi / 168.1Gi) waste: 620Mi
      GPU: 100.0% (4 / 4)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx2-45-167-a10g-4]
         CPU:  95.8%  MEM:  99.6%  GPU: 100.0%  waste: 2.0c + 620Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g5.48xlarge
  Total: 192 vCPU, 768Gi advertised (710.4Gi actual), 8 GPU
  Kubelet reserved: 550m CPU, 4.1Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 190935m CPU (190.9 cores), 705.1Gi RAM, 8 GPU

  Runners targeting this node:
    - l-x86aavx2-189-704-a10g-8: 189320m CPU, 704.5Gi RAM, 8 GPU (job: 189c+704.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx2-189-704-a10g-8: 1 pods
      CPU:  99.2% (189320m / 190935m) waste: 1615m (1.6 cores)
      MEM:  99.9% (704.5Gi / 705.1Gi) waste: 631Mi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx2-189-704-a10g-8]
         CPU:  99.2%  MEM:  99.9%  GPU: 100.0%  waste: 1.6c + 631Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g5.8xlarge
  Total: 32 vCPU, 128Gi advertised (118.4Gi actual), 1 GPU
  Kubelet reserved: 150m CPU, 2.9Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 31335m CPU (31.3 cores), 114.3Gi RAM, 1 GPU

  Runners targeting this node:
    - l-x86aavx2-29-113-a10g: 29320m CPU, 113.5Gi RAM, 1 GPU (job: 29c+113.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx2-29-113-a10g: 1 pods
      CPU:  93.6% (29320m / 31335m) waste: 2015m (2.0 cores)
      MEM:  99.3% (113.5Gi / 114.3Gi) waste: 828Mi
      GPU: 100.0% (1 / 1)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx2-29-113-a10g]
         CPU:  93.6%  MEM:  99.3%  GPU: 100.0%  waste: 2.0c + 828Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g6.12xlarge
  Total: 48 vCPU, 192Gi advertised (177.6Gi actual), 4 GPU
  Kubelet reserved: 190m CPU, 2.9Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 47295m CPU (47.3 cores), 173.5Gi RAM, 4 GPU

  Runners targeting this node:
    - l-x86aavx2-45-172-l4-4: 45320m CPU, 172.5Gi RAM, 4 GPU (job: 45c+172.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx2-45-172-l4-4: 1 pods
      CPU:  95.8% (45320m / 47295m) waste: 1975m (2.0 cores)
      MEM:  99.4% (172.5Gi / 173.5Gi) waste: 1.0Gi
      GPU: 100.0% (4 / 4)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx2-45-172-l4-4]
         CPU:  95.8%  MEM:  99.4%  GPU: 100.0%  waste: 2.0c + 1.0Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: g6.8xlarge
  Total: 32 vCPU, 128Gi advertised (118.4Gi actual), 1 GPU
  Kubelet reserved: 150m CPU, 2.9Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 31335m CPU (31.3 cores), 114.3Gi RAM, 1 GPU

  Runners targeting this node:
    - l-x86aavx2-29-113-l4: 29320m CPU, 113.5Gi RAM, 1 GPU (job: 29c+113.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx2-29-113-l4: 1 pods
      CPU:  93.6% (29320m / 31335m) waste: 2015m (2.0 cores)
      MEM:  99.3% (113.5Gi / 114.3Gi) waste: 828Mi
      GPU: 100.0% (1 / 1)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx2-29-113-l4]
         CPU:  93.6%  MEM:  99.3%  GPU: 100.0%  waste: 2.0c + 828Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: m6i.32xlarge
  Total: 128 vCPU, 512Gi advertised (473.7Gi actual)
  Kubelet reserved: 390m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 127195m CPU (127.2 cores), 464.5Gi RAM

  Runners targeting this node:
    - l-x86aavx512-125-463: 125320m CPU, 463.5Gi RAM (job: 125c+463.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86aavx512-125-463: 1 pods
      CPU:  98.5% (125320m / 127195m) waste: 1875m (1.9 cores)
      MEM:  99.8% (463.5Gi / 464.5Gi) waste: 991Mi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-x86aavx512-125-463]
         CPU:  98.5%  MEM:  99.8%  waste: 1.9c + 991Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: m7i.48xlarge
  Total: 192 vCPU, 768Gi advertised (710.4Gi actual)
  Kubelet reserved: 550m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 191035m CPU (191.0 cores), 701.2Gi RAM

  Runners targeting this node:
    - l-x86iamx-32-128: 32320m CPU, 128.5Gi RAM (job: 32c+128.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-8-32: 8320m CPU, 32.5Gi RAM (job: 8c+32.0Gi, hooks: 320m+522Mi)
    - l-x86iavx2-40-160: 40320m CPU, 160.5Gi RAM (job: 40c+160.0Gi, hooks: 320m+522Mi)
    - l-x86iavx2-8-32: 8320m CPU, 32.5Gi RAM (job: 8c+32.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iamx-32-128: 5 pods
      CPU:  84.6% (161600m / 191035m) waste: 29435m (29.4 cores)
      MEM:  91.6% (642.5Gi / 701.2Gi) waste: 58.6Gi
      Bottleneck: CPU
    l-x86iamx-8-32: 21 pods
      CPU:  91.5% (174720m / 191035m) waste: 16315m (16.3 cores)
      MEM:  97.4% (682.7Gi / 701.2Gi) waste: 18.5Gi
      Bottleneck: MEM
    l-x86iavx2-40-160: 4 pods
      CPU:  84.4% (161280m / 191035m) waste: 29755m (29.8 cores)
      MEM:  91.6% (642.0Gi / 701.2Gi) waste: 59.1Gi
      Bottleneck: CPU
    l-x86iavx2-8-32: 21 pods
      CPU:  91.5% (174720m / 191035m) waste: 16315m (16.3 cores)
      MEM:  97.4% (682.7Gi / 701.2Gi) waste: 18.5Gi
      Bottleneck: MEM

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 131

    Top 5 most efficient:
      #1 [1xl-x86iamx-32-128, 17xl-x86iamx-8-32]
         CPU:  91.0%  MEM:  97.1%  waste: 17.3c + 20.0Gi
      #2 [1xl-x86iamx-32-128, 16xl-x86iamx-8-32, 1xl-x86iavx2-8-32]
         CPU:  91.0%  MEM:  97.1%  waste: 17.3c + 20.0Gi
      #3 [1xl-x86iamx-32-128, 15xl-x86iamx-8-32, 2xl-x86iavx2-8-32]
         CPU:  91.0%  MEM:  97.1%  waste: 17.3c + 20.0Gi
      #4 [1xl-x86iamx-32-128, 14xl-x86iamx-8-32, 3xl-x86iavx2-8-32]
         CPU:  91.0%  MEM:  97.1%  waste: 17.3c + 20.0Gi
      #5 [1xl-x86iamx-32-128, 13xl-x86iamx-8-32, 4xl-x86iavx2-8-32]
         CPU:  91.0%  MEM:  97.1%  waste: 17.3c + 20.0Gi

    Bottom 5 least efficient (money on the table):
      #1 [1xl-x86iamx-32-128, 1xl-x86iamx-8-32, 3xl-x86iavx2-40-160, 1xl-x86iavx2-8-32]
         CPU:  88.9%  MEM:  96.3%  waste: 21.1c + 26.1Gi
      #2 [1xl-x86iamx-32-128, 3xl-x86iavx2-40-160, 2xl-x86iavx2-8-32]
         CPU:  88.9%  MEM:  96.3%  waste: 21.1c + 26.1Gi
      #3 [4xl-x86iamx-32-128, 1xl-x86iavx2-40-160]
         CPU:  88.8%  MEM:  96.2%  waste: 21.4c + 26.6Gi
      #4 [1xl-x86iamx-8-32, 4xl-x86iavx2-40-160]
         CPU:  88.8%  MEM:  96.2%  waste: 21.4c + 26.6Gi
      #5 [4xl-x86iavx2-40-160, 1xl-x86iavx2-8-32]
         CPU:  88.8%  MEM:  96.2%  waste: 21.4c + 26.6Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: m8g.16xlarge
  Total: 64 vCPU, 256Gi advertised (236.9Gi actual)
  Kubelet reserved: 230m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 63355m CPU (63.4 cores), 227.6Gi RAM

  Runners targeting this node:
    - l-barm64g4-62-226: 62320m CPU, 226.5Gi RAM (job: 62c+226.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-barm64g4-62-226: 1 pods
      CPU:  98.4% (62320m / 63355m) waste: 1035m (1.0 cores)
      MEM:  99.5% (226.5Gi / 227.6Gi) waste: 1.1Gi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-barm64g4-62-226]
         CPU:  98.4%  MEM:  99.5%  waste: 1.0c + 1.1Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: m8g.48xlarge
  Total: 192 vCPU, 768Gi advertised (710.4Gi actual)
  Kubelet reserved: 550m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 191035m CPU (191.0 cores), 701.2Gi RAM

  Runners targeting this node:
    - l-arm64g2-6-32: 6320m CPU, 29.5Gi RAM (job: 6c+29.0Gi, hooks: 320m+522Mi)
    - l-arm64g3-16-62: 16320m CPU, 62.5Gi RAM (job: 16c+62.0Gi, hooks: 320m+522Mi)
    - l-arm64g4-16-62: 16320m CPU, 62.5Gi RAM (job: 16c+62.0Gi, hooks: 320m+522Mi)
    - rel-l-arm64g4-16-62: 16320m CPU, 62.5Gi RAM (job: 16c+62.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-arm64g2-6-32: 23 pods
      CPU:  76.1% (145360m / 191035m) waste: 45675m (45.7 cores)
      MEM:  96.8% (678.7Gi / 701.2Gi) waste: 22.4Gi
      Bottleneck: MEM
    l-arm64g3-16-62: 11 pods
      CPU:  94.0% (179520m / 191035m) waste: 11515m (11.5 cores)
      MEM:  98.1% (687.6Gi / 701.2Gi) waste: 13.6Gi
      Bottleneck: CPU
    l-arm64g4-16-62: 11 pods
      CPU:  94.0% (179520m / 191035m) waste: 11515m (11.5 cores)
      MEM:  98.1% (687.6Gi / 701.2Gi) waste: 13.6Gi
      Bottleneck: CPU
    rel-l-arm64g4-16-62: 11 pods
      CPU:  94.0% (179520m / 191035m) waste: 11515m (11.5 cores)
      MEM:  98.1% (687.6Gi / 701.2Gi) waste: 13.6Gi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 354

    Top 5 most efficient:
      #1 [11xl-arm64g3-16-62]
         CPU:  94.0%  MEM:  98.1%  waste: 11.5c + 13.6Gi
      #2 [10xl-arm64g3-16-62, 1xl-arm64g4-16-62]
         CPU:  94.0%  MEM:  98.1%  waste: 11.5c + 13.6Gi
      #3 [10xl-arm64g3-16-62, 1xrel-l-arm64g4-16-62]
         CPU:  94.0%  MEM:  98.1%  waste: 11.5c + 13.6Gi
      #4 [9xl-arm64g3-16-62, 2xl-arm64g4-16-62]
         CPU:  94.0%  MEM:  98.1%  waste: 11.5c + 13.6Gi
      #5 [9xl-arm64g3-16-62, 1xl-arm64g4-16-62, 1xrel-l-arm64g4-16-62]
         CPU:  94.0%  MEM:  98.1%  waste: 11.5c + 13.6Gi

    Bottom 5 least efficient (money on the table):
      #1 [17xl-arm64g2-6-32, 1xl-arm64g3-16-62, 2xrel-l-arm64g4-16-62]
         CPU:  81.9%  MEM:  98.3%  waste: 34.6c + 12.0Gi
      #2 [17xl-arm64g2-6-32, 3xl-arm64g4-16-62]
         CPU:  81.9%  MEM:  98.3%  waste: 34.6c + 12.0Gi
      #3 [17xl-arm64g2-6-32, 2xl-arm64g4-16-62, 1xrel-l-arm64g4-16-62]
         CPU:  81.9%  MEM:  98.3%  waste: 34.6c + 12.0Gi
      #4 [17xl-arm64g2-6-32, 1xl-arm64g4-16-62, 2xrel-l-arm64g4-16-62]
         CPU:  81.9%  MEM:  98.3%  waste: 34.6c + 12.0Gi
      #5 [17xl-arm64g2-6-32, 3xrel-l-arm64g4-16-62]
         CPU:  81.9%  MEM:  98.3%  waste: 34.6c + 12.0Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: p6-b200.48xlarge
  Total: 192 vCPU, 2048Gi advertised (1894.4Gi actual), 8 GPU
  Kubelet reserved: 550m CPU, 2.5Gi RAM
  DaemonSet overhead: 515m CPU, 1.2Gi RAM
  Allocatable for runners: 190935m CPU (190.9 cores), 1890.7Gi RAM, 8 GPU

  Runners targeting this node:
    - l-bx86iamx-176-1800-b200-8: 176320m CPU, 1800.5Gi RAM, 8 GPU (job: 176c+1800.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-22-225-b200: 22320m CPU, 225.5Gi RAM, 1 GPU (job: 22c+225.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-44-450-b200-2: 44320m CPU, 450.5Gi RAM, 2 GPU (job: 44c+450.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-88-900-b200-4: 88320m CPU, 900.5Gi RAM, 4 GPU (job: 88c+900.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-bx86iamx-176-1800-b200-8: 1 pods
      CPU:  92.3% (176320m / 190935m) waste: 14615m (14.6 cores)
      MEM:  95.2% (1800.5Gi / 1890.7Gi) waste: 90.2Gi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU
    l-x86iamx-22-225-b200: 8 pods
      CPU:  93.5% (178560m / 190935m) waste: 12375m (12.4 cores)
      MEM:  95.4% (1804.1Gi / 1890.7Gi) waste: 86.6Gi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU
    l-x86iamx-44-450-b200-2: 4 pods
      CPU:  92.8% (177280m / 190935m) waste: 13655m (13.7 cores)
      MEM:  95.3% (1802.0Gi / 1890.7Gi) waste: 88.7Gi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU
    l-x86iamx-88-900-b200-4: 2 pods
      CPU:  92.5% (176640m / 190935m) waste: 14295m (14.3 cores)
      MEM:  95.3% (1801.0Gi / 1890.7Gi) waste: 89.7Gi
      GPU: 100.0% (8 / 8)
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 10

    Top 5 most efficient:
      #1 [8xl-x86iamx-22-225-b200]
         CPU:  93.5%  MEM:  95.4%  GPU: 100.0%  waste: 12.4c + 86.6Gi
      #2 [6xl-x86iamx-22-225-b200, 1xl-x86iamx-44-450-b200-2]
         CPU:  93.4%  MEM:  95.4%  GPU: 100.0%  waste: 12.7c + 87.1Gi
      #3 [4xl-x86iamx-22-225-b200, 2xl-x86iamx-44-450-b200-2]
         CPU:  93.2%  MEM:  95.4%  GPU: 100.0%  waste: 13.0c + 87.6Gi
      #4 [4xl-x86iamx-22-225-b200, 1xl-x86iamx-88-900-b200-4]
         CPU:  93.0%  MEM:  95.3%  GPU: 100.0%  waste: 13.3c + 88.2Gi
      #5 [2xl-x86iamx-22-225-b200, 3xl-x86iamx-44-450-b200-2]
         CPU:  93.0%  MEM:  95.3%  GPU: 100.0%  waste: 13.3c + 88.2Gi

    Bottom 5 least efficient (money on the table):
      #1 [2xl-x86iamx-22-225-b200, 1xl-x86iamx-44-450-b200-2, 1xl-x86iamx-88-900-b200-4]
         CPU:  92.8%  MEM:  95.3%  GPU: 100.0%  waste: 13.7c + 88.7Gi
      #2 [4xl-x86iamx-44-450-b200-2]
         CPU:  92.8%  MEM:  95.3%  GPU: 100.0%  waste: 13.7c + 88.7Gi
      #3 [2xl-x86iamx-44-450-b200-2, 1xl-x86iamx-88-900-b200-4]
         CPU:  92.7%  MEM:  95.3%  GPU: 100.0%  waste: 14.0c + 89.2Gi
      #4 [2xl-x86iamx-88-900-b200-4]
         CPU:  92.5%  MEM:  95.3%  GPU: 100.0%  waste: 14.3c + 89.7Gi
      #5 [1xl-bx86iamx-176-1800-b200-8]
         CPU:  92.3%  MEM:  95.2%  GPU: 100.0%  waste: 14.6c + 90.2Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: r7a.48xlarge
  Total: 192 vCPU, 1536Gi advertised (1420.8Gi actual)
  Kubelet reserved: 550m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 191035m CPU (191.0 cores), 1411.6Gi RAM

  Runners targeting this node:
    - l-x86iavx512-16-128: 16320m CPU, 128.5Gi RAM (job: 16c+128.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-32-256: 32320m CPU, 256.5Gi RAM (job: 32c+256.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-48-384: 48320m CPU, 384.5Gi RAM (job: 48c+384.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-8-64: 8320m CPU, 64.5Gi RAM (job: 8c+64.0Gi, hooks: 320m+522Mi)
    - l-x86iavx512-94-768: 94320m CPU, 740.5Gi RAM (job: 94c+740.0Gi, hooks: 320m+522Mi)
    - rel-l-x86iavx512-8-64: 8320m CPU, 64.5Gi RAM (job: 8c+64.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iavx512-16-128: 10 pods
      CPU:  85.4% (163200m / 191035m) waste: 27835m (27.8 cores)
      MEM:  91.0% (1285.1Gi / 1411.6Gi) waste: 126.5Gi
      Bottleneck: MEM
    l-x86iavx512-32-256: 5 pods
      CPU:  84.6% (161600m / 191035m) waste: 29435m (29.4 cores)
      MEM:  90.9% (1282.5Gi / 1411.6Gi) waste: 129.0Gi
      Bottleneck: CPU
    l-x86iavx512-48-384: 3 pods
      CPU:  75.9% (144960m / 191035m) waste: 46075m (46.1 cores)
      MEM:  81.7% (1153.5Gi / 1411.6Gi) waste: 258.0Gi
      Bottleneck: CPU
    l-x86iavx512-8-64: 21 pods
      CPU:  91.5% (174720m / 191035m) waste: 16315m (16.3 cores)
      MEM:  96.0% (1354.7Gi / 1411.6Gi) waste: 56.9Gi
      Bottleneck: MEM
    l-x86iavx512-94-768: 1 pods
      CPU:  49.4% (94320m / 191035m) waste: 96715m (96.7 cores)
      MEM:  52.5% (740.5Gi / 1411.6Gi) waste: 671.1Gi
      Bottleneck: MEM
    rel-l-x86iavx512-8-64: 21 pods
      CPU:  91.5% (174720m / 191035m) waste: 16315m (16.3 cores)
      MEM:  96.0% (1354.7Gi / 1411.6Gi) waste: 56.9Gi
      Bottleneck: MEM

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 565

    Top 5 most efficient:
      #1 [3xl-x86iavx512-16-128, 1xl-x86iavx512-32-256, 2xl-x86iavx512-48-384]
         CPU:  93.1%  MEM: 100.0%  waste: 13.1c + 519Mi
      #2 [2xl-x86iavx512-16-128, 3xl-x86iavx512-32-256, 1xl-x86iavx512-48-384]
         CPU:  93.1%  MEM: 100.0%  waste: 13.1c + 519Mi
      #3 [1xl-x86iavx512-16-128, 5xl-x86iavx512-32-256]
         CPU:  93.1%  MEM: 100.0%  waste: 13.1c + 519Mi
      #4 [1xl-x86iavx512-16-128, 3xl-x86iavx512-48-384, 2xl-x86iavx512-8-64]
         CPU:  93.1%  MEM: 100.0%  waste: 13.1c + 519Mi
      #5 [1xl-x86iavx512-16-128, 3xl-x86iavx512-48-384, 1xl-x86iavx512-8-64, 1xrel-l-x86iavx512-8-64]
         CPU:  93.1%  MEM: 100.0%  waste: 13.1c + 519Mi

    Bottom 5 least efficient (money on the table):
      #1 [5xl-x86iavx512-32-256, 1xrel-l-x86iavx512-8-64]
         CPU:  88.9%  MEM:  95.4%  waste: 21.1c + 64.5Gi
      #2 [3xl-x86iavx512-48-384, 3xl-x86iavx512-8-64]
         CPU:  88.9%  MEM:  95.4%  waste: 21.1c + 64.5Gi
      #3 [3xl-x86iavx512-48-384, 2xl-x86iavx512-8-64, 1xrel-l-x86iavx512-8-64]
         CPU:  88.9%  MEM:  95.4%  waste: 21.1c + 64.5Gi
      #4 [3xl-x86iavx512-48-384, 1xl-x86iavx512-8-64, 2xrel-l-x86iavx512-8-64]
         CPU:  88.9%  MEM:  95.4%  waste: 21.1c + 64.5Gi
      #5 [3xl-x86iavx512-48-384, 3xrel-l-x86iavx512-8-64]
         CPU:  88.9%  MEM:  95.4%  waste: 21.1c + 64.5Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: r7g.16xlarge
  Total: 64 vCPU, 512Gi advertised (473.7Gi actual)
  Kubelet reserved: 230m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 63355m CPU (63.4 cores), 464.5Gi RAM

  Runners targeting this node:
    - l-arm64g3-61-463: 61320m CPU, 463.5Gi RAM (job: 61c+463.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-arm64g3-61-463: 1 pods
      CPU:  96.8% (61320m / 63355m) waste: 2035m (2.0 cores)
      MEM:  99.8% (463.5Gi / 464.5Gi) waste: 991Mi
      Bottleneck: CPU

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 1

    Top 1 most efficient:
      #1 [1xl-arm64g3-61-463]
         CPU:  96.8%  MEM:  99.8%  waste: 2.0c + 991Mi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Node Type: r7i.48xlarge
  Total: 192 vCPU, 1536Gi advertised (1420.8Gi actual)
  Kubelet reserved: 550m CPU, 8.3Gi RAM
  DaemonSet overhead: 415m CPU, 994Mi RAM
  Allocatable for runners: 191035m CPU (191.0 cores), 1411.6Gi RAM

  Runners targeting this node:
    - l-x86iamx-16-128: 16320m CPU, 128.5Gi RAM (job: 16c+128.0Gi, hooks: 320m+522Mi)
    - l-x86iamx-8-64: 8320m CPU, 64.5Gi RAM (job: 8c+64.0Gi, hooks: 320m+522Mi)

  Homogeneous packing (single runner type fills the node):
    l-x86iamx-16-128: 10 pods
      CPU:  85.4% (163200m / 191035m) waste: 27835m (27.8 cores)
      MEM:  91.0% (1285.1Gi / 1411.6Gi) waste: 126.5Gi
      Bottleneck: MEM
    l-x86iamx-8-64: 21 pods
      CPU:  91.5% (174720m / 191035m) waste: 16315m (16.3 cores)
      MEM:  96.0% (1354.7Gi / 1411.6Gi) waste: 56.9Gi
      Bottleneck: MEM

  Maximal mixed combos (node fully packed, no room for another pod):
    Total maximal combos: 10

    Top 5 most efficient:
      #1 [1xl-x86iamx-16-128, 19xl-x86iamx-8-64]
         CPU:  91.3%  MEM:  95.9%  waste: 16.6c + 57.4Gi
      #2 [2xl-x86iamx-16-128, 17xl-x86iamx-8-64]
         CPU:  91.1%  MEM:  95.9%  waste: 17.0c + 57.9Gi
      #3 [3xl-x86iamx-16-128, 15xl-x86iamx-8-64]
         CPU:  91.0%  MEM:  95.9%  waste: 17.3c + 58.4Gi
      #4 [4xl-x86iamx-16-128, 13xl-x86iamx-8-64]
         CPU:  90.8%  MEM:  95.8%  waste: 17.6c + 58.9Gi
      #5 [5xl-x86iamx-16-128, 11xl-x86iamx-8-64]
         CPU:  90.6%  MEM:  95.8%  waste: 17.9c + 59.4Gi

    Bottom 5 least efficient (money on the table):
      #1 [6xl-x86iamx-16-128, 9xl-x86iamx-8-64]
         CPU:  90.5%  MEM:  95.8%  waste: 18.2c + 59.9Gi
      #2 [7xl-x86iamx-16-128, 7xl-x86iamx-8-64]
         CPU:  90.3%  MEM:  95.7%  waste: 18.6c + 60.4Gi
      #3 [8xl-x86iamx-16-128, 5xl-x86iamx-8-64]
         CPU:  90.1%  MEM:  95.7%  waste: 18.9c + 60.9Gi
      #4 [9xl-x86iamx-16-128, 3xl-x86iamx-8-64]
         CPU:  90.0%  MEM:  95.6%  waste: 19.2c + 61.4Gi
      #5 [10xl-x86iamx-16-128, 1xl-x86iamx-8-64]
         CPU:  89.8%  MEM:  95.6%  waste: 19.5c + 62.0Gi

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Found 12 runner type(s) with homogeneous utilization below 90.0%

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Unused resource headroom per node (homogeneous packing only):

  Node Type                 Min CPU    Max CPU    Min MEM    Max MEM
  ────────────────────────────────────────────────────────────────
  c7a.48xlarge              4435m     96715m      3.2Gi    156.5Gi
  c7i.12xlarge              1075m      5795m      470Mi      2.4Gi
  c7i.metal-24xl            2955m      2955m      876Mi      876Mi
  g4dn.12xlarge             1975m      1975m      1.0Gi      1.0Gi
  g4dn.8xlarge              2015m      2015m      716Mi      716Mi
  g4dn.metal                 855m       855m      1.2Gi      1.2Gi
  g5.12xlarge               1975m      1975m      620Mi      620Mi
  g5.48xlarge               1615m      1615m      631Mi      631Mi
  g5.8xlarge                2015m      2015m      828Mi      828Mi
  g6.12xlarge               1975m      1975m      1.0Gi      1.0Gi
  g6.8xlarge                2015m      2015m      828Mi      828Mi
  m6i.32xlarge              1875m      1875m      991Mi      991Mi
  m7i.48xlarge             16315m     29755m     18.5Gi     59.1Gi
  m8g.16xlarge              1035m      1035m      1.1Gi      1.1Gi
  m8g.48xlarge             11515m     45675m     13.6Gi     22.4Gi
  p6-b200.48xlarge         12375m     14615m     86.6Gi     90.2Gi
  r7a.48xlarge             16315m     96715m     56.9Gi    671.1Gi
  r7g.16xlarge              2035m      2035m      991Mi      991Mi
  r7i.48xlarge             16315m     27835m     56.9Gi    126.5Gi
  ────────────────────────────────────────────────────────────────
  WORST CASE                 855m     96715m      470Mi    671.1Gi

  The tightest node has only 855m CPU and 470Mi RAM free.
  Any new DaemonSet must fit within these limits or runners will fail to schedule.
```