### PR TITLE
Bump runner-container-hooks to v0.8.12 (forward GHA cancel into pod)

### DIFF
--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -69,7 +69,7 @@ Every Karpenter NodePool applies this startup taint via the `startupTaints` fiel
 Runner pods include an init container that polls for a file on the host filesystem before the runner container can start. This file is placed by a DaemonSet.
 
 **DaemonSet**: `runner-hooks-warmer` (`modules/arc-runners/kubernetes/hooks-warmer.yaml`)
-- Downloads patched `runner-container-hooks` v0.8.11 from GitHub releases
+- Downloads patched `runner-container-hooks` v0.8.12-cancel.1 from GitHub releases (huydhn fork pre-release)
 - Extracts to `/mnt/runner-container-hooks/dist/` on host NVMe
 - Validates `dist/index.js` exists after extraction
 - Writes version marker for idempotency

--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -69,7 +69,7 @@ Every Karpenter NodePool applies this startup taint via the `startupTaints` fiel
 Runner pods include an init container that polls for a file on the host filesystem before the runner container can start. This file is placed by a DaemonSet.
 
 **DaemonSet**: `runner-hooks-warmer` (`modules/arc-runners/kubernetes/hooks-warmer.yaml`)
-- Downloads patched `runner-container-hooks` v0.8.12-cancel.1 from GitHub releases (huydhn fork pre-release)
+- Downloads patched `runner-container-hooks` v0.8.12 from GitHub releases
 - Extracts to `/mnt/runner-container-hooks/dist/` on host NVMe
 - Validates `dist/index.js` exists after extraction
 - Writes version marker for idempotency

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -2,10 +2,12 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# Fix: find -exec stat {} \; -> find -exec stat {} + (10-100x faster)
-# Fix: exit code propagation — OOM-killed processes now correctly report failure
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.11
-# Remove this when upstream merges the fixes into actions/runner-container-hooks
+# Pre-release pinned to huydhn/runner-container-hooks v0.8.12-cancel.1 —
+# adds POST /kill + SIGTERM/SIGINT cleanup callbacks so GHA cancellation
+# is forwarded into the workflow pod and post-cleanup steps don't fail
+# with "RPC /exec failed (409): A job is already running".
+# See upstream PR: https://github.com/jeanschmidt/runner-container-hooks/pull/5
+# Revert to jeanschmidt/runner-container-hooks once that PR is merged + released.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -63,8 +65,8 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.11"
-              HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
+              HOOKS_VERSION="0.8.12-cancel.1"
+              HOOKS_URL="https://github.com/huydhn/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"
 

--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -2,12 +2,11 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# Pre-release pinned to huydhn/runner-container-hooks v0.8.12-cancel.1 —
-# adds POST /kill + SIGTERM/SIGINT cleanup callbacks so GHA cancellation
-# is forwarded into the workflow pod and post-cleanup steps don't fail
-# with "RPC /exec failed (409): A job is already running".
-# See upstream PR: https://github.com/jeanschmidt/runner-container-hooks/pull/5
-# Revert to jeanschmidt/runner-container-hooks once that PR is merged + released.
+# v0.8.12 adds POST /kill + SIGTERM/SIGINT cleanup callbacks so GHA
+# cancellation is forwarded into the workflow pod and post-cleanup steps
+# don't fail with "RPC /exec failed (409): A job is already running".
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.12
+# Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -65,8 +64,8 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.12-cancel.1"
-              HOOKS_URL="https://github.com/huydhn/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
+              HOOKS_VERSION="0.8.12"
+              HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"
 

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -292,7 +292,7 @@ template:
             value: /home/runner/hook-extensions/job-pod.yaml
           # Use OSDC wrapper that validates env vars and surfaces errors
           # clearly, then delegates to patched hooks from DaemonSet.
-          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.11
+          # See: https://github.com/huydhn/runner-container-hooks/releases/tag/v0.8.12-cancel.1
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS
             value: /home/runner/hook-extensions/wrapper.js
           # PyTorch CI workflows depend on Docker images built in parallel by
@@ -557,6 +557,9 @@ data:
     process.on('SIGTERM', () => forwardSignal('SIGTERM'));
     process.on('SIGINT', () => forwardSignal('SIGINT'));
 
