### PR TITLE
Make eniconfigs deploy.sh work on stock macOS bash 3.2

### DIFF
--- a/osdc/base/kubernetes/eniconfigs/deploy.sh
+++ b/osdc/base/kubernetes/eniconfigs/deploy.sh
@@ -41,7 +41,11 @@ fi
 SUBNETS_JSON=$(tofu output -json private_subnets_by_az)
 cd - >/dev/null
 
-mapfile -t AZS < <(jq -r 'keys[]' <<<"$SUBNETS_JSON")
+# macOS ships /bin/bash 3.2, where `mapfile` is unavailable. Read the
+# `jq` output line-by-line into the array so the script works on stock
+# bash 3.2 and modern bash alike.
+AZS=()
+while IFS= read -r line; do AZS+=("$line"); done < <(jq -r 'keys[]' <<<"$SUBNETS_JSON")
 if [[ ${#AZS[@]} -eq 0 ]]; then
   echo "ERROR: private_subnets_by_az is empty for cluster ${CLUSTER}" >&2
   exit 1


### PR DESCRIPTION
**Impact:** Anyone running `just deploy <cluster> base` (or the parent `just deploy`) from macOS without Homebrew bash on PATH
**Risk:** none — pure shell-syntax change, identical semantics

## What

Replace the single `mapfile -t` invocation in `base/kubernetes/eniconfigs/deploy.sh` with a `while read` loop that populates the same array. `mapfile` is a bash 4 builtin; macOS still ships `/bin/bash` 3.2, so any contributor on a stock Mac hits

```
base/kubernetes/eniconfigs/deploy.sh: line 44: mapfile: command not found
```

when `just deploy arc-staging` reaches the eniconfigs base step.

## Why

The rest of the codebase's shell scripts are bash-3.2-compatible already — this `mapfile` was the only outlier. Pinning a newer bash via `mise.toml` would work but adds a tool dep for one line; a portable rewrite is cheaper and keeps macOS contributors unblocked without extra setup.

## How

```diff
-mapfile -t AZS < <(jq -r 'keys[]' <<<"$SUBNETS_JSON")
+AZS=()
+while IFS= read -r line; do AZS+=("$line"); done < <(jq -r 'keys[]' <<<"$SUBNETS_JSON")
```

Same result: every line of `jq -r 'keys[]'` ends up in `AZS[]`. No whitespace handling changes — `IFS=` + `-r` preserve raw lines, which is what `mapfile -t` did.

## Testing

- `just lint` — all 13 linters pass.
- Confirmed locally on `/bin/bash` 3.2.57 that the rewritten loop populates the array identically for representative `jq` output.