### PR TITLE
refactor(vpc): per-(bucket, AZ) NAT GW topology with configurable EIP count

### DIFF
--- a/osdc/modules/eks/terraform/main.tf
+++ b/osdc/modules/eks/terraform/main.tf
@@ -48,8 +48,8 @@ module "vpc" {
     cidrsubnet(var.vpc_cidr, 8, 194),
   ]
 
-  enable_nat_gateway = true
-  single_nat_gateway = var.single_nat_gateway
+  enable_nat_gateway    = true
+  nat_gateway_eip_count = var.nat_gateway_eip_count
 
   pod_cidr_buckets = var.pod_cidr_buckets
 

--- a/osdc/modules/eks/terraform/modules/vpc/main.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/main.tf
@@ -184,38 +184,6 @@ resource "aws_ec2_subnet_cidr_reservation" "pd_prefix" {
   description      = "VPC CNI Prefix Delegation reservation (${each.key})"
 }
 
-# Elastic IPs for NAT Gateways
-resource "aws_eip" "nat" {
-  count  = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
-  domain = "vpc"
-
-  tags = merge(
-    var.tags,
-    {
-      Name = "${var.name}-nat-${count.index + 1}"
-    }
-  )
-
-  depends_on = [aws_internet_gateway.this]
-}
-
-# NAT Gateways
-resource "aws_nat_gateway" "this" {
-  count = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
-
-  allocation_id = aws_eip.nat[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
-
-  tags = merge(
-    var.tags,
-    {
-      Name = "${var.name}-nat-${count.index + 1}"
-    }
-  )
-
-  depends_on = [aws_internet_gateway.this]
-}
-
 # Public Route Table
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.this.id
@@ -240,31 +208,5 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
 }
 
-# Private Route Tables
-resource "aws_route_table" "private" {
-  count = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : length(var.azs)
-
-  vpc_id = aws_vpc.this.id
-
-  dynamic "route" {
-    for_each = var.enable_nat_gateway ? [1] : []
-    content {
-      cidr_block     = "0.0.0.0/0"
-      nat_gateway_id = var.single_nat_gateway ? aws_nat_gateway.this[0].id : aws_nat_gateway.this[count.index].id
-    }
-  }
-
-  tags = merge(
-    var.tags,
-    {
-      Name = "${var.name}-private-${count.index + 1}"
-    }
-  )
-}
-
-resource "aws_route_table_association" "private" {
-  count = length(var.private_subnets)
-
-  subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = var.single_nat_gateway ? aws_route_table.private[0].id : aws_route_table.private[count.index].id
-}
+# NAT Gateway / EIP / private + pod route tables live in nat.tf -- per-(bucket,
+# AZ) topology with configurable EIP count per NAT GW.

--- a/osdc/modules/eks/terraform/modules/vpc/nat.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/nat.tf
@@ -1,0 +1,220 @@
+# Per-(bucket, AZ) NAT Gateway topology with configurable EIP count.
+#
+# Each (bucket, AZ) pod subnet gets its own NAT GW so pod egress source IPs
+# are isolated per bucket. Each NAT GW gets var.nat_gateway_eip_count EIPs
+# (1 primary + N-1 secondary, AWS hard cap of 8) for source-IP diversity to
+# mitigate per-IP rate limits at upstream services.
+#
+# Production end state: 4 buckets x 3 AZs = 12 NAT GWs, 96 EIPs at default 8.
+# Staging end state: 4 buckets x 2 AZs = 8 NAT GWs, 8 EIPs at override 1.
+#
+# Base node egress (private subnets, primary CIDR) routes through the
+# default_node_egress_bucket NAT GW per AZ -- preserves a single egress
+# source-IP set for base nodes regardless of bucket count.
+
+locals {
+  # AZ keys derived from pod_cidr_buckets, NOT var.azs. Pod-subnet topology is
+  # the single source of truth for AZ placement; var.azs is positional and
+  # AWS-API-discovered. Used only for the precondition cross-check below.
+  pod_azs = sort(distinct(flatten([
+    for bucket_name, az_map in var.pod_cidr_buckets : keys(az_map)
+  ])))
+
+  # The bucket whose per-AZ NAT GWs serve base-node (private subnet) egress.
+  # Base nodes live in the primary CIDR; they need exactly one NAT GW per AZ
+  # (not one per bucket per AZ). Lexicographically first bucket name is the
+  # stable, deterministic choice.
+  #
+  # All base-node (private subnet) egress for a given AZ routes through THIS one
+  # bucket's NAT GW. SPOF: if bucket-1's NAT GW fails in an AZ, ALL base nodes
+  # in that AZ lose internet egress (Harbor pulls, Karpenter EC2 calls, ARC
+  # heartbeats, Alloy -> Grafana Cloud). Acceptable trade-off vs adding 3+ extra
+  # NAT GWs (~$100/mo overhead) just for base-node redundancy. Pod egress is
+  # diversified per-bucket as designed.
+  default_node_egress_bucket = sort(keys(var.pod_cidr_buckets))[0]
+
+  # Flat map of secondary EIP slots keyed "${bucket}-${az}-${slot}" for slot
+  # in 2..nat_gateway_eip_count. Empty map when nat_gateway_eip_count == 1.
+  nat_secondary_assignments = merge([
+    for nat_key, assoc in local.pod_cidr_associations : {
+      for slot in range(2, var.nat_gateway_eip_count + 1) :
+      "${nat_key}-${slot}" => {
+        bucket  = assoc.bucket
+        az      = assoc.az
+        slot    = slot
+        nat_key = nat_key
+      }
+    }
+  ]...)
+
+  # Subnet-by-AZ maps derived from the actual aws_subnet attribute, NOT
+  # positional var.azs[i]. The existing private_subnets_by_az output uses
+  # positional indexing; these locals are intentionally separate to avoid
+  # drift if the count ordering ever diverges from var.azs.
+  public_subnets_by_az = {
+    for s in aws_subnet.public : s.availability_zone => s.id
+  }
+
+  private_subnets_by_az_local = {
+    for s in aws_subnet.private : s.availability_zone => s.id
+  }
+}
+
+# Primary EIP per NAT GW. Always exactly 1 per (bucket, AZ).
+resource "aws_eip" "nat_primary" {
+  for_each = var.enable_nat_gateway ? local.pod_cidr_associations : {}
+
+  domain = "vpc"
+
+  tags = merge(
+    var.tags,
+    {
+      Name                   = "${var.name}-nat-${each.value.bucket}-${each.value.az}-primary"
+      "osdc.io/nat-bucket"   = each.value.bucket
+      "osdc.io/nat-az"       = each.value.az
+      "osdc.io/nat-eip-role" = "primary"
+    }
+  )
+
+  depends_on = [aws_internet_gateway.this]
+
+  lifecycle {
+    # Pod-subnet AZ keys MUST match the cluster's available AZs. If they drift,
+    # NAT placement either fails (missing public subnet for the AZ) or worse,
+    # silently picks the wrong AZ. Fail at plan time with a clear message.
+    precondition {
+      condition = sort(local.pod_azs) == sort(var.azs)
+      error_message = format(
+        "pod_cidr_buckets AZ keys (%s) must match var.azs (%s). Pod subnets and node subnets must live in the same AZs.",
+        jsonencode(local.pod_azs),
+        jsonencode(var.azs)
+      )
+    }
+  }
+}
+
+# Secondary EIPs per NAT GW (slots 2..nat_gateway_eip_count). Empty when
+# nat_gateway_eip_count == 1.
+resource "aws_eip" "nat_secondary" {
+  for_each = var.enable_nat_gateway ? local.nat_secondary_assignments : {}
+
+  domain = "vpc"
+
+  tags = merge(
+    var.tags,
+    {
+      Name                   = "${var.name}-nat-${each.value.bucket}-${each.value.az}-secondary-${each.value.slot}"
+      "osdc.io/nat-bucket"   = each.value.bucket
+      "osdc.io/nat-az"       = each.value.az
+      "osdc.io/nat-eip-role" = "secondary"
+      "osdc.io/nat-eip-slot" = tostring(each.value.slot)
+    }
+  )
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# NAT Gateway per (bucket, AZ). Allocation = 1 primary EIP + (N-1) secondary
+# EIPs. Lives in the matching public subnet (looked up by AZ from the
+# attribute-derived map -- avoids positional var.azs[i] drift).
+resource "aws_nat_gateway" "this" {
+  for_each = var.enable_nat_gateway ? local.pod_cidr_associations : {}
+
+  allocation_id = aws_eip.nat_primary[each.key].id
+  secondary_allocation_ids = [
+    for slot in range(2, var.nat_gateway_eip_count + 1) :
+    aws_eip.nat_secondary["${each.key}-${slot}"].id
+  ]
+  subnet_id = local.public_subnets_by_az[each.value.az]
+
+  tags = merge(
+    var.tags,
+    {
+      Name                 = "${var.name}-nat-${each.value.bucket}-${each.value.az}"
+      "osdc.io/nat-bucket" = each.value.bucket
+      "osdc.io/nat-az"     = each.value.az
+    }
+  )
+
+  depends_on = [aws_internet_gateway.this]
+
+  lifecycle {
+    # Pod-subnet AZ keys MUST match the cluster's available AZs. If they drift,
+    # NAT placement either fails (missing public subnet for the AZ) or worse,
+    # silently picks the wrong AZ. Fail at plan time with a clear message.
+    precondition {
+      condition = sort(local.pod_azs) == sort(var.azs)
+      error_message = format(
+        "pod_cidr_buckets AZ keys (%s) must match var.azs (%s). Pod subnets and node subnets must live in the same AZs.",
+        jsonencode(local.pod_azs),
+        jsonencode(var.azs)
+      )
+    }
+  }
+}
+
+# Pod route table per (bucket, AZ). Always created (NOT gated by
+# enable_nat_gateway) so the pod subnet associations remain stable; the
+# default route is gated dynamically and disappears when NAT is disabled.
+# This preserves the off-switch without destroy/recreate churn on the route
+# table itself.
+resource "aws_route_table" "pod" {
+  for_each = local.pod_cidr_associations
+
+  vpc_id = aws_vpc.this.id
+
+  dynamic "route" {
+    for_each = var.enable_nat_gateway ? [1] : []
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.this[each.key].id
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name                       = "${var.name}-pod-${each.value.bucket}-${each.value.az}"
+      "osdc.io/pod-route-bucket" = each.value.bucket
+      "osdc.io/pod-route-az"     = each.value.az
+    }
+  )
+}
+
+resource "aws_route_table_association" "pod" {
+  for_each = local.pod_cidr_associations
+
+  subnet_id      = aws_subnet.pod[each.key].id
+  route_table_id = aws_route_table.pod[each.key].id
+}
+
+# Private (base node) route table per AZ. Routes through the
+# default_node_egress_bucket's NAT GW for that AZ -- base nodes share a single
+# egress source-IP set per AZ regardless of bucket count.
+resource "aws_route_table" "private" {
+  for_each = toset(var.azs)
+
+  vpc_id = aws_vpc.this.id
+
+  dynamic "route" {
+    for_each = var.enable_nat_gateway ? [1] : []
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.this["${local.default_node_egress_bucket}-${each.value}"].id
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name}-private-${each.value}"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = local.private_subnets_by_az_local
+
+  subnet_id      = each.value
+  route_table_id = aws_route_table.private[each.key].id
+}

