### PR TITLE
Mitigate CVE-2026-31431 (algif_aead LPE) across all OSDC clusters

### DIFF
--- a/osdc/base/kubernetes/algif-mitigation.yaml
+++ b/osdc/base/kubernetes/algif-mitigation.yaml
@@ -1,0 +1,183 @@
+# algif_aead Module Mitigation DaemonSet (CVE-2026-31431 "Copy Fail")
+#
+# Linux kernel LPE in the algif_aead AF_ALG interface. The flaw crosses
+# container boundaries via the shared page cache, so on a multi-tenant CI
+# cluster any unprivileged workflow code can escalate to root on the node.
+# CVSS 7.8 / CISA KEV.
+#
+# AL2023 ships algif_aead as a loadable module (CONFIG_CRYPTO_USER_API_AEAD=m),
+# verified on kernel 6.12.79-101.147.amzn2023. The module is not loaded by
+# default — this DaemonSet writes /etc/modprobe.d/disable-algif.conf to
+# block on-demand loading, then defensively rmmod's it if anything has
+# already loaded it.
+#
+# Runs on EVERY node (base infra + Karpenter ARC + BuildKit + GPU + H100/B200).
+# Same shape as registry-mirror-config.yaml.
+#
+# REMOVE this DaemonSet (and the modprobe.d file via the script's exit path)
+# once all nodes are running a patched AL2023 AMI (kernel 6.12.85+).
+# Track: https://explore.alas.aws.amazon.com/CVE-2026-31431.html
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: algif-mitigation-script
+  namespace: kube-system
+data:
+  disable-algif.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    echo "=== algif_aead Mitigation (CVE-2026-31431 'Copy Fail') ==="
+    echo "Node: $(hostname 2>/dev/null || echo 'unknown')"
+    echo "Date: $(date)"
+    echo ""
+
+    MARKER_FILE="/var/lib/algif-mitigation/.configured"
+    MODPROBE_FILE="/etc/modprobe.d/disable-algif.conf"
+
+    # =========================================================================
+    # Idempotency — re-verify on pod restart, skip rewrite if still in place
+    # =========================================================================
+    if [ -f "$MARKER_FILE" ] && [ -f "$MODPROBE_FILE" ]; then
+      echo "Already configured. Re-checking module is not loaded..."
+      if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+        echo "  WARNING: algif_aead is loaded despite blacklist. Unloading..."
+        modprobe -r algif_aead || echo "  rmmod failed (module in use); reboot required for full mitigation."
+      else
+        echo "  algif_aead not loaded — mitigation effective."
+      fi
+      exit 0
+    fi
+
+    # =========================================================================
+    # Step 1 — install modprobe.d blacklist
+    # =========================================================================
+    echo "[1/2] Writing $MODPROBE_FILE..."
+    mkdir -p "$(dirname "$MODPROBE_FILE")"
+    cat > "$MODPROBE_FILE" <<'EOF'
+    # CVE-2026-31431 ("Copy Fail") — algif_aead LPE mitigation.
+    # Redirects on-demand loading of algif_aead to /bin/false so the module
+    # is never inserted into the running kernel.
+    # Managed by base/kubernetes/algif-mitigation.yaml DaemonSet.
+    # Remove this file (and the DaemonSet) once nodes are running a patched
+    # AL2023 kernel (6.12.85+).
+    install algif_aead /bin/false
+    EOF
+    echo "  Wrote blacklist."
+
+    # =========================================================================
+    # Step 2 — unload module if currently loaded (defensive)
+    # =========================================================================
+    echo "[2/2] Checking if algif_aead is loaded..."
+    if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+      echo "  Module loaded. Unloading (modprobe -r)..."
+      if modprobe -r algif_aead; then
+        echo "  Unloaded."
+      else
+        echo "  WARNING: rmmod failed. Module may be in use by an active AF_ALG"
+        echo "  socket. New bind() calls will be blocked from now on, but the"
+        echo "  vulnerable code path remains reachable until the node reboots."
+      fi
+    else
+      echo "  Module not loaded."
+    fi
+
+    # Marker — written last so a partial run re-attempts on next pod start
+    mkdir -p "$(dirname "$MARKER_FILE")"
+    date -Iseconds 2>/dev/null > "$MARKER_FILE" || date > "$MARKER_FILE"
+
+    echo ""
+    echo "=== Mitigation Applied ==="
+    echo "Future kernel attempts to load algif_aead will be redirected to /bin/false."
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: algif-mitigation
+  namespace: kube-system
+  labels:
+    app: algif-mitigation
+    app.kubernetes.io/name: algif-mitigation
+    app.kubernetes.io/component: node-configuration
+spec:
+  selector:
+    matchLabels:
+      app: algif-mitigation
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+
+  template:
+    metadata:
+      labels:
+        app: algif-mitigation
+
+    spec:
+      hostNetwork: true
+      hostPID: true
+
+      priorityClassName: system-node-critical
+
+      # Run on ALL nodes (base infra + Karpenter-managed: ARC, BuildKit, GPU, H100, B200)
+      tolerations:
+        - operator: Exists
+
+      # NO nodeSelector — must run on every node in the cluster
+
+      serviceAccountName: algif-mitigation
+
+      initContainers:
+        - name: disable-algif
+          image: public.ecr.aws/amazonlinux/amazonlinux:2023
+          command: ["/bin/bash", "-c"]
+          args:
+            # hostPID gives access to host's PID 1 root filesystem.
+            # nsenter runs the script in the host's mount/UTS/IPC/net namespaces
+            # so modprobe, lsmod, and writes to /etc/modprobe.d hit the host.
+            # stdin redirection reads the script from the container's ConfigMap
+            # mount before nsenter switches namespaces.
+            - /proc/1/root/usr/bin/nsenter -t 1 -m -u -i -n -- /bin/bash < /scripts/disable-algif.sh
+
+          securityContext:
+            privileged: true
+
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+
+      containers:
+        - name: sleep
+          image: public.ecr.aws/docker/library/alpine:3.19
+          command:
+            - /bin/sh
+            - -c
+            - "echo 'algif_aead mitigation applied. Sleeping...'; sleep infinity"
+
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+
+      volumes:
+        - name: scripts
+          configMap:
+            name: algif-mitigation-script
+            defaultMode: 0755
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: algif-mitigation
+  namespace: kube-system
+  labels:
+    app: algif-mitigation

