### PR TITLE
Add A100 (p4de.24xlarge) on-demand GPU nodepool with 1/2/4/8x splits

### DIFF
--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-bx86iavx512-88-1000-a100-8 (8x NVIDIA A100 80GB, full node)
+# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+runner:
+  name: l-bx86iavx512-88-1000-a100-8
+  instance_type: p4de.24xlarge
+  disk_size: 200
+  vcpu: 88
+  memory: 1000Gi
+  gpu: 8

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
@@ -1,0 +1,10 @@
+# ARC runner definition: l-x86iavx512-11-125-a100 (1x NVIDIA A100 80GB)
+# Scheduled on NodePool: p4de-24xlarge (from nodepools module)
+# Resource math: 88 usable vCPU / 8 GPUs = 11 vCPU/GPU, 1000 GiB / 8 = 125 GiB/GPU
+runner:
+  name: l-x86iavx512-11-125-a100
+  instance_type: p4de.24xlarge
+  disk_size: 200
+  vcpu: 11
+  memory: 125Gi
+  gpu: 1

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-22-250-a100-2.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-22-250-a100-2.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-x86iavx512-22-250-a100-2 (2x NVIDIA A100 80GB)
+# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+runner:
+  name: l-x86iavx512-22-250-a100-2
+  instance_type: p4de.24xlarge
+  disk_size: 200
+  vcpu: 22
+  memory: 250Gi
+  gpu: 2

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
@@ -1,0 +1,9 @@
+# ARC runner definition: l-x86iavx512-44-500-a100-4 (4x NVIDIA A100 80GB)
+# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+runner:
+  name: l-x86iavx512-44-500-a100-4
+  instance_type: p4de.24xlarge
+  disk_size: 200
+  vcpu: 44
+  memory: 500Gi
+  gpu: 4

