### PR TITLE
Fix prod smoke test failures from GPU submodules and admission-injected tolerations

### DIFF
--- a/osdc/modules/arc-runners/tests/smoke/conftest.py
+++ b/osdc/modules/arc-runners/tests/smoke/conftest.py
@@ -7,6 +7,7 @@ test).
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -14,47 +15,83 @@ import pytest
 import yaml
 from smoke_conftest import *  # noqa: F403
 
+# Submodules that delegate to arc-runners/deploy.sh with their own defs/
+# (e.g. arc-runners-b200, arc-runners-h100). They share the upstream template
+# but live under their own modules/ directory and emit YAMLs into their own
+# generated/ dir. The fixture below regenerates each one separately so the
+# coherence tests see ALL listener pods, not just the base arc-runners ones.
+_ARC_RUNNERS_MODULE_PREFIX = "arc-runners"
+
 
 @pytest.fixture(scope="session")
-def generated_arc_runners(cluster_id: str, upstream_dir: Path) -> dict[str, dict]:
+def generated_arc_runners(
+    cluster_id: str,
+    upstream_dir: Path,
+    enabled_modules: list[str],
+) -> dict[str, dict]:
     """Regenerate ARC runner YAMLs for the cluster and return them parsed.
 
-    Runs ``just generate-arc-runners <cluster>`` exactly once per pytest
-    session (session scope) so the on-disk generated YAMLs match the cluster
-    under test before any test reads them. This is the only legitimate way to
-    get post-override values (e.g. ``force_proactive_capacity_zero`` flips
-    ``CAPACITY_AWARE_PROACTIVE_CAPACITY`` to ``"0"`` on staging).
+    Runs ``just generate-arc-runners <cluster>`` exactly once per enabled
+    ``arc-runners*`` module (session scope). Per-class submodules
+    (arc-runners-b200, arc-runners-h100, ...) reuse the same generator with
+    ``ARC_RUNNERS_DEFS_DIR`` / ``ARC_RUNNERS_OUTPUT_DIR`` /
+    ``ARC_RUNNERS_MODULE_NAME`` overrides so their listener pods are covered
+    by the coherence tests too. Without this aggregation, listeners owned by
+    GPU submodules look like "stale scale-sets" to the test.
 
     Returns:
         Mapping ``def_name -> parsed first YAML document`` (the chart values
         block, which contains ``listenerTemplate``). The second YAML doc (the
         ConfigMap) is intentionally dropped — coherence tests only need the
-        listener env block.
+        listener env block. Def names are unique across modules.
     """
-    result = subprocess.run(
-        ["just", "generate-arc-runners", cluster_id],
-        cwd=str(upstream_dir),
-        capture_output=True,
-        text=True,
-        timeout=300,
-        check=False,
-    )
-    if result.returncode != 0:
-        pytest.fail(
-            f"`just generate-arc-runners {cluster_id}` failed (rc={result.returncode}):\n"
-            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
-        )
+    arc_modules = [
+        m for m in enabled_modules if m == _ARC_RUNNERS_MODULE_PREFIX or m.startswith(f"{_ARC_RUNNERS_MODULE_PREFIX}-")
+    ]
+    if not arc_modules:
+        pytest.skip("no arc-runners* modules enabled for this cluster")
 
-    generated_dir = upstream_dir / "modules" / "arc-runners" / "generated"
     out: dict[str, dict] = {}
