### PR TITLE
Add ENIConfig CRs and base node AZ labels

### DIFF
--- a/osdc/base/kubernetes/eniconfigs/deploy.sh
+++ b/osdc/base/kubernetes/eniconfigs/deploy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# AZ-named ENIConfig deploy script.
+# Called from the justfile's deploy-base recipe.
+#
+# Args: $1=cluster-id
+#
+# Renders one ENIConfig per AZ from eniconfig.yaml.tpl, pointing at the
+# matching primary /18 private subnet from the base terraform output
+# `private_subnets_by_az`. Resources are inert until VPC CNI Custom
+# Networking is enabled in a later PR.
+
+CLUSTER="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OSDC_UPSTREAM="${OSDC_UPSTREAM:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$OSDC_UPSTREAM/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$OSDC_UPSTREAM/scripts/kubectl-apply.sh"
+# shellcheck source=/dev/null
+source "$OSDC_UPSTREAM/scripts/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
+CFG="$OSDC_UPSTREAM/scripts/cluster-config.py"
+
+BUCKET=$(uv run "$CFG" "$CLUSTER" state_bucket)
+
+cd "$OSDC_UPSTREAM/modules/eks/terraform"
+INIT_ERR=$(mktemp)
+trap 'rm -f "$INIT_ERR"' EXIT
+if ! tofu init -reconfigure \
+  -backend-config="bucket=${BUCKET}" \
+  -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
+  -backend-config="region=${STATE_REGION}" \
+  -backend-config="dynamodb_table=ciforge-terraform-locks" \
+  >/dev/null 2>"$INIT_ERR"; then
+  echo "ERROR: tofu init failed for cluster ${CLUSTER}" >&2
+  cat "$INIT_ERR" >&2
+  exit 1
+fi
+SUBNETS_JSON=$(tofu output -json private_subnets_by_az)
+cd - >/dev/null
+
+mapfile -t AZS < <(jq -r 'keys[]' <<<"$SUBNETS_JSON")
+if [[ ${#AZS[@]} -eq 0 ]]; then
+  echo "ERROR: private_subnets_by_az is empty for cluster ${CLUSTER}" >&2
+  exit 1
+fi
+
+echo "Applying ${#AZS[@]} ENIConfig(s) for cluster ${CLUSTER}..."
+for az in "${AZS[@]}"; do
+  subnet_id=$(jq -r --arg k "$az" '.[$k]' <<<"$SUBNETS_JSON")
+  echo "  ENIConfig ${az} -> ${subnet_id}"
+  sed \
+    -e "s|__ENICONFIG_NAME__|${az}|g" \
+    -e "s|__SUBNET_ID__|${subnet_id}|g" \
+    "$SCRIPT_DIR/eniconfig.yaml.tpl" \
+    | kubectl_apply_if_changed -f -
+done
+
+echo "ENIConfigs deployed (${#AZS[@]} AZs)."

--- a/osdc/base/kubernetes/eniconfigs/eniconfig.yaml.tpl
+++ b/osdc/base/kubernetes/eniconfigs/eniconfig.yaml.tpl
@@ -1,0 +1,24 @@
+# Generic ENIConfig template for VPC CNI Custom Networking.
+#
+# Rendered by a deploy script (currently base/kubernetes/eniconfigs/deploy.sh,
+# which uses the AZ name as the ENIConfig name). The same template is reusable
+# by other deploy scripts that need bucket-prefixed names (e.g.
+# bucket-${N}-${AZ}). The placeholder __ENICONFIG_NAME__ is substituted with
+# the resource name and __SUBNET_ID__ with the matching private subnet ID
+# from the base terraform `private_subnets_by_az` output.
+#
+# securityGroups is intentionally omitted: when absent, VPC CNI inherits
+# the security groups attached to the node's primary ENI, which is the
+# AWS-recommended default and matches the existing node SG.
+#
+# These resources are inert until VPC CNI Custom Networking is enabled
+# (AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true on the aws-node DaemonSet) in
+# a later PR. Removal criterion: only delete after Custom Networking is
+# permanently disabled cluster-wide.
+---
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+  name: __ENICONFIG_NAME__
+spec:
+  subnet: __SUBNET_ID__

--- a/osdc/base/kubernetes/tests/smoke/test_base_eniconfigs.py
+++ b/osdc/base/kubernetes/tests/smoke/test_base_eniconfigs.py
@@ -1,0 +1,230 @@
+"""Smoke tests for base MNG eni-config AZ label + AZ-named ENIConfigs.
+
+The base AZ labeling and ENIConfig setup is two coupled changes that must agree end-to-end:
+
+1. Every base node (EKS Managed Node Group ``base``, labeled
+   ``role=base-infrastructure``) carries a ``ipam.osdc.internal/eni-config``
+   label whose value matches the node's ``topology.kubernetes.io/zone``
+   label. The label is set by a userData shellscript at first boot
+   (see ``base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh``).
+
+2. There is one ``ENIConfig`` CR (``crd.k8s.amazonaws.com/v1alpha1``) per
+   available AZ in the cluster, named exactly after the AZ string
+   (e.g. ``us-east-2a``). Each ENIConfig's ``spec.subnet`` is a subnet
+   that lives in the AZ matching the ENIConfig's name.
+
+These resources are inert until VPC CNI Custom Networking is enabled in a
+later PR; this test verifies the prerequisites are in place and self-consistent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from cni_constants import ENI_CONFIG_LABEL
+from helpers import run_aws, run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+ZONE_LABEL = "topology.kubernetes.io/zone"
+BASE_ROLE_LABEL_VALUE = "base-infrastructure"
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def base_nodes(all_nodes: dict) -> list[dict]:
+    """All nodes carrying ``role=base-infrastructure`` (base node AZ labeling target set)."""
+    items = [
+        n
+        for n in all_nodes.get("items", [])
+        if n.get("metadata", {}).get("labels", {}).get("role") == BASE_ROLE_LABEL_VALUE
+    ]
+    assert items, "No base-infrastructure nodes found — cannot validate AZ-named ENIConfig invariants"
+    return items
+
+
+@pytest.fixture(scope="module")
+def base_node_azs(base_nodes: list[dict]) -> set[str]:
+    """Set of AZs covered by the base node group (derived from node labels)."""
+    azs = set()
+    for node in base_nodes:
+        az = node.get("metadata", {}).get("labels", {}).get(ZONE_LABEL)
+        if az:
+            azs.add(az)
+    assert azs, f"Base nodes carry no '{ZONE_LABEL}' labels — cloud-controller-manager not running?"
+    return azs
+
+
+@pytest.fixture(scope="module")
+def all_eniconfigs() -> dict:
+    """All ENIConfig CRs in the cluster (returns empty items list if CRD missing)."""
+    try:
+        return run_kubectl(["get", "eniconfigs.crd.k8s.amazonaws.com"])
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            f"Failed to list ENIConfig CRs (CRD missing or RBAC issue): {exc.stderr or exc}. "
+            "AZ-named ENIConfig setup requires the ENIConfig CRD installed by the VPC CNI addon."
+        )
+
+
+# ============================================================================
+# Part A: base node label-AZ consistency
+# ============================================================================
+
+
+class TestBaseNodeENIConfigLabel:
+    """Every base node has eni-config label equal to its zone label."""
+
+    def test_base_nodes_have_zone_label(self, base_nodes: list[dict]) -> None:
+        """Every base node has ``topology.kubernetes.io/zone`` (set by cloud-controller-manager)."""
+        missing = [
+            n["metadata"]["name"] for n in base_nodes if not n.get("metadata", {}).get("labels", {}).get(ZONE_LABEL)
+        ]
+        assert not missing, (
+            f"Base nodes missing '{ZONE_LABEL}' label (cloud-controller-manager not labelling them?): {missing}"
+        )
+
+    def test_base_nodes_have_eni_config_label(self, base_nodes: list[dict]) -> None:
+        """Every base node has ``ipam.osdc.internal/eni-config`` (set by base node AZ labeling userData)."""
+        missing = [
+            n["metadata"]["name"]
+            for n in base_nodes
+            if not n.get("metadata", {}).get("labels", {}).get(ENI_CONFIG_LABEL)
+        ]
+        assert not missing, (
+            f"Base nodes missing '{ENI_CONFIG_LABEL}' label (base node AZ labeling userData drop-in not applied?): {missing}"
+        )
+
+    def test_base_node_eni_config_matches_zone(self, base_nodes: list[dict]) -> None:
+        """eni-config label value equals zone label value on every base node.
+
+        A mismatch means the userData script picked up a different AZ than
+        cloud-controller-manager — usually means the node was relabeled
+        manually or the IMDS read returned the wrong zone at first boot.
+        Once VPC CNI Custom Networking is enabled, mismatched nodes will
+        fail pod IP allocation with ``ErrNoENIConfig``.
+        """
+        mismatches: list[str] = []
+        for node in base_nodes:
+            labels = node.get("metadata", {}).get("labels", {})
+            zone = labels.get(ZONE_LABEL, "")
+            eni = labels.get(ENI_CONFIG_LABEL, "")
+            if zone != eni:
+                mismatches.append(f"{node['metadata']['name']}: zone={zone!r} eni-config={eni!r}")
+        assert not mismatches, "Base nodes have eni-config != zone (AZ labeling invariant violated):\n  " + "\n  ".join(
+            mismatches
+        )
+
+
+# ============================================================================
+# Part B: ENIConfig CRD presence — one per base-node AZ
+# ============================================================================
+
+
+class TestBaseENIConfigCRsPresent:
+    """One ENIConfig CR exists per AZ found on base nodes, named exactly the AZ."""
+
+    def test_eniconfig_per_base_az(self, base_node_azs: set[str], all_eniconfigs: dict) -> None:
+        """Every AZ a base node sits in has a same-named ``ENIConfig`` CR.
+
+        Without this, the AZ-named ENIConfig setup is incomplete and pod
+        restarts after the Custom Networking flip will fail with
+        ``ErrNoENIConfig`` for the missing AZ.
+        """
+        existing = {ec["metadata"]["name"] for ec in all_eniconfigs.get("items", [])}
+        missing = sorted(az for az in base_node_azs if az not in existing)
+        assert not missing, (
+            f"Missing ENIConfig CRs for base-node AZs: {missing}. "
+            f"Existing ENIConfigs: {sorted(existing)}. "
+            "AZ-named ENIConfig setup must create one CR per AZ (matching the AZ name exactly)."
+        )
+
+    def test_eniconfig_specs_have_subnet(self, base_node_azs: set[str], all_eniconfigs: dict) -> None:
+        """Each AZ-named ENIConfig declares a non-empty ``spec.subnet``."""
+        by_name = {ec["metadata"]["name"]: ec for ec in all_eniconfigs.get("items", [])}
+        empty: list[str] = []
+        for az in sorted(base_node_azs):
+            ec = by_name.get(az)
+            if ec is None:
+                # Already covered by test_eniconfig_per_base_az
+                continue
+            subnet = ec.get("spec", {}).get("subnet", "")
+            if not subnet:
+                empty.append(az)
+        assert not empty, (
+            f"ENIConfig(s) missing 'spec.subnet': {empty}. "
+            "AZ-named ENIConfig setup must point each AZ-named ENIConfig at the matching primary subnet."
+        )
+
+
+# ============================================================================
+# Part C: ENIConfig subnet AZ matches ENIConfig name (cross-checked via AWS)
+# ============================================================================
+
+
+class TestBaseENIConfigSubnetAZ:
+    """Each ENIConfig's spec.subnet lives in the AZ matching the ENIConfig's name.
+
+    This catches the silent failure mode where an ENIConfig points at a subnet
+    in the wrong AZ — pods will be unable to receive an IP because ENIs are
+    AZ-bound and VPC CNI cannot attach a same-AZ ENI to the node.
+    """
+
+    @pytest.mark.aws
+    def test_eniconfig_subnet_in_matching_az(
+        self,
+        base_node_azs: set[str],
+        all_eniconfigs: dict,
+        cluster_config: dict,
+    ) -> None:
+        region = cluster_config["cluster"].get("region", "us-west-2")
+        by_name = {ec["metadata"]["name"]: ec for ec in all_eniconfigs.get("items", [])}
+
+        # Collect the subnet IDs we need to look up in one batch — one
+        # describe-subnets call beats N round-trips and keeps the test fast.
+        subnets_to_check: dict[str, str] = {}  # az -> subnet_id
+        for az in sorted(base_node_azs):
+            ec = by_name.get(az)
+            if ec is None:
+                continue
+            subnet = ec.get("spec", {}).get("subnet", "")
+            if subnet:
+                subnets_to_check[az] = subnet
+
+        if not subnets_to_check:
+            pytest.fail(
+                "No ENIConfig subnets to verify — earlier tests should have caught this; "
+                "indicates either no base-node AZs or no ENIConfig CRs."
+            )
+
+        result = run_aws(
+            [
+                "ec2",
+                "describe-subnets",
+                "--region",
+                region,
+                "--subnet-ids",
+                *subnets_to_check.values(),
+            ],
+            timeout=120,
+        )
+        az_by_subnet = {s["SubnetId"]: s.get("AvailabilityZone", "") for s in result.get("Subnets", [])}
+
+        mismatches: list[str] = []
+        for az, subnet_id in sorted(subnets_to_check.items()):
+            actual_az = az_by_subnet.get(subnet_id, "")
+            if not actual_az:
+                mismatches.append(f"ENIConfig {az!r}: subnet {subnet_id} not returned by describe-subnets")
+            elif actual_az != az:
+                mismatches.append(
+                    f"ENIConfig {az!r}: spec.subnet {subnet_id} lives in AZ {actual_az!r}, expected {az!r}"
+                )
+        assert not mismatches, (
+            "ENIConfig name <-> subnet AZ mismatch (would break pod IP allocation under Custom Networking):\n  "
+            + "\n  ".join(mismatches)
+        )

--- a/osdc/base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh
+++ b/osdc/base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p /etc/eks/nodeadm.d
+
+IMDS_BASE="http://169.254.169.254"
+IMDS_TOKEN_TTL_SECONDS=21600
+IMDS_RETRIES=5
+IMDS_RETRY_SLEEP=2
+
+# IMDS can return transient failures during early boot before the network stack is fully ready.
+fetch_imds() {
+  local method=$1
+  local path=$2
+  local extra_header=$3
+  local attempt
+  for attempt in $(seq 1 "$IMDS_RETRIES"); do
+    if curl -fsS --connect-timeout 2 --max-time 5 -X "$method" -H "$extra_header" "${IMDS_BASE}${path}"; then
+      return 0
+    fi
+    echo "[eks-base-pre-nodeadm] IMDS ${method} ${path} attempt ${attempt}/${IMDS_RETRIES} failed" >&2
+    sleep "$IMDS_RETRY_SLEEP"
+  done
+  return 1
+}
+
+TOKEN=$(fetch_imds PUT /latest/api/token "X-aws-ec2-metadata-token-ttl-seconds: ${IMDS_TOKEN_TTL_SECONDS}")
+AZ=$(fetch_imds GET /latest/meta-data/placement/availability-zone "X-aws-ec2-metadata-token: ${TOKEN}")
+
+if [[ ! "$AZ" =~ ^[a-z]{2}-[a-z]+-[0-9][a-z]$ ]]; then
+  echo "[eks-base-pre-nodeadm] IMDS returned malformed AZ value: '${AZ}'" >&2
+  exit 1
+fi
+
+# 'ipam.osdc.internal/eni-config' is the canonical eni-config label key —
+# also defined as ENI_CONFIG_LABEL in scripts/python/cni_constants.py and
+# referenced by the nodepool generator and smoke tests. Keep in sync.
+cat >/etc/eks/nodeadm.d/50-eni-config-az.yaml <<YAML
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  kubelet:
+    flags:
+      - --node-labels=ipam.osdc.internal/eni-config=${AZ}
+YAML
+
+echo "[eks-base-pre-nodeadm] wrote drop-in for AZ=${AZ}"

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -83,6 +83,7 @@ just deploy <cluster-id>
 │   ├── mirror-images                               ← Harbor images to ECR
 │   ├── kubectl apply -k base/kubernetes/           ← StorageClass, NVIDIA, image-cache-janitor, etc.
 │   ├── git-cache/deploy.sh                         ← Git cache central StatefulSet
+│   ├── eniconfigs/deploy.sh                          ← AZ-named ENIConfig CRs (one per AZ from terraform output)
 │   ├── deploy-harbor                               ← Helm install Harbor (pull-through cache)
 │   ├── node-compactor/deploy.sh                    ← if enabled in clusters.yaml
 │   └── image-cache-janitor/deploy.sh               ← prunes stale image content from node disks

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -306,6 +306,8 @@ deploy-base cluster:
     #!/usr/bin/env bash
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    source "{{UPSTREAM}}/scripts/state-config.sh"
+    : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
     export OSDC_ROOT="{{ROOT}}"
     export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
@@ -314,7 +316,6 @@ deploy-base cluster:
     CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
     BUCKET=$(uv run {{CFG}} "$CLUSTER" state_bucket)
     TFVARS=$(uv run {{CFG}} "$CLUSTER" tfvars)
-    STATE_REGION="us-west-2"  # state buckets always in us-west-2
 
     # Preflight: check state bucket exists
     if ! aws s3api head-bucket --bucket "${BUCKET}" --region "${STATE_REGION}" 2>/dev/null; then
@@ -397,6 +398,10 @@ deploy-base cluster:
     {{UPSTREAM}}/base/kubernetes/git-cache/deploy.sh "$CLUSTER"
 
     echo ""
+    echo "━━━ BASE: Deploy ENIConfigs ━━━"
+    {{UPSTREAM}}/base/kubernetes/eniconfigs/deploy.sh "$CLUSTER"
+
+    echo ""
     echo "━━━ BASE: Deploy Harbor ━━━"
     cd "{{ROOT}}"
     just _deploy-harbor "$CLUSTER"
@@ -421,6 +426,8 @@ deploy-module cluster module force="":
     #!/usr/bin/env bash
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    source "{{UPSTREAM}}/scripts/state-config.sh"
+    : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
     export OSDC_ROOT="{{ROOT}}"
     export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
@@ -468,7 +475,7 @@ deploy-module cluster module force="":
         tofu init -reconfigure \
             -backend-config="bucket=${BUCKET}" \
             -backend-config="key=${CLUSTER}/${MODULE}/terraform.tfstate" \
-            -backend-config="region=us-west-2" \
+            -backend-config="region=${STATE_REGION}" \
             -backend-config="dynamodb_table=ciforge-terraform-locks"
 
         # Modules get cluster_name and aws_region as minimum vars
@@ -526,6 +533,8 @@ plan cluster:
     #!/usr/bin/env bash
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    source "{{UPSTREAM}}/scripts/state-config.sh"
+    : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
     export OSDC_ROOT="{{ROOT}}"
     export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
@@ -534,7 +543,6 @@ plan cluster:
     CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
     BUCKET=$(uv run {{CFG}} "$CLUSTER" state_bucket)
     TFVARS=$(uv run {{CFG}} "$CLUSTER" tfvars)
-    STATE_REGION="us-west-2"
 
     if ! aws s3api head-bucket --bucket "${BUCKET}" --region "${STATE_REGION}" 2>/dev/null; then
         echo "ERROR: State bucket '${BUCKET}' does not exist. Run: just bootstrap ${CLUSTER}"
@@ -874,6 +882,8 @@ _deploy-harbor cluster:
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
     source "{{UPSTREAM}}/scripts/helm-upgrade.sh"
+    source "{{UPSTREAM}}/scripts/state-config.sh"
+    : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
     export OSDC_ROOT="{{ROOT}}"
     export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
@@ -900,7 +910,7 @@ _deploy-harbor cluster:
     tofu init -reconfigure \
         -backend-config="bucket=${BUCKET}" \
         -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
-        -backend-config="region=us-west-2" \
+        -backend-config="region=${STATE_REGION}" \
         -backend-config="dynamodb_table=ciforge-terraform-locks" \
         >/dev/null 2>&1
     HARBOR_ROLE=$(tofu output -raw harbor_role_arn)

--- a/osdc/modules/eks/scripts/mirror-images.sh
+++ b/osdc/modules/eks/scripts/mirror-images.sh
@@ -13,10 +13,17 @@ set -euo pipefail
 if [[ -n "${OSDC_UPSTREAM:-}" ]]; then
   # shellcheck source=/dev/null
   source "$OSDC_UPSTREAM/scripts/mise-activate.sh"
-else
   # shellcheck source=/dev/null
-  source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts" && pwd)/mise-activate.sh"
+  source "$OSDC_UPSTREAM/scripts/state-config.sh"
+else
+  _SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts" && pwd)"
+  # shellcheck source=/dev/null
+  source "$_SCRIPTS_DIR/mise-activate.sh"
+  # shellcheck source=/dev/null
+  source "$_SCRIPTS_DIR/state-config.sh"
+  unset _SCRIPTS_DIR
 fi
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
 
 # Colors
 RED='\033[0;31m'
@@ -79,7 +86,7 @@ log_info "Initializing tofu backend for $CLUSTER..."
   tofu init -reconfigure \
     -backend-config="bucket=$BUCKET" \
     -backend-config="key=$CLUSTER/base/terraform.tfstate" \
-    -backend-config="region=us-west-2" \
+    -backend-config="region=$STATE_REGION" \
     -backend-config="dynamodb_table=ciforge-terraform-locks" \
     >/dev/null 2>&1
 )

--- a/osdc/modules/eks/terraform/modules/eks/main.tf
+++ b/osdc/modules/eks/terraform/modules/eks/main.tf
@@ -392,6 +392,7 @@ resource "aws_launch_template" "base" {
     cluster_endpoint      = aws_eks_cluster.this.endpoint
     cluster_ca_data       = aws_eks_cluster.this.certificate_authority[0].data
     service_cidr          = aws_eks_cluster.this.kubernetes_network_config[0].service_ipv4_cidr
+    pre_nodeadm_script    = file("${path.root}/../../../base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh")
     post_bootstrap_script = file("${path.root}/../../../base/scripts/bootstrap/eks-base-bootstrap.sh")
   }))
 

--- a/osdc/modules/eks/terraform/modules/eks/user-data-base.sh.tpl
+++ b/osdc/modules/eks/terraform/modules/eks/user-data-base.sh.tpl
@@ -24,6 +24,11 @@ spec:
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 
+${pre_nodeadm_script}
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
 ${post_bootstrap_script}
 
 --==BOUNDARY==--

--- a/osdc/modules/eks/terraform/modules/vpc/outputs.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/outputs.tf
@@ -13,6 +13,11 @@ output "private_subnet_ids" {
   value       = aws_subnet.private[*].id
 }
 
+output "private_subnets_by_az" {
+  description = "Map of availability zone name to private subnet ID"
+  value       = { for i, s in aws_subnet.private : var.azs[i] => s.id }
+}
+
 output "public_subnet_ids" {
   description = "List of IDs of public subnets"
   value       = aws_subnet.public[*].id

--- a/osdc/modules/eks/terraform/outputs.tf
+++ b/osdc/modules/eks/terraform/outputs.tf
@@ -22,6 +22,11 @@ output "private_subnet_ids" {
   value = module.vpc.private_subnet_ids
 }
 
+output "private_subnets_by_az" {
+  description = "Map of availability zone name to private subnet ID"
+  value       = module.vpc.private_subnets_by_az
+}
+
 output "cluster_security_group_id" {
   value = module.eks.cluster_security_group_id
 }

--- a/osdc/modules/karpenter/deploy.sh
+++ b/osdc/modules/karpenter/deploy.sh
@@ -18,10 +18,12 @@ UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
 source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
 # shellcheck source=/dev/null
 source "$UPSTREAM_ROOT/scripts/helm-upgrade.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
 CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
 
 BUCKET=$(uv run "$CFG" "$CLUSTER" state_bucket)
-STATE_REGION="us-west-2"
 
 # Read karpenter module terraform outputs
 cd "$MODULE_DIR/terraform"

--- a/osdc/modules/pypi-cache/deploy.sh
+++ b/osdc/modules/pypi-cache/deploy.sh
@@ -25,6 +25,9 @@ UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
 source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
 # shellcheck source=/dev/null
 source "$UPSTREAM_ROOT/scripts/kubectl-apply.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
 CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
 CLUSTERS_YAML="${CLUSTERS_YAML:-$UPSTREAM_ROOT/clusters.yaml}"
 
@@ -36,7 +39,6 @@ TARGET_ARCH=$(uv run "$CFG" "$CLUSTER" pypi_cache.target_architectures "x86_64,a
 TARGET_MANYLINUX=$(uv run "$CFG" "$CLUSTER" pypi_cache.target_manylinux "2_28")
 LOG_MAX_AGE_DAYS=$(uv run "$CFG" "$CLUSTER" pypi_cache.log_max_age_days "30")
 BUCKET=$(uv run "$CFG" "$CLUSTER" state_bucket)
-STATE_REGION="us-west-2"
 
 # --- Read terraform output: EFS filesystem ID ---
 echo "[pypi-cache] Reading terraform outputs..."

--- a/osdc/scripts/bootstrap-state.sh
+++ b/osdc/scripts/bootstrap-state.sh
@@ -16,11 +16,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/mise-activate.sh"
+# State buckets live in a fixed region regardless of cluster region.
+# STATE_REGION is exported by state-config.sh.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
 CONFIG_PY="$SCRIPT_DIR/cluster-config.py"
 
 LOCK_TABLE="ciforge-terraform-locks"
-# State buckets live in a fixed region regardless of cluster region
-STATE_REGION="us-west-2"
 
 bootstrap_cluster() {
   local cluster_id="$1"

--- a/osdc/scripts/python/cni_constants.py
+++ b/osdc/scripts/python/cni_constants.py
@@ -1,0 +1,26 @@
+"""Shared VPC CNI / IPAM constants used across OSDC generators and smoke tests.
+
+Single source of truth for label keys consumed by the AWS VPC CNI ``aws-node``
+DaemonSet (Custom Networking). Centralized here so the bootstrap script,
+nodepool generator, smoke tests, and tofu addon configuration all reference
+the same literal value without drift.
+
+Importers today:
+- ``base/kubernetes/tests/smoke/test_base_eniconfigs.py`` (PR 14 smoke check)
+- ``modules/nodepools/scripts/python/generate_nodepools.py`` (future PR 6
+  Karpenter NodePool generator — emits ``ENI_CONFIG_LABEL`` on each NodePool)
+
+Also referenced as a string literal (cannot import Python here):
+- ``base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh`` (PR 14 base MNG
+  userData drop-in writing the kubelet ``--node-labels=`` flag at first boot)
+- ``modules/eks/terraform/modules/eks/main.tf`` (future PR 7 VPC CNI addon
+  ``configuration_values.ENI_CONFIG_LABEL_DEF``)
+"""
+
+# Custom node label whose value selects the matching ``ENIConfig`` CR for
+# AWS VPC CNI Custom Networking. Set per-node by:
+#   - userData bootstrap (base MNG nodes; value = node's AZ)
+#   - Karpenter NodePool ``spec.template.metadata.labels`` (workload nodes;
+#     value = ``bucket-${N}-${AZ}``)
+# Read by aws-node ipamd via the addon's ``ENI_CONFIG_LABEL_DEF`` env var.
+ENI_CONFIG_LABEL = "ipam.osdc.internal/eni-config"

--- a/osdc/scripts/python/test_cni_constants.py
+++ b/osdc/scripts/python/test_cni_constants.py
@@ -1,0 +1,22 @@
+"""Tests for cni_constants module."""
+
+from cni_constants import ENI_CONFIG_LABEL
+
+
+class TestEniConfigLabel:
+    def test_is_string(self):
+        assert isinstance(ENI_CONFIG_LABEL, str)
+
+    def test_value(self):
+        # The literal value MUST stay in lockstep with:
+        #   - base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh
+        #   - the future VPC CNI addon ENI_CONFIG_LABEL_DEF setting
+        #   - the future Karpenter NodePool generator's static label
+        assert ENI_CONFIG_LABEL == "ipam.osdc.internal/eni-config"
+
+    def test_is_qualified_label_key(self):
+        # Kubernetes label keys with a domain prefix have exactly one '/'.
+        assert ENI_CONFIG_LABEL.count("/") == 1
+        prefix, name = ENI_CONFIG_LABEL.split("/")
+        assert prefix
+        assert name

--- a/osdc/scripts/state-config.sh
+++ b/osdc/scripts/state-config.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+#
+# Source this to obtain the OpenTofu remote-state backend region.
+#
+# Single source of truth for the AWS region that hosts the shared state
+# bucket(s) and the DynamoDB lock table — independent of each cluster's
+# own region. Centralizing it here means a future state-region migration
+# is a one-file edit instead of a sprawling search-and-replace across
+# every justfile recipe and module deploy script.
+#
+# Usage (from a justfile shebang recipe):
+#   source "{{UPSTREAM}}/scripts/state-config.sh"
+#
+# Usage (from a standalone shell script that already knows OSDC_UPSTREAM):
+#   source "$OSDC_UPSTREAM/scripts/state-config.sh"
+#
+# Variables exported:
+#   STATE_REGION  — AWS region of the tofu state bucket + lock table
+export STATE_REGION="us-west-2"

--- a/osdc/tests/smoke/smoke_conftest.py
+++ b/osdc/tests/smoke/smoke_conftest.py
@@ -23,10 +23,19 @@ import contextlib
 import importlib.util
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from helpers import run_helm, run_kubectl
+
+# Make scripts/python/ importable from smoke tests so they can share the
+# same constants modules as generators (e.g. cni_constants.ENI_CONFIG_LABEL).
+# Mirrors the sys.path insert pattern used by every generator under
+# modules/.../scripts/python/.
+_scripts_python = str(Path(__file__).resolve().parents[2] / "scripts" / "python")
+if _scripts_python not in sys.path:
+    sys.path.insert(0, _scripts_python)
 
 __all__ = [
     "all_daemonsets",


### PR DESCRIPTION
**Impact:** Base EKS Managed Node Group (base-infrastructure nodes), deploy pipeline (`just deploy-base`, `just deploy-module`, `just plan`), all module deploy scripts that reference STATE_REGION
**Risk:** medium

Part of the migration: https://github.com/pytorch/ci-infra/issues/544

## What

Adds two coupled prerequisites for VPC CNI Custom Networking: (1) a userData bootstrap script that labels every base MNG node with `ipam.osdc.internal/eni-config=<AZ>` at first boot via IMDSv2, and (2) one AZ-named `ENIConfig` CR per available AZ pointing at the matching primary `/18` private subnet. Also consolidates the hardcoded `STATE_REGION="us-west-2"` into a single-source-of-truth shell module (`scripts/state-config.sh`) and exposes a new `private_subnets_by_az` terraform output.

## Why

When VPC CNI Custom Networking is enabled (future PR 7), every node must carry an `ipam.osdc.internal/eni-config` label that maps to a matching `ENIConfig` CR — otherwise pod IP allocation fails with `ErrNoENIConfig`. Base MNG nodes are not Karpenter-managed, so they cannot get static labels from NodePool specs. Without this PR, the Custom Networking cutover would break all base node pod scheduling.

The `STATE_REGION` consolidation eliminates 6+ independent hardcoded `"us-west-2"` strings scattered across the justfile and module deploy scripts, making a future state-region migration a one-file edit.

## How

- **AZ label injection via nodeadm drop-in**: A pre-nodeadm shellscript (`eks-base-pre-nodeadm-az-label.sh`) runs before nodeadm during base node boot. It fetches the AZ from IMDSv2 (with retry logic for early-boot transient failures), validates the format, and writes a nodeadm config drop-in at `/etc/eks/nodeadm.d/50-eni-config-az.yaml` that adds the kubelet `--node-labels` flag. Inserted as a new MIME part in the base launch template user-data before the existing post-bootstrap script.
- **ENIConfig deploy from terraform output**: Rather than hardcoding AZ lists, `eniconfigs/deploy.sh` reads the new `private_subnets_by_az` terraform output (a map of AZ name → subnet ID) and renders one ENIConfig per AZ from a template. This adapts automatically to clusters with different AZ counts (3 in us-east-2, 2 in us-west-1).
- **ENIConfigs are inert until activation**: The CRs exist but have no effect until `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true` is set on the VPC CNI addon in a later PR. Safe to deploy ahead of the cutover.
- **STATE_REGION single source of truth**: `scripts/state-config.sh` exports `STATE_REGION="us-west-2"`. All consumers source it and assert the variable is set. No behavioral change — just deduplication.

## Changes

**New files:**
- `scripts/state-config.sh` — single source of truth for tofu state backend region
- `scripts/python/cni_constants.py` — shared `ENI_CONFIG_LABEL` constant for Python consumers
- `scripts/python/test_cni_constants.py` — unit tests for the constant value and format
- `base/scripts/bootstrap/eks-base-pre-nodeadm-az-label.sh` — IMDSv2-based AZ label bootstrap script
- `base/kubernetes/eniconfigs/deploy.sh` — renders and applies AZ-named ENIConfig CRs from terraform output
- `base/kubernetes/eniconfigs/eniconfig.yaml.tpl` — ENIConfig CR template
- `base/kubernetes/tests/smoke/test_base_eniconfigs.py` — live smoke tests (label-AZ consistency, ENIConfig presence, subnet-AZ cross-check via AWS API)

**Modified files:**
- `modules/eks/terraform/modules/eks/main.tf` — adds `pre_nodeadm_script` variable to base launch template user-data
- `modules/eks/terraform/modules/eks/user-data-base.sh.tpl` — new MIME part for pre-nodeadm script
- `modules/eks/terraform/modules/vpc/outputs.tf` — new `private_subnets_by_az` output (map of AZ → subnet ID)
- `modules/eks/terraform/outputs.tf` — surfaces `private_subnets_by_az` from VPC module
- `justfile` — `deploy-base`, `deploy-module`, `plan`, `_deploy-harbor` recipes: source `state-config.sh` instead of hardcoding `STATE_REGION`
- `modules/karpenter/deploy.sh` — source `state-config.sh` instead of hardcoding
- `modules/pypi-cache/deploy.sh` — source `state-config.sh` instead of hardcoding
- `modules/eks/scripts/mirror-images.sh` — source `state-config.sh` instead of hardcoding
- `scripts/bootstrap-state.sh` — source `state-config.sh` instead of hardcoding
- `tests/smoke/smoke_conftest.py` — adds `scripts/python/` to `sys.path` so smoke tests can import `cni_constants`
- `docs/architecture.md` — adds eniconfigs deploy step to base deploy sequence diagram

## Notes

- **Apply impact**: `tofu apply` on the EKS module will trigger a launch template version change, which causes EKS-managed rolling replacement of all base nodes (respects PDBs and `base_node_max_unavailable_percentage`). Plan for this during a low-activity window.
- **Post-deploy verification**: every base node should have `ipam.osdc.internal/eni-config` label matching its `topology.kubernetes.io/zone` label. Run `kubectl get nodes -l role=base-infrastructure -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.topology\.kubernetes\.io/zone}{"\t"}{.metadata.labels.ipam\.osdc\.internal/eni-config}{"\n"}{end}'` to verify.
- **ENIConfigs are inert** — no behavioral change to pod networking until Custom Networking is enabled in a later PR.
- The label key `ipam.osdc.internal/eni-config` is defined in three places that must stay in sync: `cni_constants.py` (Python), `eks-base-pre-nodeadm-az-label.sh` (bash string literal), and future PR 7's VPC CNI addon `ENI_CONFIG_LABEL_DEF` setting. The unit test in `test_cni_constants.py` pins the value.

## Testing
...the usual, arc-staging, smoke, integration tests...