### PR TITLE
Increase load test timeout to 2 hours

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -188,7 +188,7 @@ jobs:
     if: ${{ !cancelled() && !failure() && inputs.run_load_test }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: osdc


### PR DESCRIPTION
- Bump load-test job timeout from 60 to 120 minutes

Staging CI load tests were hitting the 60-minute timeout before completing. Doubling to 2 hours matches the AWS role-duration-seconds (7200s) already configured for the job.

ex: https://github.com/pytorch/ci-infra/actions/runs/25769307746/job/75691484365