+    // Result shape: { code, signal }. When the child is killed by a signal
+    // Node.js reports code === null and signal !== null; we preserve both so
+    // callers can distinguish cancellation (signal) from script failure (code).
     function spawnReal(stdinData) {
       return new Promise((resolve) => {
         const child = spawn(process.execPath, [REAL_HOOKS], {
@@ -565,16 +568,29 @@ data:
         activeChild = child;
         child.stdin.write(stdinData);
         child.stdin.end();
-        child.on('close', (code) => {
+        child.on('close', (code, signal) => {
           activeChild = null;
-          resolve(code !== null ? code : 1);
+          if (signal) {
+            resolve({ code: null, signal: signal });
+            return;
+          }
+          resolve({ code: code !== null ? code : 1, signal: null });
         });
         child.on('error', (err) => {
           activeChild = null;
           emit('warning', '[OSDC] Hook spawn error: ' + err.message);
-          resolve(1);
+          resolve({ code: 1, signal: null });
         });
       });
+    }
+
+    // Coerce a {code, signal} result into a numeric exit code for the parent.
+    // SIGINT -> 130, SIGTERM -> 143 (POSIX 128+signum convention).
+    function exitCodeFor(result) {
+      if (result.signal === 'SIGINT') return 130;
+      if (result.signal === 'SIGTERM') return 143;
+      if (result.signal) return 128;
+      return result.code;
     }
 
     async function readStdin() {
@@ -588,12 +604,12 @@ data:
       try {
         input = JSON.parse(stdinData);
       } catch (_) {
-        return await spawnReal(stdinData);
+        return exitCodeFor(await spawnReal(stdinData));
       }
 
       const cmd = input.command;
       if (cmd !== 'run_script_step' && cmd !== 'run_container_step') {
-        return await spawnReal(stdinData);
+        return exitCodeFor(await spawnReal(stdinData));
       }
 
       // Feature 2: Validate environment variables
@@ -617,15 +633,41 @@ data:
       }
 
       // Feature 1: Enhanced exit code surfacing
-      const code = await spawnReal(stdinData);
-      if (code !== 0) {
+      //
+      // Three outcomes worth distinguishing in the log:
+      //   1. Cancellation: child was killed by a signal we forwarded from
+      //      GitHub Actions, OR the child handled the signal itself and
+      //      exited with the canonical 128+signum convention. The hook
+      //      (runner-container-hooks v0.8.12-cancel.1+) installs SIGTERM/SIGINT
+      //      handlers that run cleanup and then process.exit(143|130),
+      //      which collapses signal info to a numeric code. We treat those
+      //      two exact codes as cancellation. NOT a script/workflow error.
+      //   2. Script failure: child exited with non-zero code (any other).
+      //   3. Success: nothing to print.
+      const result = await spawnReal(stdinData);
+      const cancelSignal =
+        result.signal ||
+        (result.code === 130 ? 'SIGINT' :
+         result.code === 143 ? 'SIGTERM' : null);
+      if (cancelSignal) {
         emit('error',
-          '[OSDC] Step script exited with code ' + code + '. ' +
+          '[OSDC] Step cancelled by GitHub Actions (received ' + cancelSignal + '). ' +
+          'This typically means matrix fail-fast, a manual cancel, a workflow ' +
+          'concurrency override, or a run-level cancellation — NOT an OSDC ' +
+          'infrastructure failure. Check the workflow-run page for the actual ' +
+          'cause; the in-pod subprocess is terminated by the hook so post-cleanup ' +
+          'steps can run.'
+        );
+        return exitCodeFor(result);
+      }
+      if (result.code !== 0) {
+        emit('error',
+          '[OSDC] Step script exited with code ' + result.code + '. ' +
           'This is a script/workflow error, not an infrastructure issue. ' +
           'Check the step logs above for the actual failure.'
         );
       }
-      return code;
+      return result.code;
     }
 
     // Fail-open: read stdin once, run main, fall back on crash
@@ -635,7 +677,7 @@ data:
       } catch (err) {
         emit('warning', '[OSDC] Wrapper error (fail-open): ' + err.message);
         try {
-          process.exit(await spawnReal(stdinData));
+          process.exit(exitCodeFor(await spawnReal(stdinData)));
         } catch (_) {
           process.exit(1);
         }

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -292,7 +292,7 @@ template:
             value: /home/runner/hook-extensions/job-pod.yaml
           # Use OSDC wrapper that validates env vars and surfaces errors
           # clearly, then delegates to patched hooks from DaemonSet.
-          # See: https://github.com/huydhn/runner-container-hooks/releases/tag/v0.8.12-cancel.1
+          # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.12
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS
             value: /home/runner/hook-extensions/wrapper.js
           # PyTorch CI workflows depend on Docker images built in parallel by
@@ -638,7 +638,7 @@ data:
       //   1. Cancellation: child was killed by a signal we forwarded from
       //      GitHub Actions, OR the child handled the signal itself and
       //      exited with the canonical 128+signum convention. The hook
-      //      (runner-container-hooks v0.8.12-cancel.1+) installs SIGTERM/SIGINT
+      //      (runner-container-hooks v0.8.12+) installs SIGTERM/SIGINT
       //      handlers that run cleanup and then process.exit(143|130),
       //      which collapses signal info to a numeric code. We treat those
       //      two exact codes as cancellation. NOT a script/workflow error.


### PR DESCRIPTION
**Impact:** All GitHub Actions runner pods on c7i-runner nodes
**Risk:** low (single version-string bump on top of the existing v0.8.11 pin, plus a log-message refinement in the OSDC wrapper)

## What

Bumps the patched `runner-container-hooks` from **v0.8.11 → v0.8.12** (https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.12, merged via [jeanschmidt/runner-container-hooks#5](https://github.com/jeanschmidt/runner-container-hooks/pull/5)) and teaches the OSDC hook wrapper to recognise cancellation signals so the log line stops masquerading as a "script/workflow error".

## Why

On any GHA cancellation (matrix fail-fast, manual cancel, run-level cancel, workflow concurrency override) every post-cleanup step currently fails with the misleading

```
##[error]Error: failed to run script step: Error: RPC /exec failed (409): {"error": "A job is already running"}
```

…and the OSDC wrapper compounds the confusion with

```
##[error][OSDC] Step script exited with code 1. This is a script/workflow error, not an infrastructure issue.
```

Root cause: the cancel signal only reaches the hook process. The user's subprocess inside the workflow pod keeps running because nothing forwards the cancel through the RPC boundary, so the in-pod RPC server holds its `_job_status = "running"` state and rejects subsequent `/exec` calls with 409 until the heartbeat watchdog finally kills the process 60s later.

Example job that shows the symptom: https://github.com/pytorch/pytorch/actions/runs/25829794167/job/75893418921

## How

Two coordinated changes:

**Hook side** (now in upstream `runner-container-hooks` v0.8.12):
- New `POST /kill` endpoint on the in-pod RPC server (idempotent, auth-checked).
- New `killRpcJob()` — best-effort fire-and-forget POST `/kill` with a 5s timeout.
- Cleanup-callback registry in `safety/process-handlers`; SIGTERM/SIGINT handlers run registered callbacks (with 5s cap, timer correctly cleared) before exiting 143/130.
- `run-script-step` registers `killRpcJob` as a cleanup callback around the `rpcPodStep` call.
- The 409 error path classifies "A job is already running" specifically and emits a cancellation-aware message — retained as a safety-net for the SIGKILL / hook-crash case.

**OSDC wrapper** (`modules/arc-runners/templates/runner.yaml.tpl`):
- `spawnReal` now returns `{code, signal}` instead of dropping signal info.
- Recognises both signal-killed children AND the canonical 130 (SIGINT) / 143 (SIGTERM) exit codes the new hook handler emits.
- Emits `[OSDC] Step cancelled by GitHub Actions (received SIGTERM)…` for cancellations, keeping the original "script error" message only for genuine non-zero exits.

### Before / after log (the user-visible win)

**Before:**

```
##[error][OSDC] Step script exited with code 1. This is a script/workflow error, not an infrastructure issue. Check the step logs above for the actual failure.
##[error]Executing the custom container implementation failed. Please contact your self hosted runner administrator.
…
##[error]Error: failed to run script step: Error: RPC /exec failed (409): {"error": "A job is already running"}
(repeated for every post-cleanup step)
```

**After:**

```
##[error][OSDC] Step cancelled by GitHub Actions (received SIGTERM). This typically means matrix fail-fast, a manual cancel, a workflow concurrency override, or a run-level cancellation — NOT an OSDC infrastructure failure. Check the workflow-run page for the actual cause; the in-pod subprocess is terminated by the hook so post-cleanup steps can run.
```

…and the post-cleanup steps run normally (no 409 spam) because the hook forwards `/kill` into the pod before exit.

## Changes

- `modules/arc-runners/kubernetes/hooks-warmer.yaml` — `HOOKS_VERSION` 0.8.11 → 0.8.12; header comment rewritten to point at the new release. (URL stays at jeanschmidt/runner-container-hooks.)
- `modules/arc-runners/templates/runner.yaml.tpl` — wrapper.js `spawnReal` / main signal handling; release URL comment bumped.
- `docs/node-warmup-and-scheduling-gates.md` — version reference bumped.

## Notes

- Generated YAMLs under `modules/arc-runners*/generated/` are not git-tracked and will be re-rendered by the deploy pipeline from the updated template.
- Upstream v0.8.12 carries the full test suite for the fix — 78 TS unit + 70 Python unit + 13 kind e2e tests, all of which run on PR in https://github.com/jeanschmidt/runner-container-hooks/actions.

## Testing

- `just lint` — all 13 linters pass.
- Cluster smoke: pending — this PR is the rollout vehicle.