--- a/osdc/modules/nodepools/defs/p4de-24xlarge.yaml
+++ b/osdc/modules/nodepools/defs/p4de-24xlarge.yaml
@@ -1,0 +1,21 @@
+# Karpenter NodePool definition: p4de.24xlarge (GPU compute, 8x NVIDIA A100 80GB SXM4)
+# Used by: l-x86iavx512-11-125-a100, l-x86iavx512-22-250-a100-2, l-x86iavx512-44-500-a100-4, l-bx86iavx512-88-1000-a100-8
+# Capacity: on-demand (no Capacity Block reservation — AWS sells p4de.24xlarge on-demand,
+# Karpenter provisions on demand). Nodes scale fully with workload — no warm
+# floor; a cold start adds ~5-10 min to the first job after consolidation.
+# Node disk: 100Gi OS only — NVMe instance storage (8x1000GB) handles container data
+# Registry mirrors, CPU governor, and GPU persistence are configured by the base
+# registry-mirror-config and node-performance-tuning DaemonSets — no per-nodepool
+# user_data_script needed (same pattern as g5/g6/g4dn).
+nodepool:
+  name: p4de-24xlarge
+  instance_type: p4de.24xlarge
+  arch: amd64
+  node_disk_size: 100
+  gpu: true
+  has_nvme: true
+  topology_manager_policy: single-numa-node
+  topology_manager_scope: pod
+  baremetal: true
+  exclude_regions:
+    - us-west-1

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -92,6 +92,7 @@ INSTANCE_SPECS: dict[str, dict] = {
     "g4dn.metal": {"vcpu": 96, "memory_gib": 384, "memory_mi": 363724, "gpu": 8, "arch": "amd64"},
     "g5.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
     "g6.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
+    "p4de.24xlarge": {"vcpu": 96, "memory_gib": 1152, "memory_mi": 1090765, "gpu": 8, "arch": "amd64"},
     "p5.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     "p6-b200.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     # pypi-cache instances
@@ -173,6 +174,7 @@ ENI_MAX_PODS: dict[str, int] = {
     "g6.12xlarge": 234,
     "g6.24xlarge": 234,
     "g6.48xlarge": 737,
+    "p4de.24xlarge": 250,
     "p5.48xlarge": 198,
     "p6-b200.48xlarge": 198,
     # pypi-cache instance types

--- a/osdc/scripts/python/pytorch_workload_data.py
+++ b/osdc/scripts/python/pytorch_workload_data.py
@@ -63,6 +63,11 @@ OLD_TO_NEW_LABEL: dict[str, str] = {
     "a.linux.h100.2": "l-x86iamx-44-450-h100-2",
     "a.linux.h100.4": "l-x86iamx-88-900-h100-4",
     "a.linux.h100.8": "l-bx86iamx-176-1800-h100-8",
+    # x86 GPU — A100 (p4de)
+    "a.linux.a100": "l-x86iavx512-11-125-a100",
+    "a.linux.a100.2": "l-x86iavx512-22-250-a100-2",
+    "a.linux.a100.4": "l-x86iavx512-44-500-a100-4",
+    "a.linux.a100.8": "l-bx86iavx512-88-1000-a100-8",
     # ARM64
     "linux.arm64.2xlarge": "l-arm64g2-6-32",
     "linux.arm64.2xlarge.ephemeral": "l-arm64g2-6-32",


### PR DESCRIPTION
**Impact:** ARC runner infrastructure on arc-cbr-production (us-east-2)
**Risk:** low

## What

Adds the p4de.24xlarge nodepool (8x NVIDIA A100 80GB) to the existing
`nodepools` module and four ARC runner sizes (1x/2x/4x/8x A100) to the
existing `arc-runners` module. Karpenter provisions p4de nodes purely
on demand — no warm floor.

## Why

PyTorch CI workloads currently submit ~1,803 jobs / 30d to
`linux.aws.a100` peaking at 38 concurrent (per
`docs/current_runner_load_distribution.md`) — a workload tier OSDC has
no on-cluster equivalent for. p4de.24xlarge offers 8x A100 80GB
on-demand at ~$40.97/hr in us-east-2 without a Capacity Block
reservation, so Karpenter can provision it directly on demand.

## How

- p4de.24xlarge goes into the existing `nodepools` module (not a
separate `nodepools-a100`) because it is plain on-demand Karpenter —
same lifecycle as g5/g6/g4dn. The `nodepools-h100` / `nodepools-b200`
modules stay separate only because they are tied to per-cluster
Capacity Block reservation IDs with their own renewal lifecycle.
- Single-instance `nodepool:` def format (matching H100/B200) since
p4de.24xlarge has fixed topology requirements
(`single-numa-node`, `topology_manager_scope: pod`) that don't fit the
multi-instance fleet pattern.
- No per-nodepool `user_data_script`: registry mirrors, CPU governor,
and GPU persistence mode are already handled cluster-wide by the base
`registry-mirror-config` and `node-performance-tuning` DaemonSets,
which tolerate every Karpenter taint. Same pattern as g5/g6/g4dn.
- `exclude_regions: [us-west-1]` keeps the nodepool out of arc-staging
(matching the g5/g6 pattern).
- No `proactive_capacity` on any A100 runner def — at ~$40.97/hr per
node, holding warm capacity is too expensive to justify by default.
Nodes scale up only when real jobs arrive; jobs absorb the ~5-10 min
provisioning latency on cold start. If queue times prove painful in
practice, raise `proactive_capacity` on the 1x A100 runner.
- Per-runner split: 88 vCPU / 1000 GiB usable across 8 GPUs (kubelet
reserves the remaining 8 vCPU / 152 GiB), proportional 11/125, 22/250,
44/500, 88/1000 splits.
- Runner names use `iavx512` (p4de.24xlarge runs Intel Cascade Lake —
AVX-512, no AMX), distinguishing them from H100/B200 `iamx`-tagged
runners.

## Changes

- **New** `modules/nodepools/defs/p4de-24xlarge.yaml` — single-instance
NodePool def, on-demand, `baremetal: true` for slow consolidation,
`exclude_regions: [us-west-1]`
- **New** four runner defs in `modules/arc-runners/defs/`:
  - `l-x86iavx512-11-125-a100.yaml` (1x A100)
  - `l-x86iavx512-22-250-a100-2.yaml` (2x A100)
  - `l-x86iavx512-44-500-a100-4.yaml` (4x A100)
  - `l-bx86iavx512-88-1000-a100-8.yaml` (8x A100, full node)
- **Modified** `scripts/python/instance_specs.py` — added
`p4de.24xlarge` (96 vCPU, 1152 GiB, 8 GPU) and ENI_MAX_PODS=250
- **Modified** `scripts/python/pytorch_workload_data.py` — added
`a.linux.a100[.{2,4,8}]` → new label mappings

## Notes

- p4de capacity is sometimes regionally constrained — Karpenter will
surface `InsufficientInstanceCapacity` if AWS has no p4de left in
us-east-2. Jobs queue until capacity returns.
- Cost: p4de.24xlarge ≈ $40.97/hr on-demand list price (~2.5x
g5.48xlarge). Pure on-demand scaling means $0 idle cost; peak (38
concurrent observed) bills 5 nodes for the duration of the burst.
- All four runner defs are deployed to both arc-staging and
arc-cbr-production by the existing `arc-runners` module wiring; only
the cbr cluster has a backing nodepool, so staging scale sets exist
without compute (matching how g5/g6 runners already behave).

## Testing

```
just test    # all tests pass, 99% coverage
just lint    # 13 linters pass
just plan arc-cbr-production
```
