### PR TITLE
Replace expired H100 capacity reservation ID

### DIFF
--- a/osdc/modules/nodepools-h100/defs/p5-48xlarge.yaml
+++ b/osdc/modules/nodepools-h100/defs/p5-48xlarge.yaml
@@ -13,6 +13,6 @@ nodepool:
   topology_manager_scope: pod
   capacity_type: reserved
   capacity_reservation_ids:
-    - cr-0fea9e9472d5e76c6
+    - cr-0c3f05dffb85ed832
   baremetal: true
   user_data_script: scripts/h100-node-setup.sh


### PR DESCRIPTION
## Summary
- The previous AWS Capacity Block reservation `cr-0fea9e9472d5e76c6` backing the `p5.48xlarge` (H100) nodepool has expired.
- Swap it for the renewed reservation `cr-0c3f05dffb85ed832` in `osdc/modules/nodepools-h100/defs/p5-48xlarge.yaml` so Karpenter can keep launching H100 baremetal nodes.

## Test plan
- [ ] Re-run `just deploy-module <cluster> nodepools-h100` and confirm the generated NodePool references the new reservation ID.
- [ ] Verify new H100 nodes can launch against the updated capacity reservation.