-    for yaml_file in sorted(generated_dir.glob("*.yaml")):
-        # Each generated YAML is a multi-doc file: doc 1 = chart values (with
-        # listenerTemplate), doc 2 = job-pod hook ConfigMap. Coherence tests
-        # only consume doc 1; keep just that.
-        docs = list(yaml.safe_load_all(yaml_file.read_text()))
-        if not docs or not isinstance(docs[0], dict):
-            pytest.fail(f"Generated YAML {yaml_file} has no parseable first document")
-        out[yaml_file.stem] = docs[0]
+    for module in arc_modules:
+        module_dir = upstream_dir / "modules" / module
+        if not module_dir.is_dir():
+            # Consumer-only module not present in this checkout — skip rather
+            # than fail; the live cluster may still have its listeners, but
+            # we have no defs to validate them against here.
+            continue
+        defs_dir = module_dir / "defs"
+        generated_dir = module_dir / "generated"
+        env = {
+            **os.environ,
+            "ARC_RUNNERS_DEFS_DIR": str(defs_dir),
+            "ARC_RUNNERS_OUTPUT_DIR": str(generated_dir),
+            "ARC_RUNNERS_MODULE_NAME": module,
+        }
+        result = subprocess.run(
+            ["just", "generate-arc-runners", cluster_id],
+            cwd=str(upstream_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+            env=env,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"`just generate-arc-runners {cluster_id}` failed for module {module!r} "
+                f"(rc={result.returncode}):\n"
+                f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+            )
+
+        for yaml_file in sorted(generated_dir.glob("*.yaml")):
+            # Each generated YAML is a multi-doc file: doc 1 = chart values
+            # (with listenerTemplate), doc 2 = job-pod hook ConfigMap. Coherence
+            # tests only consume doc 1; keep just that.
+            docs = list(yaml.safe_load_all(yaml_file.read_text()))
+            if not docs or not isinstance(docs[0], dict):
+                pytest.fail(f"Generated YAML {yaml_file} has no parseable first document")
+            out[yaml_file.stem] = docs[0]
+
     if not out:
-        pytest.fail(f"No generated YAMLs found in {generated_dir} after running the recipe")
+        pytest.fail(f"No generated YAMLs found across enabled arc-runners modules: {arc_modules}")
     return out

--- a/osdc/modules/arc-runners/tests/smoke/conftest.py
+++ b/osdc/modules/arc-runners/tests/smoke/conftest.py
@@ -28,6 +28,7 @@ def generated_arc_runners(
     cluster_id: str,
     upstream_dir: Path,
     enabled_modules: list[str],
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> dict[str, dict]:
     """Regenerate ARC runner YAMLs for the cluster and return them parsed.
 
@@ -38,6 +39,12 @@ def generated_arc_runners(
     ``ARC_RUNNERS_MODULE_NAME`` overrides so their listener pods are covered
     by the coherence tests too. Without this aggregation, listeners owned by
     GPU submodules look like "stale scale-sets" to the test.
+
+    Output is redirected to a per-worker tmpdir rather than each module's
+    on-disk ``generated/`` directory: pytest-xdist runs this session-scoped
+    fixture once per worker, and concurrent regenerations into the same
+    repo path race (one worker can wipe-and-rewrite while another is mid-read,
+    yielding a ``FileNotFoundError``).
 
     Returns:
         Mapping ``def_name -> parsed first YAML document`` (the chart values
@@ -51,6 +58,8 @@ def generated_arc_runners(
     if not arc_modules:
         pytest.skip("no arc-runners* modules enabled for this cluster")
 
+    base_tmp = tmp_path_factory.mktemp("generated-arc-runners")
+
     out: dict[str, dict] = {}
     for module in arc_modules:
         module_dir = upstream_dir / "modules" / module
@@ -60,7 +69,8 @@ def generated_arc_runners(
             # we have no defs to validate them against here.
             continue
         defs_dir = module_dir / "defs"
-        generated_dir = module_dir / "generated"
+        generated_dir = base_tmp / module
+        generated_dir.mkdir(parents=True, exist_ok=True)
         env = {
             **os.environ,
             "ARC_RUNNERS_DEFS_DIR": str(defs_dir),

--- a/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
@@ -188,6 +188,23 @@ def _toleration_key(t: dict[str, Any]) -> tuple:
     return (t.get("key"), t.get("operator"), t.get("value"), t.get("effect"))
 
 
+# Tolerations the K8s `DefaultTolerationSeconds` admission controller injects
+# on every pod that doesn't already declare them. The placeholder pod is
+# observed LIVE (post-admission) while the workflow pod is loaded from the
+# hook ConfigMap (pre-admission template), so these would always appear as
+# spurious "excess" entries. Filter them out — when the workflow pod is
+# actually scheduled, admission will inject the same defaults.
+_K8S_DEFAULT_TOLERATION_KEYS = frozenset({"node.kubernetes.io/not-ready", "node.kubernetes.io/unreachable"})
+
+
+def _is_k8s_default_toleration(t: dict[str, Any]) -> bool:
+    return (
+        t.get("key") in _K8S_DEFAULT_TOLERATION_KEYS
+        and t.get("operator") == "Exists"
+        and t.get("effect") == "NoExecute"
+    )
+
+
 def _excess_tolerations(placeholder_spec: dict, workflow_spec: dict) -> list[dict]:
     """Return placeholder tolerations NOT present on the workflow pod.
 
@@ -196,7 +213,11 @@ def _excess_tolerations(placeholder_spec: dict, workflow_spec: dict) -> list[dic
     pod cannot. Returns [] when placeholder ⊆ workflow.
     """
     wf = {_toleration_key(t) for t in (workflow_spec.get("tolerations") or [])}
-    return [t for t in (placeholder_spec.get("tolerations") or []) if _toleration_key(t) not in wf]
+    return [
+        t
+        for t in (placeholder_spec.get("tolerations") or [])
+        if _toleration_key(t) not in wf and not _is_k8s_default_toleration(t)
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
@@ -188,21 +188,32 @@ def _toleration_key(t: dict[str, Any]) -> tuple:
     return (t.get("key"), t.get("operator"), t.get("value"), t.get("effect"))
 
 
-# Tolerations the K8s `DefaultTolerationSeconds` admission controller injects
-# on every pod that doesn't already declare them. The placeholder pod is
-# observed LIVE (post-admission) while the workflow pod is loaded from the
-# hook ConfigMap (pre-admission template), so these would always appear as
-# spurious "excess" entries. Filter them out — when the workflow pod is
-# actually scheduled, admission will inject the same defaults.
-_K8S_DEFAULT_TOLERATION_KEYS = frozenset({"node.kubernetes.io/not-ready", "node.kubernetes.io/unreachable"})
+# Tolerations injected by K8s admission controllers that are absent from the
+# pre-admission workflow pod template loaded from the hook ConfigMap. The
+# placeholder is observed LIVE (post-admission), so these would always
+# appear as spurious "excess" entries. Filter them on the placeholder side
+# — when the workflow pod is actually scheduled, admission will inject the
+# same tolerations.
+#
+# Sources:
+#   - DefaultTolerationSeconds → not-ready / unreachable @ NoExecute (300s)
+#     added to every pod that doesn't already declare them.
+#   - ExtendedResourceToleration → nvidia.com/gpu @ NoSchedule added to any
+#     pod requesting that extended resource. Workflow pods request the GPU
+#     so they get it; placeholders mirror it explicitly to land on the same
+#     nodes (placeholders themselves don't request the resource).
+_ADMISSION_NOEXECUTE_KEYS = frozenset({"node.kubernetes.io/not-ready", "node.kubernetes.io/unreachable"})
+_ADMISSION_NOSCHEDULE_EXTENDED_RESOURCE_KEYS = frozenset({"nvidia.com/gpu"})
 
 
-def _is_k8s_default_toleration(t: dict[str, Any]) -> bool:
-    return (
-        t.get("key") in _K8S_DEFAULT_TOLERATION_KEYS
-        and t.get("operator") == "Exists"
-        and t.get("effect") == "NoExecute"
-    )
+def _is_admission_injected_toleration(t: dict[str, Any]) -> bool:
+    if t.get("operator") != "Exists":
+        return False
+    effect = t.get("effect")
+    key = t.get("key")
+    if effect == "NoExecute" and key in _ADMISSION_NOEXECUTE_KEYS:
+        return True
+    return effect == "NoSchedule" and key in _ADMISSION_NOSCHEDULE_EXTENDED_RESOURCE_KEYS
 
 
 def _excess_tolerations(placeholder_spec: dict, workflow_spec: dict) -> list[dict]:
@@ -216,7 +227,7 @@ def _excess_tolerations(placeholder_spec: dict, workflow_spec: dict) -> list[dic
     return [
         t
         for t in (placeholder_spec.get("tolerations") or [])
-        if _toleration_key(t) not in wf and not _is_k8s_default_toleration(t)
+        if _toleration_key(t) not in wf and not _is_admission_injected_toleration(t)
     ]
 
 

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -2,7 +2,14 @@
 
 import pytest
 import yaml
-from helpers import get_recently_stable_node_names, get_unstable_node_names, run_aws, run_kubectl
+from helpers import (
+    RECENTLY_STABLE_AGE_SECONDS,
+    get_recently_stable_node_names,
+    get_unstable_node_names,
+    pod_age_seconds,
+    run_aws,
+    run_kubectl,
+)
 
 pytestmark = [pytest.mark.live, pytest.mark.aws]
 
@@ -121,13 +128,23 @@ class TestEKSAddons:
 
         not_running = []
         for p in pods:
-            if p["status"].get("phase") == "Running":
+            phase = p["status"].get("phase")
+            if phase == "Running":
                 continue
             node = p["spec"].get("nodeName")
             if node in unstable:
                 continue
-            if node in recently_stable and p["status"].get("phase") == "Pending":
-                continue
+            if phase == "Pending":
+                # Skip Pending pods that are still inside the startup window
+                # — either because the node itself is recently stable, or
+                # because the pod was freshly (re)scheduled (rolling restart,
+                # eviction) onto a long-stable node and is still pulling
+                # images / initializing containers.
+                if node in recently_stable:
+                    continue
+                age = pod_age_seconds(p)
+                if age is not None and age < RECENTLY_STABLE_AGE_SECONDS:
+                    continue
             not_running.append(p["metadata"]["name"])
 
         assert not not_running, (

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -2,7 +2,7 @@
 
 import pytest
 import yaml
-from helpers import get_unstable_node_names, run_aws, run_kubectl
+from helpers import get_recently_stable_node_names, get_unstable_node_names, run_aws, run_kubectl
 
 pytestmark = [pytest.mark.live, pytest.mark.aws]
 
@@ -113,15 +113,26 @@ class TestEKSAddons:
 
         nodes_result = run_kubectl(["get", "nodes"])
         unstable = get_unstable_node_names(nodes_result)
+        # Recently-stable nodes (between min_node_age and recently_stable_age)
+        # passed the unstable threshold but DaemonSet pods on them may still
+        # be pulling images or creating containers. Tolerate Pending phase
+        # there — same grace window the rest of the smoke suite applies.
+        recently_stable = get_recently_stable_node_names(nodes_result)
 
-        not_running = [
-            p["metadata"]["name"]
-            for p in pods
-            if p["status"].get("phase") != "Running" and p["spec"].get("nodeName") not in unstable
-        ]
+        not_running = []
+        for p in pods:
+            if p["status"].get("phase") == "Running":
+                continue
+            node = p["spec"].get("nodeName")
+            if node in unstable:
+                continue
+            if node in recently_stable and p["status"].get("phase") == "Pending":
+                continue
+            not_running.append(p["metadata"]["name"])
+
         assert not not_running, (
             f"Addon {addon_name} status is {status} and pods are unhealthy on stable nodes: "
-            f"{not_running} ({len(unstable)} unstable nodes excluded)"
+            f"{not_running} ({len(unstable)} unstable, {len(recently_stable)} recently-stable nodes excluded)"
         )
 
 

--- a/osdc/tests/smoke/helpers.py
+++ b/osdc/tests/smoke/helpers.py
@@ -190,6 +190,19 @@ def _parse_k8s_timestamp(ts: str) -> float:
     return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
 
 
+def pod_age_seconds(pod: dict) -> float | None:
+    """Pod age in seconds from metadata.creationTimestamp, or None if missing.
+
+    Use to grant a startup window to freshly-(re)scheduled pods independent
+    of node age — DaemonSets can roll/evict onto long-stable nodes, and the
+    new pod needs the same image-pull/init time as one on a young node.
+    """
+    created = pod.get("metadata", {}).get("creationTimestamp", "")
+    if not created:
+        return None
+    return time.time() - _parse_k8s_timestamp(created)
+
+
 def _is_node_unstable(node: dict, min_node_age: int = MIN_NODE_AGE_SECONDS) -> bool:
     """Check if a single node is unstable (new, NotReady, cordoned, or being deleted)."""
     meta = node.get("metadata", {})


### PR DESCRIPTION
## Summary

Fix four prod-smoke-test methodology bugs, all surfaced against `arc-cbr-production`. Production state is fine; the tests just had blind spots.

### `test_listener_env_vars_match_generated_yaml` — GPU submodules invisible to fixture
The `generated_arc_runners` fixture only regenerated YAMLs for the base `arc-runners` module, missing per-class submodules (`arc-runners-b200`, `arc-runners-h100`) that delegate to `arc-runners/deploy.sh` via `ARC_RUNNERS_*` env-var overrides. Eight GPU listeners (B200 + H100) were flagged as "stale scale-set". Now aggregates generated YAMLs across every enabled `arc-runners*` module.

### `generated_arc_runners` — xdist race writing into the shared `generated/` dir
pytest-xdist runs session-scoped fixtures once per worker. With each worker re-running the generator into the same on-disk `modules/<arc-runners*>/generated/` directories, two workers could wipe-and-rewrite the path while a third was mid-read, surfacing as `FileNotFoundError`. Redirect output to per-session tmpdirs via `tmp_path_factory`.

### `test_workflow_placeholder_parity` — comparing post-admission live placeholder vs pre-admission workflow template
Every placeholder pod was being flagged for tolerations the workflow pod template didn't declare. These are admission-controller-injected at runtime and absent from the raw template loaded from the hook ConfigMap:
- `DefaultTolerationSeconds` → `node.kubernetes.io/{not-ready,unreachable}:NoExecute:Exists` (300s) on every pod that doesn't already declare them.
- `ExtendedResourceToleration` → `nvidia.com/gpu:NoSchedule:Exists` on any pod requesting that extended resource. Workflow pods request the GPU and so receive it; placeholders mirror it explicitly to land on the same nodes.

Filter both classes from the placeholder side before the parity comparison — when the workflow pod is actually scheduled, admission injects the same tolerations.

### `TestEKSAddons.test_addon_healthy` — startup grace too narrow
The test excluded pods on "unstable" nodes (<10 min old, NotReady, cordoned, deleting) but treated everything else as fair game, even though the rest of the smoke suite uses a second window — "recently stable" nodes (10–20 min old) where DaemonSet pods may still be pulling images and `Pending` is expected. Two fixes layered:

1. Tolerate `Pending` phase on recently-stable nodes via `get_recently_stable_node_names`.
2. Tolerate `Pending` pods that are themselves young (< `RECENTLY_STABLE_AGE_SECONDS`) on any node — DaemonSets can roll-restart or get evicted onto long-stable nodes, and the freshly-scheduled pod needs the same image-pull/init window. Adds a `pod_age_seconds()` helper.

`Failed`/`Unknown` phases and `Pending` pods older than the window still fail the test.

## Test plan
- [x] `just lint`
- [x] `just test`
- [x] Smoke tests pass against `arc-staging`
- [x] Smoke tests pass against `arc-cbr-production`