### PR TITLE
feat(karpenter): reservedENIs=1 + per-EC2NodeClass kubelet.maxPods for prefix delegation

### DIFF
--- a/osdc/modules/karpenter/helm/values.yaml
+++ b/osdc/modules/karpenter/helm/values.yaml
@@ -26,6 +26,8 @@ settings:
   clusterName: ""
   clusterEndpoint: ""
   interruptionQueue: ""
+  # Reserve 1 ENI for node-only traffic (required for VPC CNI Custom Networking).
+  reservedENIs: 1
   # Feature gates
   featureGates:
     spotToSpotConsolidation: true

--- a/osdc/modules/nodepools/defs/c7i-runner.yaml
+++ b/osdc/modules/nodepools/defs/c7i-runner.yaml
@@ -4,6 +4,8 @@ fleet:
   name: c7i-runner
   arch: amd64
   gpu: false
+  # Runner pool packs up to 250 pods/node — opt out of the 110 default cap.
+  max_pods: 250
   instances:
     - type: c7i.48xlarge
       weight: 100

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -32,12 +32,73 @@ _scripts_python = str(Path(__file__).resolve().parents[4] / "scripts" / "python"
 if _scripts_python not in sys.path:
     sys.path.insert(0, _scripts_python)
 
-from instance_specs import INSTANCE_SPECS  # noqa: E402
+from instance_specs import INSTANCE_ENI_DATA, INSTANCE_SPECS  # noqa: E402
 
 # ANSI colors
 GREEN = "\033[0;32m"
 RED = "\033[0;31m"
 NC = "\033[0m"
+
+# Kubelet max-pods caps for prefix-delegation math.
+# Defaults follow AWS's max-pods-calculator.sh: 110 for instances with vCPU<=30,
+# 250 for vCPU>30 (per-AWS recommended cap for IP-dense workloads).
+DEFAULT_MAX_PODS_CAP = 110
+PD_HARD_CEILING = 250
+PREFIXES_PER_SLOT = 16  # Each ENI slot holds one /28 prefix = 16 IPs under PD
+
+
+def compute_pd_max_pods(instance_type: str, *, custom_networking: bool = True) -> int:
+    """Return the prefix-delegation-derived kubelet max-pods ceiling for an instance type.
+
+    Mirrors AWS's max-pods-calculator.sh (used by AL2/AL2023 EKS AMIs). The
+    ``(eni_count - 1)`` term reserves the primary ENI for node-only traffic when
+    VPC CNI Custom Networking is on. ``PD_HARD_CEILING=250`` matches AWS's
+    recommended cap for >30 vCPU instances; smaller instances cap at 110.
+
+    Source: github.com/awslabs/amazon-eks-ami nodeadm/internal/kubelet/eni_max_pods.go
+    """
+    if instance_type not in INSTANCE_ENI_DATA:
+        raise ValueError(
+            f"{instance_type} missing from INSTANCE_ENI_DATA in scripts/python/instance_specs.py — "
+            f"add eni_count + ipv4_per_eni from awslabs/amazon-eks-ami nodeadm/internal/kubelet/instance-info.jsonl"
+        )
+    if instance_type not in INSTANCE_SPECS:
+        raise ValueError(f"{instance_type} missing from INSTANCE_SPECS in scripts/python/instance_specs.py")
+    eni = INSTANCE_ENI_DATA[instance_type]
+    spec = INSTANCE_SPECS[instance_type]
+    usable_enis = eni["eni_count"] - (1 if custom_networking else 0)
+    if usable_enis < 1:
+        raise ValueError(
+            f"{instance_type} has eni_count={eni['eni_count']} → usable_enis={usable_enis} "
+            f"with custom_networking={custom_networking}; cannot host pods"
+        )
+    raw = usable_enis * (eni["ipv4_per_eni"] - 1) * PREFIXES_PER_SLOT + 2
+    cap = PD_HARD_CEILING if spec["vcpu"] > 30 else DEFAULT_MAX_PODS_CAP
+    return min(cap, raw)
+
+
+def resolve_max_pods(nodepool_def: dict) -> int:
+    """Resolve the kubelet max-pods value to render on an EC2NodeClass.
+
+    - If def has explicit ``max_pods: <int>``, use it (must be <= PD ceiling).
+    - Otherwise default to ``min(110, pd_ceiling)`` \u2014 conservative for general
+      pools, prevents future fleets from silently hitting the kubelet 110 wall.
+    """
+    instance_type = nodepool_def["instance_type"]
+    name = nodepool_def.get("name", "<unnamed>")
+    pd_ceiling = compute_pd_max_pods(instance_type)
+    explicit = nodepool_def.get("max_pods")
+    if explicit is not None:
+        if isinstance(explicit, bool) or not isinstance(explicit, int):
+            raise ValueError(
+                f"max_pods for pool '{name}' ({instance_type}) must be an int, got {type(explicit).__name__}"
+            )
+        if explicit > pd_ceiling:
+            raise ValueError(f"max_pods={explicit} for pool '{name}' ({instance_type}) exceeds PD ceiling {pd_ceiling}")
+        if explicit < 1:
+            raise ValueError(f"max_pods={explicit} for pool '{name}' ({instance_type}) must be >= 1")
+        return explicit
+    return min(DEFAULT_MAX_PODS_CAP, pd_ceiling)
 
 
 def log_info(msg):
@@ -133,6 +194,11 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     indented_userdata = _read_user_data_script(user_data_script_path, defs_dir) if defs_dir else None
 
     node_disk_size = _get_node_disk_size(nodepool_def)
+
+    # ----- Kubelet max-pods (prefix-delegation aware) -----
+    # Karpenter only honors kubelet keys you set on EC2NodeClass.spec.kubelet.
+    # Set ONLY here — do NOT also set in user-data NodeConfig (avoids drift).
+    max_pods = resolve_max_pods(nodepool_def)
 
     # ----- Capacity block / reservation support -----
     capacity_type = nodepool_def.get("capacity_type", "on-demand")
@@ -319,6 +385,9 @@ spec:
         karpenter.sh/discovery: "CLUSTER_NAME_PLACEHOLDER"
 
   role: "CLUSTER_NAME_PLACEHOLDER-node-role"
+
+  kubelet:
+    maxPods: {max_pods}
 {"  instanceStorePolicy: RAID0" + chr(10) if has_nvme else ""}\
 {capacity_reservation_block}\
   userData: |
@@ -453,6 +522,14 @@ def _build_fleet_nodepool_def(fleet_data, inst, name_suffix="", extra_labels=Non
         val = inst.get(key)
         if val is not None:
             nodepool_def[key] = val
+
+    # max_pods: fleet-level default with per-instance override
+    fleet_default_max_pods = fleet_data.get("max_pods")
+    inst_max_pods = inst.get("max_pods")
+    if inst_max_pods is not None:
+        nodepool_def["max_pods"] = inst_max_pods
+    elif fleet_default_max_pods is not None:
+        nodepool_def["max_pods"] = fleet_default_max_pods
 
     if extra_labels:
         merged = dict(nodepool_def["extra_labels"])

--- a/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
@@ -13,8 +13,10 @@ from generate_nodepools import (
     _get_node_disk_size,
     _read_user_data_script,
     _user_data_script_mime_part,
+    compute_pd_max_pods,
     generate_nodepool_yaml,
     main,
+    resolve_max_pods,
 )
 
 # ============================================================================
@@ -1369,3 +1371,155 @@ class TestExcludeRegions:
         assert result == 0
         generated = sorted(f.name for f in output_dir.glob("*.yaml"))
         assert "legacy-pool.yaml" not in generated
+
+
+# ============================================================================
+# Prefix-delegation max-pods (PR 8 part C)
+# ============================================================================
+
+
+class TestComputePdMaxPods:
+    """Tests for compute_pd_max_pods — the AWS max-pods-calculator formula."""
+
+    @pytest.mark.parametrize(
+        ("instance_type", "expected"),
+        [
+            ("c7i.48xlarge", 250),  # 14*49*16+2=10978 → cap 250
+            ("c7i.8xlarge", 250),  # 7*29*16+2=3250 → cap 250
+            ("r7i.2xlarge", 110),  # 3*14*16+2=674 → cap 110 (vcpu<=30)
+            ("p5.48xlarge", 250),  # 1*49*16+2=786 → cap 250
+            ("g5.48xlarge", 250),  # 6*49*16+2=4706 → cap 250
+        ],
+    )
+    def test_compute_pd_max_pods_formula(self, instance_type, expected):
+        assert compute_pd_max_pods(instance_type) == expected
+
+    def test_compute_pd_max_pods_no_custom_networking(self):
+        # Big instances stay capped at 250 even without custom networking.
+        assert compute_pd_max_pods("c7i.48xlarge", custom_networking=False) == 250
+        # Small instance still caps at 110 (vcpu<=30).
+        assert compute_pd_max_pods("r7i.2xlarge", custom_networking=False) == 110
+
+
+class TestResolveMaxPods:
+    """Tests for resolve_max_pods — explicit override + default behavior."""
+
+    def test_resolve_max_pods_default_caps_at_110(self):
+        # No explicit max_pods → default cap of 110 even if PD ceiling is higher.
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge")
+        nodepool_def.pop("max_pods", None)
+        assert resolve_max_pods(nodepool_def) == 110
+
+    def test_resolve_max_pods_explicit_below_ceiling(self):
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=200)
+        assert resolve_max_pods(nodepool_def) == 200
+
+    def test_resolve_max_pods_explicit_at_ceiling(self):
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=250)
+        assert resolve_max_pods(nodepool_def) == 250
+
+    def test_resolve_max_pods_explicit_above_ceiling_raises(self):
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=300)
+        with pytest.raises(ValueError, match="exceeds PD ceiling"):
+            resolve_max_pods(nodepool_def)
+
+    def test_resolve_max_pods_explicit_negative_raises(self):
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=0)
+        with pytest.raises(ValueError, match="must be >= 1"):
+            resolve_max_pods(nodepool_def)
+
+    def test_resolve_max_pods_explicit_non_int_raises(self):
+        # str rejected
+        nodepool_def_str = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods="250")
+        with pytest.raises(ValueError, match="must be an int"):
+            resolve_max_pods(nodepool_def_str)
+        # bool rejected (even though bool is technically an int subclass)
+        nodepool_def_bool = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=True)
+        with pytest.raises(ValueError, match="must be an int"):
+            resolve_max_pods(nodepool_def_bool)
+
+
+class TestEc2NodeClassMaxPods:
+    """Tests for the rendered EC2NodeClass kubelet.maxPods block."""
+
+    def _parse(self, text: str) -> list[dict]:
+        return parse_all_yaml(text)
+
+    def test_generated_ec2nodeclass_has_kubelet_max_pods(self):
+        # Default (no explicit max_pods) → 110 for c7i.48xlarge.
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge")
+        nodepool_def.pop("max_pods", None)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        assert ec2["spec"]["kubelet"]["maxPods"] == 110
+
+    def test_generated_ec2nodeclass_has_kubelet_max_pods_explicit(self):
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=250)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        assert ec2["spec"]["kubelet"]["maxPods"] == 250
+
+    def test_user_data_nodeconfig_does_NOT_have_max_pods(self):
+        """Regression guard: maxPods must NOT be set inside the user-data NodeConfig.
+
+        Karpenter sets kubelet keys via EC2NodeClass.spec.kubelet only.  Setting
+        maxPods in two places risks silent disagreement and confuses Karpenter's
+        scheduler math.
+        """
+        nodepool_def = _make_nodepool_def(instance_type="c7i.48xlarge", max_pods=250)
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        userdata = ec2["spec"]["userData"]
+        assert "maxPods" not in userdata
+
+
+class TestFleetMaxPodsPropagation:
+    """Tests for fleet/per-instance max_pods propagation."""
+
+    def _parse(self, text: str) -> list[dict]:
+        return parse_all_yaml(text)
+
+    def test_fleet_max_pods_propagates_to_instances(self):
+        fleet = {"name": "c7i-runner", "arch": "amd64", "gpu": False, "max_pods": 250}
+        instances = [
+            {"type": "c7i.48xlarge", "weight": 100, "node_disk_size": 3750},
+            {"type": "c7i.24xlarge", "weight": 85, "node_disk_size": 1900},
+        ]
+        for inst in instances:
+            nodepool_def = _build_fleet_nodepool_def(fleet, inst)
+            output = generate_nodepool_yaml(nodepool_def, "nodepools")
+            docs = self._parse(output)
+            ec2 = docs[1]
+            assert ec2["spec"]["kubelet"]["maxPods"] == 250, (
+                f"{inst['type']}: expected 250, got {ec2['spec']['kubelet']['maxPods']}"
+            )
+
+    def test_per_instance_max_pods_overrides_fleet(self):
+        fleet = {"name": "c7i-runner", "arch": "amd64", "gpu": False, "max_pods": 200}
+        # Override only on the 48xlarge entry.
+        inst_override = {"type": "c7i.48xlarge", "weight": 100, "node_disk_size": 3750, "max_pods": 250}
+        inst_default = {"type": "c7i.24xlarge", "weight": 85, "node_disk_size": 1900}
+
+        np_override = _build_fleet_nodepool_def(fleet, inst_override)
+        np_default = _build_fleet_nodepool_def(fleet, inst_default)
+
+        ec2_override = self._parse(generate_nodepool_yaml(np_override, "nodepools"))[1]
+        ec2_default = self._parse(generate_nodepool_yaml(np_default, "nodepools"))[1]
+
+        assert ec2_override["spec"]["kubelet"]["maxPods"] == 250
+        assert ec2_default["spec"]["kubelet"]["maxPods"] == 200
+
+    def test_real_def_c7i_runner_uses_explicit_max_pods(self):
+        """Round-trip: c7i-runner.yaml renders maxPods=250 on every instance."""
+        c7i_runner_defs = [d for d in _load_all_real_defs() if d.get("fleet_name") == "c7i-runner"]
+        assert c7i_runner_defs, "expected c7i-runner instances in real defs"
+        for d in c7i_runner_defs:
+            output = generate_nodepool_yaml(d, "nodepools", REAL_DEFS_DIR)
+            docs = parse_all_yaml(output)
+            ec2 = docs[1]
+            assert ec2["spec"]["kubelet"]["maxPods"] == 250, (
+                f"{d['name']}: expected 250, got {ec2['spec']['kubelet']['maxPods']}"
+            )

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -5,8 +5,20 @@ Single source of truth for instance hardware specs used across OSDC scripts:
 - generate_buildkit.py (BuildKit pod sizing)
 - collect_instance_memory.py (live memory collection)
 - simulate_cluster.py (cluster simulation)
