### PR TITLE
Pin CoreDNS replica count and topology spread constraints

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -31,6 +31,10 @@ defaults:
   eks_version: "1.35"
   single_nat_gateway: false
 
+  # --- CoreDNS sizing ---
+  coredns:
+    replicas: 6
+
   # --- Git cache central ---
   git_cache:
     central_replicas: 2
@@ -123,6 +127,8 @@ clusters:
       base_node_max_unavailable_percentage: 100  # all-at-once for staging
       single_nat_gateway: true       # cost optimization for staging
       vpc_cidr: "10.0.0.0/16"
+    coredns:
+      replicas: 2
     harbor:
       core_replicas: 1
       registry_replicas: 1

--- a/osdc/modules/eks/terraform/main.tf
+++ b/osdc/modules/eks/terraform/main.tf
@@ -78,6 +78,8 @@ module "eks" {
   base_node_max_unavailable_percentage = var.base_node_max_unavailable_percentage
   base_node_ami_version                = var.base_node_ami_version
 
+  coredns_replicas = var.coredns_replicas
+
   authentication_mode      = var.authentication_mode
   cluster_admin_role_names = var.cluster_admin_role_names
 

--- a/osdc/modules/eks/terraform/modules/eks/main.tf
+++ b/osdc/modules/eks/terraform/modules/eks/main.tf
@@ -178,8 +178,19 @@ resource "aws_eks_addon" "coredns" {
   addon_version               = "v1.13.2-eksbuild.1"
   resolve_conflicts_on_update = "PRESERVE"
 
-  # CoreDNS must tolerate base node taints to run on infrastructure nodes
+  # CoreDNS pinned topology:
+  # - replicaCount: per-cluster from clusters.yaml (default 6, staging 2)
+  # - autoScaling explicitly disabled (defensive against addon-version flips)
+  # - Hard zone spread (DoNotSchedule, maxSkew=2) + soft hostname spread (ScheduleAnyway, maxSkew=1)
+  # - PDB maxUnavailable=1 (matches addon default)
+  # - Required so CoreDNS pods land on the CriticalAddonsOnly-tainted base nodes.
+  #   Setting tolerations REPLACES (does not merge with) the addon default —
+  #   the addon's default tolerations include this one, so we preserve compat.
   configuration_values = jsonencode({
+    replicaCount = var.coredns_replicas
+    autoScaling = {
+      enabled = false
+    }
     tolerations = [
       {
         key      = "CriticalAddonsOnly"
@@ -188,6 +199,33 @@ resource "aws_eks_addon" "coredns" {
         effect   = "NoSchedule"
       }
     ]
+    topologySpreadConstraints = [
+      {
+        # maxSkew=2 tolerates AWS subnet placement drift (e.g. 4-2-0 across AZs after
+        # AMI rolls) while still preventing catastrophic 6-0-0 single-AZ pinning.
+        maxSkew           = 2
+        topologyKey       = "topology.kubernetes.io/zone"
+        whenUnsatisfiable = "DoNotSchedule"
+        labelSelector = {
+          matchLabels = {
+            "k8s-app" = "kube-dns"
+          }
+        }
+      },
+      {
+        maxSkew           = 1
+        topologyKey       = "kubernetes.io/hostname"
+        whenUnsatisfiable = "ScheduleAnyway"
+        labelSelector = {
+          matchLabels = {
+            "k8s-app" = "kube-dns"
+          }
+        }
+      }
+    ]
+    podDisruptionBudget = {
+      maxUnavailable = 1
+    }
   })
 
   tags = var.tags

--- a/osdc/modules/eks/terraform/modules/eks/variables.tf
+++ b/osdc/modules/eks/terraform/modules/eks/variables.tf
@@ -54,6 +54,17 @@ variable "base_node_count" {
   default     = 5
 }
 
+variable "coredns_replicas" {
+  description = "Number of CoreDNS replicas (pinned; autoscaling disabled). Per-cluster via clusters.yaml."
+  type        = number
+  default     = 6
+
+  validation {
+    condition     = var.coredns_replicas >= 2
+    error_message = "coredns_replicas must be >= 2 (single-replica CoreDNS deadlocks the PDB; zero replicas means no DNS)."
+  }
+}
+
 variable "base_node_instance_type" {
   description = "Instance type for base infrastructure nodes"
   type        = string

--- a/osdc/modules/eks/terraform/variables.tf
+++ b/osdc/modules/eks/terraform/variables.tf
@@ -29,6 +29,17 @@ variable "base_node_count" {
   default     = 3
 }
 
+variable "coredns_replicas" {
+  description = "Number of CoreDNS replicas (pinned; autoscaling disabled). Per-cluster via clusters.yaml."
+  type        = number
+  default     = 6
+
+  validation {
+    condition     = var.coredns_replicas >= 2
+    error_message = "coredns_replicas must be >= 2 (single-replica CoreDNS deadlocks the PDB; zero replicas means no DNS)."
+  }
+}
+
 variable "base_node_instance_type" {
   description = "Instance type for base infrastructure nodes"
   type        = string

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -1,5 +1,7 @@
 """Smoke tests for EKS cluster and AWS infrastructure."""
 
+import subprocess
+
 import pytest
 import yaml
 from helpers import get_unstable_node_names, pod_is_on_unstable_node, run_aws, run_kubectl
@@ -158,3 +160,107 @@ class TestECRImages:
 
         missing = [repo for repo in expected_repos if repo not in ecr_repo_names]
         assert not missing, f"ECR repositories missing for bootstrap images: {missing}"
+
+
+# ============================================================================
+# CoreDNS Topology Pinning
+# ============================================================================
+
+
+class TestCoreDNSTopology:
+    """Verify CoreDNS replicaCount, topology spread, autoscaling, and PDB.
+
+    Pinned via aws_eks_addon.coredns configuration_values in
+    modules/eks/terraform/modules/eks/main.tf. Replica count is per-cluster
+    via clusters.yaml (coredns.replicas — default 6, staging 2).
+    """
+
+    def test_replica_count_matches_clusters_yaml(self, resolve_config):
+        expected = resolve_config("coredns.replicas", 6)
+        deploy = run_kubectl(["get", "deployment", "coredns"], namespace="kube-system")
+        actual = deploy.get("spec", {}).get("replicas")
+        assert actual == expected, (
+            f"CoreDNS Deployment.spec.replicas={actual} does not match clusters.yaml expected={expected}"
+        )
+
+    def test_zone_topology_spread_is_hard(self, resolve_config):
+        deploy = run_kubectl(["get", "deployment", "coredns"], namespace="kube-system")
+        constraints = deploy.get("spec", {}).get("template", {}).get("spec", {}).get("topologySpreadConstraints", [])
+        zone_rules = [
+            c
+            for c in constraints
+            if c.get("topologyKey") == "topology.kubernetes.io/zone" and c.get("whenUnsatisfiable") == "DoNotSchedule"
+        ]
+        assert zone_rules, (
+            f"CoreDNS Deployment missing hard zone spread (topology.kubernetes.io/zone, DoNotSchedule). "
+            f"Found constraints: {constraints}"
+        )
+        # maxSkew=2 tolerates AWS subnet placement drift (e.g. 4-2-0 across AZs after
+        # AMI rolls) while still preventing catastrophic 6-0-0 single-AZ pinning.
+        for rule in zone_rules:
+            assert rule.get("maxSkew") == 2, (
+                f"CoreDNS zone spread maxSkew={rule.get('maxSkew')}, expected 2. Constraint: {rule}"
+            )
+            assert rule.get("labelSelector", {}).get("matchLabels", {}).get("k8s-app") == "kube-dns", (
+                f"CoreDNS zone spread labelSelector mismatch. Constraint: {rule}"
+            )
+
+    def test_hostname_topology_spread_is_soft(self, resolve_config):
+        """Soft hostname spread (ScheduleAnyway) keeps replicas off the same node when possible."""
+        deploy = run_kubectl(["get", "deployment", "coredns"], namespace="kube-system")
+        constraints = deploy.get("spec", {}).get("template", {}).get("spec", {}).get("topologySpreadConstraints", [])
+        host_rules = [
+            c
+            for c in constraints
+            if c.get("topologyKey") == "kubernetes.io/hostname" and c.get("whenUnsatisfiable") == "ScheduleAnyway"
+        ]
+        assert host_rules, (
+            f"CoreDNS Deployment missing soft hostname spread (kubernetes.io/hostname, ScheduleAnyway). "
+            f"Found constraints: {constraints}"
+        )
+        for rule in host_rules:
+            assert rule.get("maxSkew") == 1, (
+                f"CoreDNS hostname spread maxSkew={rule.get('maxSkew')}, expected 1. Constraint: {rule}"
+            )
+            assert rule.get("labelSelector", {}).get("matchLabels", {}).get("k8s-app") == "kube-dns", (
+                f"CoreDNS hostname spread labelSelector mismatch. Constraint: {rule}"
+            )
+
+    def test_no_cluster_proportional_autoscaler(self, cluster_config):
+        """Addon-managed autoscaling must be off — no CPA Deployment should exist for coredns.
+
+        EKS CoreDNS uses the cluster-proportional-autoscaler (CPA), which runs as a
+        Deployment named 'coredns-autoscaler' (newer addon versions) or 'eks-coredns-autoscaler'
+        (older spelling). It is NOT a HorizontalPodAutoscaler. With autoScaling.enabled=false
+        in the addon configuration_values, neither Deployment should be present.
+        """
+        cluster_name = cluster_config["cluster"]["cluster_name"]
+        for cpa_name in ("coredns-autoscaler", "eks-coredns-autoscaler"):
+            try:
+                deploy = run_kubectl(["get", "deployment", cpa_name], namespace="kube-system")
+            except subprocess.CalledProcessError:
+                # 'NotFound' surfaces as kubectl exit 1 — that's the desired state.
+                continue
+            # If we got JSON back, the CPA Deployment exists — that's a regression.
+            pytest.fail(
+                f"Unexpected cluster-proportional-autoscaler Deployment '{cpa_name}' in kube-system "
+                f"on {cluster_name} (autoScaling.enabled=false should prevent this): {deploy}"
+            )
+
+    def test_pdb_max_unavailable_is_one(self):
+        pdbs = run_kubectl(["get", "poddisruptionbudgets"], namespace="kube-system")
+        items = pdbs.get("items", [])
+        coredns_pdbs = [
+            p
+            for p in items
+            if p.get("spec", {}).get("selector", {}).get("matchLabels", {}).get("k8s-app") == "kube-dns"
+        ]
+        assert coredns_pdbs, f"No PodDisruptionBudget found targeting CoreDNS (k8s-app=kube-dns). Items: {items}"
+        # EKS addon picks one PDB resource name (typically 'coredns'); assert all
+        # found PDBs have maxUnavailable=1 (defensive against multiple stale PDBs).
+        for pdb in coredns_pdbs:
+            spec = pdb.get("spec", {})
+            max_unavail = spec.get("maxUnavailable")
+            assert max_unavail == 1, (
+                f"CoreDNS PDB {pdb['metadata']['name']} has maxUnavailable={max_unavail}, expected 1"
+            )

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -52,6 +52,11 @@ def resolve(cluster_cfg, defaults, dotpath):
 def tfvars(cluster_id, cluster_cfg, defaults):
     """Produce -var flags for tofu from cluster config."""
     base = {**defaults, **(cluster_cfg.get("base") or {})}
+    # Resolve nested config (e.g. coredns.replicas) using the same lookup
+    # rules as resolve(): cluster value wins; otherwise defaults.
+    coredns_replicas = resolve(cluster_cfg, defaults, "coredns.replicas")
+    if coredns_replicas is None:
+        coredns_replicas = 6
     pairs = {
         "cluster_name": cluster_cfg["cluster_name"],
         "aws_region": cluster_cfg["region"],
@@ -62,6 +67,7 @@ def tfvars(cluster_id, cluster_cfg, defaults):
         "base_node_max_unavailable_percentage": base.get("base_node_max_unavailable_percentage", 33),
         "base_node_ami_version": base.get("base_node_ami_version", defaults.get("base_node_ami_version", "v*")),
         "eks_version": base.get("eks_version", defaults.get("eks_version", "1.35")),
+        "coredns_replicas": coredns_replicas,
     }
     # Optional fields — only emit if explicitly set
     access_config = cluster_cfg.get("access_config") or base.get("access_config") or {}

--- a/osdc/scripts/test_cluster_config.py
+++ b/osdc/scripts/test_cluster_config.py
@@ -166,6 +166,29 @@ class TestTfvars:
         assert '-var="base_node_max_unavailable_percentage=33"' in out
         assert '-var="base_node_ami_version=v*"' in out
         assert '-var="eks_version=1.35"' in out
+        # coredns.replicas not set anywhere — falls back to hardcoded default 6
+        assert '-var="coredns_replicas=6"' in out
+
+    def test_coredns_replicas_from_defaults(self, capsys):
+        cluster_cfg = {
+            "cluster_name": "c",
+            "region": "r",
+        }
+        defaults = {"coredns": {"replicas": 4}}
+        cluster_config.tfvars("c", cluster_cfg, defaults)
+        out = capsys.readouterr().out.strip()
+        assert '-var="coredns_replicas=4"' in out
+
+    def test_coredns_replicas_cluster_override(self, capsys):
+        cluster_cfg = {
+            "cluster_name": "c",
+            "region": "r",
+            "coredns": {"replicas": 2},
+        }
+        defaults = {"coredns": {"replicas": 6}}
+        cluster_config.tfvars("c", cluster_cfg, defaults)
+        out = capsys.readouterr().out.strip()
+        assert '-var="coredns_replicas=2"' in out
 
     def test_cluster_overrides(self, capsys):
         cluster_cfg = {


### PR DESCRIPTION
**Impact:** All EKS clusters (production and staging) — CoreDNS pod placement and scaling
**Risk:** medium

## What
Pins CoreDNS replica count, topology spread constraints, and PDB configuration via the EKS addon `configuration_values`, and explicitly disables the cluster-proportional-autoscaler. Replica count is driven per-cluster from `clusters.yaml` (default 6, staging 2).

## Why
Without explicit topology constraints, CoreDNS pods can end up pinned to a single AZ (e.g. 6-0-0) after node rolls or AMI upgrades, creating a DNS single-point-of-failure. The EKS addon's built-in autoscaler can also silently re-enable across addon version bumps, overriding the intended replica count. This change makes the CoreDNS topology deterministic and auditable through infrastructure-as-code.

## How
- Replica count is a new `coredns_replicas` Terraform variable threaded from `clusters.yaml` through `cluster-config.py` → tofu vars → the EKS module, with a `>= 2` validation gate (single-replica deadlocks the PDB; zero means no DNS).
- Autoscaling is explicitly disabled (`autoScaling.enabled = false`) as a defensive measure against addon-version flips re-enabling the cluster-proportional-autoscaler.
- Two topology spread constraints are set: a **hard** zone spread (`DoNotSchedule`, `maxSkew=2`) to prevent catastrophic single-AZ pinning while tolerating AWS subnet placement drift, and a **soft** hostname spread (`ScheduleAnyway`, `maxSkew=1`) to prefer distributing across nodes.
- PDB is pinned to `maxUnavailable=1` (matches the addon default, but now explicit).
- The existing `CriticalAddonsOnly` toleration is preserved — `configuration_values` replaces (not merges) the addon defaults, so it must be re-stated.

## Changes
- **`clusters.yaml`**: Add `coredns.replicas` default (6) and staging override (2)
- **`modules/eks/terraform/modules/eks/main.tf`**: Expand CoreDNS addon `configuration_values` with `replicaCount`, `autoScaling`, `topologySpreadConstraints`, and `podDisruptionBudget`
- **`modules/eks/terraform/modules/eks/variables.tf`**: Add `coredns_replicas` variable with `>= 2` validation
- **`modules/eks/terraform/variables.tf`**: Mirror `coredns_replicas` variable at root module level
- **`modules/eks/terraform/main.tf`**: Thread `coredns_replicas` from root to inner EKS module
- **`scripts/cluster-config.py`**: Resolve `coredns.replicas` from clusters.yaml and emit as `-var="coredns_replicas=..."` in tfvars output
- **`scripts/test_cluster_config.py`**: Add unit tests for coredns_replicas tfvar resolution (default fallback, defaults section, cluster override)
- **`modules/eks/tests/smoke/test_eks.py`**: Add `TestCoreDNSTopology` smoke test class verifying replica count, hard zone spread, soft hostname spread, no CPA deployment, and PDB maxUnavailable=1

## Testing
```
============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-05-09 00:58 UTC

  PR Workflow Jobs:
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-cpu-x86-avx512            success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-pypi-cache-defaults       success
    ✓ test-cpu-arm64                 success
    ✓ test-cpu-x86-amx               success
    ✓ test-git-cache                 success
    ✓ test-gpu-t4-multi              success
    ✓ test-release-arm64             success
    ✓ test-gpu-t4                    success
    ✓ test-harbor                    success
    ✓ test-cache-enforcer            success
    ✓ build-arm64 / build            success
    ✓ build-amd64 / build            success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================
```
```

============================================================================================================================ test session starts ============================================================================================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ci-infra/osdc
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0
16 workers [237 items]
.......................................................................s..........................................................................................................................s............s.............................                         [100%]
========================================================================================================================== short test summary info ==========================================================================================================================
SKIPPED [1] modules/arc-runners/tests/smoke/test_capacity_parity.py:300: no scale sets with proactive_capacity > 0
SKIPPED [1] modules/cache-enforcer/tests/smoke/test_cache_enforcer.py:107: No cache-enforcer pods desired (no runner nodes in cluster)
SKIPPED [1] modules/monitoring/tests/smoke/test_monitoring.py:173: No dcgm-exporter pods found (no GPU nodes)
====================================================================================================================== 234 passed, 3 skipped in 34.00s ======================================================================================================================

Smoke tests completed in 35s
```