### PR TITLE
Fix Alloy OOMs: increase resource limits and add GOMEMLIMIT for centralized Deployments

### DIFF
--- a/osdc/modules/logging/deploy.sh
+++ b/osdc/modules/logging/deploy.sh
@@ -141,8 +141,9 @@ alloy:
           key: loki-api-key-write
     - name: GOGC
       value: "200"
+    # Centralized Deployment — generous limits, GOMEMLIMIT at ~85% of cgroup. The alloy-logging DaemonSet is tuned smaller because its cost multiplies by node count.
     - name: GOMEMLIMIT
-      value: "1800MiB"
+      value: "3500MiB"
 EOF
 
 helm_upgrade_if_changed alloy-events "$NAMESPACE" \

--- a/osdc/modules/logging/helm/alloy-events-values.yaml
+++ b/osdc/modules/logging/helm/alloy-events-values.yaml
@@ -35,11 +35,11 @@ alloy:
 
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 500m
+      memory: 1Gi
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: "2"
+      memory: 4Gi
 
   clustering:
     enabled: false                # Single replica — no clustering needed

--- a/osdc/modules/monitoring/deploy.sh
+++ b/osdc/modules/monitoring/deploy.sh
@@ -119,6 +119,9 @@ alloy:
       value: "${GCLOUD_BASE_URL}"
     - name: CLUSTER_NAME
       value: "${CNAME}"
+    # Centralized Deployment — generous limits, GOMEMLIMIT at ~85% of cgroup. Mirrors alloy-events tuning.
+    - name: GOMEMLIMIT
+      value: "7000MiB"
 EOF
 
   ALLOY_CHART_VERSION=$(uv run "$CFG" "$CLUSTER" alloy_chart_version 1.6.2)

--- a/osdc/modules/monitoring/helm/alloy-values.yaml
+++ b/osdc/modules/monitoring/helm/alloy-values.yaml
@@ -25,11 +25,11 @@ alloy:
     enabled: true
   resources:
     requests:
-      cpu: 250m
-      memory: 1536Mi
+      cpu: 500m
+      memory: 2Gi
     limits:
-      cpu: "2"
-      memory: 2560Mi
+      cpu: "4"
+      memory: 8Gi
   configMap:
     content: |-
       // Discover and scrape all ServiceMonitor targets across namespaces.


### PR DESCRIPTION
**Impact:** alloy-events (logging) and alloy (monitoring) — centralized Deployments on base-infrastructure nodes
**Risk:** low

## What
Increases cgroup resource limits and sets explicit `GOMEMLIMIT` on all **centralized** Alloy Deployments to eliminate OOM kills caused by Go GC / cgroup memory accounting mismatch.

## Why
Go's garbage collector does not automatically detect cgroup memory limits — it defaults to a percentage of total host memory, which on m7i.12xlarge nodes (192 GiB) is far above the container's cgroup ceiling. This causes the Go heap to grow well past the container limit, triggering OOM kills. Setting `GOMEMLIMIT` explicitly at ~85% of the cgroup limit tells the GC to collect before hitting the ceiling. The previous alloy-events limits (256 Mi) were also simply too small — causing repeated OOMKills.

## How
- Set `GOMEMLIMIT` to ~85% of each container's cgroup memory limit, giving the GC headroom to collect before the OOM killer fires
- Sized generously because these are centralized Deployments (1–2 replicas on base-infra nodes), not DaemonSets — total cluster cost is negligible
- The alloy-logging DaemonSet is intentionally left unchanged (per-node cost multiplies by node count)

## Changes

**alloy-events (logging module — single-replica Deployment):**
- CPU requests: 50m → 500m, limits: 200m → 2 cores
- Memory requests: 128Mi → 1Gi, limits: 256Mi → 4Gi
- `GOMEMLIMIT`: 1800MiB → 3500MiB (~85% of 4Gi)

**alloy (monitoring module — 2-replica clustered Deployment):**
- CPU requests: 250m → 500m, limits: 2 → 4 cores
- Memory requests: 1536Mi → 2Gi, limits: 2560Mi → 8Gi
- Added `GOMEMLIMIT=7000MiB` (~85% of 8Gi) — was previously unset

## Testing
...the usual...