### PR TITLE
Bump ARC prepare-job timeout to 2h to survive parallel Docker image builds

### DIFF
--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -295,11 +295,18 @@ template:
           # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.10
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS
             value: /home/runner/hook-extensions/wrapper.js
-          # Allow more time for workflow pods to come online during demand surges.
-          # Default is 600s (10 min), which is exceeded when node provisioning +
-          # git-cache sync takes longer than expected under concurrent load.
+          # PyTorch CI workflows depend on Docker images built in parallel by
+          # pytorch/pytorch's docker-builds.yml. Consumer jobs use test-infra's
+          # calculate-docker-image action, which polls ECR for the built image
+          # for up to 2h. While the image is still building, the workflow pod
+          # sits in ImagePullBackOff and the container hook stays in
+          # prepare_job's waitForPodPhases. Both runner and workflow pods are
+          # already protected from node disruption via the
+          # karpenter.sh/do-not-disrupt annotation set on each template; this
+          # timeout is the last knob that would otherwise fail the job before
+          # the image arrives.
           - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
-            value: "1500"
+            value: "7200"
           # Memory management: the runner pod has 1Gi shared between the .NET
           # runner agent and Node.js container hooks. Without explicit caps,
           # .NET claims 75% (768Mi) and Node.js claims 50% (512Mi) of the


### PR DESCRIPTION
**Impact:** All ARC runner scale sets across all clusters — runner pods that pick up jobs whose Docker image is being built in parallel **Risk:** low

## What
Raises `ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS` on every runner scale set from 1500s (25 min) to 7200s (2h), matching the upstream `calculate-docker-image` poll budget in pytorch/test-infra.

## Why
PyTorch CI workflows depend on Docker images built in parallel by pytorch/pytorch's `docker-builds.yml`. Consumer jobs use `pytorch/test-infra`'s `calculate-docker-image` action, which polls ECR for the built image for up to 2h
(https://github.com/pytorch/test-infra/blob/main/.github/actions/calculate-docker-image/action.yml#L142).

While the image is still building:
- The workflow pod sits in `ImagePullBackOff` (kubelet retries indefinitely with exponential backoff — no timeout there)
- The container hook is in `prepare_job`'s `waitForPodPhases`, polling for the workflow pod to reach `Running`
- The hook gives up at `ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS` and fails the job

At 1500s the hook fails after 25 min — which is shorter than the upstream 2h poll budget. Jobs that legitimately depend on a mid-build image fail with "failed to prepare job" instead of waiting the image into existence.

## How
Both runner pod and workflow pod already carry
`karpenter.sh/do-not-disrupt: "true"` (`runner.yaml.tpl:201` and `:377`), so Karpenter consolidation/expiration won't touch their nodes during the long wait. The node-compactor only applies `NoSchedule` taints (non-destructive to existing pods) and Karpenter's `WhenEmpty` respects `do-not-disrupt`. Kubelet image-pull-backoff has no timeout. The hook timeout is the last knob that would otherwise fail the job before the image arrives.

Applied uniformly across all RSS — Docker-image dependency is a pytorch-CI-wide pattern, not GPU- or capacity-specific. Re-used the existing template literal value with no per-RSS gating.

## Changes
- **`modules/arc-runners/templates/runner.yaml.tpl`** — bumped `ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS` from `"1500"` to `"7200"` and rewrote the inline comment to explain the actual motivation (parallel Docker image builds, not node provisioning slowness).

Generated YAMLs under `modules/arc-runners*/generated/` are gitignored and will be re-emitted at deploy time by `generate_runners.py` from the updated template.

## Notes
- 7200s exactly matches the upstream 2h poll budget. No buffer added — if the image isn't ready at the 2h mark the upstream action has already given up, so a longer hook timeout would just delay the failure without changing the outcome.
- A 2h prepare-job consumes 2h of GitHub's default 6h job timeout (`timeout-minutes: 360`). Workflows that override this to a smaller value can still run out of budget; that is up to the workflow author.
- No node-level changes (`min_node_age`, `consolidationPolicy`, `expireAfter`) are needed — existing `do-not-disrupt` annotations cover every disruption path I could enumerate.

## Testing
- `just lint` — all 13 linters pass
- `just test` — all unit tests pass (98.83% coverage)
- Regenerated all three RSS modules (`arc-runners`, `arc-runners-b200`, `arc-runners-h100`) and verified `value: "7200"` appears uniformly in every generated RSS YAML