### PR TITLE
Switch A100 nodepool from p4de.24xlarge to p4d.24xlarge

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -39,7 +39,7 @@ If either fails, fix the issues before finishing. Do not defer lint or test fail
 
 ## GPU Fleet Unification & NUMA Topology
 
-GPU families (g5, g6, g4dn) use unified single-fleet definitions (all GPU counts in one fleet). GPU allocation is handled by `nvidia.com/gpu` resource requests, not fleet-level isolation. Default `topologyManagerPolicy` is `best-effort`; multi-NUMA GPU instances (p4de, p5, p6-b200) override per-def to `single-numa-node` to prevent NUMA fragmentation and TopologyAffinityError livelocks under mixed GPU packing. See `actions-knowledge-base/docs/osdc/numa-topology-gpu-fleet-unification.md` for details.
+GPU families (g5, g6, g4dn) use unified single-fleet definitions (all GPU counts in one fleet). GPU allocation is handled by `nvidia.com/gpu` resource requests, not fleet-level isolation. Default `topologyManagerPolicy` is `best-effort`; multi-NUMA GPU instances (p4d, p5, p6-b200) override per-def to `single-numa-node` to prevent NUMA fragmentation and TopologyAffinityError livelocks under mixed GPU packing. See `actions-knowledge-base/docs/osdc/numa-topology-gpu-fleet-unification.md` for details.
 
 ## Skills Reference
 

