### PR TITLE
Enable Fabric Manager and persistent IMEX on multi-GPU nodes

### DIFF
--- a/osdc/modules/nodepools-b200/scripts/b200-node-setup.sh
+++ b/osdc/modules/nodepools-b200/scripts/b200-node-setup.sh
@@ -69,4 +69,41 @@ systemctl enable cpu-performance.service
 
 # Enable GPU persistence mode for consistent performance
 nvidia-smi -pm 1 || true
+
+# ---- Fabric Manager + IMEX channel (required for NCCL NVLS multicast) ----
+# NVSwitch-connected multi-GPU nodes need the Fabric Manager running and the
+# IMEX channel device available for NCCL to use NVLS. Without these, any
+# multi-process NCCL collective will fail with:
+#   "Failed to bind NVLink SHARP (NVLS) Multicast memory"
+cat >/etc/modules-load.d/nvidia-caps-imex-channels.conf <<'EOFS'
+nvidia-caps-imex-channels
+EOFS
+
+systemctl enable nvidia-fabricmanager || {
+  echo "ERROR: failed to enable nvidia-fabricmanager" >&2
+  exit 1
+}
+
+systemctl start nvidia-fabricmanager || {
+  systemctl status nvidia-fabricmanager --no-pager || true
+  echo "ERROR: failed to start nvidia-fabricmanager" >&2
+  exit 1
+}
+
+systemctl is-active --quiet nvidia-fabricmanager || {
+  systemctl status nvidia-fabricmanager --no-pager || true
+  echo "ERROR: nvidia-fabricmanager is not active" >&2
+  exit 1
+}
+
+modprobe nvidia-caps-imex-channels || {
+  echo "ERROR: failed to load nvidia-caps-imex-channels" >&2
+  exit 1
+}
+
+if ! lsmod | grep -q '^nvidia_caps_imex_channels '; then
+  echo "ERROR: nvidia-caps-imex-channels is not loaded" >&2
+  exit 1
+fi
+
 echo "Performance configuration complete for p6-b200.48xlarge"

--- a/osdc/modules/nodepools-h100/scripts/h100-node-setup.sh
+++ b/osdc/modules/nodepools-h100/scripts/h100-node-setup.sh
@@ -69,4 +69,41 @@ systemctl enable cpu-performance.service
 
 # Enable GPU persistence mode for consistent performance
 nvidia-smi -pm 1 || true
+
+# ---- Fabric Manager + IMEX channel (required for NCCL NVLS multicast) ----
+# NVSwitch-connected multi-GPU nodes (p5.48xlarge) need the Fabric Manager
+# running and the IMEX channel device available for NCCL to use NVLS.
+# Without these, any multi-process NCCL collective will fail with:
+#   "Failed to bind NVLink SHARP (NVLS) Multicast memory"
+cat >/etc/modules-load.d/nvidia-caps-imex-channels.conf <<'EOFS'
+nvidia-caps-imex-channels
+EOFS
+
+systemctl enable nvidia-fabricmanager || {
+  echo "ERROR: failed to enable nvidia-fabricmanager" >&2
+  exit 1
+}
+
+systemctl start nvidia-fabricmanager || {
+  systemctl status nvidia-fabricmanager --no-pager || true
+  echo "ERROR: failed to start nvidia-fabricmanager" >&2
+  exit 1
+}
+
+systemctl is-active --quiet nvidia-fabricmanager || {
+  systemctl status nvidia-fabricmanager --no-pager || true
+  echo "ERROR: nvidia-fabricmanager is not active" >&2
+  exit 1
+}
+
+modprobe nvidia-caps-imex-channels || {
+  echo "ERROR: failed to load nvidia-caps-imex-channels" >&2
+  exit 1
+}
+
+if ! lsmod | grep -q '^nvidia_caps_imex_channels '; then
+  echo "ERROR: nvidia-caps-imex-channels is not loaded" >&2
+  exit 1
+fi
+
 echo "Performance configuration complete for p5.48xlarge"


### PR DESCRIPTION
## Summary

- Enable `nvidia-fabricmanager` and load `nvidia-caps-imex-channels` kernel module at cloud-init time on H100 (p5.48xlarge) and B200 (p6-b200.48xlarge) multi-GPU nodes
- Persist the module via `/etc/modules-load.d/` so it survives reboots
- Hard-fail node setup if any step fails, so broken nodes don't enter the pool

## Context

The H100 distributed CI job (`linux.aws.h100.8`) has a **100% failure rate** — every run across 2000+ commits fails with:

```
Failed to bind NVLink SHARP (NVLS) Multicast memory of size 2097152:
CUDA error 401 'the operation cannot be performed in the present state'.
This is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.
```

NCCL 2.29.7 tries to use NVLS multicast on NVSwitch-connected H100 SXM5 nodes, but the Fabric Manager service isn't running and the IMEX channel device isn't available. This causes every multi-process NCCL collective to fail at `ncclCommInit` time.

## Test plan

- [ ] Deploy to a staging H100 node and verify `systemctl is-active nvidia-fabricmanager` returns active
- [ ] Verify `lsmod | grep nvidia_caps_imex_channels` shows the module loaded
- [ ] Re-run the `h100_distributed` CI job and confirm the NVLS multicast error is gone
- [ ] Verify the B200 node setup also completes without errors

Authored with Claude.