### PR TITLE
Add drain-runners and resume-runners recipes to justfile

### DIFF
--- a/osdc/justfile
+++ b/osdc/justfile
@@ -706,6 +706,164 @@ untaint-nodes cluster:
         echo "Warning: $FAILED node(s) failed to untaint. Re-run to retry."
     fi
 
+# Drain ARC runner scale sets cluster-wide and wait for in-flight runner pods to finish
+drain-runners cluster:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export OSDC_ROOT="{{ROOT}}"
+    export OSDC_UPSTREAM="{{UPSTREAM}}"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+
+    # Ensure kubectl is configured for the target cluster
+    just kubeconfig "$CLUSTER"
+
+    echo "Draining ARC runner scale sets for $CLUSTER ($CNAME)..."
+    echo ""
+
+    ARS_NAMES=$(kubectl get autoscalingrunnersets -n arc-runners --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null || true)
+    if [ -z "$ARS_NAMES" ]; then
+        echo "  No AutoscalingRunnerSets found in arc-runners — nothing to drain."
+        DRAINED=0
+        ALREADY=0
+        ARS_FAILED=0
+    else
+        DRAINED=0
+        ALREADY=0
+        ARS_FAILED=0
+        for ars in $ARS_NAMES; do
+            CURRENT=$(kubectl get autoscalingrunnerset "$ars" -n arc-runners -o jsonpath='{.spec.maxRunners}' 2>/dev/null || echo "")
+            if [ "$CURRENT" = "0" ]; then
+                echo "  $ars — already at 0"
+                ALREADY=$((ALREADY + 1))
+                continue
+            fi
+            if PATCH_OUT=$(kubectl patch autoscalingrunnerset "$ars" -n arc-runners --type=merge -p '{"spec":{"maxRunners":0}}' 2>&1); then
+                echo "  $ars — drained (maxRunners=0)"
+                DRAINED=$((DRAINED + 1))
+            else
+                echo "  $ars — FAILED: ${PATCH_OUT}"
+                ARS_FAILED=$((ARS_FAILED + 1))
+            fi
+        done
+    fi
+
+    echo ""
+    echo "Applying refresh taint to runner nodes..."
+    just taint-nodes "$CLUSTER"
+    TAINTED_NODES=$(kubectl get nodes -l workload-type=github-runner --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+    echo ""
+    # Default 1h covers typical PyTorch suite duration; override via OSDC_DRAIN_TIMEOUT_SECS for longer/shorter windows.
+    DRAIN_TIMEOUT="${OSDC_DRAIN_TIMEOUT_SECS:-3600}"
+    DRAIN_INTERVAL=30
+    echo "Waiting for in-flight runner pods to drain (timeout: ${DRAIN_TIMEOUT}s)..."
+    SECONDS=0
+    DRAIN_DEADLINE=$((SECONDS + DRAIN_TIMEOUT))
+    REMAINING=$(kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    while [ "$REMAINING" -gt 0 ] && [ "$SECONDS" -lt "$DRAIN_DEADLINE" ]; do
+        echo "  ${REMAINING} runner pod(s) still running (elapsed: ${SECONDS}s)..."
+        sleep "$DRAIN_INTERVAL"
+        REMAINING=$(kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    done
+
+    if (( SECONDS < 60 )); then elapsed="${SECONDS}s"; else elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"; fi
+
+    echo ""
+    if [ "$REMAINING" -eq 0 ]; then
+        echo "All runner pods drained (elapsed: ${elapsed})."
+        STRAGGLERS_MSG="all drained"
+        EXIT_CODE=0
+    else
+        echo "Drain timeout reached after ${DRAIN_TIMEOUT}s. Override with OSDC_DRAIN_TIMEOUT_SECS=<seconds> to extend."
+        echo "Timed out after ${elapsed} with ${REMAINING} runner pod(s) still running."
+        echo "Stragglers:"
+        kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner -o wide 2>/dev/null || true
+        echo ""
+        echo "Operator decision required:"
+        echo "  (a) Wait — re-run with OSDC_DRAIN_TIMEOUT_SECS=<larger> to give jobs more time to finish."
+        echo "  (b) Force-terminate stragglers: kubectl delete pod -n arc-runners <pod> --grace-period=0 --force"
+        echo "      WARNING: this aborts the running GitHub Actions job mid-execution. The job will be"
+        echo "      marked failed/timeout on the GitHub side and may auto-retry. The runner registration"
+        echo "      may dangle in the GitHub UI until the ARC controller reconciles. Coordinate with"
+        echo "      pytorch/pytorch on-call before force-terminating."
+        STRAGGLERS_MSG="${REMAINING} stragglers remaining"
+        EXIT_CODE=1
+    fi
+
+    echo ""
+    echo "Summary: ${DRAINED} AutoscalingRunnerSets drained, ${TAINTED_NODES} nodes tainted, ${STRAGGLERS_MSG}."
+    if [ "$ARS_FAILED" -gt 0 ]; then
+        echo "Warning: ${ARS_FAILED} AutoscalingRunnerSet(s) failed to patch."
+    fi
+    if [ "$ALREADY" -gt 0 ]; then
+        echo "Note: ${ALREADY} AutoscalingRunnerSet(s) were already at maxRunners=0."
+    fi
+    exit "$EXIT_CODE"
+
+# Restore maxRunners on every live AutoscalingRunnerSet from def files (out-of-band recovery; cutover uses just deploy)
+resume-runners cluster:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export OSDC_ROOT="{{ROOT}}"
+    export OSDC_UPSTREAM="{{UPSTREAM}}"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+
+    # Ensure kubectl is configured for the target cluster
+    just kubeconfig "$CLUSTER"
+
+    echo "Resuming ARC runner scale sets for $CLUSTER ($CNAME)..."
+    echo ""
+
+    # Build desired-state map { ars-name: maxRunners } from def files
+    MAP=$(uv run "{{UPSTREAM}}/modules/arc-runners/scripts/python/runner_max_map.py" "$CLUSTER")
+
+    EXIT_CODE=0
+    ARS_NAMES=$(kubectl get autoscalingrunnersets -n arc-runners -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    if [ -z "$ARS_NAMES" ]; then
+        echo "  No AutoscalingRunnerSets found in arc-runners — nothing to resume."
+        RESTORED=0
+        WARNINGS=0
+        RES_FAILED=0
+    else
+        RESTORED=0
+        WARNINGS=0
+        RES_FAILED=0
+        for ars in $ARS_NAMES; do
+            DESIRED=$(echo "$MAP" | jq -r --arg n "$ars" '.[$n] // empty')
+            if [ -z "$DESIRED" ]; then
+                echo "  $ars — WARNING: no matching def, leaving as-is"
+                WARNINGS=$((WARNINGS + 1))
+                EXIT_CODE=1
+                continue
+            fi
+            if PATCH_OUT=$(kubectl patch autoscalingrunnerset "$ars" -n arc-runners --type=merge -p "{\"spec\":{\"maxRunners\":$DESIRED}}" 2>&1); then
+                echo "  $ars — restored maxRunners=${DESIRED}"
+                RESTORED=$((RESTORED + 1))
+            else
+                echo "  $ars — FAILED: ${PATCH_OUT}"
+                RES_FAILED=$((RES_FAILED + 1))
+                EXIT_CODE=1
+            fi
+        done
+    fi
+
+    echo ""
+    echo "Removing refresh taint from runner nodes..."
+    just untaint-nodes "$CLUSTER"
+
+    echo ""
+    echo "Summary: ${RESTORED} restored, ${WARNINGS} warnings, ${RES_FAILED} failures."
+    if [ "$EXIT_CODE" -ne 0 ]; then
+        echo "Action: investigate failures/warnings above. Run \`just deploy $CLUSTER\` to reconcile from def files."
+    fi
+    exit "$EXIT_CODE"
+
 # ============================================================================
 # INTERNAL: Base sub-deploys
 # ============================================================================

--- a/osdc/modules/arc-runners/scripts/python/runner_max_map.py
+++ b/osdc/modules/arc-runners/scripts/python/runner_max_map.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Compute the desired AutoscalingRunnerSet maxRunners map for a cluster.
+
+Reads runner def YAMLs directly (no compile step) and emits a JSON object
+keyed by the AutoscalingRunnerSet metadata.name (after the chart's
+runnerScaleSetName -> metadata.name transformation).
+
+Used by `just resume-runners <cluster>` to restore per-RSS maxRunners after
+a `just drain-runners` cutover.
+
+Output (stdout): JSON object, sorted keys, two-space indent.
+Diagnostics: stderr only.
+
+Example:
+    uv run runner_max_map.py arc-cbr-production
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+# Import the SAME prefix-resolution path generate_runners.py uses to produce
+# the ARS resources. Whole-block resolution (cluster's arc-runners dict wins
+# entirely if present, otherwise defaults' dict) differs from per-key
+# resolution when a cluster overrides only some keys — and we MUST match
+# generate_runners.py exactly or `resume-runners` will compute ARS names that
+# don't exist on the cluster. Both files live in the same directory so the
+# import is direct; pytest's testpaths puts this dir on sys.path too.
+from generate_runners import resolve_value
+
+# The actions-runner-controller chart substitutes nil maxRunners with
+# math.MaxInt32 (controllers/actions.github.com/resourcebuilder.go:94-101 in
+# the upstream fork). Mirror that here so the JSON we emit is the literal
+# value the controller would have produced — required so kubectl patches
+# round-trip identically when the def omits max_runners.
+MAX_INT32 = 2**31 - 1  # 2147483647
+
+
+def find_repo_root(start: Path) -> Path:
+    """Walk upwards from `start` until a directory containing clusters.yaml is found.
+
+    Mirrors generate_runners.py's resolution: prefer OSDC_ROOT env var when set,
+    otherwise walk up. Caller passes the script directory; we walk up its
+    parents looking for clusters.yaml.
+
+    Raises FileNotFoundError if no clusters.yaml is found before reaching the
+    filesystem root.
+    """
+    if "OSDC_ROOT" in os.environ:
+        root = Path(os.environ["OSDC_ROOT"])
+        if not (root / "clusters.yaml").exists():
+            raise FileNotFoundError(f"OSDC_ROOT={root} does not contain clusters.yaml")
+        return root
+
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "clusters.yaml").exists():
+            return candidate
+    raise FileNotFoundError(f"clusters.yaml not found walking up from {start}")
+
+
+def load_clusters_yaml(repo_root: Path) -> dict:
+    """Load and parse clusters.yaml from the repository root."""
+    with open(repo_root / "clusters.yaml") as f:
+        return yaml.safe_load(f) or {}
+
+
+def get_cluster(clusters_yaml: dict, cluster_id: str) -> dict:
+    """Return the per-cluster config, raising KeyError if cluster_id is unknown."""
+    clusters = clusters_yaml.get("clusters", {})
+    if cluster_id not in clusters:
+        known = ", ".join(sorted(clusters.keys())) or "<none>"
+        raise KeyError(f"Unknown cluster '{cluster_id}'. Known clusters: {known}")
+    return clusters[cluster_id]
+
+
+def resolve_dotted(cluster_cfg: dict, defaults: dict, dotpath: str):
+    """Resolve a dot-separated path against cluster config with defaults fallback.
+
+    Mirrors scripts/cluster-config.py and generate_runners.py semantics so the
+    same configuration values are read consistently across helpers.
+    """
+    parts = dotpath.split(".")
+    val = cluster_cfg
+    dval = defaults
+    for part in parts:
+        val = val.get(part) if isinstance(val, dict) else None
+        dval = dval.get(part) if isinstance(dval, dict) else None
+    if val is not None:
+        return val
+    return dval
+
+
+def resolve_runner_name_prefix(clusters_yaml: dict, cluster_id: str) -> str:
+    """Return arc-runners.runner_name_prefix for the cluster (defaults fallback).
+
+    Uses generate_runners.py's WHOLE-BLOCK resolution (not per-key dotted lookup):
+    the cluster's `arc-runners` dict wins entirely if present, else defaults' dict.
+    See generate_runners.py:332 — `resolve_value(cluster_cfg, defaults, "arc-runners")`.
+    Per-key dotted resolution would diverge when a cluster overrides only some
+    keys (e.g. github_config_url) and leaves runner_name_prefix unset, falling
+    through to defaults — but the chart actually generates ARS resources from
+    the whole-block path, so that fallback would compute names that don't exist
+    on the cluster.
+    """
+    cluster_cfg = get_cluster(clusters_yaml, cluster_id)
+    defaults = clusters_yaml.get("defaults", {})
+    arc_runners_config = resolve_value(cluster_cfg, defaults, "arc-runners") or {}
+    return arc_runners_config.get("runner_name_prefix", "") or ""
+
+
+def enabled_arc_runner_modules(clusters_yaml: dict, cluster_id: str) -> list[str]:
+    """Return enabled module names matching `arc-runners` or `arc-runners-*`.
+
+    Matches the variant pattern used by the GPU shims (arc-runners-h100,
+    arc-runners-b200, ...) without hardcoding the variant list — any future
+    variant module that follows the `arc-runners-<suffix>` naming will be
+    picked up automatically.
+    """
+    cluster_cfg = get_cluster(clusters_yaml, cluster_id)
+    modules = cluster_cfg.get("modules", []) or []
+    return [m for m in modules if m == "arc-runners" or m.startswith("arc-runners-")]
+
+
+def compute_ars_name(prefix: str, runner_name: str) -> str:
+    """Return the AutoscalingRunnerSet metadata.name the chart will produce.
+
+    The chart's autoscalingrunnerset.yaml computes:
+        name: {{ include "gha-runner-scale-set.scale-set-name" . | replace "_" "-" }}
+    where scale-set-name resolves to .Values.runnerScaleSetName.
+
+    The values file emits runnerScaleSetName as the literal "{prefix}{name}"
+    (generate_runners.py:258 — RUNNER_NAME placeholder is the raw def name,
+    NOT the {{RUNNER_NAME_NORMALIZED}} variant). The chart then strips
+    underscores. Dots are NOT stripped by the chart, so do not strip them
+    here either — round-tripping requires byte-identical names.
+    """
+    return (prefix + runner_name).replace("_", "-")
+
+
+def parse_def_file(def_file: Path) -> tuple[str, int | None]:
+    """Read a runner def YAML and return (runner_name, max_runners).
+
+    max_runners is None when the def omits it (caller substitutes MAX_INT32).
+    Raises ValueError if `runner.name` is missing or `max_runners` is invalid.
+    Mirrors generate_runners.py:152,158,162-164 validation rules.
+    """
+    with open(def_file) as f:
+        data = yaml.safe_load(f) or {}
+
+    runner = data.get("runner") or {}
+    name = runner.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"Invalid def file {def_file}: missing required 'runner.name'")
+
+    max_runners = runner.get("max_runners")
+    if max_runners is not None and (not isinstance(max_runners, int) or max_runners < 1):
+        raise ValueError(f"Invalid def file {def_file}: max_runners must be a positive integer, got {max_runners!r}")
+    return name, max_runners
+
+
+def iter_def_files(repo_root: Path, module: str) -> list[Path]:
+    """Return sorted list of *.yaml files under modules/<module>/defs/.
+
+    Returns an empty list (not an error) when the module directory or its
+    defs subdirectory does not exist, so a misconfigured cluster does not
+    abort the whole map. Caller may log a stderr warning.
+    """
+    defs_dir = repo_root / "modules" / module / "defs"
+    if not defs_dir.is_dir():
+        return []
+    return sorted(defs_dir.glob("*.yaml"))
+
+
+def build_max_runners_map(repo_root: Path, clusters_yaml: dict, cluster_id: str) -> dict[str, int]:
+    """Build {ars_name: max_runners} for every def in every enabled arc-runners* module.
+
+    Pure function (modulo file reads). Raises if cluster is unknown or any def
+    is malformed. Logs to stderr (via warn callback) when a module has no defs
+    directory.
+    """
+    prefix = resolve_runner_name_prefix(clusters_yaml, cluster_id)
+    modules = enabled_arc_runner_modules(clusters_yaml, cluster_id)
+
+    result: dict[str, int] = {}
+    for module in modules:
+        def_files = iter_def_files(repo_root, module)
+        if not def_files:
+            print(f"warning: module '{module}' has no def files at modules/{module}/defs/", file=sys.stderr)
+            continue
+        for def_file in def_files:
+            name, max_runners = parse_def_file(def_file)
+            ars_name = compute_ars_name(prefix, name)
+            result[ars_name] = max_runners if max_runners is not None else MAX_INT32
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint. Prints JSON map to stdout, diagnostics to stderr."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 1:
+        print("Usage: runner_max_map.py <cluster-id>", file=sys.stderr)
+        print("Example: runner_max_map.py arc-cbr-production", file=sys.stderr)
+        return 2
+
+    cluster_id = argv[0]
+
+    try:
+        repo_root = find_repo_root(Path(__file__).parent)
+        clusters_yaml = load_clusters_yaml(repo_root)
+        result = build_max_runners_map(repo_root, clusters_yaml, cluster_id)
+    except (FileNotFoundError, KeyError, ValueError, yaml.YAMLError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/osdc/modules/arc-runners/scripts/python/test_runner_max_map.py
+++ b/osdc/modules/arc-runners/scripts/python/test_runner_max_map.py
@@ -1,0 +1,694 @@
+"""Tests for runner_max_map.py."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from runner_max_map import (
+    MAX_INT32,
+    build_max_runners_map,
+    compute_ars_name,
+    enabled_arc_runner_modules,
+    find_repo_root,
+    get_cluster,
+    iter_def_files,
+    load_clusters_yaml,
+    main,
+    parse_def_file,
+    resolve_dotted,
+    resolve_runner_name_prefix,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ============================================================================
+# Helpers — build a fake repo (clusters.yaml + modules/<m>/defs/*.yaml)
+# ============================================================================
+
+
+def make_repo(tmp_path: Path, clusters_yaml: dict, modules: dict[str, dict[str, dict]]) -> Path:
+    """Create a fake repo layout under tmp_path.
+
+    `modules` is {module_name: {def_basename: runner_dict}} where def_basename
+    is the YAML filename without the suffix and runner_dict becomes the
+    `runner:` mapping in the def file.
+    """
+    (tmp_path / "clusters.yaml").write_text(yaml.safe_dump(clusters_yaml))
+    for module, defs in modules.items():
+        defs_dir = tmp_path / "modules" / module / "defs"
+        defs_dir.mkdir(parents=True, exist_ok=True)
+        for basename, runner in defs.items():
+            (defs_dir / f"{basename}.yaml").write_text(yaml.safe_dump({"runner": runner}))
+    return tmp_path
+
+
+# ============================================================================
+# MAX_INT32 sanity
+# ============================================================================
+
+
+class TestMaxInt32:
+    def test_value_matches_controller_substitution(self):
+        # Mirrors controllers/actions.github.com/resourcebuilder.go:94-101 in the
+        # actions-runner-controller fork: math.MaxInt32 is the canonical "no cap".
+        assert MAX_INT32 == 2147483647
+
+
+# ============================================================================
+# compute_ars_name — chart's runnerScaleSetName -> metadata.name transform
+# ============================================================================
+
+
+class TestComputeArsName:
+    def test_no_prefix(self):
+        assert compute_ars_name("", "linux-cpu") == "linux-cpu"
+
+    def test_with_prefix(self):
+        assert compute_ars_name("mt-", "linux-cpu") == "mt-linux-cpu"
+
+    def test_underscores_replaced_with_dashes(self):
+        # Chart: `replace "_" "-"`. Confirmed in
+        # charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml.
+        assert compute_ars_name("c-mt-", "weird_name_with_underscores") == "c-mt-weird-name-with-underscores"
+
+    def test_dots_NOT_replaced(self):
+        # Chart only strips underscores. Dots pass through (and would fail the
+        # k8s name validator at apply time, but that's a def author bug, not
+        # something we should silently mask).
+        assert compute_ars_name("", "name.with.dots") == "name.with.dots"
+
+    def test_underscore_in_prefix(self):
+        assert compute_ars_name("c_mt_", "x") == "c-mt-x"
+
+    def test_empty_runner_name(self):
+        # Pathological — the parser rejects this upstream, but compute_ars_name
+        # is a pure function and should still produce a deterministic answer.
+        assert compute_ars_name("p-", "") == "p-"
+
+
+# ============================================================================
+# find_repo_root
+# ============================================================================
+
+
+class TestFindRepoRoot:
+    def test_finds_repo_root_from_nested_dir(self, tmp_path):
+        (tmp_path / "clusters.yaml").write_text("clusters: {}\n")
+        nested = tmp_path / "modules" / "arc-runners" / "scripts" / "python"
+        nested.mkdir(parents=True)
+        assert find_repo_root(nested) == tmp_path.resolve()
+
+    def test_uses_OSDC_ROOT_when_set(self, tmp_path, monkeypatch):
+        (tmp_path / "clusters.yaml").write_text("clusters: {}\n")
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        # Even though cwd has no clusters.yaml, OSDC_ROOT wins.
+        unrelated = tmp_path.parent
+        assert find_repo_root(unrelated) == tmp_path
+
+    def test_OSDC_ROOT_without_clusters_yaml_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        with pytest.raises(FileNotFoundError, match="OSDC_ROOT"):
+            find_repo_root(tmp_path)
+
+    def test_no_clusters_yaml_anywhere_raises(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OSDC_ROOT", raising=False)
+        # tmp_path is under /private/tmp or /tmp; ensure no clusters.yaml exists
+        # in the walk path. We point at a freshly created subdir to be safe.
+        sub = tmp_path / "some" / "deep" / "dir"
+        sub.mkdir(parents=True)
+        with pytest.raises(FileNotFoundError, match=r"clusters\.yaml not found"):
+            find_repo_root(sub)
+
+
+# ============================================================================
+# load_clusters_yaml + get_cluster + resolve_dotted + resolve_runner_name_prefix
+# ============================================================================
+
+
+class TestLoadClustersYaml:
+    def test_loads_valid_yaml(self, tmp_path):
+        (tmp_path / "clusters.yaml").write_text("clusters:\n  arc-x: {}\n")
+        result = load_clusters_yaml(tmp_path)
+        assert result == {"clusters": {"arc-x": {}}}
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        (tmp_path / "clusters.yaml").write_text("")
+        assert load_clusters_yaml(tmp_path) == {}
+
+
+class TestGetCluster:
+    def test_returns_cluster_dict(self):
+        cy = {"clusters": {"arc-x": {"region": "us-east-1"}}}
+        assert get_cluster(cy, "arc-x") == {"region": "us-east-1"}
+
+    def test_unknown_cluster_raises(self):
+        cy = {"clusters": {"arc-known": {}}}
+        with pytest.raises(KeyError, match="Unknown cluster 'arc-missing'"):
+            get_cluster(cy, "arc-missing")
+
+    def test_unknown_cluster_with_no_clusters_section(self):
+        with pytest.raises(KeyError, match="Unknown cluster 'arc-missing'"):
+            get_cluster({}, "arc-missing")
+
+
+class TestResolveDotted:
+    def test_finds_in_cluster_cfg(self):
+        assert resolve_dotted({"a": {"b": "x"}}, {}, "a.b") == "x"
+
+    def test_falls_back_to_defaults(self):
+        assert resolve_dotted({}, {"a": {"b": "y"}}, "a.b") == "y"
+
+    def test_cluster_overrides_defaults(self):
+        assert resolve_dotted({"a": {"b": "x"}}, {"a": {"b": "y"}}, "a.b") == "x"
+
+    def test_returns_none_when_missing(self):
+        assert resolve_dotted({}, {}, "a.b") is None
+
+    def test_dashed_key(self):
+        # arc-runners is the actual dict key; only literal dots in the dotpath
+        # split the path. Underscores and dashes pass through unchanged.
+        cfg = {"arc-runners": {"runner_name_prefix": "mt-"}}
+        assert resolve_dotted(cfg, {}, "arc-runners.runner_name_prefix") == "mt-"
+
+
+class TestResolveRunnerNamePrefix:
+    def test_reads_per_cluster_value(self):
+        cy = {
+            "defaults": {},
+            "clusters": {"arc-x": {"arc-runners": {"runner_name_prefix": "mt-"}}},
+        }
+        assert resolve_runner_name_prefix(cy, "arc-x") == "mt-"
+
+    def test_falls_back_to_defaults_when_cluster_block_absent(self):
+        # Whole-block resolution: cluster has NO arc-runners block at all,
+        # so defaults' arc-runners block applies in full.
+        cy = {
+            "defaults": {"arc-runners": {"runner_name_prefix": "default-"}},
+            "clusters": {"arc-x": {}},
+        }
+        assert resolve_runner_name_prefix(cy, "arc-x") == "default-"
+
+    def test_returns_empty_string_when_missing(self):
+        cy = {"defaults": {}, "clusters": {"arc-x": {}}}
+        assert resolve_runner_name_prefix(cy, "arc-x") == ""
+
+    def test_partial_override_does_NOT_inherit_prefix_from_defaults(self):
+        # REGRESSION: divergence case between per-key and whole-block resolution.
+        # Cluster supplies its own arc-runners block (overriding the whole dict),
+        # but does NOT specify runner_name_prefix. Whole-block resolution
+        # (mirroring generate_runners.py:332) returns the cluster's dict as a
+        # single unit — defaults' runner_name_prefix is NOT inherited. Per-key
+        # resolution would have wrongly returned "default-", causing
+        # `resume-runners` to compute ARS names that don't exist on the cluster.
+        cy = {
+            "defaults": {"arc-runners": {"runner_name_prefix": "default-"}},
+            "clusters": {
+                "arc-x": {
+                    "modules": ["arc-runners"],
+                    "arc-runners": {"github_config_url": "https://x"},
+                }
+            },
+        }
+        assert resolve_runner_name_prefix(cy, "arc-x") == ""
+
+    def test_consistent_block_with_prefix_returns_prefix(self):
+        # Cluster supplies a complete arc-runners block including prefix —
+        # both per-key and whole-block resolution produce the same answer.
+        cy = {
+            "defaults": {},
+            "clusters": {"arc-x": {"arc-runners": {"runner_name_prefix": "c-"}}},
+        }
+        assert resolve_runner_name_prefix(cy, "arc-x") == "c-"
+
+    def test_explicit_null_prefix_falls_through_to_empty(self):
+        # YAML may render an explicit `runner_name_prefix:` (no value) as None.
+        # Mirror generate_runners.py's behaviour (cluster_config.get(..., "")):
+        # None should be treated as no prefix, not propagated.
+        cy = {
+            "defaults": {},
+            "clusters": {"arc-x": {"arc-runners": {"runner_name_prefix": None}}},
+        }
+        assert resolve_runner_name_prefix(cy, "arc-x") == ""
+
+
+# ============================================================================
+# enabled_arc_runner_modules
+# ============================================================================
+
+
+class TestEnabledArcRunnerModules:
+    def test_only_arc_runners(self):
+        cy = {"clusters": {"arc-x": {"modules": ["karpenter", "arc-runners", "buildkit"]}}}
+        assert enabled_arc_runner_modules(cy, "arc-x") == ["arc-runners"]
+
+    def test_includes_variant_modules(self):
+        cy = {
+            "clusters": {
+                "arc-x": {
+                    "modules": [
+                        "karpenter",
+                        "arc-runners",
+                        "arc-runners-h100",
+                        "arc-runners-b200",
+                        "buildkit",
+                    ]
+                }
+            }
+        }
+        assert enabled_arc_runner_modules(cy, "arc-x") == [
+            "arc-runners",
+            "arc-runners-h100",
+            "arc-runners-b200",
+        ]
+
+    def test_excludes_unrelated_modules(self):
+        # `arc-runners-rel` (any future suffix) is included; `arc` alone is NOT.
+        cy = {"clusters": {"arc-x": {"modules": ["arc", "arc-runners-rel"]}}}
+        assert enabled_arc_runner_modules(cy, "arc-x") == ["arc-runners-rel"]
+
+    def test_no_modules_section(self):
+        cy = {"clusters": {"arc-x": {}}}
+        assert enabled_arc_runner_modules(cy, "arc-x") == []
+
+    def test_explicit_null_modules(self):
+        # YAML may render an empty list as None; make sure we don't crash.
+        cy = {"clusters": {"arc-x": {"modules": None}}}
+        assert enabled_arc_runner_modules(cy, "arc-x") == []
+
+
+# ============================================================================
+# iter_def_files
+# ============================================================================
+
+
+class TestIterDefFiles:
+    def test_returns_sorted_yaml_files(self, tmp_path):
+        defs_dir = tmp_path / "modules" / "arc-runners" / "defs"
+        defs_dir.mkdir(parents=True)
+        (defs_dir / "b.yaml").write_text("runner: {}\n")
+        (defs_dir / "a.yaml").write_text("runner: {}\n")
+        (defs_dir / "c.yaml").write_text("runner: {}\n")
+        result = iter_def_files(tmp_path, "arc-runners")
+        assert [p.name for p in result] == ["a.yaml", "b.yaml", "c.yaml"]
+
+    def test_missing_module_returns_empty(self, tmp_path):
+        # The "module enabled but defs/ doesn't exist" case is tolerable —
+        # caller logs a warning and continues. Do not raise.
+        assert iter_def_files(tmp_path, "arc-runners-missing") == []
+
+    def test_empty_defs_dir_returns_empty(self, tmp_path):
+        (tmp_path / "modules" / "arc-runners" / "defs").mkdir(parents=True)
+        assert iter_def_files(tmp_path, "arc-runners") == []
+
+    def test_ignores_non_yaml_files(self, tmp_path):
+        defs_dir = tmp_path / "modules" / "arc-runners" / "defs"
+        defs_dir.mkdir(parents=True)
+        (defs_dir / "valid.yaml").write_text("runner: {}\n")
+        (defs_dir / "README.md").write_text("# notes\n")
+        (defs_dir / "stash.bak").write_text("ignored\n")
+        result = iter_def_files(tmp_path, "arc-runners")
+        assert [p.name for p in result] == ["valid.yaml"]
+
+
+# ============================================================================
+# parse_def_file
+# ============================================================================
+
+
+class TestParseDefFile:
+    def test_returns_name_and_max_runners(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu", "max_runners": 8}}))
+        assert parse_def_file(f) == ("linux-cpu", 8)
+
+    def test_max_runners_omitted_returns_none(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu"}}))
+        name, max_runners = parse_def_file(f)
+        assert name == "linux-cpu"
+        assert max_runners is None
+
+    def test_missing_runner_section_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text("other_key: 1\n")
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+    def test_missing_name_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"instance_type": "m5.large"}}))
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+    def test_empty_name_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": ""}}))
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+    def test_non_string_name_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": 42}}))
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+    def test_zero_max_runners_raises(self, tmp_path):
+        # Mirrors generate_runners.py:162 — max_runners must be POSITIVE.
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "x", "max_runners": 0}}))
+        with pytest.raises(ValueError, match=r"max_runners must be a positive integer"):
+            parse_def_file(f)
+
+    def test_negative_max_runners_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "x", "max_runners": -1}}))
+        with pytest.raises(ValueError, match=r"max_runners must be a positive integer"):
+            parse_def_file(f)
+
+    def test_string_max_runners_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "x", "max_runners": "8"}}))
+        with pytest.raises(ValueError, match=r"max_runners must be a positive integer"):
+            parse_def_file(f)
+
+    def test_empty_yaml_file_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text("")
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+    def test_null_runner_section_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text("runner: null\n")
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            parse_def_file(f)
+
+
+# ============================================================================
+# build_max_runners_map (integration over fake repo)
+# ============================================================================
+
+
+class TestBuildMaxRunnersMap:
+    def test_happy_path_single_module(self, tmp_path):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": "mt-"},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {
+                "linux-cpu": {"name": "linux-cpu", "max_runners": 4},
+                "linux-arm": {"name": "linux-arm"},  # no max_runners -> MAX_INT32
+            }
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        result = build_max_runners_map(repo, clusters_yaml, "arc-x")
+        assert result == {
+            "mt-linux-cpu": 4,
+            "mt-linux-arm": MAX_INT32,
+        }
+
+    def test_multi_module_merge(self, tmp_path):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners", "arc-runners-h100", "arc-runners-b200"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {"cpu-1": {"name": "cpu-1"}},
+            "arc-runners-h100": {"h100-1": {"name": "h100-1", "max_runners": 8}},
+            "arc-runners-b200": {"b200-1": {"name": "b200-1", "max_runners": 1}},
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        result = build_max_runners_map(repo, clusters_yaml, "arc-x")
+        assert result == {
+            "cpu-1": MAX_INT32,
+            "h100-1": 8,
+            "b200-1": 1,
+        }
+
+    def test_normalization_underscores_in_def_name(self, tmp_path):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": "p-"},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {"weird_name": {"name": "weird_name", "max_runners": 2}},
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        result = build_max_runners_map(repo, clusters_yaml, "arc-x")
+        # underscores -> dashes (chart behaviour)
+        assert result == {"p-weird-name": 2}
+
+    def test_missing_module_dir_skipped_with_warning(self, tmp_path, capsys):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners", "arc-runners-h100"],
+                }
+            },
+        }
+        # Only arc-runners has defs; arc-runners-h100 is enabled but missing.
+        modules = {"arc-runners": {"cpu": {"name": "cpu"}}}
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        result = build_max_runners_map(repo, clusters_yaml, "arc-x")
+        captured = capsys.readouterr()
+        assert result == {"cpu": MAX_INT32}
+        assert "arc-runners-h100" in captured.err
+        assert "no def files" in captured.err
+
+    def test_unknown_cluster_raises(self, tmp_path):
+        clusters_yaml = {"defaults": {}, "clusters": {"arc-real": {"modules": []}}}
+        repo = make_repo(tmp_path, clusters_yaml, {})
+        with pytest.raises(KeyError, match="Unknown cluster 'arc-missing'"):
+            build_max_runners_map(repo, clusters_yaml, "arc-missing")
+
+    def test_invalid_def_file_raises(self, tmp_path):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {"arc-runners": {"broken": {"instance_type": "m5.large"}}}
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        with pytest.raises(ValueError, match=r"missing required 'runner\.name'"):
+            build_max_runners_map(repo, clusters_yaml, "arc-x")
+
+    def test_no_arc_runner_modules_returns_empty(self, tmp_path):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {"arc-x": {"modules": ["karpenter", "buildkit"]}},
+        }
+        repo = make_repo(tmp_path, clusters_yaml, {})
+        assert build_max_runners_map(repo, clusters_yaml, "arc-x") == {}
+
+
+# ============================================================================
+# main() — CLI surface
+# ============================================================================
+
+
+class TestMain:
+    def test_happy_path_emits_sorted_json(self, tmp_path, monkeypatch, capsys):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": "mt-"},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {
+                "z-runner": {"name": "z-runner", "max_runners": 2},
+                "a-runner": {"name": "a-runner"},
+            }
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        monkeypatch.setenv("OSDC_ROOT", str(repo))
+        rc = main(["arc-x"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        parsed = json.loads(captured.out)
+        assert parsed == {"mt-a-runner": MAX_INT32, "mt-z-runner": 2}
+        # Confirm sorted-keys ordering in raw stdout (alphabetical).
+        assert captured.out.index('"mt-a-runner"') < captured.out.index('"mt-z-runner"')
+        # Confirm indented (human-readable) output, not single-line.
+        assert "\n" in captured.out.strip()
+
+    def test_no_args_prints_usage(self, capsys):
+        rc = main([])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "Usage:" in captured.err
+        assert captured.out == ""
+
+    def test_too_many_args_prints_usage(self, capsys):
+        rc = main(["arc-x", "extra"])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "Usage:" in captured.err
+
+    def test_uses_argv_when_argv_param_is_none(self, tmp_path, monkeypatch, capsys):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {"arc-runners": {"r": {"name": "r"}}}
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        monkeypatch.setenv("OSDC_ROOT", str(repo))
+        monkeypatch.setattr("sys.argv", ["runner_max_map.py", "arc-x"])
+        rc = main()
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert json.loads(captured.out) == {"r": MAX_INT32}
+
+    def test_unknown_cluster_returns_1_and_logs_stderr(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "clusters.yaml").write_text(
+            yaml.safe_dump({"defaults": {}, "clusters": {"arc-real": {"modules": []}}})
+        )
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        rc = main(["arc-missing"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "Unknown cluster" in captured.err
+        assert captured.out == ""
+
+    def test_invalid_def_returns_1(self, tmp_path, monkeypatch, capsys):
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-x": {
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {"arc-runners": {"broken": {"instance_type": "m5.large"}}}
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        monkeypatch.setenv("OSDC_ROOT", str(repo))
+        rc = main(["arc-x"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "missing required 'runner.name'" in captured.err
+        assert captured.out == ""
+
+    def test_yaml_parse_error_returns_1(self, tmp_path, monkeypatch, capsys):
+        # Malformed YAML in clusters.yaml -> caught and reported, exit 1.
+        (tmp_path / "clusters.yaml").write_text("clusters: {not: valid: yaml}\n")
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        rc = main(["arc-x"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "error:" in captured.err
+
+    def test_missing_OSDC_ROOT_raises_caught_as_error(self, tmp_path, monkeypatch, capsys):
+        # OSDC_ROOT pointing somewhere with no clusters.yaml -> handled as error.
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setenv("OSDC_ROOT", str(empty_dir))
+        rc = main(["arc-x"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "OSDC_ROOT" in captured.err
+
+
+# ============================================================================
+# End-to-end with realistic def-file content
+# ============================================================================
+
+
+class TestEndToEnd:
+    def test_realistic_production_like_setup(self, tmp_path, monkeypatch, capsys):
+        """Mirrors the arc-cbr-production cluster shape: prefix=mt-, three modules."""
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-cbr-production": {
+                    "arc-runners": {"runner_name_prefix": "mt-"},
+                    "modules": [
+                        "karpenter",
+                        "arc",
+                        "nodepools",
+                        "arc-runners",
+                        "arc-runners-h100",
+                        "arc-runners-b200",
+                    ],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {
+                "l-x86iavx512-2-4": {"name": "l-x86iavx512-2-4"},
+                "l-arm64g3-16-62": {"name": "l-arm64g3-16-62"},
+            },
+            "arc-runners-h100": {
+                "l-x86iamx-22-225-h100": {"name": "l-x86iamx-22-225-h100", "max_runners": 8},
+            },
+            "arc-runners-b200": {
+                "l-x86iamx-22-225-b200": {"name": "l-x86iamx-22-225-b200", "max_runners": 1},
+            },
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        monkeypatch.setenv("OSDC_ROOT", str(repo))
+        rc = main(["arc-cbr-production"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        parsed = json.loads(captured.out)
+        assert parsed == {
+            "mt-l-arm64g3-16-62": MAX_INT32,
+            "mt-l-x86iamx-22-225-b200": 1,
+            "mt-l-x86iamx-22-225-h100": 8,
+            "mt-l-x86iavx512-2-4": MAX_INT32,
+        }
+
+    def test_def_file_with_extra_fields_is_tolerated(self, tmp_path):
+        """Real def files have many fields besides name/max_runners."""
+        defs_dir = tmp_path / "modules" / "arc-runners" / "defs"
+        defs_dir.mkdir(parents=True)
+        full_def = textwrap.dedent("""\
+            runner:
+              name: l-x86iamx-8-16
+              instance_type: c7i.12xlarge
+              disk_size: 150
+              vcpu: 8
+              memory: 16Gi
+              gpu: 0
+              proactive_capacity: 30
+              max_burst_capacity: 2000
+        """)
+        (defs_dir / "l-x86iamx-8-16.yaml").write_text(full_def)
+        name, max_runners = parse_def_file(defs_dir / "l-x86iamx-8-16.yaml")
+        assert name == "l-x86iamx-8-16"
+        assert max_runners is None


### PR DESCRIPTION
**Impact:** OSDC operators performing cluster-wide infrastructure migrations
**Risk:** low

## What
Adds two new `just` recipes (`drain-runners` and `resume-runners`) and a supporting Python helper (`runner_max_map.py`) to safely quiesce and restore the ARC runner fleet during maintenance windows.

## Why
The upcoming IPv4 capacity expansion (`INCREASE_IPV4.md`) requires a drain-apply-resume cutover cycle per cluster — the entire PR stack (VPC secondary CIDRs, Custom Networking, prefix delegation, NAT topology refactor) deploys atomically while the runner fleet is drained. These recipes automate steps 2a and the out-of-band recovery path described in that plan.

## How
- `drain-runners` patches every `AutoscalingRunnerSet` to `maxRunners=0`, taints runner nodes via `just taint-nodes`, then polls for in-flight runner pods to finish (default 1h timeout, configurable via `OSDC_DRAIN_TIMEOUT_SECS`). On timeout, it lists stragglers and provides operator guidance (wait or force-terminate).
- `resume-runners` rebuilds the desired `{ars_name: maxRunners}` map from runner def files and patches each live `AutoscalingRunnerSet` back to its configured value. It also untaints runner nodes. This is kept as out-of-band recovery — the standard cutover path restores runners via `just deploy`.
- `runner_max_map.py` computes the ARS name-to-maxRunners mapping by reading `clusters.yaml` and `modules/arc-runners*/defs/*.yaml`. It imports `resolve_value` from `generate_runners.py` to match the exact whole-block config resolution the chart uses for ARS naming — preventing name mismatches that would cause silent resume failures.

## Changes
- **`osdc/justfile`**: Added `drain-runners` and `resume-runners` recipes
- **`osdc/modules/arc-runners/scripts/python/runner_max_map.py`**: New helper that computes `{AutoscalingRunnerSet name: maxRunners}` from def files for a given cluster, matching the chart's naming transform (underscore-to-dash, prefix resolution)
- **`osdc/modules/arc-runners/scripts/python/test_runner_max_map.py`**: Comprehensive test suite (694 lines) covering all public functions, edge cases, config resolution divergence scenarios, and end-to-end CLI behavior

## Notes
- `resume-runners` is intentionally not part of the standard cutover flow — `just deploy` re-syncs `maxRunners` from defs as part of the normal deploy pipeline. `resume-runners` exists for out-of-band recovery if the deploy path is blocked.
- The drain timeout defaults to 1 hour (covers typical PyTorch suite duration). Override with `OSDC_DRAIN_TIMEOUT_SECS=<seconds>` for longer windows.
- Force-terminating straggler pods aborts the GitHub Actions job mid-execution and may leave dangling runner registrations — coordinate with pytorch/pytorch on-call before using.

## Testing
```
 $  just drain-runners arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
Draining ARC runner scale sets for arc-staging (pytorch-arc-staging)...

  c-mt-l-arm64g2-6-32 — drained (maxRunners=0)
  c-mt-l-arm64g3-16-62 — drained (maxRunners=0)
  c-mt-l-arm64g3-61-463 — drained (maxRunners=0)
  c-mt-l-arm64g4-16-62 — drained (maxRunners=0)
  c-mt-l-barm64g4-62-226 — drained (maxRunners=0)
  c-mt-l-bx86iamx-92-167 — drained (maxRunners=0)
  c-mt-l-bx86iavx512-88-1000-a100-8 — drained (maxRunners=0)
  c-mt-l-bx86iavx512-94-344-t4-8 — drained (maxRunners=0)
  c-mt-l-x86aavx2-189-704-a10g-8 — drained (maxRunners=0)
  c-mt-l-x86aavx2-29-113-a10g — drained (maxRunners=0)
  c-mt-l-x86aavx2-29-113-l4 — drained (maxRunners=0)
  c-mt-l-x86aavx2-45-167-a10g-4 — drained (maxRunners=0)
  c-mt-l-x86aavx2-45-172-l4-4 — drained (maxRunners=0)
  c-mt-l-x86aavx512-125-463 — drained (maxRunners=0)
  c-mt-l-x86iamx-14-27 — drained (maxRunners=0)
  c-mt-l-x86iamx-16-128 — drained (maxRunners=0)
  c-mt-l-x86iamx-22-41 — drained (maxRunners=0)
  c-mt-l-x86iamx-32-128 — drained (maxRunners=0)
  c-mt-l-x86iamx-46-84 — drained (maxRunners=0)
  c-mt-l-x86iamx-8-16 — drained (maxRunners=0)
  c-mt-l-x86iamx-8-32 — drained (maxRunners=0)
  c-mt-l-x86iamx-8-64 — drained (maxRunners=0)
  c-mt-l-x86iavx2-40-160 — drained (maxRunners=0)
  c-mt-l-x86iavx2-8-32 — drained (maxRunners=0)
  c-mt-l-x86iavx512-11-125-a100 — drained (maxRunners=0)
  c-mt-l-x86iavx512-16-128 — drained (maxRunners=0)
  c-mt-l-x86iavx512-16-32 — drained (maxRunners=0)
  c-mt-l-x86iavx512-2-4 — drained (maxRunners=0)
  c-mt-l-x86iavx512-22-250-a100-2 — drained (maxRunners=0)
  c-mt-l-x86iavx512-29-115-t4 — drained (maxRunners=0)
  c-mt-l-x86iavx512-32-256 — drained (maxRunners=0)
  c-mt-l-x86iavx512-37-68 — drained (maxRunners=0)
  c-mt-l-x86iavx512-44-500-a100-4 — drained (maxRunners=0)
  c-mt-l-x86iavx512-45-172-t4-4 — drained (maxRunners=0)
  c-mt-l-x86iavx512-46-85 — drained (maxRunners=0)
  c-mt-l-x86iavx512-48-384 — drained (maxRunners=0)
  c-mt-l-x86iavx512-8-16 — drained (maxRunners=0)
  c-mt-l-x86iavx512-8-64 — drained (maxRunners=0)
  c-mt-l-x86iavx512-94-192 — drained (maxRunners=0)
  c-mt-l-x86iavx512-94-768 — drained (maxRunners=0)
  c-mt-rel-l-arm64g4-16-62 — drained (maxRunners=0)
  c-mt-rel-l-x86iavx512-8-64 — drained (maxRunners=0)

Applying refresh taint to runner nodes...
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
Tainting ARC runner nodes for arc-staging (pytorch-arc-staging)...
  Taint: deploy.osdc.io/refresh-pending=true:NoSchedule

node/ip-10-0-121-14.us-west-1.compute.internal tainted
  ip-10-0-121-14.us-west-1.compute.internal — tainted

Summary: 1 tainted, 0 already tainted, 0 failed, 1 total runner nodes.

Waiting for in-flight runner pods to drain (timeout: 3600s)...

All runner pods drained (elapsed: 2s).

Summary: 42 AutoscalingRunnerSets drained, 1 nodes tainted, all drained.
```
```
 $  just resume-runners arc-staging
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
Resuming ARC runner scale sets for arc-staging (pytorch-arc-staging)...

  c-mt-l-arm64g2-6-32 — restored maxRunners=2147483647
  c-mt-l-arm64g3-16-62 — restored maxRunners=2147483647
  c-mt-l-arm64g3-61-463 — restored maxRunners=2147483647
  c-mt-l-arm64g4-16-62 — restored maxRunners=2147483647
  c-mt-l-barm64g4-62-226 — restored maxRunners=2147483647
  c-mt-l-bx86iamx-92-167 — restored maxRunners=2147483647
  c-mt-l-bx86iavx512-88-1000-a100-8 — restored maxRunners=2147483647
  c-mt-l-bx86iavx512-94-344-t4-8 — restored maxRunners=2147483647
  c-mt-l-x86aavx2-189-704-a10g-8 — restored maxRunners=2147483647
  c-mt-l-x86aavx2-29-113-a10g — restored maxRunners=2147483647
  c-mt-l-x86aavx2-29-113-l4 — restored maxRunners=2147483647
  c-mt-l-x86aavx2-45-167-a10g-4 — restored maxRunners=2147483647
  c-mt-l-x86aavx2-45-172-l4-4 — restored maxRunners=2147483647
  c-mt-l-x86aavx512-125-463 — restored maxRunners=2147483647
  c-mt-l-x86iamx-14-27 — restored maxRunners=2147483647
  c-mt-l-x86iamx-16-128 — restored maxRunners=2147483647
  c-mt-l-x86iamx-22-41 — restored maxRunners=2147483647
  c-mt-l-x86iamx-32-128 — restored maxRunners=2147483647
  c-mt-l-x86iamx-46-84 — restored maxRunners=2147483647
  c-mt-l-x86iamx-8-16 — restored maxRunners=2147483647
  c-mt-l-x86iamx-8-32 — restored maxRunners=2147483647
  c-mt-l-x86iamx-8-64 — restored maxRunners=2147483647
  c-mt-l-x86iavx2-40-160 — restored maxRunners=2147483647
  c-mt-l-x86iavx2-8-32 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-11-125-a100 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-16-128 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-16-32 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-2-4 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-22-250-a100-2 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-29-115-t4 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-32-256 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-37-68 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-44-500-a100-4 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-45-172-t4-4 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-46-85 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-48-384 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-8-16 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-8-64 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-94-192 — restored maxRunners=2147483647
  c-mt-l-x86iavx512-94-768 — restored maxRunners=2147483647
  c-mt-rel-l-arm64g4-16-62 — restored maxRunners=2147483647
  c-mt-rel-l-x86iavx512-8-64 — restored maxRunners=2147483647

Removing refresh taint from runner nodes...
Updating kubeconfig for pytorch-arc-staging (us-west-1)...
Updated context pytorch-arc-staging in /Users/jschmidt/.kube/config
Removing refresh taint from ARC runner nodes for arc-staging (pytorch-arc-staging)...
  Taint: deploy.osdc.io/refresh-pending:NoSchedule

node/ip-10-0-121-14.us-west-1.compute.internal untainted
  ip-10-0-121-14.us-west-1.compute.internal — taint removed
  ip-10-0-58-192.us-west-1.compute.internal — not tainted, skipping

Summary: 1 untainted, 1 not tainted, 0 failed, 2 total runner nodes.

Summary: 42 restored, 0 warnings, 0 failures.
```