--- a/osdc/docs/current_runner_load_distribution.md
+++ b/osdc/docs/current_runner_load_distribution.md
@@ -4,7 +4,7 @@ Job counts and peak concurrency by runner type over the last 30 days. Source: `d
 
 > **Staleness note:** The load tables below are a point-in-time snapshot from 2026-03-18. They do **not** reflect changes made since then, including:
 > - H100 runners (`l-x86iamx-22-225-h100`, `…-2`, `…-4`, `…-8` on `nodepools-h100/p5-48xlarge`, added 2026-05-01).
-> - A100 runners (`l-x86iavx512-11-125-a100`, `…-2`, `…-4`, `l-bx86iavx512-88-1000-a100-8` on `nodepools/p4de-24xlarge`, added 2026-05-06).
+> - A100 runners (`l-x86iavx512-11-125-a100`, `…-2`, `…-4`, `l-bx86iavx512-88-1000-a100-8` on `nodepools/p4d-24xlarge`, added 2026-05-06).
 > - The `c7i-runner` Karpenter NodePool (proactive-capacity PoC; isolated from the shared `c7i` pool by the `node-fleet=c7i-runner` taint).
 > - Release runners (`rel-l-arm64g4-16-62`, `rel-l-x86iavx512-8-64`) on `m8g-48xlarge-release` / `r7a-48xlarge-release` nodepools — they have `proactive_capacity: 30` and consume real fleet capacity but are not modelled because they don't run pytorch/pytorch jobs.
 >
@@ -152,7 +152,7 @@ Estimated node count and resource usage when all runners hit their peak concurre
 
 **Date:** 2026-03-24. **Scope:** pytorch/pytorch self-hosted Linux runners only (same scope as the load data above). Runner types with no old-label mapping (e.g., some AMX variants on c7i.12xlarge and r7i.48xlarge) are not included — actual fleet will be slightly larger.
 
-> **Stale snapshot.** The fleet sizing below predates the H100 (`nodepools-h100/p5-48xlarge`, 8x H100 reserved-capacity nodes), A100 (`nodepools/p4de-24xlarge`, on-demand), and `c7i-runner` nodepools. Reserved-capacity GPU nodes don't terminate during low-load periods — they sit warm — so the daily-churn model below also no longer holds for the GPU portion of the fleet. Re-run `just simulate-cluster` after the next load-data refresh.
+> **Stale snapshot.** The fleet sizing below predates the H100 (`nodepools-h100/p5-48xlarge`, 8x H100 reserved-capacity nodes), A100 (`nodepools/p4d-24xlarge`, on-demand), and `c7i-runner` nodepools. Reserved-capacity GPU nodes don't terminate during low-load periods — they sit warm — so the daily-churn model below also no longer holds for the GPU portion of the fleet. Re-run `just simulate-cluster` after the next load-data refresh.
 >
 > **Release runners excluded.** `rel-l-arm64g4-16-62` (m8g.48xlarge-release) and `rel-l-x86iavx512-8-64` (r7a.48xlarge-release) are in the fleet but `runner_class: release` and serve no pytorch/pytorch jobs; their `proactive_capacity: 30` floor still consumes nodes that are not represented in the totals below.
 

--- a/osdc/docs/node-utilization-optimization.md
+++ b/osdc/docs/node-utilization-optimization.md
@@ -70,7 +70,7 @@ Runners have ISA (instruction set) requirements encoded in their names that cons
 | g4dn.12xlarge | 48c/192Gi @ $3.91/hr | 1 (T4) | **95.6%** | `l-x86iavx512-45-172-t4-4` fills the node (FIXED) |
 | g4dn.metal | 96c/384Gi @ $7.82/hr | 1 (T4) | 96.0% | Good — `l-bx86iavx512-94-344-t4-8` fills the node |
 | p6-b200.48xlarge | 192c/2048Gi @ $55.47/hr | 4 (B200) | 88.1% | Good — runners scale proportionally to GPU count |
-| p4de.24xlarge | 96c/1152Gi (8x A100) | 4 (A100) | n/a | Added after this snapshot — `l-x86iavx512-{11-125,22-250,44-500}-a100*` + `l-bx86iavx512-88-1000-a100-8`, 1/2/4/8 GPU splits |
+| p4d.24xlarge | 96c/1152Gi (8x A100) | 4 (A100) | n/a | Added after this snapshot — `l-x86iavx512-{11-125,22-250,44-500}-a100*` + `l-bx86iavx512-88-1000-a100-8`, 1/2/4/8 GPU splits |
 | p5.48xlarge | 192c/2048Gi (8x H100) | 4 (H100) | n/a | Added after this snapshot — `l-x86iamx-{22-225,44-450,88-900}-h100*` + `l-bx86iamx-176-1800-h100-8`, 1/2/4/8 GPU splits |
 
 ### Critical Issue: T4 Runner Cannot Schedule (RESOLVED)
@@ -161,7 +161,7 @@ GPU nodepools are constrained by GPU count, limiting instance options. The curre
 
 This increased from 8 to 14 nodepool defs in the original Phase 2 plan. Each nodepool is a Karpenter NodePool CRD — lightweight, no ongoing cost. The infrastructure impact is minimal.
 
-**Post-snapshot state**: After commit `fa950b4` ("Migrate nodepool defs from single-instance to fleet format"), the per-instance-size nodepool defs were collapsed into family-level **fleet** files. Each fleet lists multiple weighted instance sizes (`c7i.48xlarge`, `c7i.24xlarge`, …) and Karpenter picks an appropriate size per workload. The current `modules/nodepools/defs/` directory holds 14 fleet files (`c7a`, `c7i`, `c7i-runner`, `g4dn`, `g5`, `g6`, `m6i`, `m7i`, `m8g`, `p4de-24xlarge`, `r5`, `r7a`, `r7g`, `r7i`), plus separate `nodepools-h100/defs/p5-48xlarge.yaml` and `nodepools-b200/defs/p6-b200-48xlarge.yaml`. The runner-to-instance-size pinning shown above is now a soft preference (fleet weights), not a hard one-pool-per-size split.
+**Post-snapshot state**: After commit `fa950b4` ("Migrate nodepool defs from single-instance to fleet format"), the per-instance-size nodepool defs were collapsed into family-level **fleet** files. Each fleet lists multiple weighted instance sizes (`c7i.48xlarge`, `c7i.24xlarge`, …) and Karpenter picks an appropriate size per workload. The current `modules/nodepools/defs/` directory holds 14 fleet files (`c7a`, `c7i`, `c7i-runner`, `g4dn`, `g5`, `g6`, `m6i`, `m7i`, `m8g`, `p4d-24xlarge`, `r5`, `r7a`, `r7g`, `r7i`), plus separate `nodepools-h100/defs/p5-48xlarge.yaml` and `nodepools-b200/defs/p6-b200-48xlarge.yaml`. The runner-to-instance-size pinning shown above is now a soft preference (fleet weights), not a hard one-pool-per-size split.
 
 **Dedicated runner pool (`c7i-runner`)**: Added after this snapshot for the proactive-capacity / preemption design. It is a name-only clone of the `c7i` fleet, separated by the `node-fleet=c7i-runner` taint, and hosts the lightweight ARC runner pods (placeholders) — workflow pods continue to land on c7a/c7i/m7i/etc. See `PROACTIVE_CAPACITY.md`.
 

--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -69,7 +69,7 @@ Runner pods include an init container that polls for a file on the host filesyst
 - Extracts to `/mnt/runner-container-hooks/dist/` on host NVMe
 - Validates `dist/index.js` exists after extraction
 - Writes version marker for idempotency
-- Pinned via `nodeSelector: node-fleet: c7i-runner` — runs only on the dedicated c7i-runner pool, where runner pods live. Workflow-pool nodes and GPU runner pools (g4dn/g5/g6/p4de/p5/p6) do NOT get this DaemonSet because runner pods never schedule there.
+- Pinned via `nodeSelector: node-fleet: c7i-runner` — runs only on the dedicated c7i-runner pool, where runner pods live. Workflow-pool nodes and GPU runner pools (g4dn/g5/g6/p4d/p5/p6) do NOT get this DaemonSet because runner pods never schedule there.
 
 **Init container**: `wait-for-hooks` (`modules/arc-runners/templates/runner.yaml.tpl`)
 - Polls `/mnt/host-hooks/dist/index.js` every 10 seconds
@@ -145,7 +145,7 @@ Runs on ALL nodes (no nodeSelector, tolerates everything). Idempotent via `/var/
 | `instance-type={type}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (scheduling constraint) |
 | `node-fleet={fleet}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (fleet-based scheduling) |
 | `workload/buildkit-{arch}=true` | Permanent | `NoSchedule` | BuildKit NodePools | Never (scheduling constraint) |