--- a/osdc/base/kubernetes/kustomization.yaml
+++ b/osdc/base/kubernetes/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - harbor-namespace.yaml
   - git-cache/
   - registry-mirror-config.yaml
+  - algif-mitigation.yaml
   # image-cache-janitor is deployed via its own deploy.sh (builds custom image)
   # NOTE: Namespaces for modules (arc-runners, arc-systems, buildkit, etc.)
   # are created by the module's own kubernetes/ directory, not here.

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -24,6 +24,9 @@ defaults:
   base_node_count: 5
   base_node_instance_type: m7i.4xlarge
   base_node_max_unavailable_percentage: 33
+  # TODO(CVE-2026-31431): when bumping to a kernel 6.12.85+ AL2023 AMI,
+  # remove osdc/base/kubernetes/algif-mitigation.yaml.
+  # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
   base_node_ami_version: "v20260318"
   eks_version: "1.35"
   single_nat_gateway: false

--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -117,6 +117,16 @@ Runs a privileged init container (`tune-node`) that configures:
 
 Runs on nodes with `workload-type` in `[github-runner, buildkit]`.
 
+### algif_aead Module Blacklist (TEMPORARY — CVE-2026-31431)
+
+**File**: `base/kubernetes/algif-mitigation.yaml`
+
+Writes `/etc/modprobe.d/disable-algif.conf` (`install algif_aead /bin/false`) and defensively `modprobe -r algif_aead` on every node. Mitigates CVE-2026-31431 ("Copy Fail" — Linux kernel `algif_aead` LPE that crosses container boundaries via the shared page cache). Privileged init container `nsenter`'s into PID 1's namespaces to operate on the host kernel.
+
+Runs on ALL nodes (no nodeSelector, tolerates everything). Idempotent via `/var/lib/algif-mitigation/.configured` marker.
+
+**TODO — REMOVE this DaemonSet** once all nodes are running an AL2023 AMI with kernel 6.12.85+. Watch https://explore.alas.aws.amazon.com/CVE-2026-31431.html and the AMI pinnings tagged with the same TODO marker (`clusters.yaml`, `modules/nodepools/scripts/python/generate_nodepools.py`, `modules/buildkit/scripts/python/generate_buildkit.py`, `modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl`).
+
 ## Taint Summary
 
 | Taint Key | Type | Effect | Scope | Removed By |
@@ -179,4 +189,5 @@ This ensures DaemonSet pods schedule on nodes immediately at provisioning time, 
 | `modules/arc-runners/templates/runner.yaml.tpl` | Runner pod template with `wait-for-hooks` init container |
 | `base/kubernetes/registry-mirror-config.yaml` | Containerd registry mirror DaemonSet |
 | `base/kubernetes/node-performance-tuning.yaml` | CPU/GPU tuning DaemonSet |
+| `base/kubernetes/algif-mitigation.yaml` | TEMPORARY: blacklists algif_aead module to mitigate CVE-2026-31431 (remove when AL2023 AMI has kernel 6.12.85+) |
 | `modules/arc-runners/scripts/python/validate_runner_qos.py` | Deploy-time validation (checks hooks init container exists) |

