### PR TITLE
Mitigate CVE-2026-43284 + CVE-2026-43500 (DirtyFrag LPE) on all cluster nodes

### DIFF
--- a/osdc/base/kubernetes/dirtyfrag-mitigation.yaml
+++ b/osdc/base/kubernetes/dirtyfrag-mitigation.yaml
@@ -1,0 +1,215 @@
+# DirtyFrag Mitigation DaemonSet (CVE-2026-43284 + CVE-2026-43500)
+#
+# DirtyFrag = two related Linux kernel page-cache write LPEs in the IPv4/IPv6
+# datagram zero-copy path. __ip_append_data() fails to set SKBFL_SHARED_FRAG
+# on splice-attached pages, then ESP (xfrm) and RxRPC perform in-place crypto
+# over them — mutating the page cache of read-only files like /usr/bin/su
+# and /etc/passwd.
+#   - CVE-2026-43284: xfrm-ESP variant. Requires unshare(CLONE_NEWUSER|
+#     CLONE_NEWNET) to acquire CAP_NET_ADMIN in a user namespace.
+#   - CVE-2026-43500: RxRPC variant. Requires no privileges — but rxrpc.ko
+#     is not built into the AL2023 default kernel (blacklisted defensively
+#     per AWS bulletin 2026-027-AWS).
+#
+# Crosses container boundaries via the shared page cache, so on a multi-tenant
+# CI cluster any unprivileged workflow code can escalate to root on the node.
+#
+# AWS Security Bulletin: https://aws.amazon.com/security/security-bulletins/2026-027-aws/
+# ALAS2023-2026-1694 (kernel 6.1, fixed in 6.1.170-210.320.amzn2023)
+# ALAS2023-2026-1695 (kernel 6.12, fixed in 6.12.83-113.160.amzn2023)
+# Released 2026-05-09.
+#
+# AS OF 2026-05-11, no patched EKS-optimized AMI exists yet (latest v20260505
+# ships kernel 6.1.168 / 6.12.80 — both pre-patch).
+#
+# This DaemonSet writes /etc/modprobe.d/disable-dirtyfrag.conf to block
+# on-demand loading of esp4, esp6, and rxrpc, then defensively rmmod's any
+# that have already loaded, then drops the page cache to evict any
+# DirtyFrag-poisoned pages of read-only files.
+#
+# Runs on EVERY node (base infra + Karpenter ARC + BuildKit + GPU + H100/B200).
+# Same shape as algif-mitigation.yaml.
+#
+# REMOVE this DaemonSet once all nodes are running a patched AL2023 AMI
+# (kernel 6.1.170+ or 6.12.83+).
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dirtyfrag-mitigation-script
+  namespace: kube-system
+data:
+  disable-dirtyfrag.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    echo "=== DirtyFrag Mitigation (CVE-2026-43284 + CVE-2026-43500) ==="
+    echo "Node: $(hostname 2>/dev/null || echo 'unknown')"
+    echo "Date: $(date)"
+    echo ""
+
+    MARKER_FILE="/var/lib/dirtyfrag-mitigation/.configured"
+    MODPROBE_FILE="/etc/modprobe.d/disable-dirtyfrag.conf"
+    MODULES="esp4 esp6 rxrpc"
+
+    # =========================================================================
+    # Idempotency — re-verify on pod restart, skip rewrite if still in place
+    # =========================================================================
+    if [ -f "$MARKER_FILE" ] && [ -f "$MODPROBE_FILE" ]; then
+      echo "Already configured. Re-checking modules are not loaded..."
+      for mod in $MODULES; do
+        if lsmod | awk '{print $1}' | grep -qx "$mod"; then
+          echo "  WARNING: $mod is loaded despite blacklist. Unloading..."
+          modprobe -r "$mod" || echo "  rmmod $mod failed (module in use); reboot required for full mitigation."
+        else
+          echo "  $mod not loaded — mitigation effective."
+        fi
+      done
+      exit 0
+    fi
+
+    # =========================================================================
+    # Step 1 — install modprobe.d blacklist
+    # =========================================================================
+    echo "[1/3] Writing $MODPROBE_FILE..."
+    mkdir -p "$(dirname "$MODPROBE_FILE")"
+    cat > "$MODPROBE_FILE" <<'EOF'
+    # CVE-2026-43284 + CVE-2026-43500 ("DirtyFrag") — page-cache write LPE mitigation.
+    # Redirects on-demand loading of esp4, esp6, and rxrpc to /bin/false so the
+    # modules are never inserted into the running kernel.
+    # Managed by base/kubernetes/dirtyfrag-mitigation.yaml DaemonSet.
+    # Remove this file (and the DaemonSet) once nodes are running a patched
+    # AL2023 kernel (6.1.170+ or 6.12.83+).
+    install esp4 /bin/false
+    install esp6 /bin/false
+    install rxrpc /bin/false
+    EOF
+    echo "  Wrote blacklist."
+
+    # =========================================================================
+    # Step 2 — unload modules if currently loaded (defensive, each individually)
+    # =========================================================================
+    echo "[2/3] Checking if vulnerable modules are loaded..."
+    for mod in $MODULES; do
+      if lsmod | awk '{print $1}' | grep -qx "$mod"; then
+        echo "  $mod loaded. Unloading (modprobe -r)..."
+        if modprobe -r "$mod"; then
+          echo "  Unloaded $mod."
+        else
+          echo "  WARNING: rmmod $mod failed. Module may be in use. New attempts"
+          echo "  will be blocked from now on, but the vulnerable code path"
+          echo "  remains reachable until the node reboots."
+        fi
+      else
+        echo "  $mod not loaded."
+      fi
+    done
+
+    # =========================================================================
+    # Step 3 — drop page cache to evict any DirtyFrag-poisoned pages
+    # =========================================================================
+    # Best-effort: only evicts unmapped clean pages. Pages currently mapped by
+    # running processes (libc, sshd, /etc/passwd held open, etc.) cannot be
+    # evicted this way and will retain any prior poisoning until the node
+    # reboots or the holding process exits.
+    echo "[3/3] Dropping page cache (echo 3 > /proc/sys/vm/drop_caches)..."
+    echo 3 > /proc/sys/vm/drop_caches || echo "  WARNING: drop_caches failed."
+
+    # Marker — written last so a partial run re-attempts on next pod start
+    mkdir -p "$(dirname "$MARKER_FILE")"
+    date -Iseconds 2>/dev/null > "$MARKER_FILE" || date > "$MARKER_FILE"
+
+    echo ""
+    echo "=== Mitigation Applied ==="
+    echo "Future kernel attempts to load esp4/esp6/rxrpc will be redirected to /bin/false."
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dirtyfrag-mitigation
+  namespace: kube-system
+  labels:
+    app: dirtyfrag-mitigation
+    app.kubernetes.io/name: dirtyfrag-mitigation
+    app.kubernetes.io/component: node-configuration
+spec:
+  selector:
+    matchLabels:
+      app: dirtyfrag-mitigation
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+
+  template:
+    metadata:
+      labels:
+        app: dirtyfrag-mitigation
+
+    spec:
+      hostNetwork: true
+      hostPID: true
+
+      priorityClassName: system-node-critical
+
+      # Run on ALL nodes (base infra + Karpenter-managed: ARC, BuildKit, GPU, H100, B200)
+      tolerations:
+        - operator: Exists
+
+      # NO nodeSelector — must run on every node in the cluster
+
+      serviceAccountName: dirtyfrag-mitigation
+
+      initContainers:
+        - name: disable-dirtyfrag
+          image: public.ecr.aws/amazonlinux/amazonlinux:2023
+          command: ["/bin/bash", "-c"]
+          args:
+            # hostPID gives access to host's PID 1 root filesystem.
+            # nsenter runs the script in the host's mount/UTS/IPC/net namespaces
+            # so modprobe, lsmod, and writes to /etc/modprobe.d hit the host.
+            # stdin redirection reads the script from the container's ConfigMap
+            # mount before nsenter switches namespaces.
+            - /proc/1/root/usr/bin/nsenter -t 1 -m -u -i -n -- /bin/bash < /scripts/disable-dirtyfrag.sh
+
+          securityContext:
+            privileged: true
+
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+
+      containers:
+        - name: sleep
+          image: public.ecr.aws/docker/library/alpine:3.19
+          command:
+            - /bin/sh
+            - -c
+            - "echo 'DirtyFrag mitigation applied. Sleeping...'; sleep infinity"
+
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+
+      volumes:
+        - name: scripts
+          configMap:
+            name: dirtyfrag-mitigation-script
+            defaultMode: 0755
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dirtyfrag-mitigation
+  namespace: kube-system
+  labels:
+    app: dirtyfrag-mitigation

