### PR TITLE
Add PodDisruptionBudgets for Harbor

### DIFF
--- a/osdc/base/helm/harbor/tests/smoke/test_harbor.py
+++ b/osdc/base/helm/harbor/tests/smoke/test_harbor.py
@@ -125,3 +125,46 @@ class TestHarborProxyCacheProjects:
         for pod in core_pods:
             phase = pod["status"].get("phase", "Unknown")
             assert phase == "Running", f"Harbor core pod {pod['metadata']['name']} is {phase}"
+
+
+# ============================================================================
+# Harbor PodDisruptionBudgets
+# ============================================================================
+
+
+# Components covered by Harbor PDBs. Replicas key is derived as
+# f"harbor.{component}_replicas" — single source of truth is clusters.yaml.
+_HARBOR_PDB_COMPONENTS: list[tuple[str, str]] = [
+    ("harbor-core", "core"),
+    ("harbor-registry", "registry"),
+    ("harbor-nginx", "nginx"),
+]
+
+
+class TestHarborPDBs:
+    """Verify Harbor PodDisruptionBudgets exist, are healthy, and match clusters.yaml."""
+
+    @pytest.mark.parametrize(("pdb_name", "component"), _HARBOR_PDB_COMPONENTS)
+    def test_pdb_exists_and_healthy(self, all_pods, resolve_config, pdb_name, component):
+        pdb = run_kubectl(["get", "pdb", pdb_name], namespace=HARBOR_NAMESPACE)
+        assert pdb["metadata"]["name"] == pdb_name
+
+        expected_max = resolve_config("harbor.pdb_max_unavailable")
+        assert pdb["spec"].get("maxUnavailable") == expected_max, (
+            f"{pdb_name}: spec.maxUnavailable={pdb['spec'].get('maxUnavailable')!r}, expected {expected_max!r}"
+        )
+
+        status = pdb.get("status", {})
+        current = status.get("currentHealthy", 0)
+        desired = status.get("desiredHealthy", 0)
+        assert current >= desired, f"{pdb_name}: currentHealthy={current} < desiredHealthy={desired}"
+
+        selector_labels = pdb["spec"].get("selector", {}).get("matchLabels", {})
+        assert selector_labels, f"{pdb_name}: selector.matchLabels is empty"
+        matched = filter_pods(all_pods, namespace=HARBOR_NAMESPACE, labels=selector_labels)
+        replicas_key = f"harbor.{component}_replicas"
+        expected_replicas = int(resolve_config(replicas_key))
+        assert len(matched) == expected_replicas, (
+            f"{pdb_name}: selector matches {len(matched)} pods, expected {expected_replicas} "
+            f"(selector={selector_labels})"
+        )

--- a/osdc/base/kubernetes/harbor/pdb.yaml.tpl
+++ b/osdc/base/kubernetes/harbor/pdb.yaml.tpl
@@ -1,0 +1,55 @@
+# PodDisruptionBudgets for Harbor multi-replica components.
+#
+# The upstream Harbor Helm chart (v1.18.2) does not generate PDBs. This
+# template is sed-substituted (__MAX_UNAVAILABLE__) and applied by the
+# _deploy-harbor recipe in the justfile via kubectl_apply_if_changed.
+#
+# Per-cluster value: clusters.yaml -> harbor.pdb_max_unavailable
+#   default:     1       (conservative — at most 1 pod down per component)
+#   arc-staging: "100%"  (aggressive — staging has 1 replica each)
+#
+# Single-replica components (jobservice, portal, exporter, internal redis/db)
+# are intentionally NOT covered: a PDB on a 1-replica Deployment with
+# minAvailable=1 deadlocks node drains.
+#
+# Selectors mirror the labels rendered by the Harbor chart's per-component
+# Deployments: app=harbor, component=<name>, release=harbor.
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: harbor-core
+  namespace: harbor-system
+spec:
+  maxUnavailable: __MAX_UNAVAILABLE__
+  selector:
+    matchLabels:
+      app: harbor
+      component: core
+      release: harbor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: harbor-registry
+  namespace: harbor-system
+spec:
+  maxUnavailable: __MAX_UNAVAILABLE__
+  selector:
+    matchLabels:
+      app: harbor
+      component: registry
+      release: harbor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: harbor-nginx
+  namespace: harbor-system
+spec:
+  maxUnavailable: __MAX_UNAVAILABLE__
+  selector:
+    matchLabels:
+      app: harbor
+      component: nginx
+      release: harbor

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -48,6 +48,7 @@ defaults:
     core_replicas: 4
     registry_replicas: 4
     nginx_replicas: 6