-| `nvidia.com/gpu=true` | Permanent | `NoSchedule` | GPU NodePools only — applied by both the standard `generate_nodepools.py` (g4dn, g5, g6, p4de) and the specialized H100 (`modules/nodepools-h100`) and B200 (`modules/nodepools-b200`) generators. H100/B200 pools also pin `topology_manager_policy: single-numa-node` (scope `pod`) instead of the runner default (`best-effort`/`container`). | Never (scheduling constraint) |
+| `nvidia.com/gpu=true` | Permanent | `NoSchedule` | GPU NodePools only — applied by both the standard `generate_nodepools.py` (g4dn, g5, g6, p4d) and the specialized H100 (`modules/nodepools-h100`) and B200 (`modules/nodepools-b200`) generators. H100/B200 pools also pin `topology_manager_policy: single-numa-node` (scope `pod`) instead of the runner default (`best-effort`/`container`). | Never (scheduling constraint) |
 | `node-compactor.osdc.io/consolidating=true` | Runtime (dynamic) | `NoSchedule` | Applied by node-compactor | node-compactor controller (protected by `min_node_age`: 900s) |
 | `CriticalAddonsOnly=true` | Permanent | `NoSchedule` | Base infrastructure nodes (EKS-managed) | Never |
 

--- a/osdc/docs/runner_naming_convention.md
+++ b/osdc/docs/runner_naming_convention.md
@@ -30,7 +30,7 @@ Reference: [actions/actions-runner-controller#2697](https://github.com/actions/a
 | `features` | Yes (x86 only) | CPU instruction set extensions — tells the workflow what SIMD/AI instructions are available | `avx2` = AVX2, `avx512` = AVX-512, `amx` = Intel AMX (Advanced Matrix Extensions) |
 | `vcpu` | Yes | Number of vCPUs allocated to the runner | Integer (e.g. `2`, `8`, `16`, `48`, `94`) |
 | `memory` | Yes | Memory in GiB allocated to the runner | Integer (e.g. `4`, `16`, `64`, `192`, `768`) |
-| `gpu_type` | No | GPU model (omitted for CPU-only runners) | `t4` = NVIDIA T4, `a10g` = NVIDIA A10G, `l4` = NVIDIA L4, `a100` = NVIDIA A100 80GB, `h100` = NVIDIA H100, `b200` = NVIDIA B200 |
+| `gpu_type` | No | GPU model (omitted for CPU-only runners) | `t4` = NVIDIA T4, `a10g` = NVIDIA A10G, `l4` = NVIDIA L4, `a100` = NVIDIA A100 40GB, `h100` = NVIDIA H100, `b200` = NVIDIA B200 |
 | `gpu_count` | No | Number of GPUs (omitted when count is 1) | Integer (e.g. `4`, `8`) |
 
 ## Examples
@@ -177,15 +177,15 @@ Additional AMX runners (no direct old-label mapping; provisioned for OSDC CI wor
 | a.linux.h100.4 | p5.48xlarge | mt-l-x86iamx-88-900-h100-4 |
 | a.linux.h100.8 | p5.48xlarge | mt-l-bx86iamx-176-1800-h100-8 |
 
-### x86 GPU — A100 (p4de family)
+### x86 GPU — A100 (p4d family)
 
 
 | **Old Label** | **Instance** | **New Label** |
 | --- | --- | --- |
-| a.linux.a100 | p4de.24xlarge | mt-l-x86iavx512-11-125-a100 |
-| a.linux.a100.2 | p4de.24xlarge | mt-l-x86iavx512-22-250-a100-2 |
-| a.linux.a100.4 | p4de.24xlarge | mt-l-x86iavx512-44-500-a100-4 |
-| a.linux.a100.8 | p4de.24xlarge | mt-l-bx86iavx512-88-1000-a100-8 |
+| a.linux.a100 | p4d.24xlarge | mt-l-x86iavx512-11-125-a100 |
+| a.linux.a100.2 | p4d.24xlarge | mt-l-x86iavx512-22-250-a100-2 |
+| a.linux.a100.4 | p4d.24xlarge | mt-l-x86iavx512-44-500-a100-4 |
+| a.linux.a100.8 | p4d.24xlarge | mt-l-bx86iavx512-88-1000-a100-8 |
 
 ### x86 GPU — V100 (p3 family)
 

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
@@ -1,8 +1,8 @@
-# ARC runner definition: l-bx86iavx512-88-1000-a100-8 (8x NVIDIA A100 80GB, full node)
-# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+# ARC runner definition: l-bx86iavx512-88-1000-a100-8 (8x NVIDIA A100 40GB, full node)
+# Scheduled on NodePool: p4d-24xlarge (from nodepools module)
 runner:
   name: l-bx86iavx512-88-1000-a100-8
-  instance_type: p4de.24xlarge
+  instance_type: p4d.24xlarge
   disk_size: 200
   vcpu: 88
   memory: 1000Gi

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
@@ -1,9 +1,9 @@
-# ARC runner definition: l-x86iavx512-11-125-a100 (1x NVIDIA A100 80GB)
-# Scheduled on NodePool: p4de-24xlarge (from nodepools module)
+# ARC runner definition: l-x86iavx512-11-125-a100 (1x NVIDIA A100 40GB)
+# Scheduled on NodePool: p4d-24xlarge (from nodepools module)
 # Resource math: 88 usable vCPU / 8 GPUs = 11 vCPU/GPU, 1000 GiB / 8 = 125 GiB/GPU
 runner:
   name: l-x86iavx512-11-125-a100
-  instance_type: p4de.24xlarge
+  instance_type: p4d.24xlarge
   disk_size: 200
   vcpu: 11
   memory: 125Gi

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-22-250-a100-2.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-22-250-a100-2.yaml
@@ -1,8 +1,8 @@
-# ARC runner definition: l-x86iavx512-22-250-a100-2 (2x NVIDIA A100 80GB)
-# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+# ARC runner definition: l-x86iavx512-22-250-a100-2 (2x NVIDIA A100 40GB)
+# Scheduled on NodePool: p4d-24xlarge (from nodepools module)
 runner:
   name: l-x86iavx512-22-250-a100-2
-  instance_type: p4de.24xlarge
+  instance_type: p4d.24xlarge
   disk_size: 200
   vcpu: 22
   memory: 250Gi

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
@@ -1,8 +1,8 @@
-# ARC runner definition: l-x86iavx512-44-500-a100-4 (4x NVIDIA A100 80GB)
-# Scheduled on NodePool: p4de-24xlarge (from nodepools-a100 module)
+# ARC runner definition: l-x86iavx512-44-500-a100-4 (4x NVIDIA A100 40GB)
+# Scheduled on NodePool: p4d-24xlarge (from nodepools module)
 runner:
   name: l-x86iavx512-44-500-a100-4
-  instance_type: p4de.24xlarge
+  instance_type: p4d.24xlarge
   disk_size: 200
   vcpu: 44
   memory: 500Gi

--- a/osdc/modules/nodepools/defs/p4d-24xlarge.yaml
+++ b/osdc/modules/nodepools/defs/p4d-24xlarge.yaml
@@ -1,6 +1,6 @@
-# Karpenter NodePool definition: p4de.24xlarge (GPU compute, 8x NVIDIA A100 80GB SXM4)
+# Karpenter NodePool definition: p4d.24xlarge (GPU compute, 8x NVIDIA A100 40GB SXM4)
 # Used by: l-x86iavx512-11-125-a100, l-x86iavx512-22-250-a100-2, l-x86iavx512-44-500-a100-4, l-bx86iavx512-88-1000-a100-8
-# Capacity: on-demand (no Capacity Block reservation — AWS sells p4de.24xlarge on-demand,
+# Capacity: on-demand (no Capacity Block reservation — AWS sells p4d.24xlarge on-demand,
 # Karpenter provisions on demand). Nodes scale fully with workload — no warm
 # floor; a cold start adds ~5-10 min to the first job after consolidation.
 # Node disk: 100Gi OS only — NVMe instance storage (8x1000GB) handles container data
@@ -8,8 +8,8 @@
 # registry-mirror-config and node-performance-tuning DaemonSets — no per-nodepool
 # user_data_script needed (same pattern as g5/g6/g4dn).
 nodepool:
-  name: p4de-24xlarge
-  instance_type: p4de.24xlarge
+  name: p4d-24xlarge
+  instance_type: p4d.24xlarge
   arch: amd64
   node_disk_size: 100
   gpu: true

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -92,7 +92,7 @@ INSTANCE_SPECS: dict[str, dict] = {
     "g4dn.metal": {"vcpu": 96, "memory_gib": 384, "memory_mi": 363724, "gpu": 8, "arch": "amd64"},
     "g5.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
     "g6.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 8, "arch": "amd64"},
-    "p4de.24xlarge": {"vcpu": 96, "memory_gib": 1152, "memory_mi": 1090765, "gpu": 8, "arch": "amd64"},
+    "p4d.24xlarge": {"vcpu": 96, "memory_gib": 1152, "memory_mi": 1090765, "gpu": 8, "arch": "amd64"},
     "p5.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     "p6-b200.48xlarge": {"vcpu": 192, "memory_gib": 2048, "memory_mi": 1939865, "gpu": 8, "arch": "amd64"},
     # pypi-cache instances
@@ -174,7 +174,7 @@ ENI_MAX_PODS: dict[str, int] = {
     "g6.12xlarge": 234,
     "g6.24xlarge": 234,
     "g6.48xlarge": 737,
-    "p4de.24xlarge": 250,
+    "p4d.24xlarge": 250,
     "p5.48xlarge": 198,
     "p6-b200.48xlarge": 198,
     # pypi-cache instance types

--- a/osdc/scripts/python/pytorch_workload_data.py
+++ b/osdc/scripts/python/pytorch_workload_data.py
@@ -63,7 +63,7 @@ OLD_TO_NEW_LABEL: dict[str, str] = {
     "a.linux.h100.2": "l-x86iamx-44-450-h100-2",
     "a.linux.h100.4": "l-x86iamx-88-900-h100-4",
     "a.linux.h100.8": "l-bx86iamx-176-1800-h100-8",
-    # x86 GPU — A100 (p4de)
+    # x86 GPU — A100 (p4d)
     "a.linux.a100": "l-x86iavx512-11-125-a100",
     "a.linux.a100.2": "l-x86iavx512-22-250-a100-2",
     "a.linux.a100.4": "l-x86iavx512-44-500-a100-4",


### PR DESCRIPTION
**Impact:** A100 runners on arc-cbr-production
**Risk:** low (no live A100 nodes ever provisioned — current pool is empty)

## What

Renames `nodepools/defs/p4de-24xlarge.yaml` → `p4d-24xlarge.yaml` and flips `instance_type: p4de.24xlarge` → `p4d.24xlarge` across:
- the four A100 runner defs (1×/2×/4×/8×) in `modules/arc-runners/defs/`
- `scripts/python/instance_specs.py` (specs + max-pods table)
- `scripts/python/pytorch_workload_data.py` (section comment)
- four docs (`runner_naming_convention.md`, `node-utilization-optimization.md`, `node-warmup-and-scheduling-gates.md`, `current_runner_load_distribution.md`)
- `CLAUDE.md` (multi-NUMA GPU list)

GPU memory mentions updated from "A100 80GB" → "A100 40GB". CPU and RAM math is unchanged because both instance types are 96 vCPU / 1152 GiB.

## Why

`p4de.24xlarge` is **not offered by AWS in `us-east-2`**, where `pytorch-arc-cbr-production` lives:

```
$ aws ec2 describe-instance-type-offerings --region us-east-2 \
    --filters Name=instance-type,Values=p4de.24xlarge
{ "InstanceTypeOfferings": [] }
```

After PR #534 deployed, the resulting Karpenter NodePool was healthy (`Ready=True`) but provisioned zero nodes. Karpenter logged `skipping, nodepool requirements filtered out all instance types` for `p4de-24xlarge` every reconcile, and 230+ A100 placeholder workflow pods sat `Pending`. p4de is offered in us-east-1 / us-west-2 / eu-central-1 / ap-northeast-1 / ap-southeast-1, but not us-east-2.

`p4d.24xlarge` (40 GB A100 instead of 80 GB) **is** offered in us-east-2 across all three AZs (a, b, c) and on-demand without a Capacity Reservation, so Karpenter can provision it the same way the PR #534 nodepool was originally intended.

## How

- Same vCPU (96), RAM (1152 GiB), 8× A100, 100 Gbps network → all resource math in the runner defs (`11/125`, `22/250`, `44/500`, `88/1000`) stays valid.
- Only spec change is GPU VRAM: 80 GB → 40 GB. Workloads that need
  >40 GB per GPU will OOM and need to land elsewhere.
- `exclude_regions: [us-west-1]` is preserved — p4d isn't offered in us-west-1 either.

## Notes

- This **does not** unblock the currently-stuck pytorch CI run waiting on `mt-l-x86iavx512-11-125-a100`. The four A100 runner defs are also missing `proactive_capacity` / `max_burst_capacity`, which makes the ARC listener advertise 0 capacity to GitHub regardless of nodepool state. That fix is intentionally separate.

## Testing

```
just test    # 98.83% coverage, all tests pass (1m18s)
just lint    # 13/13 linters pass (11s)
```

A100 test run https://github.com/pytorch/pytorch/actions/runs/25471464987