### PR TITLE
Add NodeLocal DNSCache as a base component

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -55,6 +55,7 @@ Detailed instructions are broken into on-demand skills. Load the relevant skill 
 | `osdc-cli-debugging` | Read-only kubectl, aws, helm, tofu commands and safety boundaries | Investigating cluster state, debugging pods |
 | `osdc-harbor` | Harbor Helm chart gotchas, image mirroring, proxy cache configuration | Working on Harbor or container registry config |
 | `osdc-pypi-cache` | PyPI wheel cache module — per-CUDA nginx+pypiserver fanout, EFS wheelhouse, S3 wheel pipeline, slug naming, prebuilt-cache.txt, NetworkPolicy, IRSA | Working on the pypi-cache module or debugging pip install failures on runners |
+| `osdc-nodelocaldns` | NodeLocal DNSCache base component — iptables-mode rationale, kube-dns ClusterIP substitution, Service-before-DaemonSet ordering, two metrics ports (9253/9353), `coredns_nodecache_*` prefix, soak gate | Working on the nodelocaldns base component or debugging DNS issues on runner nodes |
 
 Load the relevant `osdc-*` skill when you need detailed instructions on any specific topic.
 

--- a/osdc/base/kubernetes/kustomization.yaml
+++ b/osdc/base/kubernetes/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - registry-mirror-config.yaml
   - algif-mitigation.yaml
   # image-cache-janitor is deployed via its own deploy.sh (builds custom image)
+  # nodelocaldns is deployed via its own deploy.sh (resolves kube-dns ClusterIP at apply time)
   # NOTE: Namespaces for modules (arc-runners, arc-systems, buildkit, etc.)
   # are created by the module's own kubernetes/ directory, not here.

--- a/osdc/base/kubernetes/nodelocaldns/configmap.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/configmap.yaml
@@ -1,0 +1,71 @@
+# Corefile for NodeLocal DNSCache.
+# - __PILLAR__CLUSTER__DNS__ is substituted at runtime by the
+#   k8s-dns-node-cache binary from the kube-dns-upstream Service ClusterIP
+#   (resolved via the -upstreamsvc flag in the DaemonSet args).
+# - __KUBE_DNS_CLUSTER_IP__ is OUR placeholder; deploy.sh sed-substitutes
+#   the live kube-dns Service ClusterIP at apply time (cluster service CIDR
+#   is dynamic, cannot be hardcoded).
+# - force_tcp on cluster.local/in-addr.arpa/ip6.arpa: persistent TCP back to
+#   cluster CoreDNS reduces conntrack churn and improves head-of-line behavior.
+# - .:53 (catch-all) forwards to /etc/resolv.conf so external lookups bypass
+#   cluster CoreDNS entirely (upstream default).
+# - health 169.254.20.10:8080 is declared ONLY on cluster.local:53. The health
+#   plugin opens a singleton listener; declaring it in a second server block
+#   would race for the same address and risk "address already in use" at
+#   CoreDNS startup. Matches upstream nodelocaldns.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    app.kubernetes.io/managed-by: osdc-base
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+            success 9984 30
+            denial 9984 5
+        }
+        reload
+        loop
+        bind 169.254.20.10 __KUBE_DNS_CLUSTER_IP__
+        forward . __PILLAR__CLUSTER__DNS__ {
+            force_tcp
+        }
+        prometheus :9253
+        health 169.254.20.10:8080
+    }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10 __KUBE_DNS_CLUSTER_IP__
+        forward . __PILLAR__CLUSTER__DNS__ {
+            force_tcp
+        }
+        prometheus :9253
+    }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10 __KUBE_DNS_CLUSTER_IP__
+        forward . __PILLAR__CLUSTER__DNS__ {
+            force_tcp
+        }
+        prometheus :9253
+    }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10 __KUBE_DNS_CLUSTER_IP__
+        forward . /etc/resolv.conf
+        prometheus :9253
+    }

--- a/osdc/base/kubernetes/nodelocaldns/daemonset.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/daemonset.yaml
@@ -1,0 +1,123 @@
+# NodeLocal DNSCache DaemonSet: per-node CoreDNS instance that absorbs
+# DNS queries from local pods via iptables NOTRACK interception.
+#
+# Design notes (see ~/meta/actions-knowledge-base/docs/osdc/ for full rationale):
+# - hostNetwork + privileged: NLD manipulates iptables, the dummy nodelocaldns
+#   interface, and binds the link-local IP. NET_ADMIN alone does not cover
+#   all of these on AL2023.
+# - dnsPolicy: Default (NOT ClusterFirstWithHostNet): NLD must NOT depend on
+#   itself for DNS resolution. Default uses the host's resolv.conf.
+# - No memory limit: OOMKill orphans iptables → cluster-wide DNS degradation.
+#   system-node-critical priorityClass already prevents eviction.
+# - No CPU limit: throttling = DNS latency.
+# - terminationGracePeriodSeconds: 30 matches upstream NLD default; gives the
+#   binary's signal-handler TeardownNetworking() time to delete iptables NOTRACK
+#   rules and the dummy nodelocaldns interface before kubelet kills the pod.
+#   Spec §4.9 had 5s but that risks orphaned rules on slow nodes during rolling
+#   restart.
+# - __KUBE_DNS_CLUSTER_IP__ is substituted by deploy.sh at apply time.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    app.kubernetes.io/managed-by: osdc-base
+spec:
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1%
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      hostNetwork: true
+      dnsPolicy: Default
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
+        - key: instance-type
+          operator: Exists
+          effect: NoSchedule
+        - key: git-cache-not-ready
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: node-cache
+          image: registry.k8s.io/dns/k8s-dns-node-cache:1.26.8
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-localip"
+            - "169.254.20.10,__KUBE_DNS_CLUSTER_IP__"
+            - "-conf"
+            - "/etc/Corefile"
+            - "-upstreamsvc"
+            - "kube-dns-upstream"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 100Mi
+          ports:
+            - name: dns
+              containerPort: 53
+              protocol: UDP
+            - name: dns-tcp
+              containerPort: 53
+              protocol: TCP
+            - name: metrics
+              containerPort: 9253
+              protocol: TCP
+            - name: metrics-binary
+              containerPort: 9353
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              host: 169.254.20.10
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
+            - name: kube-dns-config
+              mountPath: /etc/kube-dns
+            - name: config-volume
+              mountPath: /etc/coredns
+      volumes:
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: kube-dns-config
+          configMap:
+            name: kube-dns
+            optional: true
+        - name: config-volume
+          configMap:
+            name: node-local-dns
+            items:
+              - key: Corefile
+                path: Corefile.base