+    pdb_max_unavailable: 1  # conservative: at most 1 pod down per component
 
   # --- Module defaults ---
   karpenter:
@@ -133,6 +134,7 @@ clusters:
       core_replicas: 1
       registry_replicas: 1
       nginx_replicas: 1
+      pdb_max_unavailable: "100%"  # aggressive: staging has 1 replica each
     karpenter:
       replicas: 1
       log_level: debug

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -874,6 +874,7 @@ _deploy-harbor cluster:
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
     source "{{UPSTREAM}}/scripts/helm-upgrade.sh"
+    source "{{UPSTREAM}}/scripts/kubectl-apply.sh"
     export OSDC_ROOT="{{ROOT}}"
     export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
@@ -972,6 +973,16 @@ _deploy-harbor cluster:
     HARBOR_CORE_REPLICAS=$(uv run {{CFG}} "$CLUSTER" harbor.core_replicas 2)
     HARBOR_REGISTRY_REPLICAS=$(uv run {{CFG}} "$CLUSTER" harbor.registry_replicas 2)
     HARBOR_NGINX_REPLICAS=$(uv run {{CFG}} "$CLUSTER" harbor.nginx_replicas 3)
+    HARBOR_PDB_MAX_UNAVAILABLE=$(uv run {{CFG}} "$CLUSTER" harbor.pdb_max_unavailable 1)
+
+    # Validate: positive integer or "1%"-"100%". Rejects 0/"0%" (deadlocks
+    # all evictions), empty strings (renders broken YAML), and any value
+    # containing sed/shell metacharacters that would corrupt the substitution.
+    if [[ ! "$HARBOR_PDB_MAX_UNAVAILABLE" =~ ^([1-9][0-9]*|[1-9][0-9]?%|100%)$ ]]; then
+        echo "ERROR: harbor.pdb_max_unavailable='${HARBOR_PDB_MAX_UNAVAILABLE}' is invalid." >&2
+        echo "       Expected: positive integer (e.g., 1, 2, 5) or percentage '1%'-'100%' (quoted)." >&2
+        exit 1
+    fi
 
     # Install Harbor (using traditional Helm repo to avoid ghcr.io auth/rate-limit issues)
     echo "Installing Harbor..."
@@ -1025,6 +1036,17 @@ _deploy-harbor cluster:
         echo "  Helm upgrade attempt $attempt/$HELM_MAX_RETRIES failed, retrying in 30s..."
         sleep 30
     done
+    echo ""
+
+    # Apply Harbor PodDisruptionBudgets (chart has no native PDB support).
+    # Generated from base/kubernetes/harbor/pdb.yaml.tpl with maxUnavailable
+    # substituted from clusters.yaml -> harbor.pdb_max_unavailable.
+    echo "Applying Harbor PodDisruptionBudgets..."
+    GENERATED_HARBOR_PDB=$(mktemp)
+    trap 'rm -f "$GENERATED_HARBOR_PDB"' EXIT
+    sed -e "s|__MAX_UNAVAILABLE__|${HARBOR_PDB_MAX_UNAVAILABLE}|g" \
+        "{{UPSTREAM}}/base/kubernetes/harbor/pdb.yaml.tpl" >"$GENERATED_HARBOR_PDB"
+    kubectl_apply_if_changed -f "$GENERATED_HARBOR_PDB"
     echo ""
 
     # Ensure Harbor admin password matches the K8s secret.