--- a/osdc/modules/buildkit/scripts/python/generate_buildkit.py
+++ b/osdc/modules/buildkit/scripts/python/generate_buildkit.py
@@ -344,6 +344,10 @@ kind: EC2NodeClass
 metadata:
   name: buildkit-{arch}
 spec:
+  # TODO(CVE-2026-31431): al2023@latest tracks the newest AL2023 AMI; once node
+  # rotation picks up a kernel 6.12.85+ AMI, remove
+  # osdc/base/kubernetes/algif-mitigation.yaml.
+  # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
   amiSelectorTerms:
     - alias: al2023@latest
 

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -157,6 +157,11 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
         compactor_label = ""
 
     # ----- GPU vs CPU settings -----
+    # TODO(CVE-2026-31431): the AL2023 aliases / name globs below already track
+    # @latest, so node rotation picks up the fix automatically once AWS ships a
+    # kernel 6.12.85+ AMI. Once rolled out across all nodes, remove
+    # osdc/base/kubernetes/algif-mitigation.yaml.
+    # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
     if is_gpu:
         ami_family_block = "  amiFamily: AL2023"
         ami_selector_block = """  amiSelectorTerms:

--- a/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
@@ -8,6 +8,10 @@ kind: EC2NodeClass
 metadata:
   name: pypi-cache
 spec:
+  # TODO(CVE-2026-31431): al2023@latest tracks the newest AL2023 AMI; once node
+  # rotation picks up a kernel 6.12.85+ AMI, remove
+  # osdc/base/kubernetes/algif-mitigation.yaml.
+  # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
   amiSelectorTerms:
     - alias: al2023@latest
 


### PR DESCRIPTION
**Impact:** All nodes in all OSDC clusters (base infra, ARC runners, BuildKit, GPU, pypi-cache)
**Risk:** low

## What
Deploys a privileged DaemonSet to every node that blacklists the vulnerable `algif_aead` kernel module via `modprobe.d` and defensively unloads it if already present. Adds TODO breadcrumbs to every AMI pinning so the mitigation is removed once a patched kernel ships.

## Why
CVE-2026-31431 ("Copy Fail") is a Linux kernel local privilege escalation in the `algif_aead` AF_ALG interface (CVSS 7.8, CISA KEV). The flaw crosses container boundaries via the shared page cache — on a multi-tenant CI cluster, any unprivileged GitHub Actions workflow can escalate to root on the node. AL2023 ships `algif_aead` as a loadable module (`CONFIG_CRYPTO_USER_API_AEAD=m`) that is not loaded by default; no patched AMI (kernel 6.12.85+) is available yet.

## How
- Follows the established node-configuration DaemonSet pattern (`registry-mirror-config.yaml`): ConfigMap-backed script, privileged init container with `nsenter` into PID 1, idempotent marker file, `sleep infinity` sidecar
- `install algif_aead /bin/false` in `/etc/modprobe.d/` blocks future on-demand module loading; `modprobe -r` defensively removes it if something already triggered a load
- Runs on every node via `tolerations: [operator: Exists]` with no `nodeSelector` — covers base infra, Karpenter-managed (ARC, BuildKit, GPU, H100, B200), and pypi-cache nodes
- `priorityClassName: system-node-critical` ensures scheduling even under resource pressure
- TODO markers placed at every AMI pinning/selector (`clusters.yaml`, `generate_nodepools.py`, `generate_buildkit.py`, `ec2nodeclass.yaml.tpl`) so the mitigation is discoverable and removable in one pass

## Changes
- **New** `base/kubernetes/algif-mitigation.yaml` — ConfigMap + DaemonSet + ServiceAccount in `kube-system` that blacklists and unloads `algif_aead` on every node
- **Modified** `base/kubernetes/kustomization.yaml` — added `algif-mitigation.yaml` to the base resource list
- **Modified** `clusters.yaml` — TODO comment on `base_node_ami_version` linking to CVE tracker
- **Modified** `modules/nodepools/scripts/python/generate_nodepools.py` — TODO comment on AMI selector terms
- **Modified** `modules/buildkit/scripts/python/generate_buildkit.py` — TODO comment on AMI selector terms
- **Modified** `modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl` — TODO comment on AMI selector terms
- **Modified** `docs/node-warmup-and-scheduling-gates.md` — documented the new DaemonSet, its scope, idempotency, and removal criteria; added to the reference table

## Notes
- **Temporary mitigation** — this entire DaemonSet should be removed once all nodes are running an AL2023 AMI with kernel 6.12.85+. Track at https://explore.alas.aws.amazon.com/CVE-2026-31431.html
- All TODO markers are tagged `TODO(CVE-2026-31431)` for easy grep-based discovery
- If `algif_aead` is already loaded and in active use (open AF_ALG socket), `modprobe -r` will fail gracefully — new `bind()` calls are blocked but the vulnerable path stays reachable until node reboot
- The sleep sidecar uses minimal resources (10m CPU / 32Mi memory request)