--- a/osdc/base/kubernetes/nodelocaldns/deploy.sh
+++ b/osdc/base/kubernetes/nodelocaldns/deploy.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Deploy NodeLocal DNSCache (NLD) as a per-node DaemonSet.
+# Called from the justfile's deploy-base recipe.
+#
+# Args: $1=cluster-id
+#
+# NLD requires the kube-dns ClusterIP at config-render time and the
+# kube-dns-upstream Service to exist BEFORE the DaemonSet pods are
+# scheduled (the binary reads KUBE_DNS_UPSTREAM_SERVICE_HOST, which
+# kubelet only injects for Services existing at pod-create time).
+
+# shellcheck disable=SC2034  # CLUSTER is part of the deploy.sh interface
+CLUSTER="$1"
+if [[ -z "$CLUSTER" ]]; then
+  echo "ERROR: cluster-id arg is required" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OSDC_UPSTREAM="${OSDC_UPSTREAM:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$OSDC_UPSTREAM/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$OSDC_UPSTREAM/scripts/kubectl-apply.sh"
+
+# --- Cleanup trap ---
+WORK_DIR=""
+cleanup() {
+  [[ -n "$WORK_DIR" ]] && rm -rf "$WORK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Step 1: Precondition — verify kube-dns-upstream Service is ours (or absent) ---
+echo "→ NodeLocal DNSCache: checking kube-dns-upstream Service precondition..."
+UPSTREAM_FIRST_DEPLOY=true
+EXISTING_SELECTOR=""
+if kubectl get svc kube-dns-upstream -n kube-system &>/dev/null; then
+  UPSTREAM_FIRST_DEPLOY=false
+  EXISTING_SELECTOR=$(kubectl get svc kube-dns-upstream -n kube-system \
+    -o jsonpath='{.spec.selector.k8s-app}' 2>/dev/null)
+  if [[ "$EXISTING_SELECTOR" != "kube-dns" ]]; then
+    echo "ERROR: kube-dns-upstream Service exists with selector k8s-app=${EXISTING_SELECTOR:-<empty>}." >&2
+    echo "       Expected selector k8s-app=kube-dns. Refusing to overwrite." >&2
+    exit 1
+  fi
+  echo "  kube-dns-upstream already present with correct selector — no rollout restart needed."
+else
+  echo "  kube-dns-upstream not present — will create (rollout restart will follow)."
+fi
+
+# --- Step 2: Resolve kube-dns ClusterIP ---
+echo "→ NodeLocal DNSCache: resolving kube-dns ClusterIP..."
+KUBE_DNS_CLUSTER_IP=$(kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+if [[ -z "$KUBE_DNS_CLUSTER_IP" ]]; then
+  echo "ERROR: failed to resolve kube-dns ClusterIP (empty result)." >&2
+  exit 1
+fi
+if [[ ! "${KUBE_DNS_CLUSTER_IP}" =~ ^[0-9a-fA-F:.]+$ ]]; then
+  echo "ERROR: KUBE_DNS_CLUSTER_IP value is not a valid IPv4/IPv6 address: ${KUBE_DNS_CLUSTER_IP}" >&2
+  exit 1
+fi
+echo "  kube-dns ClusterIP: $KUBE_DNS_CLUSTER_IP"
+
+# --- Step 3: Render manifests via kustomize, then sed-substitute placeholders ---
+echo "→ NodeLocal DNSCache: rendering manifests..."
+WORK_DIR=$(mktemp -d)
+RENDERED="$WORK_DIR/all.yaml"
+SERVICES_FILE="$WORK_DIR/services.yaml"
+REST_FILE="$WORK_DIR/rest.yaml"
+
+kubectl kustomize "$SCRIPT_DIR" >"$RENDERED"
+
+# .bak suffix for macOS/BSD sed compatibility, then drop the backup.
+sed -i.bak "s|__KUBE_DNS_CLUSTER_IP__|${KUBE_DNS_CLUSTER_IP}|g" "$RENDERED"
+rm -f "${RENDERED}.bak"
+
+# --- Step 4: Split rendered output — Services first, everything else after ---
+# Services must exist before DaemonSet pods are scheduled so kubelet injects
+# KUBE_DNS_UPSTREAM_SERVICE_HOST/PORT into the node-cache container env.
+uv run --with pyyaml python3 - "$RENDERED" "$SERVICES_FILE" "$REST_FILE" <<'PY'
+import sys
+import yaml
+
+src, services_path, rest_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src) as fh:
+    docs = [d for d in yaml.safe_load_all(fh) if d]
+
+services = [d for d in docs if d.get("kind") == "Service"]
+rest = [d for d in docs if d.get("kind") != "Service"]
+
+with open(services_path, "w") as fh:
+    yaml.safe_dump_all(services, fh)
+with open(rest_path, "w") as fh:
+    yaml.safe_dump_all(rest, fh)
+PY
+
+# --- Step 5: Apply Services first ---
+echo "→ NodeLocal DNSCache: applying Services (kube-dns-upstream + metrics)..."
+kubectl_apply_if_changed -f "$SERVICES_FILE"
+
+# Brief settle so the Service ClusterIP is allocated before the DaemonSet
+# pods are created (kubelet snapshots Service env at pod-create time).
+sleep 3
+
+# --- Step 6: Apply ConfigMap, ServiceAccount, DaemonSet ---
+echo "→ NodeLocal DNSCache: applying ConfigMap, ServiceAccount, DaemonSet..."
+kubectl_apply_if_changed -f "$REST_FILE"
+
+# --- Step 7: Idempotency safety net ---
+# Only restart on first-time deploy: the DaemonSet pods created above (or
+# any pre-existing ones from an earlier failed install) won't have the
+# KUBE_DNS_UPSTREAM_SERVICE_HOST env var unless the Service existed before
+# they were scheduled. On steady-state re-runs, env is already populated.
+if [[ "$UPSTREAM_FIRST_DEPLOY" == "true" ]]; then
+  echo "→ NodeLocal DNSCache: first-time deploy — rolling DaemonSet to inject upstream Service env..."
+  kubectl rollout restart ds node-local-dns -n kube-system
+else
+  echo "→ NodeLocal DNSCache: not a first-time deploy — skipping rollout restart."
+fi
+
+echo "NodeLocal DNSCache deployed."

--- a/osdc/base/kubernetes/nodelocaldns/kustomization.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/kustomization.yaml
@@ -1,0 +1,15 @@
+# NodeLocal DNSCache (NLD): per-node CoreDNS DaemonSet that absorbs DNS
+# queries from local pods via iptables NOTRACK interception.
+# kube-dns ClusterIP is dynamic per cluster — deploy.sh resolves it at
+# apply time and substitutes the __KUBE_DNS_CLUSTER_IP__ placeholder.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+resources:
+  - serviceaccount.yaml
+  - upstream-service.yaml
+  - metrics-service.yaml
+  - configmap.yaml
+  - daemonset.yaml

--- a/osdc/base/kubernetes/nodelocaldns/metrics-service.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/metrics-service.yaml
@@ -1,0 +1,25 @@
+# Headless Service for PodMonitor discovery. Two ports:
+# - metrics (9253): CoreDNS plugin metrics (cache hits, forward latency, etc.)
+# - metrics-binary (9353): k8s-dns-node-cache binary metrics (coredns_nodecache_*)
+# Both must be scraped — setup-error counter lives on the binary endpoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-local-dns-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    app.kubernetes.io/managed-by: osdc-base
+spec:
+  clusterIP: None
+  selector:
+    k8s-app: node-local-dns
+  ports:
+    - name: metrics
+      port: 9253
+      protocol: TCP
+      targetPort: 9253
+    - name: metrics-binary
+      port: 9353
+      protocol: TCP
+      targetPort: 9353

--- a/osdc/base/kubernetes/nodelocaldns/serviceaccount.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/serviceaccount.yaml
@@ -1,0 +1,17 @@
+# ServiceAccount for the node-local-dns DaemonSet.
+# No RBAC: the binary does not talk to the API server. The upstream
+# Service IP is resolved by env var (KUBE_DNS_UPSTREAM_SERVICE_HOST)
+# injected by kubelet from the kube-dns-upstream Service.
+# automountServiceAccountToken: false — the binary makes no API calls,
+# so the auto-mounted SA token is unused dead weight. Disabling it
+# removes a credential-leak vector if the privileged container is
+# compromised.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    app.kubernetes.io/managed-by: osdc-base
+automountServiceAccountToken: false

--- a/osdc/base/kubernetes/nodelocaldns/upstream-service.yaml
+++ b/osdc/base/kubernetes/nodelocaldns/upstream-service.yaml
@@ -1,0 +1,25 @@
+# Second Service in front of cluster CoreDNS. NLD forwards to this
+# ClusterIP from its Corefile; the existing kube-dns Service stays
+# untouched (kubelet's --cluster-dns still points at it). Required
+# by upstream NLD so it has a separate ClusterIP to forward to
+# without iptables-redirecting through itself.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    app.kubernetes.io/managed-by: osdc-base
+spec:
+  selector:
+    k8s-app: kube-dns
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+      targetPort: 53
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 53

--- a/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
+++ b/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
@@ -1,7 +1,7 @@
 """Smoke tests for base Kubernetes resources (DaemonSets, StorageClass, nodes)."""
 
 import pytest
-from helpers import assert_daemonset_healthy
+from helpers import assert_daemonset_healthy, filter_services
 
 pytestmark = [pytest.mark.live]
 
@@ -27,6 +27,33 @@ class TestBaseDaemonSets:
 
     def test_node_performance_tuning(self, all_daemonsets, all_nodes):
         assert_daemonset_healthy(all_daemonsets, all_nodes, NAMESPACE, "node-performance-tuning", allow_zero=True)
+
+    def test_nodelocaldns_daemonset(self, all_daemonsets, all_nodes):
+        """NodeLocal DNSCache DaemonSet runs on every node."""
+        assert_daemonset_healthy(all_daemonsets, all_nodes, NAMESPACE, "node-local-dns")
+
+
+# ============================================================================
+# NodeLocal DNSCache Services
+# ============================================================================
+
+
+class TestNodeLocalDNSServices:
+    """Verify NodeLocal DNSCache supporting Services are present and correctly configured."""
+
+    def test_nodelocaldns_metrics_service_headless(self, all_services):
+        """NLD metrics service is headless (clusterIP: None) for PodMonitor discovery."""
+        svcs = filter_services(all_services, namespace=NAMESPACE, name="node-local-dns-metrics")
+        assert len(svcs) == 1, f"node-local-dns-metrics service not found in {NAMESPACE}"
+        cluster_ip = svcs[0]["spec"].get("clusterIP")
+        assert cluster_ip == "None", f"expected headless service (clusterIP: None), got {cluster_ip!r}"
+
+    def test_nodelocaldns_upstream_service_selects_kube_dns(self, all_services):
+        """kube-dns-upstream service exists and selects kube-dns pods (NLD's forward target)."""
+        svcs = filter_services(all_services, namespace=NAMESPACE, name="kube-dns-upstream")
+        assert len(svcs) == 1, f"kube-dns-upstream service not found in {NAMESPACE}"
+        selector = svcs[0]["spec"].get("selector", {})
+        assert selector.get("k8s-app") == "kube-dns", f"expected selector k8s-app=kube-dns, got {selector!r}"
 
 
 # ============================================================================

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -13,7 +13,7 @@ Every cluster gets the same base infrastructure:
 - **VPC** — public/private subnets, NAT gateways, route tables
 - **EKS** — managed Kubernetes cluster with OIDC, addons (vpc-cni, coredns, kube-proxy, ebs-csi), fixed-size base node group
 - **Harbor** — S3 bucket, IAM roles/user for pull-through container image cache
-- **Base k8s resources** — gp3 StorageClass, NVIDIA device plugin, node performance tuning DaemonSet, git-cache (two-tier: central StatefulSet + rsync DaemonSet), Harbor namespace, image-cache-janitor (prunes stale image content from node disks)
+- **Base k8s resources** — gp3 StorageClass, NVIDIA device plugin, node performance tuning DaemonSet, git-cache (two-tier: central StatefulSet + rsync DaemonSet), Harbor namespace, image-cache-janitor (prunes stale image content from node disks), NodeLocal DNSCache (per-node CoreDNS DaemonSet that intercepts pod DNS via iptables-mode NOTRACK)
 - **Node compactor** — Taints underutilized Karpenter nodes for workload consolidation (configurable via `clusters.yaml`)
 - **Karpenter** — installed as a module but required for the autoscaling story; deployed before any compute-provisioning module
 
@@ -85,7 +85,8 @@ just deploy <cluster-id>
 │   ├── git-cache/deploy.sh                         ← Git cache central StatefulSet
 │   ├── deploy-harbor                               ← Helm install Harbor (pull-through cache)
 │   ├── node-compactor/deploy.sh                    ← if enabled in clusters.yaml
-│   └── image-cache-janitor/deploy.sh               ← prunes stale image content from node disks
+│   ├── image-cache-janitor/deploy.sh               ← prunes stale image content from node disks
+│   └── nodelocaldns/deploy.sh                      ← per-node CoreDNS cache (resolves kube-dns ClusterIP at apply time)
 │
 └── deploy-module (for each module in order)
     ├── tofu apply (modules/<mod>/terraform/)        ← if exists

--- a/osdc/docs/loki_query.md
+++ b/osdc/docs/loki_query.md
@@ -184,6 +184,18 @@ curl -s -u "$LOKI_USER:$LOKI_READ_KEY" \
     --data-urlencode "end=$(date -u +%s)000000000" | jq .
 ```
 
+### NodeLocal DNSCache logs
+
+```bash
+# ... (credential extraction) ... && \
+curl -s -u "$LOKI_USER:$LOKI_READ_KEY" \
+    "$LOKI_URL/loki/api/v1/query_range" \
+    --data-urlencode 'query={cluster="pytorch-arc-cbr-production", namespace="kube-system", app="node-local-dns"}' \
+    --data-urlencode "limit=50" \
+    --data-urlencode "start=$(date -u -v-1H +%s)000000000" \
+    --data-urlencode "end=$(date -u +%s)000000000" | jq .
+```
+
 ### Kubernetes events
 
 ```bash

--- a/osdc/docs/mimir_query.md
+++ b/osdc/docs/mimir_query.md
@@ -102,6 +102,7 @@ Target counts vary continuously with cluster size and are not listed here — qu
 | `kube-state-metrics` | Filtered KSM allowlist | Keeps `kube_pod_info`, `kube_pod_container_status_*`, `kube_pod_status_reason`, `kube_deployment_status_*`, daemonset/namespace/node/statefulset/pv/hpa/job metrics |
 | `apiserver` | API server health | Only `apiserver_request_total` and `apiserver_request_terminations_total` are kept |
 | `coredns` | DNS resolution metrics | All `coredns_*` except buckets, plus `go_*`/`process_*` dropped |
+| `monitoring/nodelocaldns` | Per-node NodeLocal DNSCache (NLD) DaemonSet metrics; scrapes both ports `9253` (CoreDNS plugin) and `9353` (binary `coredns_nodecache_setup_errors_total`) at 60s | All `coredns_*` except `coredns_*_request_duration_seconds_bucket`, plus `go_*`/`process_*` dropped |
 | `karpenter` | Autoscaler counters and capacity | Only `karpenter_nodeclaims_created_total`, `karpenter_nodes_created_total`, `karpenter_nodes_terminated_total`, `karpenter_nodepools_usage`, `karpenter_nodepools_limit`, `karpenter_nodes_allocatable`, `karpenter_interruption_received_messages_total` |
 | `git-cache-central-metrics` | Git cache central service metrics | No filter — all `git_cache_central_*` flow through |
 | Git cache daemonset | Per-node git cache metrics (PodMonitor) | No filter — all `git_cache_node_*` flow through |
@@ -284,6 +285,42 @@ rate(apiserver_request_terminations_total{cluster="pytorch-arc-cbr-production"}[
 
 # CoreDNS request rate
 rate(coredns_dns_requests_total{cluster="pytorch-arc-cbr-production"}[5m])
+```
+
+### NodeLocal DNSCache (NLD)
+
+Per-node DaemonSet — each pod emits CoreDNS plugin metrics on port `9253` (zone-scoped request/cache counters) and the binary's own `coredns_nodecache_setup_errors_total` on port `9353`. The PodMonitor labels both ports with `job="monitoring/nodelocaldns"` and `pod=<nld-pod-name>` (one per node, host-network).
+
+> **Metric name gotcha**: the binary's setup-error counter is **`coredns_nodecache_setup_errors_total`** (namespace `coredns`, subsystem `nodecache`), **NOT** `nodelocaldns_setup_errors_total`. Some upstream/internal docs and PR drafts use the wrong name. Queries against `nodelocaldns_setup_errors_total` will silently return zero results — always use the `coredns_nodecache_*` form.
+
+```promql
+# Cluster-wide NLD QPS across all zones (one pod per node)
+sum(rate(coredns_dns_request_count_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m]))
+
+# Per-zone NLD QPS (cluster.local.:53, in-addr.arpa.:53, ip6.arpa.:53, .:53)
+sum by (server) (rate(coredns_dns_request_count_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m]))
+
+# Per-node NLD QPS (top 10 noisiest nodes)
+topk(10, sum by (pod) (rate(coredns_dns_request_count_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m])))
+
+# Cluster-wide cache hit ratio (success hits / (success hits + misses))
+sum(rate(coredns_cache_hits_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns", type="success"}[5m]))
+  / (sum(rate(coredns_cache_hits_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns", type="success"}[5m]))
+     + sum(rate(coredns_cache_misses_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m])))
+
+# Per-node cache hit ratio (find nodes with poor cache locality)
+sum by (pod) (rate(coredns_cache_hits_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns", type="success"}[5m]))
+  / (sum by (pod) (rate(coredns_cache_hits_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns", type="success"}[5m]))
+     + sum by (pod) (rate(coredns_cache_misses_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m])))
+
+# NLD setup errors (any non-zero value should fire NodeLocalDNSSetupErrors alert)
+coredns_nodecache_setup_errors_total{cluster="pytorch-arc-cbr-production"}
+
+# Per-node NLD setup errors broken down by error type
+sum by (pod, errortype) (coredns_nodecache_setup_errors_total{cluster="pytorch-arc-cbr-production"})
+
+# Number of NLD pods reporting metrics (should equal node count)
+count(up{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"} == 1)
 ```
 
 ### PyPI Cache

--- a/osdc/docs/node-utilization-optimization.md
+++ b/osdc/docs/node-utilization-optimization.md
@@ -20,7 +20,7 @@ Each node's allocatable resources are reduced by:
 
 1. **Kubelet reserved CPU**: 60m (first core) + 10m/core (cores 2-4) + 5m/core (cores 5-8) + 2.5m/core (cores 9+)
 2. **Kubelet reserved memory**: 255Mi + 11Mi per max_pod (ENI-based) + 100Mi eviction threshold
-3. **DaemonSet overhead**: 245m CPU / 640Mi memory (non-GPU), 345m CPU / 896Mi memory (GPU nodes)
+3. **DaemonSet overhead**: 270m CPU / 740Mi memory (non-GPU), 370m CPU / 996Mi memory (GPU nodes). Includes NodeLocal DNSCache (NLD) at 25m CPU / 100Mi memory per node, deployed on every node via DaemonSet.
 
 Each runner pod also includes a sidecar (750m CPU, 512Mi memory) on top of its job container resources.
 
@@ -182,7 +182,7 @@ The savings compound: nodes with better packing serve more concurrent runners, r
 
 Some runners (46c/85Gi, 94c/192Gi, 48c/384Gi) consistently achieve only 74-76% utilization even on perfectly-matched instance types. This is because:
 
-1. **Overhead is fixed**: Kubelet + DaemonSet overhead (~500m CPU, ~1.5Gi memory) is constant regardless of instance size
+1. **Overhead is fixed**: Kubelet + DaemonSet overhead (~525m CPU, ~1.6Gi memory; includes NLD at 25m CPU / 100Mi memory per node) is constant regardless of instance size
 2. **Large runners don't divide evenly**: A 94c runner on a 128c node leaves 34c unused — only 1 pod fits
 3. **Sidecar tax**: Each pod adds 750m CPU + 512Mi memory, which compounds at large sizes
 

--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -15,6 +15,10 @@ Node provisioned by Karpenter
 │  (blocks runner pods from scheduling on this node)
 │
 ├─ DaemonSets schedule immediately (tolerate all taints):
+│  ├─ nodelocaldns             → per-node CoreDNS cache (system-node-critical priority)
+│  │                            (ALL nodes; image lazy-pulled via Harbor proxy cache —
+│  │                             ~30-60s ImagePullBackOff race on fresh nodes until
+│  │                             registry-mirror-config writes containerd hosts.toml)
 │  ├─ git-cache-warmer         → rsyncs git repos from a central git-cache replica to local NVMe
 │  │                            (only on workload-type ∈ [github-runner, buildkit])
 │  ├─ runner-hooks-warmer      → downloads patched runner-container-hooks
@@ -101,6 +105,18 @@ This ensures freshly provisioned nodes complete their full warm-up sequence (git
 
 These DaemonSets also run on new nodes but do not block runner scheduling:
 
+### NodeLocal DNSCache (NLD)
+
+**File**: `base/kubernetes/nodelocaldns/` (deployed via `base/kubernetes/nodelocaldns/deploy.sh`, invoked from the `deploy-base` just recipe — last step, after `image-cache-janitor`)
+
+Per-node CoreDNS cache running as a DaemonSet on **every** node. Reduces cluster-wide DNS load and lowers per-pod resolution latency. Pod spec uses `priorityClassName: system-node-critical` so it lands early and won't be evicted under kubelet pressure. Resource footprint is `25m` CPU / `100Mi` memory requests, no limits (memory limit risks OOMKill → orphan iptables → cluster-wide DNS degradation).
+
+**Why no startup taint blocks workloads on NLD readiness**: NLD operates in iptables-mode. The kubelet's `--cluster-dns` value is **unchanged** — pods continue resolving via the kube-dns Service ClusterIP. NLD installs NOTRACK iptables rules on a dummy `nodelocaldns` interface that binds both `169.254.20.10` and the kube-dns Service ClusterIP. While the NLD pod is not yet ready (or fails), DNS queries fall through gracefully to cluster CoreDNS via the unchanged kube-dns Service Endpoints. There is no scheduling deadlock to protect against, so no startup taint is needed.
+
+**Cold-pull race on fresh Karpenter nodes**: The image (`registry.k8s.io/dns/k8s-dns-node-cache:1.26.8`, ~50MB) is lazy-pulled via the Harbor proxy cache — it is **not** pre-mirrored to ECR. On a brand-new node, NLD typically sees ~30-60s of `ImagePullBackOff` until `registry-mirror-config` writes containerd's `hosts.toml` and the proxy-cache pull succeeds. During that window, pods on the node continue to use cluster CoreDNS via the unchanged kube-dns Service — no pod-visible failure, just no per-node cache yet.
+
+**Tolerations**: explicit list (NOT `operator: Exists`) — `CriticalAddonsOnly`, `nvidia.com/gpu`, `node-fleet`, `instance-type`, `git-cache-not-ready`. Covers all standard runner/buildkit/GPU taints so it schedules at provisioning time.
+
 ### NVIDIA Device Plugin (GPU nodes only)
 
 **File**: `base/kubernetes/nvidia-device-plugin.yaml`
@@ -183,6 +199,8 @@ tolerations:
 ```
 
 This ensures DaemonSet pods schedule on nodes immediately at provisioning time, before any startup taints are removed.
+
+**Exception**: The `nodelocaldns` DaemonSet uses an **explicit** toleration list (NOT `operator: Exists` blanket-tolerating each key) — it explicitly tolerates `CriticalAddonsOnly`, `nvidia.com/gpu`, `node-fleet`, `instance-type`, and `git-cache-not-ready`. This is sufficient to cover all standard runner/buildkit/GPU NodePool taints. If a new permanent taint is added to any NodePool, NLD's toleration list must be updated explicitly.
 
 ## Key Files
 

--- a/osdc/docs/observability-estimates.md
+++ b/osdc/docs/observability-estimates.md
@@ -31,15 +31,16 @@ Every node managed by Karpenter runs several DaemonSets that produce metrics. Th
 | **kubelet** | Built-in (kubelet ServiceMonitor) | Whitelisted to `kubelet_running_pods`, `kubelet_running_containers`, `kubelet_node_name`. `/metrics/probes` disabled. | small fixed set per node |
 | **cAdvisor** | Built-in (kubelet) | Whitelisted to `container_memory_working_set_bytes` and `container_memory_rss`, then restricted by Alloy `cost_control` to control-plane namespaces only (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`). Runner nodes contribute zero cAdvisor series. | ~2 per control-plane container; 0 per runner pod |
 | **git-cache-warmer** | DaemonSet (all nodes) | Clone/fetch durations, cache sizes, rsync stats | ~10-20 |
+| **nodelocaldns** | DaemonSet (all nodes) | Two scrape ports: `:9253` exposes CoreDNS plugin metrics per zone (4 zones — `cluster.local`, `in-addr.arpa`, `ip6.arpa`, `.`) — request counts by type/proto/family, response codes, cache hits/misses/entries, forward stats, plus `_sum`/`_count` for duration histograms. `:9353` exposes the binary's `coredns_nodecache_setup_errors_total` (single series). Drops `go_*`, `process_*`, and `coredns_*_request_duration_seconds_bucket` at PodMonitor level (matches `coredns.yaml` convention). | ~40-60 per node (~10-15 per zone × 4 zones, plus 1 setup-errors series) |
 | **DCGM exporter** | DaemonSet (GPU nodes only) | 25 curated GPU metrics per GPU (Tier 1: 22, Tier 2: 3): utilization, memory, temp, power, ECC, XID errors, NVLink, PCIe, clocks, throttling | 25 per GPU |
 
 **Per-node totals** (varies by node type — see the stale-estimates warning at the top of this doc; the numbers below are pre-whitelist and overstate cardinality by 1–2 orders of magnitude):
 
-| Node type | node-exporter | cAdvisor | git-cache-warmer | DCGM | Total per node |
-|-----------|:---:|:---:|:---:|:---:|:---:|
-| CPU runner node (~10 containers) | ~300 | ~400 | ~15 | 0 | ~715 |
-| GPU node (8x GPUs, ~10 containers) | ~300 | ~400 | ~15 | ~208 | ~923 |
-| Base infra node (~30 containers) | ~300 | ~1200 | ~15 | 0 | ~1515 |
+| Node type | node-exporter | cAdvisor | git-cache-warmer | nodelocaldns | DCGM | Total per node |
+|-----------|:---:|:---:|:---:|:---:|:---:|:---:|
+| CPU runner node (~10 containers) | ~300 | ~400 | ~15 | ~50 | 0 | ~765 |
+| GPU node (8x GPUs, ~10 containers) | ~300 | ~400 | ~15 | ~50 | ~208 | ~973 |
+| Base infra node (~30 containers) | ~300 | ~1200 | ~15 | ~50 | 0 | ~1565 |
 
 ### Cluster-Wide (Fixed per Source)
 
@@ -62,14 +63,14 @@ These metrics come from centralized Deployments or StatefulSets. Series counts b
 
 ### Scaling Formula (Metrics)
 
-> **NOTE:** the per-node and per-pod multipliers below are stale (see warning at top of doc). They predate the metric whitelisting work — node-exporter is now ~2 series per node (not ~300) and runner-pod cAdvisor is now 0 series (not 40). The DCGM term should use 25, not 26 (the curated metrics CSV defines exactly 25 metrics). Use the formula structure but expect totals to be 1–2 orders of magnitude lower in practice.
+> **NOTE:** the per-node and per-pod multipliers below are stale (see warning at top of doc). They predate the metric whitelisting work — node-exporter is now ~2 series per node (not ~300) and runner-pod cAdvisor is now 0 series (not 40). The DCGM term should use 25, not 26 (the curated metrics CSV defines exactly 25 metrics). The nodelocaldns term (~50 per node) is post-whitelist and stable. Use the formula structure but expect totals to be 1–2 orders of magnitude lower in practice.
 
 ```
 Total series ≈ C_fixed
              + N_runner_pods × 40
-             + N_cpu_nodes × 715
-             + N_gpu_nodes × 715 + 25 × N_total_GPUs
-             + N_base_nodes × 1515
+             + N_cpu_nodes × 765      (was 715; +50 nodelocaldns)
+             + N_gpu_nodes × 765 + 25 × N_total_GPUs
+             + N_base_nodes × 1565    (was 1515; +50 nodelocaldns)
              + N_scale_sets × 85
 ```
 
@@ -130,6 +131,7 @@ Every Karpenter-managed node runs DaemonSets that produce logs. This is the per-
 | **GPU: nvidia-persistenced** (journal) | System | 0-2 | GPU nodes only |
 | **cache-enforcer** | Pod log | 1-5 | DaemonSet on `arc-cbr-production` (`modules/cache-enforcer/kubernetes/daemonset.yaml`) |
 | **image-cache-janitor** | Pod log | 1-5 | DaemonSet in base — runs on every node (`base/kubernetes/image-cache-janitor/daemonset.yaml`) |
+| **nodelocaldns** | Pod log | <1 | DaemonSet in base — runs on every node (`base/kubernetes/nodelocaldns/`). CoreDNS plugin reports + "Setup OK" messages only; near-silent at steady state |
 
 **Per-node totals**:
 

--- a/osdc/docs/observability.md
+++ b/osdc/docs/observability.md
@@ -89,6 +89,7 @@ The chart (v82.10.3) is used **only as a CRD + exporter bundle**:
 | ServiceMonitor | pypi-cache | pypi-cache | pypi-cache nginx metrics (`nginx_up`, requests, active connections) |
 | PodMonitor | coredns | kube-system | CoreDNS request rate, latency, cache hit/miss, errors |
 | PodMonitor | git-cache-daemonset | kube-system | Git cache DaemonSet metrics |
+| PodMonitor | nodelocaldns | kube-system | NodeLocal DNSCache — two endpoints: `:9253` (CoreDNS plugin metrics, `coredns_*`) and `:9353` (binary-emitted `coredns_nodecache_*` setup/error counters) |
 | PodMonitor | arc-listeners | arc-systems | ARC listener pods metrics |
 
 Plus kube-prometheus-stack built-in targets:
@@ -165,6 +166,9 @@ PrometheusRule CRDs are defined locally and synced to Grafana Cloud Mimir via Al
 | harbor-cache-recovery | `HarborCacheRecoveryFailing` | Cache-recovery CronJob failing for 15m (≥3 consecutive runs at */5) |
 | harbor-cache-recovery | `HarborCacheRecoveryOOM` | Recovery pod OOMKilled (most common root cause — listing pods cluster-wide) |
 | harbor-cache-recovery | `HarborCacheRecoveryStale` | No successful recovery run in >30m (CronJob suspended/stuck) |
+| nodelocaldns | `NodeLocalDNSSetupErrors` | `increase(coredns_nodecache_setup_errors_total[5m]) > 0` — iptables NOTRACK rule install failed |
+| nodelocaldns | `NodeLocalDNSPodRestarting` | NLD container restarting (per-node DNS interception briefly degrades to fallthrough) |
+| nodelocaldns | `NodeLocalDNSDaemonSetDegraded` | DaemonSet has unavailable pods for >15m |
 
 ### Adding a new ServiceMonitor/PodMonitor
 

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -410,6 +410,10 @@ deploy-base cluster:
     {{UPSTREAM}}/base/kubernetes/image-cache-janitor/deploy.sh "$CLUSTER"
 
     echo ""
+    echo "━━━ BASE: Deploy NodeLocal DNSCache ━━━"
+    {{UPSTREAM}}/base/kubernetes/nodelocaldns/deploy.sh "$CLUSTER"
+
+    echo ""
     echo "Base deployment complete."
 
     # Deploy audit logging — record successful completion

--- a/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - node-compactor-alerts.yaml
   - zombie-cleanup-alerts.yaml
   - harbor-cache-recovery-alerts.yaml
+  - nodelocaldns-alerts.yaml

--- a/osdc/modules/monitoring/kubernetes/alerts/nodelocaldns-alerts.yaml
+++ b/osdc/modules/monitoring/kubernetes/alerts/nodelocaldns-alerts.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: nodelocaldns-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: osdc-monitoring
+spec:
+  groups:
+    - name: nodelocaldns
+      rules:
+        - alert: NodeLocalDNSSetupErrors
+          expr: increase(coredns_nodecache_setup_errors_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "NodeLocal DNSCache setup errors on {{ $labels.pod }}"
+            description: |
+              Pod {{ $labels.pod }} on node {{ $labels.node }} reported NLD setup errors in the last 5 minutes.
+              This usually means iptables NOTRACK rules failed to install. Per-node DNS interception is degraded
+              until the next setup cycle succeeds.
+
+        - alert: NodeLocalDNSPodRestarting
+          expr: rate(kube_pod_container_status_restarts_total{namespace="kube-system", container="node-cache"}[15m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NodeLocal DNSCache pod restarting"
+            description: |
+              Pod {{ $labels.pod }} restarted in the last 15m. During restart, per-node DNS resolution falls back
+              to the cluster-wide kube-dns Service. If many NLD pods restart simultaneously, cluster CoreDNS QPS
+              will spike.
+
+        - alert: NodeLocalDNSDaemonSetDegraded
+          expr: kube_daemonset_status_number_unavailable{namespace="kube-system", daemonset="node-local-dns"} > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NodeLocal DNSCache DaemonSet has unavailable pods"
+            description: |
+              {{ $value }} NLD pods unavailable for >15m. Nodes without NLD lose DNS-cache benefit and put
+              additional load on cluster CoreDNS.

--- a/osdc/modules/monitoring/kubernetes/monitors/kustomization.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - podmonitors/arc-listeners.yaml
   - podmonitors/coredns.yaml
   - podmonitors/git-cache-daemonset.yaml
+  - podmonitors/nodelocaldns.yaml
   # DCGM ServiceMonitor (DaemonSet is in parent kustomization)
   - dcgm-servicemonitor.yaml
   # PrometheusRule alerts

--- a/osdc/modules/monitoring/kubernetes/monitors/podmonitors/nodelocaldns.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/podmonitors/nodelocaldns.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: nodelocaldns
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: osdc-monitoring
+spec:
+  # NodeLocal DNSCache (NLD) DaemonSet pods in kube-system. NLD exposes metrics
+  # on TWO ports: :9253 (CoreDNS plugin metrics, prefixed coredns_*) and :9353
+  # (binary metrics including coredns_nodecache_setup_errors_total). Both are
+  # scraped to capture the full operational picture.
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  podMetricsEndpoints:
+    # :9253 — CoreDNS plugin metrics (request counts, forward latency, cache hits)
+    - port: metrics
+      interval: 60s
+      metricRelabelings:
+        # Drop Go runtime metrics (high cardinality, low operational value)
+        - action: drop
+          sourceLabels: [__name__]
+          regex: "go_.*"
+        # Drop process metrics (CPU/memory of node-cache itself)
+        - action: drop
+          sourceLabels: [__name__]
+          regex: "process_.*"
+        # Drop histogram buckets (keep _sum/_count for latency tracking)
+        - action: drop
+          sourceLabels: [__name__]
+          regex: "coredns_.*_request_duration_seconds_bucket"
+    # :9353 — binary-emitted coredns_nodecache_* metrics (incl. setup_errors_total)
+    - port: metrics-binary
+      interval: 60s
+      metricRelabelings:
+        # Drop Go runtime metrics (high cardinality, low operational value)
+        - action: drop
+          sourceLabels: [__name__]
+          regex: "go_.*"
+        # Drop process metrics (CPU/memory of node-cache itself)
+        - action: drop
+          sourceLabels: [__name__]
+          regex: "process_.*"


### PR DESCRIPTION
**Impact:** All clusters — every node gets a per-node DNS cache DaemonSet
**Risk:** medium

Part of the migration: https://github.com/pytorch/ci-infra/issues/544

## What
Deploys [NodeLocal DNSCache](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) (NLD) as a base Kubernetes component on every OSDC cluster. Each node runs a local CoreDNS instance that intercepts pod DNS queries via iptables NOTRACK rules, caching responses and forwarding cache misses to cluster CoreDNS over persistent TCP.

## Why
High-concurrency CI runners generate significant DNS traffic (pip installs, container pulls, API calls). All of it currently funnels through the cluster-wide kube-dns CoreDNS pods, creating a centralized bottleneck. NLD absorbs the bulk of repeated lookups at the node level, reducing cluster CoreDNS QPS, eliminating conntrack overhead for DNS, and lowering per-pod DNS latency.

## How
- **iptables-mode (not `--skip-teardown`)**: NLD binds the kube-dns ClusterIP on a dummy `nodelocaldns` interface and installs NOTRACK iptables rules so pods' DNS traffic (destined for the kube-dns ClusterIP) is silently intercepted by the local cache. No pod or kubelet config changes needed.
- **`deploy.sh` with runtime substitution**: The kube-dns ClusterIP varies per cluster (dynamic service CIDR). `deploy.sh` resolves it at apply time and sed-substitutes the `__KUBE_DNS_CLUSTER_IP__` placeholder in rendered manifests. A Python splitter applies Services before the DaemonSet to ensure kubelet injects `KUBE_DNS_UPSTREAM_SERVICE_HOST` env into node-cache pods.
- **`kube-dns-upstream` Service**: A second Service fronting the same kube-dns pods, giving NLD a separate ClusterIP to forward cache misses to without creating an iptables loop through itself.
- **No memory/CPU limits**: OOMKill orphans iptables rules (cluster-wide DNS degradation); CPU throttling adds DNS latency. `system-node-critical` priorityClass prevents eviction.
- **`automountServiceAccountToken: false`**: The binary makes no API calls; disabling the token reduces credential-leak surface on a privileged container.
- **Two metrics ports**: `:9253` (CoreDNS plugin metrics — cache hits, forward latency) and `:9353` (binary-emitted `coredns_nodecache_*` counters including `setup_errors_total`). Both scraped via a single PodMonitor with cardinality-reducing `metricRelabelings` (drop `go_*`, `process_*`, histogram buckets).
- **First-deploy idempotency**: `deploy.sh` detects whether `kube-dns-upstream` already exists. On first deploy it triggers a rollout restart so pods pick up the upstream Service env var; on re-runs it skips the restart.

## Changes
**Base component (`base/kubernetes/nodelocaldns/`)**
- `configmap.yaml` — Corefile with four server blocks (cluster.local, in-addr.arpa, ip6.arpa, catch-all), `force_tcp` for cluster zones, external queries forwarded to `/etc/resolv.conf`
- `daemonset.yaml` — DaemonSet with hostNetwork, privileged, system-node-critical, tolerations for all OSDC node taints (GPU, node-fleet, instance-type, git-cache-not-ready), image `k8s-dns-node-cache:1.26.8`
- `upstream-service.yaml` — `kube-dns-upstream` Service selecting kube-dns pods (NLD forward target)
- `metrics-service.yaml` — headless `node-local-dns-metrics` Service for PodMonitor discovery (ports 9253 + 9353)
- `serviceaccount.yaml` — dedicated SA with `automountServiceAccountToken: false`
- `kustomization.yaml` — Kustomize overlay for the component
- `deploy.sh` — orchestrates: precondition check → ClusterIP resolution → kustomize render → sed substitution → Services-first apply → DaemonSet apply → conditional rollout restart

**Deployment integration**
- `justfile` — `deploy-base` recipe calls `nodelocaldns/deploy.sh` after image-cache-janitor
- `base/kubernetes/kustomization.yaml` — comment noting nodelocaldns uses its own deploy.sh (not inline kustomize)

**Monitoring**
- `podmonitors/nodelocaldns.yaml` — PodMonitor scraping both metrics ports at 60s, dropping `go_*`, `process_*`, and histogram buckets
- `nodelocaldns-alerts.yaml` — three PrometheusRule alerts: `NodeLocalDNSSetupErrors` (critical, iptables failures), `NodeLocalDNSPodRestarting` (warning), `NodeLocalDNSDaemonSetDegraded` (warning, unavailable pods >15m)
- Alert and monitor kustomizations updated

**Tests**
- `test_base_kubernetes.py` — three new smoke tests: DaemonSet healthy on all nodes, metrics service is headless, upstream service selects kube-dns pods

**Documentation**
- `architecture.md` — base resources list and deploy sequence updated
- `observability.md` — PodMonitor table and alert table updated
- `CLAUDE.md` — `osdc-nodelocaldns` skill reference added

## Notes
- **Soak gate**: After initial deploy, monitor `coredns_nodecache_setup_errors_total` and cache hit rate for 24-48h before considering NLD stable. The `NodeLocalDNSSetupErrors` alert (critical) will fire immediately if iptables rule installation fails on any node.
- **Rolling update at 1% maxUnavailable**: Conservative to avoid many nodes simultaneously losing DNS interception during upgrades.
- **External DNS bypass**: The catch-all `.:53` block forwards to `/etc/resolv.conf`, so external lookups (e.g., `download.pytorch.org`) bypass cluster CoreDNS entirely — they go through the node cache but miss → VPC resolver, not kube-dns.

## Testing
```
============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-05-09 01:27 UTC

  PR Workflow Jobs:
    ✓ test-pypi-cache-defaults       success
    ✓ test-cpu-arm64                 success
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-cpu-x86-amx               success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-gpu-t4-multi              success
    ✓ test-cpu-x86-avx512            success
    ✓ test-cache-enforcer            success
    ✓ test-release-arm64             success
    ✓ test-gpu-t4                    success
    ✓ test-harbor                    success
    ✓ test-git-cache                 success
    ✓ build-amd64 / build            success
    ✓ build-arm64 / build            success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================
```
```
============================================================================================================================ test session starts ============================================================================================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ci-infra-code-review/osdc
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0
16 workers [235 items]
......................................................s.................................................................................................s............................................s.....................................                           [100%]
========================================================================================================================== short test summary info ==========================================================================================================================
SKIPPED [1] modules/arc-runners/tests/smoke/test_capacity_parity.py:300: no scale sets with proactive_capacity > 0
SKIPPED [1] modules/cache-enforcer/tests/smoke/test_cache_enforcer.py:107: No cache-enforcer pods desired (no runner nodes in cluster)
SKIPPED [1] modules/monitoring/tests/smoke/test_monitoring.py:173: No dcgm-exporter pods found (no GPU nodes)
================================================================================================================= 232 passed, 3 skipped in 92.41s (0:01:32) =================================================================================================================

Smoke tests completed in 1m34s
```
```
 18:19  aws:308535385114  12  ~  meta  ci-infra-code-review  osdc  jeanschmidt/dnscache_daemonset_2  ? ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 $  kubectl get ds node-local-dns -n kube-system
NAME             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
node-local-dns   2         2         2       2            2           <none>          13m
 18:19  aws:308535385114  12  ~  meta  ci-infra-code-review  osdc  jeanschmidt/dnscache_daemonset_2  ? ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 $  kubectl get pods -n kube-system -l k8s-app=node-local-dns -o wide
NAME                   READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
node-local-dns-8g5km   1/1     Running   0          13m   10.0.60.247   ip-10-0-60-247.us-west-1.compute.internal   <none>           <none>
node-local-dns-r8pbv   1/1     Running   0          13m   10.0.89.138   ip-10-0-89-138.us-west-1.compute.internal   <none>           <none>
```