--- a/osdc/base/kubernetes/kustomization.yaml
+++ b/osdc/base/kubernetes/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - git-cache/
   - registry-mirror-config.yaml
   - algif-mitigation.yaml
+  - dirtyfrag-mitigation.yaml
   # image-cache-janitor is deployed via its own deploy.sh (builds custom image)
   # NOTE: Namespaces for modules (arc-runners, arc-systems, buildkit, etc.)
   # are created by the module's own kubernetes/ directory, not here.

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -27,6 +27,10 @@ defaults:
   # TODO(CVE-2026-31431): when bumping to a kernel 6.12.85+ AL2023 AMI,
   # remove osdc/base/kubernetes/algif-mitigation.yaml.
   # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
+  # TODO(CVE-2026-43284): when bumping to a kernel with the DirtyFrag fix
+  # (6.1.170+ or 6.12.83+ on AL2023), remove
+  # osdc/base/kubernetes/dirtyfrag-mitigation.yaml.
+  # https://aws.amazon.com/security/security-bulletins/2026-027-aws/
   base_node_ami_version: "v20260318"
   eks_version: "1.35"
   single_nat_gateway: false

--- a/osdc/modules/buildkit/scripts/python/generate_buildkit.py
+++ b/osdc/modules/buildkit/scripts/python/generate_buildkit.py
@@ -348,6 +348,10 @@ spec:
   # rotation picks up a kernel 6.12.85+ AMI, remove
   # osdc/base/kubernetes/algif-mitigation.yaml.
   # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