--- a/osdc/modules/eks/terraform/modules/vpc/outputs.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/outputs.tf
@@ -23,14 +23,33 @@ output "public_subnet_ids" {
   value       = aws_subnet.public[*].id
 }
 
-output "nat_gateway_ids" {
-  description = "List of NAT Gateway IDs"
-  value       = aws_nat_gateway.this[*].id
-}
-
 output "internet_gateway_id" {
   description = "The ID of the Internet Gateway"
   value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateways_by_bucket_az" {
+  description = "Map of NAT Gateway IDs keyed by '$${bucket}-$${az}'. Same key shape as pod_cidr_associations and pod_subnets_by_bucket_az (PR 5) so downstream consumers can join 1:1 without string-splitting."
+  value       = { for k, ng in aws_nat_gateway.this : k => ng.id }
+}
+
+output "nat_gateway_eips_by_bucket_az" {
+  description = "Map of NAT Gateway EIP allocation IDs keyed by '$${bucket}-$${az}'. Each value carries the primary allocation ID and the secondary allocation ID list (slots 2..nat_gateway_eip_count). Same key shape as nat_gateways_by_bucket_az."
+  value = {
+    for k, _ in aws_nat_gateway.this :
+    k => {
+      primary = aws_eip.nat_primary[k].id
+      secondary = [
+        for slot in range(2, var.nat_gateway_eip_count + 1) :
+        aws_eip.nat_secondary["${k}-${slot}"].id
+      ]
+    }
+  }
+}
+
+output "pod_route_table_ids_by_bucket_az" {
+  description = "Map of pod route table IDs keyed by '$${bucket}-$${az}'. Same key shape as pod_subnets_by_bucket_az (PR 5) so downstream consumers can join 1:1."
+  value       = { for k, rt in aws_route_table.pod : k => rt.id }
 }
 
 output "pod_cidr_associations" {

--- a/osdc/modules/eks/terraform/modules/vpc/variables.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/variables.tf
@@ -30,10 +30,15 @@ variable "enable_nat_gateway" {
   default     = true
 }
 
-variable "single_nat_gateway" {
-  description = "Use a single NAT gateway for all private subnets"
-  type        = bool
-  default     = false
+variable "nat_gateway_eip_count" {
+  description = "Number of EIPs allocated per NAT Gateway (1-8). AWS hard cap is 8. Default 8 maximizes egress source-IP diversity for anonymous per-IP rate-limit budgets."
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.nat_gateway_eip_count >= 1 && var.nat_gateway_eip_count <= 8
+    error_message = "nat_gateway_eip_count must be between 1 and 8 (AWS hard cap per NAT Gateway is 8 EIPs: 1 primary + 7 secondary)."
+  }
 }
 
 variable "enable_dns_hostnames" {
@@ -67,6 +72,11 @@ variable "pod_cidr_buckets" {
   validation {
     condition     = length(var.pod_cidr_buckets) > 0
     error_message = "pod_cidr_buckets must be non-empty."
+  }
+
+  validation {
+    condition     = alltrue([for _, az_map in var.pod_cidr_buckets : length(az_map) > 0])
+    error_message = "Every bucket in pod_cidr_buckets must have at least one AZ entry."
   }
 
   validation {

--- a/osdc/modules/eks/terraform/outputs.tf
+++ b/osdc/modules/eks/terraform/outputs.tf
@@ -42,6 +42,21 @@ output "pod_subnets_by_bucket_az" {
   value       = module.vpc.pod_subnets_by_bucket_az
 }
 
+output "nat_gateways_by_bucket_az" {
+  description = "NAT GWs keyed by '$${bucket}-$${az}', one per pod subnet (re-exported from VPC module). 12 in production / 8 in staging."
+  value       = module.vpc.nat_gateways_by_bucket_az
+}
+
+output "nat_gateway_eips_by_bucket_az" {
+  description = "NAT GW EIPs keyed by '$${bucket}-$${az}', each value an object with the primary EIP ID and a list of secondary EIP IDs (re-exported from VPC module)."
+  value       = module.vpc.nat_gateway_eips_by_bucket_az
+}
+
+output "pod_route_table_ids_by_bucket_az" {
+  description = "Pod route table IDs keyed by '$${bucket}-$${az}' (re-exported from VPC module). Each pod subnet associates with the matching route table."
+  value       = module.vpc.pod_route_table_ids_by_bucket_az
+}
+
 output "cluster_security_group_id" {
   value = module.eks.cluster_security_group_id
 }

--- a/osdc/modules/eks/terraform/variables.tf
+++ b/osdc/modules/eks/terraform/variables.tf
@@ -17,10 +17,14 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "single_nat_gateway" {
-  description = "Use a single NAT gateway (cost saving) vs one per AZ (HA)"
-  type        = bool
-  default     = false
+variable "nat_gateway_eip_count" {
+  description = "Number of EIPs per NAT GW (1-8). AWS hard cap is 8 EIPs per NAT GW (1 primary + 7 secondary)."
+  type        = number
+  default     = 8
+  validation {
+    condition     = var.nat_gateway_eip_count >= 1 && var.nat_gateway_eip_count <= 8
+    error_message = "nat_gateway_eip_count must be between 1 and 8 (AWS hard cap)."
+  }
 }
 
 variable "base_node_count" {
@@ -83,6 +87,11 @@ variable "pod_cidr_buckets" {
   validation {
     condition     = length(var.pod_cidr_buckets) > 0
     error_message = "pod_cidr_buckets must be non-empty."
+  }
+
+  validation {
+    condition     = alltrue([for _, az_map in var.pod_cidr_buckets : length(az_map) > 0])
+    error_message = "Every bucket in pod_cidr_buckets must have at least one AZ entry."
   }
 
   validation {

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -372,3 +372,357 @@ class TestVPCCNIConfig:
             f"vpc-cni addon on {cluster_name} reports {len(issues)} health issue(s) — "
             f"Env reconciliation likely failed (look for code='ConfigurationConflict'):\n  " + "\n  ".join(rendered)
         )
+
+
+# ============================================================================
+# NAT Gateway Topology
+# ============================================================================
+
+
+def _tag_value(tags: list[dict], key: str) -> str | None:
+    """Extract a tag value from an AWS-style ``[{"Key": ..., "Value": ...}]`` list."""
+    for t in tags or []:
+        if t.get("Key") == key:
+            return t.get("Value")
+    return None
+
+
+def _tags_to_dict(tags: list[dict]) -> dict[str, str]:
+    """Flatten an AWS-style tag list into a {Key: Value} dict."""
+    return {t.get("Key"): t.get("Value") for t in (tags or []) if "Key" in t}
+
+
+def _explicit_rt_for_subnet(vpc_id: str, aws_region: str, subnet_id: str) -> tuple[dict | None, str | None]:
+    """Return ``(route_table, error)`` for the EXPLICIT (non-main) RT association of a subnet.
+
+    Main RT fallback is intentionally rejected — it indicates the per-(bucket, az) RT is missing.
+    """
+    rt_lookup = run_aws(
+        [
+            "ec2",
+            "describe-route-tables",
+            "--filters",
+            f"Name=vpc-id,Values={vpc_id}",
+            f"Name=association.subnet-id,Values={subnet_id}",
+            "--region",
+            aws_region,
+        ],
+        timeout=60,
+    )
+    rts = rt_lookup.get("RouteTables", []) or []
+    explicit = [
+        rt
+        for rt in rts
+        for assoc in (rt.get("Associations") or [])
+        if assoc.get("SubnetId") == subnet_id and not assoc.get("Main", False)
+    ]
+    if len(explicit) != 1:
+        rt_ids = [r.get("RouteTableId") for r in explicit]
+        return None, f"expected exactly 1 explicit route-table association, got {len(explicit)} (rts={rt_ids})"
+    return explicit[0], None
+
+
+def _default_route_natgw(rt: dict) -> tuple[str | None, str | None]:
+    """Return ``(nat_gateway_id, error)`` for the RT's ``0.0.0.0/0`` route."""
+    default_routes = [r for r in (rt.get("Routes") or []) if r.get("DestinationCidrBlock") == "0.0.0.0/0"]
+    if len(default_routes) != 1:
+        return None, f"expected exactly one 0.0.0.0/0 route, got {len(default_routes)}"
+    ngw_id = default_routes[0].get("NatGatewayId")
+    if not ngw_id:
+        return None, f"0.0.0.0/0 route does not target a NAT GW (route={default_routes[0]})"
+    return ngw_id, None
+
+
+@pytest.fixture(scope="session")
+def vpc_id(eks_cluster_info) -> str:
+    """The cluster's primary VPC ID, sourced from the EKS cluster description."""
+    vpc = eks_cluster_info["cluster"].get("resourcesVpcConfig", {}).get("vpcId", "")
+    assert vpc, "EKS cluster description missing resourcesVpcConfig.vpcId"
+    return vpc
+
+
+@pytest.fixture(scope="session")
+def aws_region(cluster_config) -> str:
+    """The cluster's AWS region (defaulted in clusters.yaml)."""
+    return cluster_config["cluster"].get("region", "us-west-2")
+
+
+@pytest.fixture(scope="session")
+def pod_cidr_buckets(cluster_config) -> dict[str, dict[str, str]]:
+    """The bucket -> {az: cidr} mapping from clusters.yaml ``base.pod_cidr_buckets``."""
+    buckets = (cluster_config["cluster"].get("base") or {}).get("pod_cidr_buckets") or {}
+    assert buckets, (
+        "cluster config missing base.pod_cidr_buckets — required to derive the NAT topology "
+        "(every NodePool's pod subnet maps to a (bucket, AZ) NAT GW)"
+    )
+    return buckets
+
+
+@pytest.fixture(scope="session")
+def cluster_azs(pod_cidr_buckets) -> list[str]:
+    """Sorted list of AZ keys derived from the first bucket in ``pod_cidr_buckets``.
+
+    ``pod_cidr_buckets`` is the single source of truth for AZs (each bucket's keys =
+    the AZs that get pod subnets + NAT GWs); every bucket carries the same AZ keys
+    (validated by ``_validate_pod_cidr_buckets`` in ``scripts/cluster-config.py``).
+    """
+    return sorted(next(iter(pod_cidr_buckets.values())).keys())
+
+
+@pytest.fixture(scope="session")
+def default_node_egress_bucket(pod_cidr_buckets) -> str:
+    """Alphabetically first bucket — node-private RTs route through this bucket's NAT GW."""
+    return sorted(pod_cidr_buckets.keys())[0]
+
+
+@pytest.fixture(scope="session")
+def vpc_nat_gateways(vpc_id, aws_region) -> list[dict]:
+    """All NAT Gateways in the cluster's VPC (excluding deleted/deleting)."""
+    result = run_aws(
+        [
+            "ec2",
+            "describe-nat-gateways",
+            "--filter",
+            f"Name=vpc-id,Values={vpc_id}",
+            "--region",
+            aws_region,
+        ],
+        timeout=120,
+    )
+    # describe-nat-gateways returns historical entries (state=deleted) without an
+    # explicit filter; restrict to live ones so the topology assertions reflect
+    # current AWS state, not tombstones.
+    return [ng for ng in result.get("NatGateways", []) if ng.get("State") not in ("deleted", "deleting", "failed")]
+
+
+@pytest.fixture(scope="session")
+def vpc_subnets(vpc_id, aws_region) -> list[dict]:
+    """All subnets in the cluster's VPC (single AWS call shared by topology tests)."""
+    result = run_aws(
+        [
+            "ec2",
+            "describe-subnets",
+            "--filters",
+            f"Name=vpc-id,Values={vpc_id}",
+            "--region",
+            aws_region,
+        ],
+        timeout=120,
+    )
+    return result.get("Subnets", [])
+
+
+class TestNATGatewayTopology:
+    """Verify per-(bucket, AZ) NAT Gateway / EIP / route-table topology.
+
+    Read-only AWS API checks against the live VPC. Drift here means terraform
+    apply did not actually shape the topology that ``clusters.yaml`` and the VPC
+    submodule promise — typically because of a botched cutover, manual
+    intervention in the AWS console, or a stale state file.
+    """
+
+    def test_nat_gateway_count_per_bucket_az(self, vpc_nat_gateways, pod_cidr_buckets, cluster_azs):
+        """Exactly ``len(buckets) * len(azs)`` NAT GWs, each tagged with bucket+az."""
+        expected_count = len(pod_cidr_buckets) * len(cluster_azs)
+        tagged_natgws = [ng for ng in vpc_nat_gateways if _tag_value(ng.get("Tags", []), "osdc.io/nat-bucket")]
+        actual_count = len(tagged_natgws)
+        assert actual_count == expected_count, (
+            f"expected {expected_count} NAT Gateways tagged with osdc.io/nat-bucket "
+            f"(buckets={sorted(pod_cidr_buckets.keys())}, azs={cluster_azs}); "
+            f"observed {actual_count} (total live NAT GWs in VPC: {len(vpc_nat_gateways)})"
+        )
+
+        # Every (bucket, AZ) cell must be present exactly once. A duplicate cell
+        # or missing cell would still match the count above if one cell were
+        # double-tagged and another absent.
+        seen_cells: dict[tuple[str, str], list[str]] = {}
+        for ng in tagged_natgws:
+            tags = _tags_to_dict(ng.get("Tags", []))
+            cell = (tags.get("osdc.io/nat-bucket", ""), tags.get("osdc.io/nat-az", ""))
+            seen_cells.setdefault(cell, []).append(ng.get("NatGatewayId", "<unknown>"))
+
+        expected_cells = {(b, az) for b in pod_cidr_buckets for az in cluster_azs}
+        missing = expected_cells - set(seen_cells.keys())
+        duplicated = {cell: ids for cell, ids in seen_cells.items() if len(ids) > 1}
+        unexpected = set(seen_cells.keys()) - expected_cells
+        problems: list[str] = []
+        if missing:
+            problems.append(f"missing (bucket, az) cells: {sorted(missing)}")
+        if duplicated:
+            problems.append(f"duplicated (bucket, az) cells: {duplicated}")
+        if unexpected:
+            problems.append(f"unexpected tag values not in clusters.yaml: {sorted(unexpected)}")
+        assert not problems, "NAT GW topology mismatch:\n  " + "\n  ".join(problems)
+
+    def test_nat_gateway_subnet_az_consistency(self, vpc_nat_gateways, vpc_subnets):
+        """Each NAT GW's hosting subnet must report the same AZ as its osdc.io/nat-az tag.
+
+        Catches the failure mode where the public-subnets-by-AZ lookup in nat.tf
+        drifted positionally (e.g. ``var.azs[i]`` vs the actual subnet AZ) and a
+        NAT GW landed in the wrong AZ.
+        """
+        subnet_az_by_id = {s.get("SubnetId"): s.get("AvailabilityZone") for s in vpc_subnets}
+        problems: list[str] = []
+        for ng in vpc_nat_gateways:
+            ngw_id = ng.get("NatGatewayId", "<unknown>")
+            tag_az = _tag_value(ng.get("Tags", []), "osdc.io/nat-az")
+            if tag_az is None:
+                # Untagged NAT GW (legacy / unmanaged) — covered by count test;
+                # skipping here keeps this test focused on AZ consistency.
+                continue
+            subnet_id = ng.get("SubnetId")
+            actual_az = subnet_az_by_id.get(subnet_id)
+            if actual_az is None:
+                problems.append(f"{ngw_id}: subnet {subnet_id} not found among VPC subnets")
+                continue
+            if actual_az != tag_az:
+                problems.append(
+                    f"{ngw_id}: tag osdc.io/nat-az={tag_az!r} but subnet {subnet_id} reports AZ={actual_az!r}"
+                )
+        assert not problems, "NAT GW subnet/AZ mismatch:\n  " + "\n  ".join(problems)
+
+    def test_each_nat_gateway_has_expected_eip_count(self, vpc_nat_gateways, resolve_config):
+        """``1 + len(secondary_allocation_ids) == nat_gateway_eip_count`` for every NAT GW."""
+        expected_eip_count = resolve_config("nat_gateway_eip_count", 8)
+        problems: list[str] = []
+        for ng in vpc_nat_gateways:
+            ngw_id = ng.get("NatGatewayId", "<unknown>")
+            tags = _tags_to_dict(ng.get("Tags", []))
+            if tags.get("osdc.io/nat-bucket") is None:
+                continue  # Skip unmanaged NAT GWs; covered by count test.
+            addresses = ng.get("NatGatewayAddresses", []) or []
+            primary = [a for a in addresses if a.get("IsPrimary")]
+            secondary = [a for a in addresses if not a.get("IsPrimary")]
+            actual = len(primary) + len(secondary)
+            if actual != expected_eip_count:
+                problems.append(
+                    f"{ngw_id} (bucket={tags.get('osdc.io/nat-bucket')}, az={tags.get('osdc.io/nat-az')}): "
+                    f"{len(primary)} primary + {len(secondary)} secondary = {actual} EIPs, "
+                    f"expected {expected_eip_count}"
+                )
+            elif len(primary) != 1:
+                problems.append(
+                    f"{ngw_id}: expected exactly 1 primary EIP, got {len(primary)} (secondary={len(secondary)})"
+                )
+        assert not problems, f"NAT GW EIP count drift (expected {expected_eip_count} per NAT GW):\n  " + "\n  ".join(
+            problems
+        )
+
+    def test_pod_subnet_route_table_associations(self, vpc_subnets, vpc_nat_gateways, vpc_id, aws_region):
+        """Each pod subnet must be explicitly associated to a per-(bucket, az) RT
+        whose ``0.0.0.0/0`` route points at the matching NAT GW.
+
+        Verifies (a) explicit RT association (not main RT fallback);
+        (b) RT's ``osdc.io/pod-route-{bucket,az}`` tags match the subnet's
+        ``osdc.io/pod-subnet-{bucket,az}`` tags;
+        (c) RT's default route resolves to a NAT GW carrying the same bucket+az.
+        """
+        nat_by_id = {ng.get("NatGatewayId"): ng for ng in vpc_nat_gateways}
+        pod_subnets = [s for s in vpc_subnets if _tag_value(s.get("Tags", []), "osdc.io/pod-subnet-bucket")]
+        assert pod_subnets, "no subnets carry the osdc.io/pod-subnet-bucket tag — PR 5 not applied?"
+
+        problems: list[str] = []
+        for s in pod_subnets:
+            subnet_id = s.get("SubnetId")
+            stags = _tags_to_dict(s.get("Tags", []))
+            sub_bucket = stags.get("osdc.io/pod-subnet-bucket")
+            sub_az = stags.get("osdc.io/pod-subnet-az")
+            ctx = f"pod subnet {subnet_id} (bucket={sub_bucket}, az={sub_az})"
+
+            rt, err = _explicit_rt_for_subnet(vpc_id, aws_region, subnet_id)
+            if err is not None:
+                problems.append(f"{ctx}: {err}")
+                continue
+            rt_id = rt.get("RouteTableId", "<unknown>")
+            rtags = _tags_to_dict(rt.get("Tags", []))
+            rt_bucket = rtags.get("osdc.io/pod-route-bucket")
+            rt_az = rtags.get("osdc.io/pod-route-az")
+            if rt_bucket != sub_bucket or rt_az != sub_az:
+                problems.append(
+                    f"{ctx}: associated RT {rt_id} has tags pod-route-bucket={rt_bucket!r}, pod-route-az={rt_az!r}"
+                )
+                continue
+
+            ngw_id, err = _default_route_natgw(rt)
+            if err is not None:
+                problems.append(f"RT {rt_id} (bucket={rt_bucket}, az={rt_az}): {err}")
+                continue
+            ng = nat_by_id.get(ngw_id)
+            if ng is None:
+                problems.append(
+                    f"RT {rt_id} (bucket={rt_bucket}, az={rt_az}): 0.0.0.0/0 -> NAT GW {ngw_id} "
+                    f"not present in VPC NAT GW listing"
+                )
+                continue
+            ngtags = _tags_to_dict(ng.get("Tags", []))
+            if ngtags.get("osdc.io/nat-bucket") != sub_bucket or ngtags.get("osdc.io/nat-az") != sub_az:
+                problems.append(
+                    f"RT {rt_id} (bucket={rt_bucket}, az={rt_az}): 0.0.0.0/0 -> NAT GW {ngw_id} "
+                    f"with tags nat-bucket={ngtags.get('osdc.io/nat-bucket')!r}, "
+                    f"nat-az={ngtags.get('osdc.io/nat-az')!r}"
+                )
+
+        assert not problems, "pod subnet RT topology drift:\n  " + "\n  ".join(problems)
+
+    def test_private_route_table_associations_route_to_default_node_egress_bucket(
+        self,
+        vpc_subnets,
+        vpc_nat_gateways,
+        vpc_id,
+        aws_region,
+        default_node_egress_bucket,
+    ):
+        """Per-AZ private (node) RTs must route ``0.0.0.0/0`` through the
+        ``default_node_egress_bucket`` NAT GW for that AZ.
+
+        Filters: subnet has the ``Name`` tag matching ``*-private-<az>`` AND
+        does NOT carry ``osdc.io/pod-subnet-bucket`` (which would mark it as a
+        pod subnet introduced by PR 5).
+        """
+        nat_by_id = {ng.get("NatGatewayId"): ng for ng in vpc_nat_gateways}
+        private_subnets = [
+            s
+            for s in vpc_subnets
+            if _tag_value(s.get("Tags", []), "osdc.io/pod-subnet-bucket") is None
+            and (_tag_value(s.get("Tags", []), "Name") or "").rsplit("-", 1)[0].endswith("-private")
+        ]
+        assert private_subnets, (
+            "no per-AZ private subnets found (Name=*-private-<az> AND no osdc.io/pod-subnet-bucket tag)"
+        )
+
+        problems: list[str] = []
+        for s in private_subnets:
+            subnet_id = s.get("SubnetId")
+            sub_az = s.get("AvailabilityZone", "")
+            sub_name = _tag_value(s.get("Tags", []), "Name") or "<no-name>"
+            ctx = f"private subnet {subnet_id} (Name={sub_name}, az={sub_az})"
+
+            rt, err = _explicit_rt_for_subnet(vpc_id, aws_region, subnet_id)
+            if err is not None:
+                problems.append(f"{ctx}: {err}")
+                continue
+            rt_id = rt.get("RouteTableId", "<unknown>")
+            ngw_id, err = _default_route_natgw(rt)
+            if err is not None:
+                problems.append(f"private RT {rt_id} ({ctx}): {err}")
+                continue
+            ng = nat_by_id.get(ngw_id)
+            if ng is None:
+                problems.append(
+                    f"private RT {rt_id} ({ctx}): 0.0.0.0/0 -> NAT GW {ngw_id} not present in VPC NAT GW listing"
+                )
+                continue
+            ngtags = _tags_to_dict(ng.get("Tags", []))
+            ng_bucket = ngtags.get("osdc.io/nat-bucket")
+            ng_az = ngtags.get("osdc.io/nat-az")
+            if ng_bucket != default_node_egress_bucket or ng_az != sub_az:
+                problems.append(
+                    f"private RT {rt_id} ({ctx}): 0.0.0.0/0 -> NAT GW {ngw_id} with tags "
+                    f"nat-bucket={ng_bucket!r}, nat-az={ng_az!r}; expected "
+                    f"nat-bucket={default_node_egress_bucket!r}, nat-az={sub_az!r}"
+                )
+
+        assert not problems, (
+            f"private subnet RT topology drift (default_node_egress_bucket={default_node_egress_bucket!r}):\n  "
+            + "\n  ".join(problems)
+        )

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -69,6 +69,33 @@ def resolve(cluster_cfg, defaults, dotpath):
     return dval
 
 
+def _validate_nat_gateway_eip_count(cluster_id, value):
+    """Validate nat_gateway_eip_count is an int in 1..8 (AWS hard cap).
+
+    The value is emitted into a tfvars line that's later passed through
+    `eval tofu plan $TFVARS` in the justfile, so a non-int (or a string
+    containing shell metacharacters / quotes / additional `-var` flags)
+    must be rejected here BEFORE it reaches the shell. Mirrors the HCL
+    range validation in the eks module's variables.tf.
+    """
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise SystemExit(
+            f"cluster {cluster_id}: nat_gateway_eip_count must be an integer (1-8); got {value!r}"
+        ) from None
+    # Reject bool — bool is a subclass of int in Python, so int(True) == 1
+    # would silently succeed. nat_gateway_eip_count is not a flag.
+    if isinstance(value, bool):
+        raise SystemExit(f"cluster {cluster_id}: nat_gateway_eip_count must be an integer (1-8); got {value!r}")
+    if n < 1 or n > 8:
+        raise SystemExit(
+            f"cluster {cluster_id}: nat_gateway_eip_count must be in [1, 8] "
+            f"(AWS hard cap is 8 EIPs per NAT GW); got {n}"
+        )
+    return n
+
+
 def _validate_pod_cidr_buckets(cluster_name, buckets):
     """Validate pod_cidr_buckets shape, names, and CIDR uniqueness.
 
@@ -118,7 +145,7 @@ def tfvars(cluster_id, cluster_cfg, defaults):
         "cluster_name": cluster_cfg["cluster_name"],
         "aws_region": cluster_cfg["region"],
         "vpc_cidr": base.get("vpc_cidr", "10.0.0.0/16"),
-        "single_nat_gateway": str(base.get("single_nat_gateway", False)).lower(),
+        "nat_gateway_eip_count": _validate_nat_gateway_eip_count(cluster_id, base.get("nat_gateway_eip_count", 8)),
         "base_node_count": base.get("base_node_count", 3),
         "base_node_instance_type": base.get("base_node_instance_type", "m5.xlarge"),
         "base_node_max_unavailable_percentage": base.get("base_node_max_unavailable_percentage", 33),

--- a/osdc/scripts/test_cluster_config.py
+++ b/osdc/scripts/test_cluster_config.py
@@ -67,7 +67,6 @@ _VALID_POD_CIDR_BUCKETS_PROD = {
 FAKE_CONFIG = {
     "defaults": {
         "vpc_cidr": "10.0.0.0/16",
-        "single_nat_gateway": False,
         "base_node_count": 3,
         "base_node_instance_type": "m5.xlarge",
         "base_node_max_unavailable_percentage": 33,
@@ -84,7 +83,6 @@ FAKE_CONFIG = {
             "state_bucket": "my-tfstate-staging",
             "base": {
                 "vpc_cidr": "10.1.0.0/16",
-                "single_nat_gateway": True,
                 "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ,
             },
             "modules": ["karpenter", "arc", "arc-runners"],
@@ -216,7 +214,7 @@ class TestTfvars:
         assert '-var="cluster_name=test-cluster"' in out
         assert '-var="aws_region=us-west-2"' in out
         assert '-var="vpc_cidr=10.0.0.0/16"' in out
-        assert '-var="single_nat_gateway=false"' in out
+        assert '-var="nat_gateway_eip_count=8"' in out
         assert '-var="base_node_count=3"' in out
         assert '-var="base_node_instance_type=m5.xlarge"' in out
         assert '-var="base_node_max_unavailable_percentage=33"' in out
@@ -249,7 +247,6 @@ class TestTfvars:
             region="eu-west-1",
             base={
                 "vpc_cidr": "10.99.0.0/16",
-                "single_nat_gateway": True,
                 "base_node_count": 6,
                 "base_node_instance_type": "m6i.2xlarge",
                 "base_node_max_unavailable_percentage": 50,
@@ -260,31 +257,23 @@ class TestTfvars:
         )
         defaults = {
             "vpc_cidr": "10.0.0.0/16",
-            "single_nat_gateway": False,
             "base_node_count": 3,
         }
         cluster_config.tfvars("prod", cluster_cfg, defaults)
         out = capsys.readouterr().out.strip()
         assert '-var="vpc_cidr=10.99.0.0/16"' in out
-        assert '-var="single_nat_gateway=true"' in out
         assert '-var="base_node_count=6"' in out
         assert '-var="base_node_instance_type=m6i.2xlarge"' in out
         assert '-var="base_node_max_unavailable_percentage=50"' in out
         assert '-var="base_node_ami_version=v20260318"' in out
         assert '-var="eks_version=1.36"' in out
 
-    def test_bool_formatting(self, capsys):
-        """single_nat_gateway bool should be lowercased."""
-        cluster_cfg = _cfg_with_buckets(
-            cluster_name="c",
-            region="r",
-            base={"single_nat_gateway": True, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ},
-        )
-        cluster_config.tfvars("c", cluster_cfg, {})
+    def test_nat_gateway_eip_count_emitted_default(self, capsys):
+        """nat_gateway_eip_count defaults to 8 when no override; emitted as int."""
+        cluster_cfg = _cfg_with_buckets()
+        cluster_config.tfvars("test", cluster_cfg, {})
         out = capsys.readouterr().out.strip()
-        assert '-var="single_nat_gateway=true"' in out
-        # Ensure it's not Python-style True
-        assert "True" not in out
+        assert '-var="nat_gateway_eip_count=8"' in out
 
     def test_eks_version_from_defaults(self, capsys):
         cluster_cfg = _cfg_with_buckets(cluster_name="c", region="r")
@@ -456,6 +445,126 @@ class TestTfvars:
         with pytest.raises(SystemExit) as exc:
             cluster_config.tfvars("c", cluster_cfg, {})
         assert "12345" in str(exc.value)
+
+
+class TestNatGatewayEipCountValidation:
+    """Tests for _validate_nat_gateway_eip_count — defends against shell-injection
+    via clusters.yaml since the value flows into `eval tofu plan $TFVARS`.
+    """
+
+    def test_int_value_accepted(self, capsys):
+        """Plain int 8 is accepted and emitted unchanged."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": 8, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        cluster_config.tfvars("c", cluster_cfg, {})
+        out = capsys.readouterr().out.strip()
+        assert '-var="nat_gateway_eip_count=8"' in out
+
+    def test_string_int_value_accepted(self, capsys):
+        """YAML string '8' is coerced cleanly to int and emitted as 8."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": "8", "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        cluster_config.tfvars("c", cluster_cfg, {})
+        out = capsys.readouterr().out.strip()
+        assert '-var="nat_gateway_eip_count=8"' in out
+
+    def test_lower_bound_one_accepted(self, capsys):
+        """Lower-bound 1 is accepted (range is inclusive [1, 8])."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": 1, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        cluster_config.tfvars("c", cluster_cfg, {})
+        out = capsys.readouterr().out.strip()
+        assert '-var="nat_gateway_eip_count=1"' in out
+
+    def test_zero_rejected(self):
+        """Zero is below the [1, 8] lower bound."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": 0, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        msg = str(exc.value)
+        assert "1, 8" in msg or "1-8" in msg
+        assert "c" in msg
+
+    def test_nine_rejected(self):
+        """Nine exceeds the AWS hard cap of 8 EIPs per NAT GW."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": 9, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        msg = str(exc.value)
+        assert "1, 8" in msg or "1-8" in msg
+
+    def test_negative_rejected(self):
+        """Negative values are rejected by the range check."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": -1, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        assert "1, 8" in str(exc.value) or "1-8" in str(exc.value)
+
+    def test_string_with_metachars_rejected(self):
+        """A string containing shell metachars cannot be coerced to int — rejected."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": "8; rm -rf /", "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        msg = str(exc.value)
+        assert "integer" in msg
+        # The offending value must appear in the error so operators can find the typo
+        assert "8; rm -rf /" in msg
+
+    def test_quoted_injection_rejected(self):
+        """A string that would inject a second -var flag must be rejected."""
+        injection = '8" -var="cluster_name=evil'
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": injection, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        assert "integer" in str(exc.value)
+
+    def test_float_rejected(self):
+        """Floats are rejected — int('8.5') raises ValueError."""
+        # Note: passing a float literal directly works because int(8.5) silently
+        # truncates. The realistic shell-injection vector is YAML-parsed strings,
+        # so we test the string form which is what int() actually rejects.
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": "8.5", "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        assert "integer" in str(exc.value)
+
+    def test_none_rejected(self):
+        """An explicit None (e.g. `nat_gateway_eip_count: ~` in YAML) is rejected.
+
+        Note: `base.get("nat_gateway_eip_count", 8)` returns 8 if the key is
+        absent; but if the key is present with explicit null, it returns None,
+        which the validator must reject (int(None) raises TypeError).
+        """
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": None, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        assert "integer" in str(exc.value)
+
+    def test_bool_true_rejected(self):
+        """bool is a subclass of int in Python; True must NOT be silently coerced to 1."""
+        cluster_cfg = _cfg_with_buckets(
+            base={"nat_gateway_eip_count": True, "pod_cidr_buckets": _VALID_POD_CIDR_BUCKETS_2AZ}
+        )
+        with pytest.raises(SystemExit) as exc:
+            cluster_config.tfvars("c", cluster_cfg, {})
+        assert "integer" in str(exc.value)
 
 
 class TestValidatePodCidrBuckets:
@@ -826,7 +935,7 @@ class TestMain:
         assert '-var="aws_region=us-west-2"' in out
         # Staging overrides vpc_cidr via base
         assert '-var="vpc_cidr=10.1.0.0/16"' in out
-        assert '-var="single_nat_gateway=true"' in out
+        assert '-var="nat_gateway_eip_count=8"' in out
 
     def test_dotpath_resolve(self, capsys):
         code = run_main("staging", "harbor.core_replicas")
@@ -854,19 +963,6 @@ class TestMain:
         code = run_main("staging", "feature_flag")
         assert code == 0
         assert capsys.readouterr().out.strip() == "true"
-
-    def test_bool_false_field_output(self, capsys):
-        """Boolean False from defaults should print 'false'.
-
-        Production cluster has no single_nat_gateway override, so resolve()
-        falls back to defaults.single_nat_gateway=False. Verifies the
-        ``isinstance(val, bool)`` branch in main() lowercases False correctly
-        — a path that was previously not exercised because the prior version
-        of this test queried staging (which overrides to True).
-        """
-        code = run_main("production", "single_nat_gateway")
-        assert code == 0
-        assert capsys.readouterr().out.strip() == "false"
 
 
 # ============================================================================

--- a/osdc/scripts/test_vpc_nat_topology.py
+++ b/osdc/scripts/test_vpc_nat_topology.py
@@ -1,0 +1,576 @@
+"""Unit tests for the per-(bucket, AZ) NAT Gateway / EIP / route table topology.
+
+Defends the VPC NAT refactor that replaces the old per-AZ shared NAT GW
+(toggled by `var.single_nat_gateway`) with per-(bucket, AZ) NAT GWs sourced
+from `local.pod_cidr_associations`. Each NAT GW gets 1 primary EIP plus
+N-1 secondary EIPs (configurable via `var.nat_gateway_eip_count`, default 8,
+AWS hard cap 8).
+
+Topology end state (production: 4 buckets x 3 AZs):
+- 12 NAT GWs (one per bucket-AZ pair)
+- 12 dedicated pod route tables (one per bucket-AZ pair)
+- 96 EIPs at default `nat_gateway_eip_count = 8`
+- 3 per-AZ private route tables for nodes (route through bucket-1's NAT GW per AZ)
+
+Tests parse the .tf source as plain text + regex (no HCL parser available;
+matches the established convention in scripts/test_vpc_subnet_tags.py and
+scripts/test_vpc_cni_addon.py). Tests are intentionally fragile to silent
+refactors (e.g. hoisting a value into `local.x`) so test failures surface
+the change explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VPC_DIR = REPO_ROOT / "modules" / "eks" / "terraform" / "modules" / "vpc"
+VPC_NAT_TF = VPC_DIR / "nat.tf"
+VPC_MAIN_TF = VPC_DIR / "main.tf"
+VPC_VARS_TF = VPC_DIR / "variables.tf"
+ROOT_VARS_TF = REPO_ROOT / "modules" / "eks" / "terraform" / "variables.tf"
+
+VPC_NAT_TF_TEXT = VPC_NAT_TF.read_text() if VPC_NAT_TF.exists() else ""
+VPC_MAIN_TF_TEXT = VPC_MAIN_TF.read_text()
+VPC_VARS_TF_TEXT = VPC_VARS_TF.read_text()
+ROOT_VARS_TF_TEXT = ROOT_VARS_TF.read_text()
+
+# Make sibling helper module importable regardless of pytest invocation cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _tf_parse_helpers import (  # noqa: E402
+    resource_block,
+    strip_double_quoted_strings,
+)
+
+
+def _strip_hcl_comments(text: str) -> str:
+    """Remove `# ...` and `// ...` line comments and `/* ... */` block comments.
+
+    Strings are scrubbed first so a `#` inside a quoted string doesn't trigger
+    comment-stripping mid-literal.
+    """
+    scrubbed = strip_double_quoted_strings(text)
+    # Block comments first
+    scrubbed = re.sub(r"/\*.*?\*/", "", scrubbed, flags=re.DOTALL)
+    # Line comments
+    scrubbed = re.sub(r"#[^\n]*", "", scrubbed)
+    scrubbed = re.sub(r"//[^\n]*", "", scrubbed)
+    return scrubbed
+
+
+def _variable_block(text: str, name: str) -> str:
+    """Return the brace-balanced body of a top-level
+    `variable "<name>" { ... }` block (including the outer braces).
+
+    Local helper -- not added to _tf_parse_helpers because no other test
+    currently parses variable blocks. If a second consumer appears, promote
+    this to the shared module.
+    """
+    pattern = re.compile(
+        rf'variable\s+"{re.escape(name)}"\s*\{{',
+        re.MULTILINE,
+    )
+    m = pattern.search(text)
+    assert m, f'variable "{name}" not found'
+    start = m.end() - 1  # position of opening brace
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise AssertionError(f"unterminated block for variable {name}")
+
+
+def _tags_block_text(block: str) -> str:
+    """Extract the merge(...) call inside a `tags = merge(` assignment.
+
+    Returns the paren-balanced contents from `merge(` to its closing `)`.
+    Used to scope tag-content searches to the actual tag map and exclude
+    references elsewhere in the resource block (e.g. inside a precondition
+    error_message).
+    """
+    m = re.search(r"tags\s*=\s*merge\(", block)
+    assert m, "no tags = merge(...) found"
+    start = m.end()  # position right after the opening (
+    depth = 1
+    for i in range(start, len(block)):
+        if block[i] == "(":
+            depth += 1
+        elif block[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return block[start:i]
+    raise AssertionError("unterminated merge(...) block")
+
+
+def _dynamic_route_block(block: str) -> str:
+    """Extract the brace-balanced body of `dynamic "route" { ... }` (including outer braces)."""
+    m = re.search(r'dynamic\s+"route"\s*\{', block)
+    assert m, 'no dynamic "route" { ... } block found'
+    start = m.end() - 1
+    depth = 0
+    for i in range(start, len(block)):
+        if block[i] == "{":
+            depth += 1
+        elif block[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return block[start : i + 1]
+    raise AssertionError('unterminated dynamic "route" block')
+
+
+class TestNATFileExists:
+    """nat.tf must exist at the canonical path and declare all 7 NAT-topology resources.
+
+    The split out of vpc/main.tf is mandated by the 400-line file budget and to
+    keep NAT topology cohesive. Without the file, downstream tests in this module
+    cannot meaningfully run.
+    """
+
+    def test_nat_tf_file_exists(self) -> None:
+        assert VPC_NAT_TF.exists(), (
+            f"nat.tf must exist at {VPC_NAT_TF.relative_to(REPO_ROOT)} -- the VPC NAT topology "
+            "(EIPs, NAT GWs, pod route tables, refactored private route tables) lives in this file."
+        )
+
+    def test_expected_resource_declarations_present(self) -> None:
+        """Count distinct top-level resources in nat.tf -- must contain all 7
+        per-(bucket, AZ) NAT topology resources, no more, no less.
+        """
+        # All resource declarations matching the NAT topology types
+        decls = re.findall(
+            r'^resource\s+"(aws_(?:eip|nat_gateway|route_table|route_table_association))"\s+"([a-z_]+)"',
+            VPC_NAT_TF_TEXT,
+            re.MULTILINE,
+        )
+        decl_pairs = sorted(decls)
+        expected = sorted(
+            [
+                ("aws_eip", "nat_primary"),
+                ("aws_eip", "nat_secondary"),
+                ("aws_nat_gateway", "this"),
+                ("aws_route_table", "pod"),
+                ("aws_route_table", "private"),
+                ("aws_route_table_association", "pod"),
+                ("aws_route_table_association", "private"),
+            ]
+        )
+        assert decl_pairs == expected, f"nat.tf must declare exactly these 7 resources: {expected}. Got {decl_pairs}."
+
+
+class TestNATGatewayResource:
+    """aws_nat_gateway.this is the per-(bucket, AZ) NAT Gateway.
+
+    Topology contract:
+    - Keyed by `local.pod_cidr_associations` ("${bucket}-${az}")
+    - Gated by `var.enable_nat_gateway` to preserve the off-switch
+    - Primary allocation_id from aws_eip.nat_primary[each.key]
+    - Secondary EIPs via for slot in range(2, var.nat_gateway_eip_count + 1)
+    - Subnet placement via local.public_subnets_by_az[each.value.az]
+    - osdc.io/nat-{bucket,az} tags
+    - lifecycle.precondition asserting pod_azs == var.azs (defends AZ drift)
+    """
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_nat_gateway", "this") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_uses_pod_cidr_associations(self) -> None:
+        # Match the literal `local.pod_cidr_associations` after the colon -- the
+        # gating ternary `var.enable_nat_gateway ? local.pod_cidr_associations : {}`.
+        assert re.search(
+            r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*local\.pod_cidr_associations\s*:", self.block
+        ), (
+            "aws_nat_gateway.this for_each must be `var.enable_nat_gateway ? local.pod_cidr_associations : {}` "
+            "so NAT GWs are keyed per (bucket, AZ) and the off-switch is preserved."
+        )
+
+    def test_for_each_off_switch_returns_empty_map(self) -> None:
+        assert re.search(
+            r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*local\.pod_cidr_associations\s*:\s*\{\s*\}", self.block
+        ), (
+            "aws_nat_gateway.this for_each must fall back to `{}` (empty map) when "
+            "`var.enable_nat_gateway` is false. This preserves the off-switch."
+        )
+
+    def test_allocation_id_references_nat_primary(self) -> None:
+        assert re.search(r"allocation_id\s*=\s*aws_eip\.nat_primary\[each\.key\]\.id", self.block), (
+            "aws_nat_gateway.this allocation_id must be `aws_eip.nat_primary[each.key].id` -- "
+            "each NAT GW gets exactly one primary EIP keyed by the same bucket-az key."
+        )
+
+    def test_secondary_allocation_ids_uses_eip_count_range(self) -> None:
+        assert re.search(
+            r"secondary_allocation_ids\s*=\s*\[\s*for\s+slot\s+in\s+range\(\s*2\s*,\s*var\.nat_gateway_eip_count\s*\+\s*1\s*\)",
+            self.block,
+        ), (
+            "aws_nat_gateway.this secondary_allocation_ids must use "
+            "`[for slot in range(2, var.nat_gateway_eip_count + 1) : ...]` -- this is how "
+            "the variable count drives EIP attachment. Slot starts at 2 because slot 1 is the primary."
+        )
+
+    def test_secondary_allocation_ids_references_nat_secondary(self) -> None:
+        assert re.search(r"aws_eip\.nat_secondary\[", self.block), (
+            "aws_nat_gateway.this secondary_allocation_ids must reference `aws_eip.nat_secondary[...]` "
+            "(keyed by '${bucket}-${az}-${slot}'). Without this, the secondary EIPs are dangling."
+        )
+
+    def test_subnet_id_uses_public_subnets_by_az(self) -> None:
+        assert re.search(r"subnet_id\s*=\s*local\.public_subnets_by_az\[each\.value\.az\]", self.block), (
+            "aws_nat_gateway.this subnet_id must be `local.public_subnets_by_az[each.value.az]` -- "
+            "NAT GWs live in the public subnet for that AZ. Using `var.azs[i]` is positional and "
+            "vulnerable to AZ-list drift."
+        )
+
+    def test_tags_include_name_and_nat_metadata(self) -> None:
+        tags = _tags_block_text(self.block)
+        assert "Name" in tags, "aws_nat_gateway.this tags must include Name"
+        assert "osdc.io/nat-bucket" in tags, (
+            "aws_nat_gateway.this tags must include osdc.io/nat-bucket -- needed by the smoke "
+            "tests to verify per-(bucket, AZ) topology."
+        )
+        assert "osdc.io/nat-az" in tags, (
+            "aws_nat_gateway.this tags must include osdc.io/nat-az -- needed by the smoke "
+            "tests to verify per-(bucket, AZ) topology."
+        )
+
+    def test_lifecycle_precondition_asserts_pod_azs_eq_var_azs(self) -> None:
+        assert "lifecycle" in self.block, "aws_nat_gateway.this must declare a lifecycle block with a precondition."
+        assert "precondition" in self.block, (
+            "aws_nat_gateway.this lifecycle must contain a precondition asserting "
+            "`sort(local.pod_azs) == sort(var.azs)`. Without it, an AZ mismatch between "
+            "pod_cidr_buckets and var.azs would silently misplace NAT GWs."
+        )
+        assert re.search(r"sort\(\s*local\.pod_azs\s*\)\s*==\s*sort\(\s*var\.azs\s*\)", self.block), (
+            "aws_nat_gateway.this precondition must assert `sort(local.pod_azs) == sort(var.azs)` "
+            "(both sorted, both compared by ==). The sort is required because the lists have no "
+            "guaranteed order."
+        )
+
+    def test_depends_on_internet_gateway(self) -> None:
+        assert re.search(r"depends_on\s*=\s*\[[^\]]*aws_internet_gateway\.this", self.block), (
+            "aws_nat_gateway.this must depends_on aws_internet_gateway.this -- AWS rejects NAT GW "
+            "creation if the IGW isn't attached yet."
+        )
+
+
+class TestEIPPrimaryResource:
+    """aws_eip.nat_primary -- exactly one primary EIP per (bucket, AZ) NAT GW."""
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_eip", "nat_primary") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_pod_cidr_associations_gated(self) -> None:
+        assert re.search(
+            r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*local\.pod_cidr_associations\s*:\s*\{\s*\}",
+            self.block,
+        ), (
+            "aws_eip.nat_primary for_each must be "
+            "`var.enable_nat_gateway ? local.pod_cidr_associations : {}` -- one primary EIP per "
+            "bucket-AZ NAT GW, off-switch preserved."
+        )
+
+    def test_domain_is_vpc(self) -> None:
+        assert re.search(r'domain\s*=\s*"vpc"', self.block), (
+            'aws_eip.nat_primary must declare `domain = "vpc"` (post-EC2-Classic-deprecation API).'
+        )
+
+    def test_tags_include_role_primary(self) -> None:
+        tags = _tags_block_text(self.block)
+        assert re.search(r'"osdc\.io/nat-eip-role"\s*=\s*"primary"', tags), (
+            'aws_eip.nat_primary tags must include `"osdc.io/nat-eip-role" = "primary"` -- '
+            "smoke tests filter EIPs by role to verify 1-primary-per-NAT-GW topology."
+        )
+
+    def test_tags_include_bucket_and_az(self) -> None:
+        tags = _tags_block_text(self.block)
+        # Bucket / AZ tag keys may use the same prefix as the NAT GW resource
+        # (osdc.io/nat-*). Accept either `osdc.io/nat-bucket` (consistency with
+        # aws_nat_gateway.this) or `osdc.io/nat-eip-bucket`.
+        assert ("osdc.io/nat-bucket" in tags) or ("osdc.io/nat-eip-bucket" in tags), (
+            "aws_eip.nat_primary tags must include a bucket tag (osdc.io/nat-bucket or "
+            "osdc.io/nat-eip-bucket) so EIPs are filterable per bucket."
+        )
+        assert ("osdc.io/nat-az" in tags) or ("osdc.io/nat-eip-az" in tags), (
+            "aws_eip.nat_primary tags must include an AZ tag (osdc.io/nat-az or "
+            "osdc.io/nat-eip-az) so EIPs are filterable per AZ."
+        )
+
+    def test_depends_on_internet_gateway(self) -> None:
+        assert re.search(r"depends_on\s*=\s*\[[^\]]*aws_internet_gateway\.this", self.block), (
+            "aws_eip.nat_primary must depends_on aws_internet_gateway.this so EIP allocation "
+            "ordering matches the NAT GW (which also depends on the IGW)."
+        )
+
+
+class TestEIPSecondaryResource:
+    """aws_eip.nat_secondary -- slots 2..N per (bucket, AZ) NAT GW.
+
+    Empty map when nat_gateway_eip_count == 1. Each EIP keyed
+    "${bucket}-${az}-${slot}".
+    """
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_eip", "nat_secondary") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_nat_secondary_assignments_gated(self) -> None:
+        assert re.search(
+            r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*local\.nat_secondary_assignments\s*:\s*\{\s*\}",
+            self.block,
+        ), (
+            "aws_eip.nat_secondary for_each must be "
+            "`var.enable_nat_gateway ? local.nat_secondary_assignments : {}` -- one secondary "
+            "EIP per slot in 2..nat_gateway_eip_count, off-switch preserved."
+        )
+
+    def test_tags_include_role_secondary(self) -> None:
+        tags = _tags_block_text(self.block)
+        assert re.search(r'"osdc\.io/nat-eip-role"\s*=\s*"secondary"', tags), (
+            'aws_eip.nat_secondary tags must include `"osdc.io/nat-eip-role" = "secondary"` -- '
+            "smoke tests filter EIPs by role to verify N-1 secondary EIPs per NAT GW."
+        )
+
+    def test_tags_include_slot(self) -> None:
+        tags = _tags_block_text(self.block)
+        assert "osdc.io/nat-eip-slot" in tags, (
+            "aws_eip.nat_secondary tags must include osdc.io/nat-eip-slot -- needed to "
+            "disambiguate which secondary slot (2..N) this EIP fills."
+        )
+
+
+class TestPodRouteTableResource:
+    """aws_route_table.pod -- one route table per (bucket, AZ) pod subnet.
+
+    Always created (NOT gated by enable_nat_gateway) because aws_subnet.pod
+    always exists and route_table_association requires a target. The internet
+    egress route is dynamic and only created when enable_nat_gateway is true.
+    """
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_route_table", "pod") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_is_unconditional_pod_cidr_associations(self) -> None:
+        # Match the literal for_each line and confirm it does NOT include the
+        # var.enable_nat_gateway ternary -- pod RTs always exist.
+        m = re.search(r"for_each\s*=\s*([^\n]+)", self.block)
+        assert m, "aws_route_table.pod must declare a for_each"
+        for_each_rhs = m.group(1).strip()
+        assert "local.pod_cidr_associations" in for_each_rhs, (
+            f"aws_route_table.pod for_each must reference `local.pod_cidr_associations` so the "
+            f"route table exists per (bucket, AZ). Got `{for_each_rhs}`."
+        )
+        assert "var.enable_nat_gateway" not in for_each_rhs, (
+            "aws_route_table.pod for_each must NOT be gated by var.enable_nat_gateway -- the "
+            "pod route table is needed for aws_route_table_association.pod even when NAT is "
+            "disabled. Gate the dynamic route block instead, not the table itself."
+        )
+
+    def test_dynamic_route_block_gated_by_enable_nat_gateway(self) -> None:
+        dyn = _dynamic_route_block(self.block)
+        assert re.search(r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*\[\s*1\s*\]\s*:\s*\[\s*\]", dyn), (
+            'aws_route_table.pod dynamic "route" must be gated by '
+            "`for_each = var.enable_nat_gateway ? [1] : []` -- the route is only meaningful when "
+            "NAT GWs exist. The off-switch removes the route while preserving the table."
+        )
+
+    def test_dynamic_route_targets_per_key_nat_gateway(self) -> None:
+        dyn = _dynamic_route_block(self.block)
+        assert re.search(r"nat_gateway_id\s*=\s*aws_nat_gateway\.this\[each\.key\]\.id", dyn), (
+            'aws_route_table.pod dynamic "route" must set '
+            "`nat_gateway_id = aws_nat_gateway.this[each.key].id` -- pod traffic egresses through "
+            "the NAT GW for the SAME (bucket, AZ) pair as the pod subnet."
+        )
+
+    def test_tags_include_pod_route_metadata(self) -> None:
+        tags = _tags_block_text(self.block)
+        assert "osdc.io/pod-route-bucket" in tags, (
+            "aws_route_table.pod tags must include osdc.io/pod-route-bucket so the smoke "
+            "tests can verify per-(bucket, AZ) routing."
+        )
+        assert "osdc.io/pod-route-az" in tags, (
+            "aws_route_table.pod tags must include osdc.io/pod-route-az so the smoke "
+            "tests can verify per-(bucket, AZ) routing."
+        )
+
+
+class TestPodRouteTableAssociation:
+    """aws_route_table_association.pod -- one association per (bucket, AZ) pod subnet.
+
+    Maps each aws_subnet.pod[k] to its matching aws_route_table.pod[k].
+    """
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_route_table_association", "pod") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_pod_cidr_associations(self) -> None:
+        m = re.search(r"for_each\s*=\s*([^\n]+)", self.block)
+        assert m, "aws_route_table_association.pod must declare a for_each"
+        rhs = m.group(1).strip()
+        assert "local.pod_cidr_associations" in rhs, (
+            f"aws_route_table_association.pod for_each must reference `local.pod_cidr_associations` "
+            f"so each pod subnet is associated to its matching pod RT. Got `{rhs}`."
+        )
+
+    def test_subnet_id_references_pod_subnet(self) -> None:
+        assert re.search(r"subnet_id\s*=\s*aws_subnet\.pod\[each\.key\]\.id", self.block), (
+            "aws_route_table_association.pod subnet_id must be `aws_subnet.pod[each.key].id` -- "
+            "the same key drives both pod subnet and pod RT, ensuring 1:1 mapping per (bucket, AZ)."
+        )
+
+    def test_route_table_id_references_pod_rt(self) -> None:
+        assert re.search(r"route_table_id\s*=\s*aws_route_table\.pod\[each\.key\]\.id", self.block), (
+            "aws_route_table_association.pod route_table_id must be "
+            "`aws_route_table.pod[each.key].id` -- same key as the subnet, enforcing 1:1 mapping."
+        )
+
+
+class TestPrivateRouteTableRefactor:
+    """aws_route_table.private -- refactored from count-based to for_each over var.azs.
+
+    The private RT for nodes routes through a single bucket's NAT GW per AZ
+    (the default_node_egress_bucket = sorted-first bucket). Was previously
+    per-AZ shared with single_nat_gateway toggle.
+    """
+
+    block = resource_block(VPC_NAT_TF_TEXT, "aws_route_table", "private") if VPC_NAT_TF_TEXT else ""
+
+    def test_for_each_uses_toset_var_azs(self) -> None:
+        assert re.search(r"for_each\s*=\s*toset\(\s*var\.azs\s*\)", self.block), (
+            "aws_route_table.private for_each must be `toset(var.azs)` -- one private RT per AZ, "
+            "keyed by AZ name (NOT by count.index, which is index-shift fragile)."
+        )
+
+    def test_no_count_index_used(self) -> None:
+        # Strip strings + comments before scanning so a comment or error_message
+        # mentioning count.index doesn't false-positive.
+        scrubbed = _strip_hcl_comments(self.block)
+        assert "count.index" not in scrubbed, (
+            "aws_route_table.private must NOT use count.index -- the refactor moved this to "
+            "for_each = toset(var.azs). count-indexed RTs cause destroy+recreate churn on AZ-list "
+            "changes."
+        )
+
+    def test_no_count_attribute_at_top_level(self) -> None:
+        # `count = ...` at top level of the resource block is forbidden.
+        # Search for `count` as a field assignment (not preceded by var. or local. etc.).
+        scrubbed = _strip_hcl_comments(self.block)
+        assert not re.search(r"^\s*count\s*=", scrubbed, re.MULTILINE), (
+            "aws_route_table.private must NOT declare a top-level `count = ...` -- the refactor "
+            "moved this to for_each = toset(var.azs)."
+        )
+
+    def test_dynamic_route_block_gated_by_enable_nat_gateway(self) -> None:
+        dyn = _dynamic_route_block(self.block)
+        assert re.search(r"for_each\s*=\s*var\.enable_nat_gateway\s*\?\s*\[\s*1\s*\]\s*:\s*\[\s*\]", dyn), (
+            'aws_route_table.private dynamic "route" must be gated by '
+            "`for_each = var.enable_nat_gateway ? [1] : []` -- preserves the off-switch."
+        )
+
+    def test_nat_gateway_id_references_default_node_egress_bucket(self) -> None:
+        dyn = _dynamic_route_block(self.block)
+        assert "local.default_node_egress_bucket" in dyn, (
+            'aws_route_table.private dynamic "route" must reference '
+            "`local.default_node_egress_bucket` to compose the NAT GW key. This pins node egress "
+            "through bucket-1's NAT GW per AZ (the operator-sorted-first bucket)."
+        )
+        assert "each.value" in dyn, (
+            'aws_route_table.private dynamic "route" must use `each.value` to compose the NAT GW '
+            "key with the AZ portion (each.value is the AZ string from toset(var.azs))."
+        )
+        assert re.search(r"aws_nat_gateway\.this\[", dyn), (
+            'aws_route_table.private dynamic "route" must reference `aws_nat_gateway.this[...]` '
+            "(the per-(bucket, AZ) NAT GW map)."
+        )
+
+    def test_no_single_nat_gateway_reference(self) -> None:
+        scrubbed = _strip_hcl_comments(self.block)
+        assert "var.single_nat_gateway" not in scrubbed, (
+            "aws_route_table.private must NOT reference var.single_nat_gateway -- the variable is "
+            "removed by this refactor."
+        )
+        assert "single_nat_gateway" not in scrubbed, (
+            "aws_route_table.private must NOT reference single_nat_gateway in any form."
+        )
+
+
+class TestSingleNATGatewayRemoved:
+    """`var.single_nat_gateway` and the bare `single_nat_gateway` token must be
+    fully removed from the VPC submodule.
+
+    Defends against half-completed refactors where the variable is dropped from
+    one file but lingering references in another file would silently break.
+    Comments are stripped before scanning so explanatory comments don't
+    interfere -- but the variable name must not appear in code or in any tag /
+    field assignment.
+    """
+
+    def _scrub(self, text: str) -> str:
+        return _strip_hcl_comments(text)
+
+    def test_variable_declaration_removed_from_vpc_variables(self) -> None:
+        scrubbed = self._scrub(VPC_VARS_TF_TEXT)
+        assert "single_nat_gateway" not in scrubbed, (
+            "modules/eks/terraform/modules/vpc/variables.tf must not declare or reference "
+            "single_nat_gateway -- this variable was replaced by per-(bucket, AZ) NAT topology + "
+            "var.nat_gateway_eip_count."
+        )
+
+    def test_no_reference_in_vpc_main(self) -> None:
+        scrubbed = self._scrub(VPC_MAIN_TF_TEXT)
+        assert "single_nat_gateway" not in scrubbed, (
+            "modules/eks/terraform/modules/vpc/main.tf must not reference single_nat_gateway -- "
+            "the old toggle is replaced by per-(bucket, AZ) NAT topology."
+        )
+
+    def test_no_reference_in_vpc_nat(self) -> None:
+        if not VPC_NAT_TF_TEXT:
+            # Surface the underlying issue (file missing) via TestNATFileExists,
+            # not via a misleading "no references" pass here.
+            return
+        scrubbed = self._scrub(VPC_NAT_TF_TEXT)
+        assert "single_nat_gateway" not in scrubbed, (
+            "modules/eks/terraform/modules/vpc/nat.tf must not reference single_nat_gateway -- "
+            "the old toggle has no place in the refactored topology."
+        )
+
+
+class TestNATGatewayEIPCountValidation:
+    """`var.nat_gateway_eip_count` must be declared in BOTH the VPC submodule
+    and the EKS root with the same shape: number, default 8, validation 1-8.
+    """
+
+    def _assert_variable_shape(self, text: str, file_label: str) -> None:
+        block = _variable_block(text, "nat_gateway_eip_count")
+        assert re.search(r"type\s*=\s*number", block), (
+            f"{file_label}:variable nat_gateway_eip_count must declare `type = number`."
+        )
+        assert re.search(r"default\s*=\s*8\b", block), (
+            f"{file_label}:variable nat_gateway_eip_count must declare `default = 8` (AWS hard cap)."
+        )
+        assert "validation" in block, (
+            f"{file_label}:variable nat_gateway_eip_count must declare a validation block enforcing the 1-8 range."
+        )
+        # Condition must include both bounds. Match either `>= 1 && <= 8` or
+        # the symmetric `<= 8 && >= 1`. Whitespace tolerant.
+        cond_a = re.search(r">=\s*1[^&]*&&[^<]*<=\s*8", block)
+        cond_b = re.search(r"<=\s*8[^&]*&&[^>]*>=\s*1", block)
+        assert cond_a or cond_b, (
+            f"{file_label}:variable nat_gateway_eip_count validation must enforce "
+            "var.nat_gateway_eip_count >= 1 && var.nat_gateway_eip_count <= 8."
+        )
+
+    def test_vpc_submodule_variable_shape(self) -> None:
+        if "nat_gateway_eip_count" not in VPC_VARS_TF_TEXT:
+            raise AssertionError(
+                "modules/eks/terraform/modules/vpc/variables.tf is missing variable "
+                "'nat_gateway_eip_count' (number, default 8, validation 1-8)."
+            )
+        self._assert_variable_shape(VPC_VARS_TF_TEXT, "vpc/variables.tf")
+
+    def test_root_variable_shape(self) -> None:
+        if "nat_gateway_eip_count" not in ROOT_VARS_TF_TEXT:
+            raise AssertionError(
+                "modules/eks/terraform/variables.tf is missing variable 'nat_gateway_eip_count' "
+                "(number, default 8, validation 1-8); cluster-config.py emits "
+                "-var=nat_gateway_eip_count=N against this declaration."
+            )
+        self._assert_variable_shape(ROOT_VARS_TF_TEXT, "root variables.tf")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #570
* __->__ #569
* #568
* #567
* #566
* #564
* #561
* #560
* #559
* #558

**Impact:** VPC egress infrastructure — all pod and base-node internet-bound traffic routes through new per-bucket NAT GWs
**Risk:** high

## What
Replaces the old shared per-AZ NAT Gateway (toggled by `single_nat_gateway`) with a per-(bucket, AZ) NAT Gateway topology where each pod subnet gets its own NAT GW with configurable EIP count (1-8, default 8) for egress source-IP diversity.

## Why
Phase 3 of the IPv4 capacity plan: maximize egress source-IP diversity to mitigate anonymous per-IP rate limits at upstream services. Production end state is 12 NAT GWs with 96 EIPs (~32x improvement over the current 3 EIPs), isolating pod egress per bucket so rate-limit budgets don't collide across workload families.

## How
- All NAT resources use `for_each` keyed by `"${bucket}-${az}"` (from `local.pod_cidr_associations`) — no `count`-based indexing, preventing destroy/recreate churn on AZ-list changes
- Each NAT GW gets 1 primary EIP + N-1 secondary EIPs via `nat_gateway_eip_count` variable (AWS hard cap 8)
- Base-node (private subnet) egress routes through the lexicographically first bucket's NAT GW per AZ (`default_node_egress_bucket`), avoiding extra NAT GWs solely for base-node redundancy
- Pod route tables are always created (not gated by `enable_nat_gateway`); only the `0.0.0.0/0` route is dynamic — preserves the off-switch without destroy/recreate on the table resource
- Private route tables refactored from `count` to `for_each = toset(var.azs)` for AZ-keyed stability
- Subnet-by-AZ lookups use attribute-derived maps (not positional `var.azs[i]`) to prevent AZ-list drift
- `lifecycle.precondition` on EIP and NAT GW resources asserts `pod_cidr_buckets` AZ keys match `var.azs` at plan time

## Changes
- **`modules/vpc/nat.tf`** (new): 7 resources — `aws_eip.nat_primary`, `aws_eip.nat_secondary`, `aws_nat_gateway.this`, `aws_route_table.pod`, `aws_route_table_association.pod`, `aws_route_table.private`, `aws_route_table_association.private`
- **`modules/vpc/main.tf`**: removed old `count`-based `aws_eip.nat`, `aws_nat_gateway.this`, `aws_route_table.private`, `aws_route_table_association.private`
- **`modules/vpc/variables.tf`**: replaced `single_nat_gateway` (bool) with `nat_gateway_eip_count` (number, 1-8, default 8); added non-empty AZ validation on `pod_cidr_buckets`
- **`modules/vpc/outputs.tf`**: replaced `nat_gateway_ids` list with `nat_gateways_by_bucket_az`, `nat_gateway_eips_by_bucket_az`, `pod_route_table_ids_by_bucket_az` maps (keyed `"${bucket}-${az}"`)
- **`modules/eks/terraform/main.tf`**: passes `nat_gateway_eip_count` instead of `single_nat_gateway` to VPC module
- **`modules/eks/terraform/variables.tf`** + **`outputs.tf`**: mirrored variable/output changes at root level
- **`scripts/cluster-config.py`**: replaced `single_nat_gateway` tfvar with `nat_gateway_eip_count`; added `_validate_nat_gateway_eip_count()` with int coercion, bool rejection, range check, and shell-injection defense (value flows into `eval tofu plan $TFVARS`)
- **`scripts/test_cluster_config.py`**: updated tfvar assertions; added `TestNatGatewayEipCountValidation` (12 tests covering int/string/bool/None/injection/float/boundary cases)
- **`scripts/test_vpc_nat_topology.py`** (new): 576-line unit test suite parsing nat.tf as text+regex — 7 test classes validating resource declarations, `for_each` keying, tag contracts, preconditions, `single_nat_gateway` removal, and variable shape consistency
- **`modules/eks/tests/smoke/test_eks.py`**: added `TestNATGatewayTopology` class (5 smoke tests) — verifies live AWS state matches declared topology (NAT GW count per bucket-AZ, subnet-AZ consistency, EIP count per NAT GW, pod subnet RT associations, private RT routing through default_node_egress_bucket)

## Notes
- This is PR 10 of the IPv4 capacity migration stack (INCREASE_IPV4.md). Requires PRs 4+5 (pod subnets) to be applied first.
- AWS quota prerequisites: `L-0263D0A3` (EIPs/region) raised to ~120 in us-east-2 / ~20 in us-west-1; `L-FE5A380F` (NAT GWs/AZ) raised to 10 in both regions.
- PR 11 follows to set `nat_gateway_eip_count: 1` on staging in `clusters.yaml` and drop the obsolete `single_nat_gateway` key.
- Production: 12 NAT GWs × 8 EIPs = 96 EIPs (~$330/mo). Staging: 8 NAT GWs × 1 EIP = 8 EIPs.
- `tofu plan` will show destroy+create for existing NAT GW and route table resources (moving from `count` to `for_each` changes the resource address). This is expected and safe when applied during the drained cutover window.

## Testing
- `just lint` — all 13 linters must pass
- `just test` — runs `test_cluster_config.py` (including new `TestNatGatewayEipCountValidation`) and `test_vpc_nat_topology.py` (new)
- `tofu plan` against both clusters — verify additive NAT GW/EIP/RT resources, no unexpected destructive operations outside the NAT refactor
- Post-apply: `test_eks.py::TestNATGatewayTopology` smoke tests validate live AWS state matches the declared topology

Signed-off-by: Jean Schmidt <contato@jschmidt.me>