### PR TITLE
Scale up OSDC defaults for higher load

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -21,8 +21,8 @@
 
 defaults:
   # --- Terraform / base infra ---
-  base_node_count: 5
-  base_node_instance_type: m7i.4xlarge
+  base_node_count: 6
+  base_node_instance_type: m7i.12xlarge
   base_node_max_unavailable_percentage: 33
   # TODO(CVE-2026-31431): when bumping to a kernel 6.12.85+ AL2023 AMI,
   # remove osdc/base/kubernetes/algif-mitigation.yaml.
@@ -41,20 +41,20 @@ defaults:
 
   # --- Base component tuning ---
   harbor:
-    core_replicas: 2
-    registry_replicas: 2
-    nginx_replicas: 3
+    core_replicas: 4
+    registry_replicas: 4
+    nginx_replicas: 6
 
   # --- Module defaults ---
   karpenter:
-    replicas: 2
+    replicas: 4
     log_level: info
     pdb_enabled: true
     pdb_min_available: 1
   arc:
     chart_version: "0.14.1-jeanschmidt.9"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
-    replica_count: 2
+    replica_count: 4
     log_level: info
     controller_cpu_request: "1"
     controller_cpu_limit: "4"
@@ -67,13 +67,13 @@ defaults:
     min_nodes: 1
     dry_run: false
   nodepools:
-    gpu_consolidate_after: "20m"
+    gpu_consolidate_after: "40m"
     cpu_consolidate_after: "20m"
     baremetal_consolidate_after: "1h"
     gpu_disruption_budget: "20%"
     cpu_disruption_budget: "20%"
   buildkit:
-    replicas_per_arch: 4
+    replicas_per_arch: 5
   monitoring:
     grafana_cloud_url: "https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom/push"
     grafana_cloud_read_url: "https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom"
@@ -177,11 +177,11 @@ clusters:
     base:
       vpc_cidr: "10.4.0.0/16"
     git_cache:
-      central_replicas: 5
-      central_cpu_request: "6"
+      central_replicas: 15
+      central_cpu_request: "10"
       central_cpu_limit: "15"
-      central_memory_request: "8Gi"
-      central_memory_limit: "32Gi"
+      central_memory_request: "10Gi"
+      central_memory_limit: "50Gi"
     node_compactor:
       min_node_age_seconds: 900
     buildkit:
@@ -193,7 +193,7 @@ clusters:
       github_secret_name: pytorch-arc-cbr-production
       runner_name_prefix: "mt-"
     pypi_cache:
-      replicas: 5
+      replicas: 10
     modules:
       - karpenter
       - arc


### PR DESCRIPTION
**Impact:** All OSDC production and default cluster infrastructure (base nodes, Harbor, Karpenter, ARC, BuildKit, git cache, PyPI cache)
**Risk:** low
**Migration Complexity:** high

## What
Increases replica counts, resource allocations, and instance sizes across OSDC cluster defaults and the `arc-cbr-production` cluster to handle higher load.

## Why
Proactive scale-up to prevent service disruption under increased load. Taking a conservative "safer than sorry" approach — components can be scaled back down once we confirm the higher capacity is not needed.

## How
- Scales vertically (larger instance types, more CPU/memory) and horizontally (more replicas) in tandem
- Changes are applied at the defaults level where possible, so all clusters inherit the increase unless they override
- Production git cache and PyPI cache get significantly larger bumps than the defaults, reflecting their higher traffic
- GPU consolidation window doubled (20m -> 40m) to reduce churn under higher load, and reduce the likelyhood of giving instances back and not being able to get them again due to `InsufficientCapacity`.

## Changes

**Base infrastructure:**
- Base node count: 5 -> 6, instance type: m7i.4xlarge -> m7i.12xlarge (3x vCPUs/memory per node)

**Harbor (container registry cache):**
- Core replicas: 2 -> 4, registry replicas: 2 -> 4, nginx replicas: 3 -> 6

**Control plane components:**
- Karpenter replicas: 2 -> 4
- ARC controller replica count: 2 -> 4

**Build infrastructure:**
- BuildKit replicas per arch: 4 -> 5

**Node management:**
- GPU consolidation window: 20m -> 40m (more conservative node reclaim)

**arc-cbr-production overrides:**
- Git cache central replicas: 5 -> 15, CPU request: 6 -> 10, memory request: 8Gi -> 10Gi, memory limit: 32Gi -> 50Gi
- PyPI cache replicas: 5 -> 10

## Notes
- This is intentionally over-provisioned. Plan to evaluate actual utilization and scale back as appropriate.
- Staging cluster is unaffected — it has its own overrides.
- The m7i.12xlarge base nodes are 48 vCPU / 192 GiB each (up from 16 vCPU / 64 GiB), so total base node capacity increases roughly 3.6x (6 nodes * 3x resources vs 5 nodes * 1x).
- Base node (Critical taint) capacity stays 2x used capacity for disruption budgets without service interruption.

# Migration
The playbook to perform this migration with minimal disruption to live production traffic is outlined in the issue: https://github.com/pytorch/ci-infra/issues/535
