### PR TITLE
chore(clusters): replace single_nat_gateway with nat_gateway_eip_count

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -33,7 +33,7 @@ defaults:
   # https://aws.amazon.com/security/security-bulletins/2026-027-aws/
   base_node_ami_version: "v20260318"
   eks_version: "1.35"
-  single_nat_gateway: false
+  nat_gateway_eip_count: 8       # AWS hard cap per NAT GW
 
   # --- CoreDNS sizing ---
   coredns:
@@ -130,7 +130,7 @@ clusters:
       base_node_count: 2
       base_node_instance_type: m5.4xlarge
       base_node_max_unavailable_percentage: 100  # all-at-once for staging
-      single_nat_gateway: true       # cost optimization for staging
+      nat_gateway_eip_count: 1       # cost optimization for staging
       vpc_cidr: "10.0.0.0/16"
       # Per-(bucket, AZ) secondary VPC CIDRs from 100.96.0.0/12 (CGNAT).
       # Staging uses the upper /12 region (vs production's 100.64.0.0/12)

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -62,7 +62,7 @@ clusters:
     state_bucket: ciforge-tfstate-arc-staging
     base:
       vpc_cidr: "10.0.0.0/16"
-      single_nat_gateway: true
+      nat_gateway_eip_count: 1
       base_node_count: 5
     modules:
       - arc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #570
* #569
* #568
* #567
* #566
* #564
* #561
* #560
* #559
* #558

**Impact:** clusters.yaml config consumers (deploy pipeline, tofu plan); no runtime change
**Risk:** low

## What
Replaces the boolean `single_nat_gateway` knob with the new `nat_gateway_eip_count` integer introduced by the per-(bucket, AZ) NAT GW topology refactor (PR 10). Updates the example snippet in `docs/architecture.md` to match.

## Why
PR 10 refactored NAT GW provisioning from a single shared gateway (toggled by `single_nat_gateway`) to a per-pod-subnet topology with configurable EIP count per gateway. The old boolean no longer maps to anything in the terraform module — it must be replaced with the new variable that controls EIP allocation.

## How
- Default `nat_gateway_eip_count: 8` (AWS hard cap per NAT GW) replaces `single_nat_gateway: false` in defaults — production gets 96 EIPs total (12 NAT GWs × 8)
- Staging override `nat_gateway_eip_count: 1` replaces `single_nat_gateway: true` — staging gets 8 EIPs total (8 NAT GWs × 1), preserving cost optimization intent
- Documentation example updated to stay consistent with live config

## Changes
- `clusters.yaml`: replace `single_nat_gateway: false` in defaults with `nat_gateway_eip_count: 8`
- `clusters.yaml`: replace `single_nat_gateway: true` in arc-staging base with `nat_gateway_eip_count: 1`
- `docs/architecture.md`: update example clusters.yaml snippet to use `nat_gateway_eip_count: 1`

## Testing
- `just lint` — all 13 linters pass
- `just test` — all unit tests pass
- `tofu plan` for both clusters — verify no unexpected changes (this PR is config-only; the terraform variable was already added by PR 10)

Signed-off-by: Jean Schmidt <contato@jschmidt.me>