### PR DESCRIPTION
**Impact:** Harbor registry availability during node drains and Karpenter consolidation
**Risk:** low

## What
Adds PodDisruptionBudgets for Harbor's multi-replica components (core, registry, nginx) to prevent simultaneous eviction during node drains or Karpenter-driven consolidation.

## Why
The upstream Harbor Helm chart (v1.18.2) does not generate PDBs. Without them, a node drain or Karpenter consolidation event can evict all replicas of a Harbor component at once, causing registry downtime that blocks image pulls across the entire cluster. This is the same gap that was already filled for git-cache and pypi-cache.

## How
- Uses the project's established PDB pattern: a `.yaml.tpl` template with `sed` placeholder substitution, applied via `kubectl_apply_if_changed` — identical to how git-cache central PDB works.
- Chose `maxUnavailable` (rather than `minAvailable` used by git-cache) because it scales naturally with replica count changes and avoids the "minAvailable > replicas" deadlock risk.
- Only covers multi-replica components. Single-replica components (jobservice, portal, exporter, redis, database) are intentionally excluded — a PDB with `minAvailable=1` on a 1-replica Deployment deadlocks node drains.
- Staging override uses `"100%"` to avoid blocking drains in a 1-replica environment.
- Input validation rejects `0`, `0%`, empty strings, and shell/sed metacharacters to prevent broken YAML or injection via the `sed` substitution.

## Changes
- **`base/kubernetes/harbor/pdb.yaml.tpl`** — New template defining three PDBs (harbor-core, harbor-registry, harbor-nginx) with `__MAX_UNAVAILABLE__` placeholder. Selectors match the labels rendered by the Harbor chart's Deployments.
- **`clusters.yaml`** — Added `harbor.pdb_max_unavailable` to defaults (`1`) and arc-staging override (`"100%"`).
- **`justfile` (`_deploy-harbor`)** — Sources `kubectl-apply.sh`, reads and validates the new config key, generates the PDB manifest via `sed`, and applies it with `kubectl_apply_if_changed` after the Helm release.
- **`base/helm/harbor/tests/smoke/test_harbor.py`** — New `TestHarborPDBs` class that verifies each PDB exists, has the correct `maxUnavailable` from clusters.yaml, reports healthy status, and selects the expected number of pods matching the per-component replica count.

## Testing
```
============================================================================================================================================ test session starts ============================================================================================================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jschmidt/meta/ci-infra-code-review/osdc
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0
16 workers [240 items]
......................................................................................................s.....................................................................................................s...................................                                                      [100%]
========================================================================================================================================== short test summary info ==========================================================================================================================================
SKIPPED [1] modules/arc-runners/tests/smoke/test_capacity_parity.py:300: no scale sets with proactive_capacity > 0
SKIPPED [1] modules/monitoring/tests/smoke/test_monitoring.py:173: No dcgm-exporter pods found (no GPU nodes)
================================================================================================================================= 238 passed, 2 skipped in 85.80s (0:01:25) =================================================================================================================================

Smoke tests completed in 1m26s
```
```
============================================================
  OSDC Integration Test Results
============================================================
  Cluster: arc-staging (pytorch-arc-staging)
  Date:    2026-05-11 22:11 UTC

  PR Workflow Jobs:
    ✓ test-cpu-x86-amx               success
    ✓ test-git-cache                 success
    ✓ test-pypi-cache-action-cuda    success
    ✓ test-pypi-cache-defaults       success
    ✓ test-gpu-t4                    success
    ✓ test-pypi-cache-action-cpu     success
    ✓ test-gpu-t4-multi              success
    ✓ test-cpu-arm64                 success
    ✓ test-harbor                    success
    ✓ test-release-arm64             success
    ✓ test-cache-enforcer            success
    ✓ test-cpu-x86-avx512            success
    ✓ build-arm64 / build            success
    ✓ build-amd64 / build            success

  Smoke            ⊘ SKIPPED
  Compactor        ⊘ SKIPPED

  Overall: PASSED
============================================================
```