### PR TITLE
Revert "Update AMI to Windows 2019 GHA CI - 20260420192324"

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -50,5 +50,5 @@ variable "ami_filter_linux_arm64" {
 variable "ami_filter_windows" {
   description = "AMI for windows"
   type        = list
-  default     = ["Windows 2019 GHA CI - 20260420192324"]
+  default     = ["Windows 2019 GHA CI - 20260325213408"]
 }


### PR DESCRIPTION
Reverts pytorch/ci-infra#488
Broke the builds https://github.com/pytorch/pytorch/issues/181375