### PR TITLE
Fill in us-west-1 H100 capacity reservation IDs

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -223,9 +223,15 @@ clusters:
       runner_name_prefix: "mt-"
       runner_group: "arc-cbr-prod-uw1"   # distinct from us-east-2's "default" — see doc
     nodepools-h100:
-      # TODO: fill in us-west-1 H100 capacity reservation IDs before deploy.
-      # Generator change to honor this override is also pending.
-      capacity_reservation_ids: []
+      # us-west-1 H100 capacity reservations (p5.48xlarge, 8× H100 each):
+      #   cr-04d3d1d84e127a562 — 2 nodes (16 H100 GPUs)
+      #   cr-09a53051589034fb8 — 4 nodes (32 H100 GPUs)
+      # Total: 6 nodes, 48 H100 GPUs.
+      # Generator change to honor this override is pending — see
+      # docs/prod-cluster-ha-us-west-1.md "Phase 1 prerequisite 2".
+      capacity_reservation_ids:
+        - cr-04d3d1d84e127a562
+        - cr-09a53051589034fb8
     pypi_cache:
       replicas: 10
     modules:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #585
* #584
* #583
* __->__ #582
* #581
* #580
* #579

Replaces the empty placeholder with the actual reservations:

  cr-04d3d1d84e127a562 — 2 × p5.48xlarge (16 H100 GPUs)
  cr-09a53051589034fb8 — 4 × p5.48xlarge (32 H100 GPUs)

Total: 6 reserved nodes, 48 H100 GPUs in us-west-1.

Still pending before deploy: the nodepools generator change that
reads this override from clusters.yaml. Until that lands, the def
file's hardcoded us-east-2 reservation IDs would take effect, which
is wrong for us-west-1.