### PR TITLE
Fix cross-arch image-cache-janitor build for fresh cluster deploys

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -96,6 +96,14 @@ jobs:
           aws-region: us-west-1
           role-duration-seconds: 7200
 
+      # Register QEMU binfmt handlers so `docker build --platform linux/arm64`
+      # works on an amd64 runner. The base deploy builds image-cache-janitor
+      # (and node-compactor) for both archs; whenever the content-addressed
+      # tag changes (Dockerfile edit, etc.) the build branch runs and needs
+      # cross-arch emulation.
+      - name: Set up QEMU for cross-arch builds
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - name: Deploy ${{ inputs.cluster }}
         run: just deploy "${{ inputs.cluster }}"
         env:

--- a/osdc/base/kubernetes/image-cache-janitor/docker/Dockerfile
+++ b/osdc/base/kubernetes/image-cache-janitor/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12-alpine
-RUN apk add --no-cache util-linux=2.41.2-r0
+RUN apk add --no-cache util-linux=2.41.4-r0
 
 # Install crictl (CRI CLI) so the janitor is self-contained and does not
 # depend on the host AMI shipping crictl.


### PR DESCRIPTION
## Summary

Two related fixes that surface when a brand-new OSDC cluster is deployed
from CI:

- **`osdc/base/kubernetes/image-cache-janitor/docker/Dockerfile`** —
  bump `util-linux` pin from `2.41.2-r0` → `2.41.4-r0`. Alpine has
  rolled forward and the old pin no longer resolves; `apk add` fails.
- **`.github/workflows/_osdc-deploy.yml`** — add
  `docker/setup-qemu-action` before the deploy step so
  `docker build --platform linux/arm64` works on the amd64 GitHub
  Actions runner.

## Why both, why now

The janitor image's tag in the deploy script is content-addressed to the
Dockerfile (`sha256(Dockerfile)[:12]`). Existing clusters' Harbors have
the image cached against the *old* hash, so every deploy short-circuits
the build via the skip-if-exists check at
`osdc/base/kubernetes/image-cache-janitor/deploy.sh:80`. No build means
no QEMU dependency, which is why this has worked silently for months.

The Dockerfile bump in this PR rotates the hash. After merge, the next
deploy of every cluster will see a new tag, miss the Harbor cache, and
fall through to the build branch — which includes an arm64 build leg
that fails on amd64 runners without QEMU registered.

Bundling both fixes keeps the change reviewable as one
cause-and-effect: pin rot forces a rebuild; rebuild forces QEMU.

## Test plan

- [x] `just lint` and `just test` on the change (covered locally)
- [x] arc-staging-uw2 PR (#574) exercises an identical QEMU step on the
      one-off bootstrap workflow and successfully built both arch
      variants of image-cache-janitor from scratch
- [ ] First post-merge deploy of any cluster via `_osdc-deploy.yml`
      should rebuild image-cache-janitor for both archs and complete
      cleanly

## Follow-up (not in this PR)

`python:3.12-alpine` is a mutable tag. The next Alpine release will
rotate util-linux again. A later PR should pin the base by digest to
make the build reproducible and stop this from recurring.