### PR TITLE
Bump ARC fork chart to 0.14.1-jeanschmidt.10

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -61,7 +61,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.9"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.10"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 4
     log_level: info

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -17,8 +17,8 @@
 Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image and publishes the chart to GHCR.
 
 - **OCI registry**: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.9`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
-- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.9` to match the chart)
+- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.10`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
+- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.10` to match the chart)
 
 To publish a new chart version, trigger `gha-publish-chart.yaml` from the fork's GitHub Actions UI with `publish_gha_runner_scale_set_controller_chart: true`.
 
@@ -129,14 +129,14 @@ This runs `modules/arc/deploy.sh`, which:
 3. **Applies RBAC** from `modules/arc/kubernetes/capacity-monitor-rbac.yaml`
 4. **Helm upgrade** of the fork chart:
    - Chart: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.9`)
+   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.10`)
    - Image: defaults to `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<chart_version>`. Override with `arc.image_repository` / `arc.image_tag` in `clusters.yaml` for local Harbor builds.
 
 Other deploy.sh config knobs (all from `clusters.yaml`):
 
 | Key | Default | What |
 |-----|---------|------|
-| `arc.chart_version` | `0.14.1-jeanschmidt.9` | Helm chart version (fork) |
+| `arc.chart_version` | `0.14.1-jeanschmidt.10` | Helm chart version (fork) |
 | `arc.image_repository` | `ghcr.io/jeanschmidt/gha-runner-scale-set-controller` | Controller image repo (override for local Harbor builds) |
 | `arc.image_tag` | _(chart_version)_ | Controller image tag (override for local Harbor builds) |
 | `arc.replica_count` | `2` | Controller replicas |


### PR DESCRIPTION
**Impact:** All ARC-managed runner scale sets across all clusters
**Risk:** low

## What
Bumps the ARC fork Helm chart version from `0.14.1-jeanschmidt.9` to `0.14.1-jeanschmidt.10`, picking up the HUD failure fallback feature from the fork.

## Why
When the PyTorch HUD API is unreachable, the capacity monitor previously fell back to assuming 0 queued jobs. This reduced placeholder capacity exactly when visibility into queue depth was worst, increasing scheduling latency during HUD outages. The new chart version over-provisions placeholders during HUD failures to keep latency bounded.

## How
- Upstream fork commit [`d5d94fb`](https://github.com/jeanschmidt/actions-runner-controller/commit/d5d94fba4808f9a068d7cdfc829409ca9a031e73) adds a `HUDFailureMultiplier` (default 3, configurable via `CAPACITY_AWARE_HUD_FAILURE_MULTIPLIER`)
- On HUD API failure, desired placeholders become `ProactiveCapacity * HUDFailureMultiplier` instead of `ProactiveCapacity + 0`
- Existing safety bounds (`MaxRunners` headroom, `MaxBurstCapacity`) still cap the absolute blast radius
- The multiplier is a no-op when HUD is unconfigured (no token) -- only triggers on actual API failure

## Changes
- `clusters.yaml`: bump `arc.chart_version` from `0.14.1-jeanschmidt.9` to `0.14.1-jeanschmidt.10`