### PR TITLE
Replace expired B200 capacity reservation with two new ones

### DIFF
--- a/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
@@ -7,5 +7,5 @@ runner:
   vcpu: 176
   memory: 1800Gi
   gpu: 8
-  # Fixed-capacity cap: 1 reserved 8-GPU node / 8 GPUs per runner = 1 concurrent runner.
-  max_runners: 1
+  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 8 GPUs per runner = 2 concurrent runners.
+  max_runners: 2

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
@@ -8,5 +8,5 @@ runner:
   vcpu: 22
   memory: 225Gi
   gpu: 1
-  # Fixed-capacity cap: 1 reserved 8-GPU node / 1 GPU per runner = 8 concurrent runners.
-  max_runners: 8
+  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 1 GPU per runner = 16 concurrent runners.
+  max_runners: 16

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
@@ -7,5 +7,5 @@ runner:
   vcpu: 44
   memory: 450Gi
   gpu: 2
-  # Fixed-capacity cap: 1 reserved 8-GPU node / 2 GPUs per runner = 4 concurrent runners.
-  max_runners: 4
+  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 2 GPUs per runner = 8 concurrent runners.
+  max_runners: 8

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
@@ -7,5 +7,5 @@ runner:
   vcpu: 88
   memory: 900Gi
   gpu: 4
-  # Fixed-capacity cap: 1 reserved 8-GPU node / 4 GPUs per runner = 2 concurrent runners.
-  max_runners: 2
+  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 4 GPUs per runner = 4 concurrent runners.
+  max_runners: 4

--- a/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
+++ b/osdc/modules/nodepools-b200/defs/p6-b200-48xlarge.yaml
@@ -12,7 +12,10 @@ nodepool:
   topology_manager_policy: single-numa-node
   topology_manager_scope: pod
   capacity_type: reserved
+  # Two reserved p6-b200.48xlarge nodes (8 GPUs each = 16 GPUs total).
+  # arc-runners-b200/defs/*.yaml max_runners are sized assuming this count.
   capacity_reservation_ids:
-    - cr-0c366fb8339a10f69
+    - cr-02cf82c9a0f7fa8c0
+    - cr-06ec9d6c14b9d9981
   baremetal: true
   user_data_script: scripts/b200-node-setup.sh


### PR DESCRIPTION
**Impact:** B200 nodepool (`p6-b200-48xlarge`) and dependent ARC runners
**Risk:** low

## What

- Swap the single expired Capacity Block reservation `cr-0c366fb8339a10f69` in `nodepools-b200/defs/p6-b200-48xlarge.yaml` for two renewed reservations: `cr-02cf82c9a0f7fa8c0` and `cr-06ec9d6c14b9d9981`.
- Double `max_runners` on all four `arc-runners-b200/defs/*.yaml` variants to reflect the new fleet size (2 reserved 8-GPU nodes = 16 GPUs, up from 8).

## Why

The previous reservation expired so Karpenter can't launch B200 baremetal nodes. The renewed reservations cover two nodes — the cap on each runner def needs to grow proportionally or runners stay queued beyond their old single-node ceiling even though hardware is available.

## How

Following the same shape as #556 (H100 CR refresh). Generated YAMLs under `modules/nodepools-b200/generated/` and `modules/arc-runners-b200/generated/` are gitignored and will be re-rendered by the deploy pipeline from the updated defs.

| Runner | GPUs/runner | old max_runners (1 node) | new max_runners (2 nodes) |
|---|---|---|---|
| l-bx86iamx-176-1800-b200-8 | 8 | 1 | 2 |
| l-x86iamx-88-900-b200-4 | 4 | 2 | 4 |
| l-x86iamx-44-450-b200-2 | 2 | 4 | 8 |
| l-x86iamx-22-225-b200 | 1 | 8 | 16 |

## Testing

- `just lint` — all 13 linters pass.
- `just test` — all unit tests pass (98.85% coverage).
- Post-deploy: confirm the generated NodePool references both new reservation IDs and that B200 nodes launch against them; verify each runner variant accepts the new max concurrency.