+  # TODO(CVE-2026-43284): al2023@latest tracks the newest AL2023 AMI; once node
+  # rotation picks up a kernel with the DirtyFrag fix (6.1.170+ or 6.12.83+),
+  # remove osdc/base/kubernetes/dirtyfrag-mitigation.yaml.
+  # https://aws.amazon.com/security/security-bulletins/2026-027-aws/
   amiSelectorTerms:
     - alias: al2023@latest
 

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -162,6 +162,11 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     # kernel 6.12.85+ AMI. Once rolled out across all nodes, remove
     # osdc/base/kubernetes/algif-mitigation.yaml.
     # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
+    # TODO(CVE-2026-43284): the AL2023 aliases / name globs below already track
+    # @latest, so node rotation picks up the fix automatically once AWS ships a
+    # kernel with the DirtyFrag fix (6.1.170+ or 6.12.83+). Once rolled out
+    # across all nodes, remove osdc/base/kubernetes/dirtyfrag-mitigation.yaml.
+    # https://aws.amazon.com/security/security-bulletins/2026-027-aws/
     if is_gpu:
         ami_family_block = "  amiFamily: AL2023"
         ami_selector_block = """  amiSelectorTerms:

--- a/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
@@ -12,6 +12,10 @@ spec:
   # rotation picks up a kernel 6.12.85+ AMI, remove
   # osdc/base/kubernetes/algif-mitigation.yaml.
   # https://explore.alas.aws.amazon.com/CVE-2026-31431.html
+  # TODO(CVE-2026-43284): al2023@latest tracks the newest AL2023 AMI; once node
+  # rotation picks up a kernel with the DirtyFrag fix (6.1.170+ or 6.12.83+),
+  # remove osdc/base/kubernetes/dirtyfrag-mitigation.yaml.
+  # https://aws.amazon.com/security/security-bulletins/2026-027-aws/
   amiSelectorTerms:
     - alias: al2023@latest
 


### PR DESCRIPTION
**Impact:** All cluster nodes (base infra, ARC runners, BuildKit, GPU, H100/B200) — blocks a container-escape LPE exploitable by any unprivileged CI workflow
**Risk:** low

## What
Adds a privileged DaemonSet that blacklists the `esp4`, `esp6`, and `rxrpc` kernel modules via `/etc/modprobe.d`, defensively unloads any that are already loaded, and drops the page cache to evict potentially poisoned pages.

## Why
DirtyFrag (CVE-2026-43284 + CVE-2026-43500) is a pair of Linux kernel page-cache write LPEs in the IPv4/IPv6 datagram zero-copy path. `__ip_append_data()` fails to set `SKBFL_SHARED_FRAG` on splice-attached pages, allowing ESP (xfrm) and RxRPC to perform in-place crypto over them — mutating the page cache of read-only files like `/usr/bin/su` and `/etc/passwd`. The flaw crosses container boundaries via the shared page cache, so on a multi-tenant CI cluster any unprivileged workflow code can escalate to root on the host.

AWS released patched AL2023 kernels on 2026-05-09 (6.1.170+ / 6.12.83+), but as of 2026-05-11 no patched EKS-optimized AMI exists yet (latest v20260505 ships kernel 6.1.168 / 6.12.80). This DaemonSet blocks the attack surface until nodes can be rolled to a patched AMI.

## How
- Follows the exact same pattern as the existing `algif-mitigation.yaml` (CVE-2026-31431): ConfigMap script + privileged initContainer via `nsenter` into host namespaces + sleep-infinity main container
- `modprobe.d` `install` directives redirect module loading to `/bin/false` — more reliable than `blacklist` which only prevents autoload, not explicit `modprobe`
- Page cache drop (`echo 3 > /proc/sys/vm/drop_caches`) is best-effort: mapped pages held by running processes survive until the process exits or the node reboots
- Idempotent with marker file at `/var/lib/dirtyfrag-mitigation/.configured`; re-verifies module state on pod restart
- `system-node-critical` priority + `tolerations: [operator: Exists]` ensures it runs on every node type including GPU nodes with custom taints
- Temporary mitigation — annotated with TODO(CVE-2026-43284) for removal once patched AMIs ship

## Changes
- **`base/kubernetes/dirtyfrag-mitigation.yaml`** — New DaemonSet (ConfigMap + initContainer + ServiceAccount) that writes modprobe.d blacklist, unloads vulnerable modules, and drops page cache on every node
- **`base/kubernetes/kustomization.yaml`** — Wire the new DaemonSet into the base kustomize build
- **`clusters.yaml`** — Add TODO breadcrumb alongside the existing algif-mitigation TODO tracking AMI version for removal
- **`modules/buildkit/scripts/python/generate_buildkit.py`** — Add TODO breadcrumb for DirtyFrag removal in BuildKit EC2NodeClass AMI selector
- **`modules/nodepools/scripts/python/generate_nodepools.py`** — Add TODO breadcrumb for DirtyFrag removal in nodepool EC2NodeClass AMI selector
- **`modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl`** — Add TODO breadcrumb for DirtyFrag removal in pypi-cache EC2NodeClass AMI selector

## Notes
- Remove this DaemonSet (and all TODO breadcrumbs) once all nodes are running a patched AL2023 AMI with kernel 6.1.170+ or 6.12.83+. Track: ALAS2023-2026-1694 / ALAS2023-2026-1695.
- The `rxrpc` module is not built into the AL2023 default kernel — blacklisting it here is purely defensive per AWS bulletin 2026-027-AWS.
- Node resource footprint: 10m CPU / 32Mi memory (requests) for the sleep container; the initContainer runs once and exits.

## Testing
- Verify the DaemonSet is healthy on a test cluster: `kubectl get ds dirtyfrag-mitigation -n kube-system` — desired/ready counts should match node count
- Confirm the modprobe.d file was written: `kubectl logs -n kube-system -l app=dirtyfrag-mitigation -c disable-dirtyfrag` should show "Mitigation Applied"
- Verify modules are blocked: `ssh` to a node and run `modprobe esp4` — should fail with `/bin/false`
- `just lint` and `just test` pass with zero errors