### PR TITLE
Bump runner-container-hooks to v0.8.11 (OOM hardening)

### DIFF
--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -69,7 +69,7 @@ Every Karpenter NodePool applies this startup taint via the `startupTaints` fiel
 Runner pods include an init container that polls for a file on the host filesystem before the runner container can start. This file is placed by a DaemonSet.
 
 **DaemonSet**: `runner-hooks-warmer` (`modules/arc-runners/kubernetes/hooks-warmer.yaml`)
-- Downloads patched `runner-container-hooks` v0.8.10 from GitHub releases
+- Downloads patched `runner-container-hooks` v0.8.11 from GitHub releases
 - Extracts to `/mnt/runner-container-hooks/dist/` on host NVMe
 - Validates `dist/index.js` exists after extraction
 - Writes version marker for idempotency

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -4,7 +4,7 @@
 #
 # Fix: find -exec stat {} \; -> find -exec stat {} + (10-100x faster)
 # Fix: exit code propagation — OOM-killed processes now correctly report failure
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.10
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.11
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -63,7 +63,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.10"
+              HOOKS_VERSION="0.8.11"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -292,7 +292,7 @@ template:
             value: /home/runner/hook-extensions/job-pod.yaml
           # Use OSDC wrapper that validates env vars and surfaces errors
           # clearly, then delegates to patched hooks from DaemonSet.
-          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.10
+          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.11
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS
             value: /home/runner/hook-extensions/wrapper.js
           # PyTorch CI workflows depend on Docker images built in parallel by


### PR DESCRIPTION
**Impact:** All GitHub Actions runner pods on c7i-runner nodes
**Risk:** low

## What
Bumps the patched `runner-container-hooks` fork from v0.8.10 to v0.8.11 across the hooks-warmer DaemonSet, runner pod template, and scheduling-gates documentation.

## Why
v0.8.10 fixed the `find -exec stat` performance regression and basic exit-code propagation, but runner pods were still OOM-killed during workspace copy on large repos (e.g. pytorch/pytorch). The root cause: the upstream `@kubernetes/client-node` WebSocket handler streams tar data with zero back-pressure — when the cluster has network congestion, the send queue grows unboundedly until the 512Mi (now 1Gi) runner pod is killed. v0.8.11 is a hardening release that addresses this and five other failure modes discovered in production.

## How
- No OSDC logic changes — this is a version string bump only. All fixes live in the [runner-container-hooks fork](https://github.com/jeanschmidt/runner-container-hooks/pull/4).
- The hooks-warmer DaemonSet will do a rolling update, downloading the new zip on each c7i-runner node. Runner pods starting after the update will snapshot the new hooks via the existing init container + emptyDir pattern.

## Changes
- `modules/arc-runners/kubernetes/hooks-warmer.yaml`: bump `HOOKS_VERSION` from `0.8.10` to `0.8.11`, update release URL in header comment
- `modules/arc-runners/templates/runner.yaml.tpl`: update release URL comment in the `ACTIONS_RUNNER_CONTAINER_HOOKS` env var block
- `docs/node-warmup-and-scheduling-gates.md`: update version reference in Gate 2 documentation

## Notes

**What v0.8.11 fixes (upstream fork):**

1. **WebSocket back-pressure throttling** — monitors `ws.bufferedAmount` with a 50ms poll; pauses the source tar stream above 200 MiB high-water mark, resumes below 50 MiB low-water mark. Directly prevents the OOM during `execCpToPod`.
2. **Capped stderr capture** — new `CappedWritable` limits stderr buffer to 64 KiB (upstream `WritableStreamBuffer` grew unboundedly).
3. **Spurious retry storm fix** — upstream treated any non-empty stderr as failure, triggering up to 30 retries on benign tar warnings (`"Removing leading '/'"` etc.). Now only rejects on non-Success K8s exec status.
4. **Per-call exec timeout** — 60s default timeout on `execPodStep`/`execPodStepOutput`; hung WebSockets are terminated via `ws.terminate()` instead of hanging indefinitely.
5. **Process-level safety handlers** — `SIGTERM`, `uncaughtException`, and `unhandledRejection` now emit `[runner-container-hooks] FATAL: ...` to stderr before exit, giving Loki/Grafana visibility into previously silent hook deaths.
6. **`ws.terminate()` over `ws.close()`** — per `kubernetes-client/javascript#2532`, `close()` does not kill remote commands; `terminate()` (socket destroy) does. Applied on all cancel/timeout paths.
7. **Pin `@kubernetes/client-node` to 1.4.0** — the back-pressure fix relies on kc WebSocket internals; pinning prevents silent breakage from minor upgrades.