+- generate_nodepools.py (Karpenter EC2NodeClass kubelet.maxPods PD math)
 
-When adding a new instance type (runner nodepool or BuildKit node), add it here.
+This file owns THREE dicts that MUST stay in lock-step. When adding a new
+instance type (runner nodepool or BuildKit node), populate ALL THREE:
+
+- ``INSTANCE_SPECS``    — vCPU / memory / GPU / arch (compute facts).
+- ``INSTANCE_ENI_DATA`` — raw AWS ENI shape (``eni_count`` + ``ipv4_per_eni``),
+  populated from upstream
+  ``awslabs/amazon-eks-ami nodeadm/internal/kubelet/instance-info.jsonl``.
+  Required by the nodepools generator's prefix-delegation max-pods math.
+- ``ENI_MAX_PODS``      — legacy non-PD AWS-stock max-pods table used by
+  the cluster simulator and BuildKit pod-sizing math (NOT used by the
+  prefix-delegation generator).
+
 Run ``uv run scripts/python/collect_instance_memory.py`` against a live cluster
 to obtain precise memory_mi values for new entries.
 """
@@ -105,6 +117,87 @@ INSTANCE_SPECS: dict[str, dict] = {
     "c7gd.16xlarge": {"vcpu": 64, "memory_gib": 128, "memory_mi": 121241, "gpu": 0, "arch": "arm64"},
     "m7gd.16xlarge": {"vcpu": 64, "memory_gib": 256, "memory_mi": 242540, "gpu": 0, "arch": "arm64"},
     "m8gd.16xlarge": {"vcpu": 64, "memory_gib": 256, "memory_mi": 242540, "gpu": 0, "arch": "arm64"},
+}
+
+# ---------------------------------------------------------------------------
+# Per-instance ENI shape — raw AWS facts used for prefix-delegation max-pods math.
+#
+# Fields:
+#   eni_count    — default network card's max ENIs (multi-NIC instances:
+#                  default-card subset only — that's what Karpenter and
+#                  AWS's max-pods calculator both use).
+#   ipv4_per_eni — IPv4 addresses per ENI (this is the per-ENI slot count;
+#                  with prefix delegation each slot holds 16 IPs).
+#
+# Multi-NIC instances (p4d, p5, p6-b200): eni_count is the DEFAULT network
+# card's ENIs only — that's what Karpenter and the AWS max-pods calculator
+# both use.
+#
+# Source: awslabs/amazon-eks-ami nodeadm/internal/kubelet/instance-info.jsonl.
+# Schema docs: nodeadm/internal/kubelet/eni_max_pods.go.
+# ---------------------------------------------------------------------------
+INSTANCE_ENI_DATA: dict[str, dict[str, int]] = {
+    "c7a.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "c7a.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "c7a.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7a.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7a.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7i.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "c7i.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "c7i.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7i.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7i.metal-24xl": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7i.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m6i.32xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m7i.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "m7i.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "m7i.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m7i.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m7i.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r5.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r5.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r5.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r5.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7a.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r7a.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r7a.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7a.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7a.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7i.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r7i.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7i.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7i.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m8g.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "m8g.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "m8g.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m8g.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m8g.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "r7g.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g4dn.8xlarge": {"eni_count": 4, "ipv4_per_eni": 15},
+    "g4dn.16xlarge": {"eni_count": 4, "ipv4_per_eni": 15},
+    "g5.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "g5.16xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "g6.8xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "g6.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g4dn.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "g5.12xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g5.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g6.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "g6.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g4dn.metal": {"eni_count": 15, "ipv4_per_eni": 50},
+    "g5.48xlarge": {"eni_count": 7, "ipv4_per_eni": 50},  # NOT 15 — verified anomaly in upstream
+    "g6.48xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "p4d.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "p5.48xlarge": {"eni_count": 2, "ipv4_per_eni": 50},
+    "p6-b200.48xlarge": {"eni_count": 4, "ipv4_per_eni": 50},
+    "r7i.2xlarge": {"eni_count": 4, "ipv4_per_eni": 15},
+    "r7i.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "r5d.12xlarge": {"eni_count": 8, "ipv4_per_eni": 30},
+    "m8gd.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m6id.24xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "c7gd.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m7gd.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
+    "m8gd.16xlarge": {"eni_count": 15, "ipv4_per_eni": 50},
 }
 
 # ---------------------------------------------------------------------------

--- a/osdc/scripts/python/test_instance_specs.py
+++ b/osdc/scripts/python/test_instance_specs.py
@@ -1,0 +1,85 @@
+"""Tests for ``instance_specs`` ENI fields and basic invariants.
+
+These tests guard the raw AWS ENI facts (``eni_count`` and ``ipv4_per_eni``)
+that are used downstream for prefix-delegation max-pods math. They do NOT
+assert anything about ``ENI_MAX_PODS``, which is allowed to deviate
+from the AWS-stock formula (e.g. for safer node packing).
+"""
+
+from __future__ import annotations
+
+import pytest
+from instance_specs import ENI_MAX_PODS, INSTANCE_ENI_DATA, INSTANCE_SPECS
+
+# Sanity bound: the AWS-stock max-pods formula
+# (eni_count * (ipv4_per_eni - 1) + 2) is well under 750 for every
+# instance shape we use. If a future entry blows past this, it's almost
+# certainly a typo in eni_count/ipv4_per_eni.
+AWS_STOCK_MAX_PODS_SANITY_BOUND = 750
+
+
+class TestInstanceEniData:
+    def test_every_instance_spec_has_eni_data(self) -> None:
+        """Every INSTANCE_SPECS key must have a matching INSTANCE_ENI_DATA entry with positive ints."""
+        for instance_type in INSTANCE_SPECS:
+            assert instance_type in INSTANCE_ENI_DATA, f"{instance_type}: missing from INSTANCE_ENI_DATA"
+            eni = INSTANCE_ENI_DATA[instance_type]
+            assert "eni_count" in eni, f"{instance_type}: missing eni_count"
+            assert "ipv4_per_eni" in eni, f"{instance_type}: missing ipv4_per_eni"
+            assert isinstance(eni["eni_count"], int), (
+                f"{instance_type}: eni_count must be int, got {type(eni['eni_count']).__name__}"
+            )
+            assert isinstance(eni["ipv4_per_eni"], int), (
+                f"{instance_type}: ipv4_per_eni must be int, got {type(eni['ipv4_per_eni']).__name__}"
+            )
+            assert eni["eni_count"] > 0, f"{instance_type}: eni_count must be > 0, got {eni['eni_count']}"
+            assert eni["ipv4_per_eni"] > 0, f"{instance_type}: ipv4_per_eni must be > 0, got {eni['ipv4_per_eni']}"
+
+    @pytest.mark.parametrize(
+        ("instance_type", "expected_eni_count", "expected_ipv4_per_eni"),
+        [
+            ("c7i.48xlarge", 15, 50),
+            ("p5.48xlarge", 2, 50),
+            ("p6-b200.48xlarge", 4, 50),
+            ("g5.48xlarge", 7, 50),
+            ("r7i.2xlarge", 4, 15),
+            ("c7i.metal-24xl", 15, 50),
+        ],
+    )
+    def test_specific_eni_values(self, instance_type: str, expected_eni_count: int, expected_ipv4_per_eni: int) -> None:
+        """Spot-check a small set of representative rows to catch typos at edit time."""
+        eni = INSTANCE_ENI_DATA[instance_type]
+        assert eni["eni_count"] == expected_eni_count, (
+            f"{instance_type}: eni_count expected {expected_eni_count}, got {eni['eni_count']}"
+        )
+        assert eni["ipv4_per_eni"] == expected_ipv4_per_eni, (
+            f"{instance_type}: ipv4_per_eni expected {expected_ipv4_per_eni}, got {eni['ipv4_per_eni']}"
+        )
+
+    def test_known_invariants_aws_stock_max_pods_formula(self) -> None:
+        """The AWS-stock max-pods formula must stay under our sanity bound for every entry.
+
+        Formula: eni_count * (ipv4_per_eni - 1) + 2
+        This intentionally does NOT compare against ENI_MAX_PODS — those values are
+        deliberately allowed to differ.
+        """
+        for instance_type, eni in INSTANCE_ENI_DATA.items():
+            aws_stock_max_pods = eni["eni_count"] * (eni["ipv4_per_eni"] - 1) + 2
+            assert aws_stock_max_pods <= AWS_STOCK_MAX_PODS_SANITY_BOUND, (
+                f"{instance_type}: AWS-stock max-pods formula yielded {aws_stock_max_pods}, "
+                f"exceeds sanity bound {AWS_STOCK_MAX_PODS_SANITY_BOUND} "
+                f"(eni_count={eni['eni_count']}, ipv4_per_eni={eni['ipv4_per_eni']})"
+            )
+
+
+class TestInstanceSpecs:
+    def test_eni_max_pods_keys_subset_of_instance_specs(self) -> None:
+        """Every ENI_MAX_PODS key must have a matching INSTANCE_SPECS entry."""
+        missing = sorted(set(ENI_MAX_PODS.keys()) - set(INSTANCE_SPECS.keys()))
+        assert not missing, f"ENI_MAX_PODS keys missing from INSTANCE_SPECS: {missing}"
+
+    def test_vcpu_and_memory_positive(self) -> None:
+        """Every INSTANCE_SPECS row must have positive vcpu and memory_gib."""
+        for instance_type, spec in INSTANCE_SPECS.items():
+            assert spec["vcpu"] > 0, f"{instance_type}: vcpu must be > 0, got {spec['vcpu']}"
+            assert spec["memory_gib"] > 0, f"{instance_type}: memory_gib must be > 0, got {spec['memory_gib']}"

--- a/osdc/scripts/python/test_karpenter_helm_values.py
+++ b/osdc/scripts/python/test_karpenter_helm_values.py
@@ -1,0 +1,41 @@
+"""Tests for modules/karpenter/helm/values.yaml.
+
+Guards the Karpenter Helm values that affect scheduling and node provisioning.
+The reservedENIs setting is required for VPC CNI Custom Networking so the
+scheduler subtracts the primary ENI from each instance's pod-IP capacity.
+"""
+
+from pathlib import Path
+
+import yaml
+
+VALUES_PATH = Path(__file__).parents[2] / "modules" / "karpenter" / "helm" / "values.yaml"
+
+
+def _load_values() -> dict:
+    with VALUES_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+class TestKarpenterHelmValues:
+    def test_reserved_enis_set_to_one(self):
+        data = _load_values()
+        assert data["settings"]["reservedENIs"] == 1
+        # Must be an integer, not a string — the chart maps it to RESERVED_ENIS env var
+        # and the controller parses it as int.
+        assert isinstance(data["settings"]["reservedENIs"], int)
+        assert not isinstance(data["settings"]["reservedENIs"], bool)
+
+    def test_settings_block_required_keys(self):
+        data = _load_values()
+        settings = data["settings"]
+        expected = {"clusterName", "clusterEndpoint", "interruptionQueue", "reservedENIs", "featureGates"}
+        missing = expected - set(settings.keys())
+        assert not missing, f"settings block is missing required keys: {sorted(missing)}"
+
+    def test_no_top_level_reserved_enis_key(self):
+        data = _load_values()
+        # The setting MUST live under settings:, never at the top level.
+        # The chart only reads settings.reservedENIs; a top-level key would be silently ignored.
+        assert "reservedENIs" not in data
+        assert "RESERVED_ENIS" not in data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #570
* #569
* #568
* __->__ #567
* #566
* #564
* #561
* #560
* #559
* #558

**Impact:** All Karpenter-managed workload nodes — scheduling capacity math and kubelet max-pods ceiling change on next NodeClaim provisioning
**Risk:** medium

## What
Configures Karpenter to reserve the primary ENI for node networking under VPC CNI Custom Networking, and teaches the NodePool generator to compute and emit prefix-delegation-aware kubelet maxPods on every EC2NodeClass.

## Why
VPC CNI Custom Networking dedicates the primary ENI to node-only traffic — Karpenter must subtract it from pod-IP capacity calculations (`reservedENIs: 1`) or it will overschedule pods that cannot obtain IPs. Separately, prefix delegation changes per-node IP capacity dramatically, so kubelet's maxPods must be recomputed from AWS ENI shape data rather than using the legacy non-PD defaults.

## How
- `reservedENIs` is set on Karpenter Helm values (camelCase under `settings:`), NOT on the VPC CNI addon — the chart maps it to the `RESERVED_ENIS` env var on the controller
- ENI shape data (`eni_count` + `ipv4_per_eni`) added as a separate `INSTANCE_ENI_DATA` dict rather than mutating the existing `ENI_MAX_PODS` table, preserving BuildKit/simulator math unchanged
- maxPods defaults to `min(110, pd_ceiling)` (conservative) with explicit per-def opt-in for higher values; c7i-runner opts in to 250 to support its 100-250 pods/node density
- maxPods is set ONLY on EC2NodeClass `spec.kubelet`, NOT in userData NodeConfig — avoids silent disagreement between two sources

## Changes
- `modules/karpenter/helm/values.yaml`: add `settings.reservedENIs: 1`
- `scripts/python/instance_specs.py`: add `INSTANCE_ENI_DATA` dict with raw AWS ENI shape facts for all instance types (sourced from `awslabs/amazon-eks-ami nodeadm/internal/kubelet/instance-info.jsonl`)
- `modules/nodepools/scripts/python/generate_nodepools.py`: add `compute_pd_max_pods()` (AWS max-pods-calculator formula) and `resolve_max_pods()` (explicit override + default behavior); emit `spec.kubelet.maxPods` on every EC2NodeClass; propagate fleet-level and per-instance `max_pods` overrides
- `modules/nodepools/defs/c7i-runner.yaml`: add fleet-level `max_pods: 250` to break the 110 default cap
- `scripts/python/test_instance_specs.py`: new — guards INSTANCE_ENI_DATA completeness, field types, specific values, and AWS-stock formula sanity bound
- `scripts/python/test_karpenter_helm_values.py`: new — asserts reservedENIs=1 (int, not bool/string), required settings keys, no misplaced top-level key
- `modules/nodepools/scripts/python/test_generate_nodepools.py`: new test classes for PD max-pods formula, resolve_max_pods edge cases, EC2NodeClass kubelet rendering, fleet propagation, per-instance override, and real c7i-runner.yaml round-trip

## Notes
- Adding `spec.kubelet.maxPods` marks every existing NodeClaim as drifted — Karpenter's disruption controller will replace nodes honoring disruption budgets. Do NOT deploy this to any cluster outside the coordinated cutover window.
- `reservedENIs=1` takes effect on Karpenter restart; until cutover, new nodes are packed slightly less densely (~16 fewer pods/node) — conservative direction.
- Pre-existing `ENI_MAX_PODS` inaccuracies for p5.48xlarge / p4d.24xlarge are deliberately deferred to a separate chore.

## Testing
- `just test` — all unit tests pass, including the 3 new test files (20+ new test cases covering formula correctness, edge cases, type validation, rendered YAML structure, fleet propagation, and real def round-trips)
- `just lint` — all 13 linters pass
- Spot-check: verify `compute_pd_max_pods("c7i.48xlarge") == 250` and `compute_pd_max_pods("r7i.2xlarge") == 110` match AWS's max-pods-calculator.sh output
- Post-deploy verification: `kubectl -n karpenter get deploy karpenter -o yaml | grep RESERVED_ENIS` must show `1`

Signed-off-by: Jean Schmidt <contato@jschmidt.me>