### PR TITLE
Support cluster-level capacity_reservation_ids override in nodepools

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -178,6 +178,77 @@ clusters:
       - monitoring
       - logging
 
+  # arc-cbr-production-uw1: second prod cluster for HA + scale-out.
+  # See docs/prod-cluster-ha-us-west-1.md for the full design.
+  #
+  # Active/active with arc-cbr-production (us-east-2). Both clusters advertise
+  # the same mt-* runner labels but register in different runner groups so
+  # GitHub matches `runs-on` across both and routes by capacity:
+  #   - us-east-2: default group (existing)
+  #   - us-west-1: arc-cbr-prod-uw1 group (new, created at the pytorch org)
+  #
+  # Prerequisites before this cluster can be deployed:
+  #   1. Create the `arc-cbr-prod-uw1` runner group at the pytorch org.
+  #   2. Generator change to honor cluster-level `runner_group` override.
+  #   3. Generator change to honor cluster-level `capacity_reservation_ids`
+  #      override for nodepools-h100 (the def file hardcodes us-east-2 IDs).
+  #   4. Collect H100 capacity reservation IDs in us-west-1 and fill in below.
+  #
+  # B200 is intentionally omitted (no capacity reservation in us-west-1).
+  arc-cbr-production-uw1:
+    cluster_name: pytorch-arc-cbr-production-uw1
+    region: us-west-1
+    state_bucket: ciforge-tfstate-arc-cbr-prod-uw1
+    access_config:
+      authentication_mode: API_AND_CONFIG_MAP
+      cluster_admin_role_names:
+        - osdc_gha_prod
+    base:
+      vpc_cidr: "10.8.0.0/16"
+    git_cache:
+      central_replicas: 15
+      central_cpu_request: "10"
+      central_cpu_limit: "15"
+      central_memory_request: "10Gi"
+      central_memory_limit: "50Gi"
+    node_compactor:
+      min_node_age_seconds: 900
+    buildkit:
+      arm64_instance_type: c7gd.16xlarge
+      amd64_instance_type: m6id.24xlarge
+      pods_per_node: 2
+    arc-runners:
+      github_config_url: "https://github.com/pytorch"
+      github_secret_name: pytorch-arc-cbr-production
+      runner_name_prefix: "mt-"
+      runner_group: "arc-cbr-prod-uw1"   # distinct from us-east-2's "default" — see doc
+    nodepools-h100:
+      # us-west-1 H100 capacity reservations (p5.48xlarge, 8× H100 each):
+      #   cr-04d3d1d84e127a562 — 2 nodes (16 H100 GPUs)
+      #   cr-09a53051589034fb8 — 4 nodes (32 H100 GPUs)
+      # Total: 6 nodes, 48 H100 GPUs.
+      # Generator change to honor this override is pending — see
+      # docs/prod-cluster-ha-us-west-1.md "Phase 1 prerequisite 2".
+      capacity_reservation_ids:
+        - cr-04d3d1d84e127a562
+        - cr-09a53051589034fb8
+    pypi_cache:
+      replicas: 10
+    modules:
+      - karpenter
+      - arc
+      - nodepools
+      - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
+      - arc-runners
+      - arc-runners-h100
+      - buildkit
+      - pypi-cache
+      - cache-enforcer
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
+
   arc-cbr-production:
     cluster_name: pytorch-arc-cbr-production
     region: us-east-2

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -178,23 +178,6 @@ clusters:
       - monitoring
       - logging
 
-  # arc-cbr-production-uw1: second prod cluster for HA + scale-out.
-  # See docs/prod-cluster-ha-us-west-1.md for the full design.
-  #
-  # Active/active with arc-cbr-production (us-east-2). Both clusters advertise
-  # the same mt-* runner labels but register in different runner groups so
-  # GitHub matches `runs-on` across both and routes by capacity:
-  #   - us-east-2: default group (existing)
-  #   - us-west-1: arc-cbr-prod-uw1 group (new, created at the pytorch org)
-  #
-  # Prerequisites before this cluster can be deployed:
-  #   1. Create the `arc-cbr-prod-uw1` runner group at the pytorch org.
-  #   2. Generator change to honor cluster-level `runner_group` override.
-  #   3. Generator change to honor cluster-level `capacity_reservation_ids`
-  #      override for nodepools-h100 (the def file hardcodes us-east-2 IDs).
-  #   4. Collect H100 capacity reservation IDs in us-west-1 and fill in below.
-  #
-  # B200 is intentionally omitted (no capacity reservation in us-west-1).
   arc-cbr-production-uw1:
     cluster_name: pytorch-arc-cbr-production-uw1
     region: us-west-1

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -223,15 +223,9 @@ clusters:
       runner_name_prefix: "mt-"
       runner_group: "arc-cbr-prod-uw1"   # distinct from us-east-2's "default" — see doc
     nodepools-h100:
-      # us-west-1 H100 capacity reservations (p5.48xlarge, 8× H100 each):
-      #   cr-04d3d1d84e127a562 — 2 nodes (16 H100 GPUs)
-      #   cr-09a53051589034fb8 — 4 nodes (32 H100 GPUs)
-      # Total: 6 nodes, 48 H100 GPUs.
-      # Generator change to honor this override is pending — see
-      # docs/prod-cluster-ha-us-west-1.md "Phase 1 prerequisite 2".
-      capacity_reservation_ids:
-        - cr-04d3d1d84e127a562
-        - cr-09a53051589034fb8
+      # TODO: fill in us-west-1 H100 capacity reservation IDs before deploy.
+      # Generator change to honor this override is also pending.
+      capacity_reservation_ids: []
     pypi_cache:
       replicas: 10
     modules:

--- a/osdc/docs/prod-cluster-ha-us-west-1.md
+++ b/osdc/docs/prod-cluster-ha-us-west-1.md
@@ -1,251 +1,50 @@
 # Multi-region prod cluster: us-west-1 HA + scale-out
 
-Status: design validated via code review; staging cannot test the prod
-design end-to-end due to a GitHub API scope difference (see "Phase 0
-outcome" below). Ready to proceed to Phase 1.
+Deploy a second production OSDC EKS cluster (`arc-cbr-production-uw1`) in
+us-west-1 alongside the existing `arc-cbr-production` (us-east-2) for
+active/active load sharing and regional HA.
 
-## Goal
+## How it works
 
-Deploy a second production OSDC EKS cluster in **us-west-1** alongside the
-existing `arc-cbr-production` (us-east-2). The two clusters must:
+Both clusters advertise the same `mt-*` runner labels but register their
+scale sets in **different runner groups** at the `pytorch` org level.
+GitHub's uniqueness rule for scale sets is `(name, runnerGroupId)`, so the
+same name in two groups doesn't collide. Workflows that say
+`runs-on: mt-…` match runners from any visible group with that name, so
+GitHub routes incoming jobs to whichever cluster has capacity. Failover is
+implicit — if one cluster's listeners go offline, jobs land on the
+surviving group.
 
-1. Advertise the **same `runs-on` runner labels** (e.g. `mt-l-x86iavx512-46-85`)
-   so jobs queued at `github.com/pytorch` can be picked up by either cluster
-   with no workflow changes.
-2. Run **active/active**: GitHub routes incoming jobs to whichever scale set
-   has free capacity. If one region/cluster goes down, the other keeps
-   draining the queue (HA fallout).
+| Cluster                   | Region    | Runner group        |
+|---------------------------|-----------|---------------------|
+| `arc-cbr-production`      | us-east-2 | `default`           |
+| `arc-cbr-production-uw1`  | us-west-1 | `arc-cbr-prod-uw1`  |
 
-## How runner labels and groups compose
+Note: custom runner groups only work for org-scoped `githubConfigUrl`
+(`https://github.com/pytorch`). The repo-scope guard in
+`generate_runners.py:187-191` forces `default` for repo-scoped URLs, so
+this design wouldn't work on staging (which is repo-scoped at
+`pytorch/pytorch-canary`).
 
-`modules/arc-runners/templates/runner.yaml.tpl`:
+## Prerequisites
 
-```
-runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
-runnerGroup:        "{{RUNNER_GROUP}}"
-```
-
-- `RUNNER_NAME_PREFIX` ← `clusters.<id>.arc-runners.runner_name_prefix`
-  (`mt-` for prod, `c-mt-` for staging).
-- `RUNNER_NAME` ← filename under `modules/arc-runners/defs/*.yaml`.
-- `RUNNER_GROUP` ← `runner_group` on the runner def, with a hard guard in
-  `generate_runners.py:187-191` that **forces `default`** whenever
-  `githubConfigUrl` is repo-scoped (`https://github.com/<org>/<repo>`).
-  Custom groups only work for org-scoped (`https://github.com/<org>`) and
-  enterprise-scoped URLs.
-
-GitHub's uniqueness rule for scale sets is `(name, runnerGroupId)`. The
-same name in two different runner groups is allowed. Workflows that say
-`runs-on: <name>` match runners from **any** group with that name that the
-target repo is allowed to use, so jobs route by capacity across groups.
-
-**HA active/active mechanism (the design this doc proposes):**
-
-1. Both clusters set the same `runner_name_prefix` and ship the same
-   `defs/`, so every scale set advertises an identical `mt-…` label.
-2. Each cluster registers in its **own** runner group at the
-   `pytorch` org level (e.g. `arc-cbr-prod-ue2` and `arc-cbr-prod-uw1`).
-   No collision because the `(name, group)` tuple differs.
-3. Both groups are made visible to `pytorch/pytorch` (and any other repos
-   that target these labels).
-4. GitHub distributes incoming jobs across the two scale sets that match
-   the label — true active/active.
-
-Failover is implicit: if one cluster's listener goes offline, jobs route
-to the surviving group.
-
-## Phase 0 outcome — staging cannot test the prod design
-
-A staging cluster `arc-staging-uw2` was deployed in us-west-2 (mirror of
-`arc-staging` in us-west-1) intending to verify the routing model
-end-to-end. Cluster came up; ARC controllers ran; listener pods were
-created. But no scale-set duplicates appeared on the GitHub runner page,
-even after listeners stabilized.
-
-The cause is at the GitHub API level, not in our code:
-
-- `arc-staging` and `arc-staging-uw2` both use
-  `githubConfigUrl: https://github.com/pytorch/pytorch-canary`
-  (**repo-scoped**).
-- `generate_runners.py:187-191` enforces `runnerGroup = "default"` for all
-  repo-scoped URLs because GitHub's runner-scale-set API only supports
-  custom groups for org or enterprise scope.
-- Both clusters therefore tried to register the same names in the same
-  `default` group → name collision → second registration was
-  rejected/dedup'd silently.
-
-This is a property of GitHub's API + repo-scope, not a property of our
-design. Production uses `githubConfigUrl: https://github.com/pytorch`
-(**org-scoped**), where custom runner groups are supported and the
-runner-group-per-cluster design works as documented.
-
-### Validation alternative: code-reading
-
-Without an end-to-end staging test, the active/active mechanism is
-validated by:
-
-- GitHub's documented behavior: scale-set uniqueness is `(name, groupId)`;
-  same names across different groups are allowed; workflow label matching
-  spans all visible groups.
-- `generate_runners.py` already passes `runner_group` through to the helm
-  chart; the chart writes it into the scale-set registration request.
-- `arc-cbr-production` (us-east-2) today registers in the `default` group
-  (it doesn't set `runner_group`). To use the runner-group-per-cluster
-  pattern, we must first move it to a dedicated group (see "Phase 1
-  prerequisite" below).
-
-### What also went sideways on staging (not blocking — captured for the record)
-
-- **Cross-arch image-cache-janitor build failed** on the brand-new cluster
-  because Alpine had rolled forward `util-linux`, and the GitHub Actions
-  amd64 runner doesn't have QEMU registered for the arm64 build leg.
-  Fixed in #575 (Dockerfile pin bump + `docker/setup-qemu-action` in
-  `_osdc-deploy.yml`). Will hit every fresh cluster deploy until that PR
-  lands.
-- **VPC CNI IP allocation stalled** on the small 2-node base fleet after
-  ~30 listener pods + ambient DaemonSets piled on. Bumping
-  `WARM_ENI_TARGET` and restarting `aws-node` partially unstuck it but
-  listeners kept churning. Production base fleets are larger (default 6 ×
-  m7i.12xlarge) and unlikely to hit this; staging tooling could use a
-  follow-up to either enable prefix delegation or right-size the base
-  fleet for the listener density it actually hosts.
-
-### Disposition of arc-staging-uw2
-
-The cluster (and its branch `arc-staging-uw2-feasibility`) stays in place
-short-term for any further read-only investigation. Plan to tear it down
-once Phase 1 lands and the design is in production.
-
-## Phase 1 — prod cluster in us-west-1
-
-### Identity
-
-| Field            | Value                                                         |
-|------------------|---------------------------------------------------------------|
-| `cluster_id`     | `arc-cbr-production-uw1`                                      |
-| `cluster_name`   | `pytorch-arc-cbr-production-uw1`                              |
-| `region`         | `us-west-1`                                                   |
-| `state_bucket`   | `ciforge-tfstate-arc-cbr-prod-uw1` (created in us-west-2)     |
-| `vpc_cidr`       | `10.8.0.0/16` (non-overlap with 10.0/16, 10.4/16, 10.16/16)   |
-| admin role       | `osdc_gha_prod` (must exist or be created in IAM)             |
-
-### Pre-flight AWS prerequisites (per-region, not shared)
-
-- **Service quotas** in us-west-1: vCPU limits for c7i, m7i, r7i, m7g, m8g,
-  g4dn, g5, g6, p5 families. Request raises early.
-- **EKS-optimized AMIs**: confirm `base_node_ami_version: v20260318` AL2023
-  AMI is published in us-west-1, and that EKS GPU AMIs are available.
-- **GPU Capacity Reservations**:
-  - **H100 (p5)**: reservation IDs in us-west-1 — collect these for use in
-    the per-cluster override (see below).
-  - **B200 (p6-b200)**: none in us-west-1 → B200 is excluded from this
-    cluster.
-- **GitHub App credentials Secret**: reuse the existing
-  `pytorch-arc-cbr-production` GitHub App. Plant the same Kubernetes Secret
-  (same App, same private key) into the new cluster's `arc-runners`
-  namespace after `deploy-base`, before `deploy-module arc-runners`.
-
-### Phase 1 prerequisite 1 — runner group at the pytorch org
-
-The runner-group-per-cluster mechanism needs **one** org-level runner group
-created before us-west-1 registers. An org admin (write access on
-`pytorch` → Settings → Actions → Runner groups) must:
-
-1. **Create `arc-cbr-prod-uw1`** at
+1. **Runner group at the pytorch org.** Create `arc-cbr-prod-uw1` at
    `https://github.com/organizations/pytorch/settings/actions/runner-groups/new`.
    Set "Repository access" to include `pytorch/pytorch` (and any other
    repos that target `mt-…` labels).
+2. **H100 capacity reservations in us-west-1.** Collect the IDs from the
+   AWS console; B200 is omitted because there's no B200 capacity in
+   us-west-1.
+3. **us-west-1 service-quota raises** for the vCPU families this cluster
+   uses (c7i, m7i, r7i, m7g, m8g, g4dn, g5, g6, p5). File early —
+   GPU families can have long lead times.
+4. **PyPI wheel S3 feeder reachable from us-west-1.** Verify or add
+   replication.
 
-We do **not** need to migrate `arc-cbr-production` (us-east-2) off the
-`default` group. The asymmetry is functionally fine:
+The us-east-2 cluster keeps registering in `default`. We don't need to
+move it for HA to work — asymmetry is fine.
 
-- us-east-2 keeps registering in `default` (no change).
-- us-west-1 registers in `arc-cbr-prod-uw1` (new group).
-- For any shared label, GitHub matches across both groups → jobs route
-  to whichever cluster has capacity.
-
-Optional cleanup: a follow-up PR can create `arc-cbr-prod-ue2` and move
-us-east-2 into it for symmetry. Not required for HA to work.
-
-### Phase 1 prerequisite 2 — cluster-level `runner_group` override
-
-The generator (`generate_runners.py:147`) currently reads `runner_group`
-only from each runner def file. To set us-west-1's group cluster-wide
-without forking every def, we need a small generator change:
-
-- Read `clusters.<id>.arc-runners.runner_group` from `clusters.yaml`.
-- If set, override the value from the def file (subject to the existing
-  repo-scope guard at lines 187-191, which doesn't apply to us-west-1
-  since prod is org-scoped).
-- Add tests.
-
-The change is mechanically similar to the per-cluster
-`capacity_reservation_ids` override planned for H100 NodePools — same
-pattern, same place to add tests.
-
-### B200: omit from this cluster
-
-Don't add `nodepools-b200` / `arc-runners-b200` to the new cluster's
-`modules:` list. The `mt-l-…-b200-…` labels continue to be served only by
-us-east-2. No code change required; B200 simply isn't HA. Acceptable
-because there is no B200 capacity in us-west-1.
-
-### H100: per-cluster capacity-reservation override (no new module)
-
-Today `modules/nodepools-h100/defs/p5-48xlarge.yaml` hardcodes
-`cr-0c3f05dffb85ed832` (a us-east-2 reservation). The new cluster needs
-different CR IDs in us-west-1. Two ways to handle this:
-
-**Option A (recommended) — per-cluster override in `clusters.yaml`.**
-Extend the schema and teach the nodepools generator to read it:
-
-```yaml
-arc-cbr-production:
-  # … existing …
-  nodepools-h100:
-    capacity_reservation_ids: [cr-0c3f05dffb85ed832]
-
-arc-cbr-production-uw1:
-  # … existing …
-  nodepools-h100:
-    capacity_reservation_ids: [cr-XXXXXXXX, cr-YYYYYYYY]  # us-west-1
-```
-
-Generator change in
-`modules/nodepools/scripts/python/generate_nodepools.py`: after loading
-each def, if
-`clusters.<id>.<NODEPOOLS_MODULE_NAME>.capacity_reservation_ids` is set,
-override `nodepool.capacity_reservation_ids` before rendering. The
-`NODEPOOLS_MODULE_NAME` env var (already set by the `nodepools-h100` /
-`nodepools-b200` delegators) namespaces the override key naturally. Add
-unit tests under `modules/nodepools/scripts/python/`.
-
-Pros: one module, no duplication; reservation IDs live next to the rest of
-the cluster config; the same mechanism works for B200 once us-west-1
-reservations land later.
-
-Cons: ~30 lines + a test.
-
-**Option B — duplicate the module (`nodepools-h100-uw1`).**
-Faster (no code change), but creates a near-identical thin-delegator that
-must be kept in sync. AWS rotates reservation IDs periodically (see commit
-`767fce5` swapping B200 reservations) — duplication doubles that toil.
-
-**Decision: Option A.** Removes existing reservation-coupling debt while
-unblocking this work.
-
-### Region-specific items that won't auto-replicate
-
-- **Harbor pull-through cache** is per-cluster (good — no cross-region
-  pulls). Image mirroring runs during `deploy-base`.
-- **PyPI wheel cache** is per-cluster with its own EFS wheelhouse. The S3
-  wheel feeder upstream of OSDC writes to a single bucket — verify the new
-  region can read it, or add S3 replication / a second feeder.
-- **Git cache** is per-cluster; central StatefulSet clones independently.
-- **Grafana Cloud monitoring/logging**: same tenant; clusters are
-  distinguished by `cluster_name` label. No change.
-
-### clusters.yaml entry
+## clusters.yaml entry
 
 ```yaml
 arc-cbr-production-uw1:
@@ -256,7 +55,7 @@ arc-cbr-production-uw1:
     authentication_mode: API_AND_CONFIG_MAP
     cluster_admin_role_names: [osdc_gha_prod]
   base:
-    vpc_cidr: "10.8.0.0/16"
+    vpc_cidr: "10.8.0.0/16"                       # non-overlap with 10.0/16, 10.4/16
   git_cache:
     central_replicas: 15
     central_cpu_request: "10"
@@ -270,19 +69,21 @@ arc-cbr-production-uw1:
     amd64_instance_type: m6id.24xlarge
     pods_per_node: 2
   arc-runners:
-    github_config_url: "https://github.com/pytorch"               # SAME as us-east-2 prod
-    github_secret_name: pytorch-arc-cbr-production                # SAME secret name
-    runner_name_prefix: "mt-"                                     # SAME → labels match
-    runner_group: "arc-cbr-prod-uw1"                              # DISTINCT from us-east-2's "default" → no collision
+    github_config_url: "https://github.com/pytorch"
+    github_secret_name: pytorch-arc-cbr-production
+    runner_name_prefix: "mt-"
+    runner_group: "arc-cbr-prod-uw1"              # distinct from us-east-2's "default"
   nodepools-h100:
-    capacity_reservation_ids: [cr-XXXXXXXX, cr-YYYYYYYY]          # us-west-1 reservations
+    capacity_reservation_ids:                     # us-west-1 H100 reservations
+      - cr-04d3d1d84e127a562
+      - cr-09a53051589034fb8
   pypi_cache:
     replicas: 10
   modules:
     - karpenter
     - arc
     - nodepools
-    - nodepools-h100         # H100 only — B200 not yet available in us-west-1
+    - nodepools-h100        # H100 only — no B200 capacity in us-west-1
     - arc-runners
     - arc-runners-h100
     - buildkit
@@ -294,86 +95,57 @@ arc-cbr-production-uw1:
     - logging
 ```
 
-### Deploy
+## Deploy
 
 ```bash
 just bootstrap arc-cbr-production-uw1
 just deploy-base arc-cbr-production-uw1
-# Plant the GitHub App Secret (pytorch-arc-cbr-production) into the new
-# cluster's arc-runners namespace, using the same App private key as us-east-2.
+# Plant the pytorch-arc-cbr-production GitHub App Secret into the new
+# cluster's arc-runners namespace (same App, same private key as us-east-2).
 just deploy arc-cbr-production-uw1
 ```
 
-Pre-deploy gates (from `CLAUDE.md`): `just lint` and `just test` green.
+From CI: dispatch `OSDC: Deploy production` from the Actions tab and pick
+`arc-cbr-production-uw1`. Approval required via the `osdc-production`
+environment.
 
-### Post-deploy validation
+## Post-deploy validation
 
-1. `kubectl get autoscalingrunnersets -n arc-runners` on the new cluster —
-   every scale set in `RUNNING` state.
-2. On `https://github.com/organizations/pytorch/settings/actions/runner-groups/arc-cbr-prod-uw1`,
-   each `mt-…` scale set appears as a row with a healthy listener
-   heartbeat. The same names also appear in the `default` group (served
-   by us-east-2). Two groups, same names, both online.
-3. Trigger one small PR on `pytorch/pytorch` per shared label class
+1. `kubectl get autoscalingrunnersets -n arc-runners` shows every scale
+   set in `RUNNING`.
+2. The org's `arc-cbr-prod-uw1` runner group page lists every `mt-…`
+   scale set with a healthy listener heartbeat. The same names also
+   appear in the `default` group from us-east-2 — two groups, same
+   names, both online.
+3. Dispatch a small PR on `pytorch/pytorch` per shared label class
    (CPU / ARM / GPU). Confirm at least one job lands on the new cluster
-   (verify by pod node region/AZ). Repeat dispatches should land on
-   either cluster roughly in proportion to available capacity.
+   (check pod node region/AZ).
 4. Smoke tests in `osdc/tests/`.
-5. Monitoring + logging flowing into Grafana Cloud tagged with the new
-   `cluster_name`.
 
-## Active/active capacity split
+## Capacity ramp
 
-Active/active falls out for free from the same-label-different-group
-registration — GitHub matches `runs-on` across all visible groups and
-routes by capacity, no extra wiring. Two starting points for
-`proactive_capacity` split between clusters:
+Recommended go-live posture: start us-west-1 at **30%** of us-east-2's
+proactive capacity for the first week to limit blast radius, then ramp
+to 50/50 once routing looks healthy. Implement via a per-cluster
+multiplier (`clusters.<id>.arc-runners.proactive_capacity_multiplier`)
+so the ramp is one number to change, not a per-def edit.
 
-- **50/50.** Copy `defs/` as-is into both clusters. Doubles warm-pool cost
-  but maximizes burst headroom in either region.
-- **Skewed toward us-east-2 (incumbent).** First weeks: us-west-1 runs at
-  30–50% of prod proactive capacity to keep warm-pool spend in check while
-  trust builds. Two ways to express this:
-  - Edit `proactive_capacity` per def and accept that defs are now
-    cluster-aware (not great).
-  - Add a per-cluster multiplier (e.g.
-    `clusters.<id>.arc-runners.proactive_capacity_multiplier: 0.5`) and
-    apply it in `modules/arc-runners/scripts/python/generate_runners.py`.
-    Same shape as the H100 CR override change.
+us-west-1 quotas and reservations must be sized to absorb **100%** of
+prod traffic in the failover case, not just steady-state share.
 
-**Recommendation for go-live:** start with 30% us-west-1 / 100% us-east-2
-to limit blast radius, then ramp us-west-1 to 100% once a week of
-production traffic shows clean routing. Use the multiplier approach so the
-ramp is one number in `clusters.yaml`, not a per-def edit.
+## Region-specific items that don't auto-replicate
 
-### Capacity-planning note
+- **Harbor** — per-cluster pull-through cache, populated on first deploy.
+- **PyPI wheel cache** — per-cluster EFS wheelhouse; the upstream S3
+  feeder must write to a bucket us-west-1 can read.
+- **Git cache** — per-cluster, clones independently.
+- **Monitoring/logging** — Grafana Cloud tenant is shared; clusters
+  distinguished by `cluster_name` label.
 
-Quotas and reservations in us-west-1 must be sized to **absorb 100% of
-prod traffic** in the failover case, not just the steady-state share.
-Otherwise the "HA" claim doesn't hold during a us-east-2 outage.
+## Not in scope
 
-## Open questions to resolve before Phase 1
-
-1. **Org runner group `arc-cbr-prod-uw1` created** by a pytorch org admin
-   with repository access including `pytorch/pytorch`.
-2. **Cluster-level `runner_group` override landed** in
-   `generate_runners.py` (small generator change + tests).
-3. **us-west-1 H100 CR IDs** — collect before writing the clusters.yaml
-   entry.
-4. **us-west-1 service-quota raises** — file early; some GPU families have
-   long lead times.
-5. **PyPI wheel S3 feeder** — does the existing producer write to a bucket
-   that us-west-1 can read, or do we need replication?
-6. **Proactive-capacity ramp plan** — confirm the start-at-30% approach
-   with the team, or pick the 50/50 default.
-
-## What we are NOT doing in Phase 1
-
-- B200 in us-west-1 (no capacity).
-- Cross-region Harbor / PyPI / git-cache sharing (each cluster stands
-  alone; this is by design and keeps the failure domains isolated).
-- Migrating us-east-2 off the `default` runner group. The asymmetry
-  (us-east-2 in `default`, us-west-1 in `arc-cbr-prod-uw1`) is functionally
-  equivalent. A follow-up PR can symmetrize later.
-- Workflow changes in `pytorch/pytorch` — the whole point of the
-  same-label-different-group design is that workflows are untouched.
+- B200 in us-west-1 (no capacity reservation available).
+- Cross-region Harbor / PyPI / git-cache sharing — failure-domain
+  isolation is the design intent.
+- Workflow changes in `pytorch/pytorch`. The whole point of the
+  same-label-different-group design is that workflows don't change.

--- a/osdc/docs/prod-cluster-ha-us-west-1.md
+++ b/osdc/docs/prod-cluster-ha-us-west-1.md
@@ -1,0 +1,379 @@
+# Multi-region prod cluster: us-west-1 HA + scale-out
+
+Status: design validated via code review; staging cannot test the prod
+design end-to-end due to a GitHub API scope difference (see "Phase 0
+outcome" below). Ready to proceed to Phase 1.
+
+## Goal
+
+Deploy a second production OSDC EKS cluster in **us-west-1** alongside the
+existing `arc-cbr-production` (us-east-2). The two clusters must:
+
+1. Advertise the **same `runs-on` runner labels** (e.g. `mt-l-x86iavx512-46-85`)
+   so jobs queued at `github.com/pytorch` can be picked up by either cluster
+   with no workflow changes.
+2. Run **active/active**: GitHub routes incoming jobs to whichever scale set
+   has free capacity. If one region/cluster goes down, the other keeps
+   draining the queue (HA fallout).
+
+## How runner labels and groups compose
+
+`modules/arc-runners/templates/runner.yaml.tpl`:
+
+```
+runnerScaleSetName: "{{RUNNER_NAME_PREFIX}}{{RUNNER_NAME}}"
+runnerGroup:        "{{RUNNER_GROUP}}"
+```
+
+- `RUNNER_NAME_PREFIX` ← `clusters.<id>.arc-runners.runner_name_prefix`
+  (`mt-` for prod, `c-mt-` for staging).
+- `RUNNER_NAME` ← filename under `modules/arc-runners/defs/*.yaml`.
+- `RUNNER_GROUP` ← `runner_group` on the runner def, with a hard guard in
+  `generate_runners.py:187-191` that **forces `default`** whenever
+  `githubConfigUrl` is repo-scoped (`https://github.com/<org>/<repo>`).
+  Custom groups only work for org-scoped (`https://github.com/<org>`) and
+  enterprise-scoped URLs.
+
+GitHub's uniqueness rule for scale sets is `(name, runnerGroupId)`. The
+same name in two different runner groups is allowed. Workflows that say
+`runs-on: <name>` match runners from **any** group with that name that the
+target repo is allowed to use, so jobs route by capacity across groups.
+
+**HA active/active mechanism (the design this doc proposes):**
+
+1. Both clusters set the same `runner_name_prefix` and ship the same
+   `defs/`, so every scale set advertises an identical `mt-…` label.
+2. Each cluster registers in its **own** runner group at the
+   `pytorch` org level (e.g. `arc-cbr-prod-ue2` and `arc-cbr-prod-uw1`).
+   No collision because the `(name, group)` tuple differs.
+3. Both groups are made visible to `pytorch/pytorch` (and any other repos
+   that target these labels).
+4. GitHub distributes incoming jobs across the two scale sets that match
+   the label — true active/active.
+
+Failover is implicit: if one cluster's listener goes offline, jobs route
+to the surviving group.
+
+## Phase 0 outcome — staging cannot test the prod design
+
+A staging cluster `arc-staging-uw2` was deployed in us-west-2 (mirror of
+`arc-staging` in us-west-1) intending to verify the routing model
+end-to-end. Cluster came up; ARC controllers ran; listener pods were
+created. But no scale-set duplicates appeared on the GitHub runner page,
+even after listeners stabilized.
+
+The cause is at the GitHub API level, not in our code:
+
+- `arc-staging` and `arc-staging-uw2` both use
+  `githubConfigUrl: https://github.com/pytorch/pytorch-canary`
+  (**repo-scoped**).
+- `generate_runners.py:187-191` enforces `runnerGroup = "default"` for all
+  repo-scoped URLs because GitHub's runner-scale-set API only supports
+  custom groups for org or enterprise scope.
+- Both clusters therefore tried to register the same names in the same
+  `default` group → name collision → second registration was
+  rejected/dedup'd silently.
+
+This is a property of GitHub's API + repo-scope, not a property of our
+design. Production uses `githubConfigUrl: https://github.com/pytorch`
+(**org-scoped**), where custom runner groups are supported and the
+runner-group-per-cluster design works as documented.
+
+### Validation alternative: code-reading
+
+Without an end-to-end staging test, the active/active mechanism is
+validated by:
+
+- GitHub's documented behavior: scale-set uniqueness is `(name, groupId)`;
+  same names across different groups are allowed; workflow label matching
+  spans all visible groups.
+- `generate_runners.py` already passes `runner_group` through to the helm
+  chart; the chart writes it into the scale-set registration request.
+- `arc-cbr-production` (us-east-2) today registers in the `default` group
+  (it doesn't set `runner_group`). To use the runner-group-per-cluster
+  pattern, we must first move it to a dedicated group (see "Phase 1
+  prerequisite" below).
+
+### What also went sideways on staging (not blocking — captured for the record)
+
+- **Cross-arch image-cache-janitor build failed** on the brand-new cluster
+  because Alpine had rolled forward `util-linux`, and the GitHub Actions
+  amd64 runner doesn't have QEMU registered for the arm64 build leg.
+  Fixed in #575 (Dockerfile pin bump + `docker/setup-qemu-action` in
+  `_osdc-deploy.yml`). Will hit every fresh cluster deploy until that PR
+  lands.
+- **VPC CNI IP allocation stalled** on the small 2-node base fleet after
+  ~30 listener pods + ambient DaemonSets piled on. Bumping
+  `WARM_ENI_TARGET` and restarting `aws-node` partially unstuck it but
+  listeners kept churning. Production base fleets are larger (default 6 ×
+  m7i.12xlarge) and unlikely to hit this; staging tooling could use a
+  follow-up to either enable prefix delegation or right-size the base
+  fleet for the listener density it actually hosts.
+
+### Disposition of arc-staging-uw2
+
+The cluster (and its branch `arc-staging-uw2-feasibility`) stays in place
+short-term for any further read-only investigation. Plan to tear it down
+once Phase 1 lands and the design is in production.
+
+## Phase 1 — prod cluster in us-west-1
+
+### Identity
+
+| Field            | Value                                                         |
+|------------------|---------------------------------------------------------------|
+| `cluster_id`     | `arc-cbr-production-uw1`                                      |
+| `cluster_name`   | `pytorch-arc-cbr-production-uw1`                              |
+| `region`         | `us-west-1`                                                   |
+| `state_bucket`   | `ciforge-tfstate-arc-cbr-prod-uw1` (created in us-west-2)     |
+| `vpc_cidr`       | `10.8.0.0/16` (non-overlap with 10.0/16, 10.4/16, 10.16/16)   |
+| admin role       | `osdc_gha_prod` (must exist or be created in IAM)             |
+
+### Pre-flight AWS prerequisites (per-region, not shared)
+
+- **Service quotas** in us-west-1: vCPU limits for c7i, m7i, r7i, m7g, m8g,
+  g4dn, g5, g6, p5 families. Request raises early.
+- **EKS-optimized AMIs**: confirm `base_node_ami_version: v20260318` AL2023
+  AMI is published in us-west-1, and that EKS GPU AMIs are available.
+- **GPU Capacity Reservations**:
+  - **H100 (p5)**: reservation IDs in us-west-1 — collect these for use in
+    the per-cluster override (see below).
+  - **B200 (p6-b200)**: none in us-west-1 → B200 is excluded from this
+    cluster.
+- **GitHub App credentials Secret**: reuse the existing
+  `pytorch-arc-cbr-production` GitHub App. Plant the same Kubernetes Secret
+  (same App, same private key) into the new cluster's `arc-runners`
+  namespace after `deploy-base`, before `deploy-module arc-runners`.
+
+### Phase 1 prerequisite 1 — runner group at the pytorch org
+
+The runner-group-per-cluster mechanism needs **one** org-level runner group
+created before us-west-1 registers. An org admin (write access on
+`pytorch` → Settings → Actions → Runner groups) must:
+
+1. **Create `arc-cbr-prod-uw1`** at
+   `https://github.com/organizations/pytorch/settings/actions/runner-groups/new`.
+   Set "Repository access" to include `pytorch/pytorch` (and any other
+   repos that target `mt-…` labels).
+
+We do **not** need to migrate `arc-cbr-production` (us-east-2) off the
+`default` group. The asymmetry is functionally fine:
+
+- us-east-2 keeps registering in `default` (no change).
+- us-west-1 registers in `arc-cbr-prod-uw1` (new group).
+- For any shared label, GitHub matches across both groups → jobs route
+  to whichever cluster has capacity.
+
+Optional cleanup: a follow-up PR can create `arc-cbr-prod-ue2` and move
+us-east-2 into it for symmetry. Not required for HA to work.
+
+### Phase 1 prerequisite 2 — cluster-level `runner_group` override
+
+The generator (`generate_runners.py:147`) currently reads `runner_group`
+only from each runner def file. To set us-west-1's group cluster-wide
+without forking every def, we need a small generator change:
+
+- Read `clusters.<id>.arc-runners.runner_group` from `clusters.yaml`.
+- If set, override the value from the def file (subject to the existing
+  repo-scope guard at lines 187-191, which doesn't apply to us-west-1
+  since prod is org-scoped).
+- Add tests.
+
+The change is mechanically similar to the per-cluster
+`capacity_reservation_ids` override planned for H100 NodePools — same
+pattern, same place to add tests.
+
+### B200: omit from this cluster
+
+Don't add `nodepools-b200` / `arc-runners-b200` to the new cluster's
+`modules:` list. The `mt-l-…-b200-…` labels continue to be served only by
+us-east-2. No code change required; B200 simply isn't HA. Acceptable
+because there is no B200 capacity in us-west-1.
+
+### H100: per-cluster capacity-reservation override (no new module)
+
+Today `modules/nodepools-h100/defs/p5-48xlarge.yaml` hardcodes
+`cr-0c3f05dffb85ed832` (a us-east-2 reservation). The new cluster needs
+different CR IDs in us-west-1. Two ways to handle this:
+
+**Option A (recommended) — per-cluster override in `clusters.yaml`.**
+Extend the schema and teach the nodepools generator to read it:
+
+```yaml
+arc-cbr-production:
+  # … existing …
+  nodepools-h100:
+    capacity_reservation_ids: [cr-0c3f05dffb85ed832]
+
+arc-cbr-production-uw1:
+  # … existing …
+  nodepools-h100:
+    capacity_reservation_ids: [cr-XXXXXXXX, cr-YYYYYYYY]  # us-west-1
+```
+
+Generator change in
+`modules/nodepools/scripts/python/generate_nodepools.py`: after loading
+each def, if
+`clusters.<id>.<NODEPOOLS_MODULE_NAME>.capacity_reservation_ids` is set,
+override `nodepool.capacity_reservation_ids` before rendering. The
+`NODEPOOLS_MODULE_NAME` env var (already set by the `nodepools-h100` /
+`nodepools-b200` delegators) namespaces the override key naturally. Add
+unit tests under `modules/nodepools/scripts/python/`.
+
+Pros: one module, no duplication; reservation IDs live next to the rest of
+the cluster config; the same mechanism works for B200 once us-west-1
+reservations land later.
+
+Cons: ~30 lines + a test.
+
+**Option B — duplicate the module (`nodepools-h100-uw1`).**
+Faster (no code change), but creates a near-identical thin-delegator that
+must be kept in sync. AWS rotates reservation IDs periodically (see commit
+`767fce5` swapping B200 reservations) — duplication doubles that toil.
+
+**Decision: Option A.** Removes existing reservation-coupling debt while
+unblocking this work.
+
+### Region-specific items that won't auto-replicate
+
+- **Harbor pull-through cache** is per-cluster (good — no cross-region
+  pulls). Image mirroring runs during `deploy-base`.
+- **PyPI wheel cache** is per-cluster with its own EFS wheelhouse. The S3
+  wheel feeder upstream of OSDC writes to a single bucket — verify the new
+  region can read it, or add S3 replication / a second feeder.
+- **Git cache** is per-cluster; central StatefulSet clones independently.
+- **Grafana Cloud monitoring/logging**: same tenant; clusters are
+  distinguished by `cluster_name` label. No change.
+
+### clusters.yaml entry
+
+```yaml
+arc-cbr-production-uw1:
+  cluster_name: pytorch-arc-cbr-production-uw1
+  region: us-west-1
+  state_bucket: ciforge-tfstate-arc-cbr-prod-uw1
+  access_config:
+    authentication_mode: API_AND_CONFIG_MAP
+    cluster_admin_role_names: [osdc_gha_prod]
+  base:
+    vpc_cidr: "10.8.0.0/16"
+  git_cache:
+    central_replicas: 15
+    central_cpu_request: "10"
+    central_cpu_limit: "15"
+    central_memory_request: "10Gi"
+    central_memory_limit: "50Gi"
+  node_compactor:
+    min_node_age_seconds: 900
+  buildkit:
+    arm64_instance_type: c7gd.16xlarge
+    amd64_instance_type: m6id.24xlarge
+    pods_per_node: 2
+  arc-runners:
+    github_config_url: "https://github.com/pytorch"               # SAME as us-east-2 prod
+    github_secret_name: pytorch-arc-cbr-production                # SAME secret name
+    runner_name_prefix: "mt-"                                     # SAME → labels match
+    runner_group: "arc-cbr-prod-uw1"                              # DISTINCT from us-east-2's "default" → no collision
+  nodepools-h100:
+    capacity_reservation_ids: [cr-XXXXXXXX, cr-YYYYYYYY]          # us-west-1 reservations
+  pypi_cache:
+    replicas: 10
+  modules:
+    - karpenter
+    - arc
+    - nodepools
+    - nodepools-h100         # H100 only — B200 not yet available in us-west-1
+    - arc-runners
+    - arc-runners-h100
+    - buildkit
+    - pypi-cache
+    - cache-enforcer
+    - zombie-cleanup
+    - harbor-cache-recovery
+    - monitoring
+    - logging
+```
+
+### Deploy
+
+```bash
+just bootstrap arc-cbr-production-uw1
+just deploy-base arc-cbr-production-uw1
+# Plant the GitHub App Secret (pytorch-arc-cbr-production) into the new
+# cluster's arc-runners namespace, using the same App private key as us-east-2.
+just deploy arc-cbr-production-uw1
+```
+
+Pre-deploy gates (from `CLAUDE.md`): `just lint` and `just test` green.
+
+### Post-deploy validation
+
+1. `kubectl get autoscalingrunnersets -n arc-runners` on the new cluster —
+   every scale set in `RUNNING` state.
+2. On `https://github.com/organizations/pytorch/settings/actions/runner-groups/arc-cbr-prod-uw1`,
+   each `mt-…` scale set appears as a row with a healthy listener
+   heartbeat. The same names also appear in the `default` group (served
+   by us-east-2). Two groups, same names, both online.
+3. Trigger one small PR on `pytorch/pytorch` per shared label class
+   (CPU / ARM / GPU). Confirm at least one job lands on the new cluster
+   (verify by pod node region/AZ). Repeat dispatches should land on
+   either cluster roughly in proportion to available capacity.
+4. Smoke tests in `osdc/tests/`.
+5. Monitoring + logging flowing into Grafana Cloud tagged with the new
+   `cluster_name`.
+
+## Active/active capacity split
+
+Active/active falls out for free from the same-label-different-group
+registration — GitHub matches `runs-on` across all visible groups and
+routes by capacity, no extra wiring. Two starting points for
+`proactive_capacity` split between clusters:
+
+- **50/50.** Copy `defs/` as-is into both clusters. Doubles warm-pool cost
+  but maximizes burst headroom in either region.
+- **Skewed toward us-east-2 (incumbent).** First weeks: us-west-1 runs at
+  30–50% of prod proactive capacity to keep warm-pool spend in check while
+  trust builds. Two ways to express this:
+  - Edit `proactive_capacity` per def and accept that defs are now
+    cluster-aware (not great).
+  - Add a per-cluster multiplier (e.g.
+    `clusters.<id>.arc-runners.proactive_capacity_multiplier: 0.5`) and
+    apply it in `modules/arc-runners/scripts/python/generate_runners.py`.
+    Same shape as the H100 CR override change.
+
+**Recommendation for go-live:** start with 30% us-west-1 / 100% us-east-2
+to limit blast radius, then ramp us-west-1 to 100% once a week of
+production traffic shows clean routing. Use the multiplier approach so the
+ramp is one number in `clusters.yaml`, not a per-def edit.
+
+### Capacity-planning note
+
+Quotas and reservations in us-west-1 must be sized to **absorb 100% of
+prod traffic** in the failover case, not just the steady-state share.
+Otherwise the "HA" claim doesn't hold during a us-east-2 outage.
+
+## Open questions to resolve before Phase 1
+
+1. **Org runner group `arc-cbr-prod-uw1` created** by a pytorch org admin
+   with repository access including `pytorch/pytorch`.
+2. **Cluster-level `runner_group` override landed** in
+   `generate_runners.py` (small generator change + tests).
+3. **us-west-1 H100 CR IDs** — collect before writing the clusters.yaml
+   entry.
+4. **us-west-1 service-quota raises** — file early; some GPU families have
+   long lead times.
+5. **PyPI wheel S3 feeder** — does the existing producer write to a bucket
+   that us-west-1 can read, or do we need replication?
+6. **Proactive-capacity ramp plan** — confirm the start-at-30% approach
+   with the team, or pick the 50/50 default.
+
+## What we are NOT doing in Phase 1
+
+- B200 in us-west-1 (no capacity).
+- Cross-region Harbor / PyPI / git-cache sharing (each cluster stands
+  alone; this is by design and keeps the failure domains isolated).
+- Migrating us-east-2 off the `default` runner group. The asymmetry
+  (us-east-2 in `default`, us-west-1 in `arc-cbr-prod-uw1`) is functionally
+  equivalent. A follow-up PR can symmetrize later.
+- Workflow changes in `pytorch/pytorch` — the whole point of the
+  same-label-different-group design is that workflows are untouched.

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -182,6 +182,14 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     # Cluster-specific values
     github_url = cluster_config.get("github_config_url", "")
 
+    # Cluster-level runner_group override (e.g. multi-region prod assigns a
+    # per-region runner group so two clusters can share scale-set names without
+    # collision). When set, wins over the def file's value. The repo-scope
+    # guard below still applies.
+    cluster_runner_group = cluster_config.get("runner_group")
+    if cluster_runner_group:
+        runner_group = cluster_runner_group
+
     # Runner groups are an org-level GitHub concept. Repo-scoped githubConfigUrl
     # (e.g. github.com/org/repo) can't resolve runner groups — force "default".
     if runner_group != "default" and "github.com/" in github_url:

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -945,6 +945,56 @@ class TestGenerateRunner:
         docs = list(yaml.safe_load_all((output_dir / "rel-repo.yaml").read_text()))
         assert docs[0]["runnerGroup"] == "default"
 
+    def test_runner_group_cluster_override_wins(self, tmp_path):
+        """Cluster-level runner_group overrides the def file's value."""
+        # Def file says "release-runners"...
+        def_file = make_def_file(tmp_path, "ovr-def", "m6i.32xlarge", 4, 16, runner_group="release-runners")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        # ...but the cluster config says "arc-cbr-prod-uw1" — cluster wins.
+        cluster_config = {
+            "github_config_url": "https://github.com/pytorch",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "runner_group": "arc-cbr-prod-uw1",
+        }
+
+        generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners")
+        docs = list(yaml.safe_load_all((output_dir / "ovr-def.yaml").read_text()))
+        assert docs[0]["runnerGroup"] == "arc-cbr-prod-uw1"
+
+    def test_runner_group_cluster_override_no_def_value(self, tmp_path):
+        """Cluster-level runner_group applies even when the def doesn't set one."""
+        def_file = make_def_file(tmp_path, "ovr-nodef", "m6i.32xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "https://github.com/pytorch",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "runner_group": "arc-cbr-prod-uw1",
+        }
+
+        generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners")
+        docs = list(yaml.safe_load_all((output_dir / "ovr-nodef.yaml").read_text()))
+        assert docs[0]["runnerGroup"] == "arc-cbr-prod-uw1"
+
+    def test_runner_group_cluster_override_repo_scope_guard_still_wins(self, tmp_path):
+        """Repo-scoped URL still forces 'default' even when cluster sets a custom group."""
+        def_file = make_def_file(tmp_path, "ovr-repo", "m6i.32xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "https://github.com/pytorch/pytorch-canary",  # repo-scoped
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "runner_group": "arc-staging-uw2",
+        }
+
+        generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners")
+        docs = list(yaml.safe_load_all((output_dir / "ovr-repo.yaml").read_text()))
+        assert docs[0]["runnerGroup"] == "default"
+
     def test_runner_class_release(self, tmp_path):
         """Release runners get required runner-class affinity on the workflow pod;
         runner-class isolation does not apply to the runner pod (it lives on the

--- a/osdc/modules/nodepools/deploy.sh
+++ b/osdc/modules/nodepools/deploy.sh
@@ -37,6 +37,11 @@ CPU_CONSOLIDATE_AFTER=$(uv run "$CLUSTER_CONFIG" "$CLUSTER" nodepools.cpu_consol
 BAREMETAL_CONSOLIDATE_AFTER=$(uv run "$CLUSTER_CONFIG" "$CLUSTER" nodepools.baremetal_consolidate_after "")
 COMPACTOR_ENABLED=$(uv run "$CLUSTER_CONFIG" "$CLUSTER" node_compactor.enabled "false")
 
+# Cluster-level capacity_reservation_ids override, namespaced per module name
+# (e.g. `nodepools-h100.capacity_reservation_ids`). Empty if unset → generator
+# falls back to the value in each def file.
+CAPACITY_RESERVATION_IDS_OVERRIDE=$(uv run "$CLUSTER_CONFIG" "$CLUSTER" "${MODULE_NAME}.capacity_reservation_ids" "")
+
 # --- Step 1: Generate NodePools from definitions ---
 echo "Generating Karpenter NodePools from definitions..."
 NODEPOOLS_DEFS_DIR="$DEFS_DIR" \
@@ -49,6 +54,7 @@ NODEPOOLS_DEFS_DIR="$DEFS_DIR" \
   NODEPOOLS_CPU_CONSOLIDATE_AFTER="$CPU_CONSOLIDATE_AFTER" \
   NODEPOOLS_BAREMETAL_CONSOLIDATE_AFTER="$BAREMETAL_CONSOLIDATE_AFTER" \
   NODEPOOLS_COMPACTOR_ENABLED="$COMPACTOR_ENABLED" \
+  NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE="$CAPACITY_RESERVATION_IDS_OVERRIDE" \
   uv run "$MODULE_DIR/scripts/python/generate_nodepools.py"
 
 # --- Step 2: Apply NodePools (parallel) ---

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -138,6 +138,14 @@ def generate_nodepool_yaml(nodepool_def, module_name, defs_dir=None):
     capacity_type = nodepool_def.get("capacity_type", "on-demand")
     capacity_reservation_ids = nodepool_def.get("capacity_reservation_ids", [])
 
+    # Cluster-level override (set per cluster in clusters.yaml under e.g.
+    # `nodepools-h100.capacity_reservation_ids`). Used for multi-region prod
+    # where the same module ships shared defs but each cluster has its own
+    # capacity reservations. Wins over the def file's value when present.
+    cluster_cr_override = os.environ.get("NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE", "")
+    if cluster_cr_override:
+        capacity_reservation_ids = [s for s in cluster_cr_override.split(",") if s]
+
     # ----- Node compactor opt-in -----
     # NodePools labeled osdc.io/node-compactor are managed by the compactor
     # controller, which handles consolidation via NoSchedule taints instead

--- a/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/test_generate_nodepools.py
@@ -359,6 +359,52 @@ class TestGenerateNodepoolYaml:
         ec2 = docs[1]
         assert "capacityReservationSelectorTerms" not in ec2["spec"]
 
+    @patch.dict(
+        os.environ,
+        {"NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE": "cr-from-cluster-1,cr-from-cluster-2"},
+        clear=False,
+    )
+    def test_capacity_reservation_ids_cluster_override_wins(self):
+        """Cluster-level override replaces the def's capacity_reservation_ids."""
+        nodepool_def = _make_nodepool_def(
+            capacity_type="capacity-block",
+            capacity_reservation_ids=["cr-from-def"],  # should be ignored
+        )
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        terms = ec2["spec"]["capacityReservationSelectorTerms"]
+        ids = [t["id"] for t in terms]
+        assert ids == ["cr-from-cluster-1", "cr-from-cluster-2"]
+        assert "cr-from-def" not in ids
+
+    @patch.dict(
+        os.environ,
+        {"NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE": "cr-only-from-cluster"},
+        clear=False,
+    )
+    def test_capacity_reservation_ids_cluster_override_with_no_def_value(self):
+        """Cluster-level override applies even when the def has no reservations."""
+        nodepool_def = _make_nodepool_def(capacity_type="capacity-block")
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        terms = ec2["spec"]["capacityReservationSelectorTerms"]
+        assert [t["id"] for t in terms] == ["cr-only-from-cluster"]
+
+    @patch.dict(os.environ, {"NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE": ""}, clear=False)
+    def test_capacity_reservation_ids_empty_override_keeps_def_value(self):
+        """Empty override env var doesn't clobber the def's value."""
+        nodepool_def = _make_nodepool_def(
+            capacity_type="capacity-block",
+            capacity_reservation_ids=["cr-from-def"],
+        )
+        output = generate_nodepool_yaml(nodepool_def, "nodepools")
+        docs = self._parse(output)
+        ec2 = docs[1]
+        terms = ec2["spec"]["capacityReservationSelectorTerms"]
+        assert [t["id"] for t in terms] == ["cr-from-def"]
+
     @patch.dict(os.environ, {"NODEPOOLS_COMPACTOR_ENABLED": "true"}, clear=False)
     def test_compactor_enabled_sets_when_empty(self):
         nodepool_def = _make_nodepool_def()

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -128,6 +128,10 @@ def main():
                 sys.exit(1)
         elif isinstance(val, bool):
             print(str(val).lower())
+        elif isinstance(val, list):
+            # Comma-separated for shell consumption (used by nodepools deploy.sh
+            # to pass per-cluster capacity_reservation_ids into the generator).
+            print(",".join(str(v) for v in val))
         else:
             print(val)
 

--- a/osdc/scripts/test_cluster_config.py
+++ b/osdc/scripts/test_cluster_config.py
@@ -54,6 +54,12 @@ FAKE_CONFIG = {
             "cluster_name": "my-production",
             "region": "us-east-1",
             "modules": ["karpenter", "arc", "arc-runners", "buildkit", "monitoring"],
+            "nodepools-h100": {
+                "capacity_reservation_ids": ["cr-aaa111", "cr-bbb222"],
+            },
+            "nodepools-b200": {
+                "capacity_reservation_ids": [],
+            },
         },
     },
 }
@@ -371,6 +377,22 @@ class TestMain:
         code = run_main("staging", "feature_flag")
         assert code == 0
         assert capsys.readouterr().out.strip() == "true"
+
+    def test_list_value_comma_separated(self, capsys):
+        """List values print as comma-separated for shell consumption."""
+        code = run_main("production", "nodepools-h100.capacity_reservation_ids")
+        assert code == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "cr-aaa111,cr-bbb222"
+        # Must not look like a Python list repr
+        assert "[" not in out
+        assert "'" not in out
+
+    def test_empty_list_value(self, capsys):
+        """Empty list prints as empty string."""
+        code = run_main("production", "nodepools-b200.capacity_reservation_ids")
+        assert code == 0
+        assert capsys.readouterr().out.strip() == ""
 
     def test_bool_false_field_output(self, capsys):
         """Boolean False from defaults should print 'false'."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #585
* #584
* #587
* __->__ #583
* #580
* #581
* #586

Adds a per-cluster override for the capacity_reservation_ids that
were previously hardcoded in nodepool def files (e.g.
modules/nodepools-h100/defs/p5-48xlarge.yaml). The override key in
clusters.yaml is namespaced per module so b200 and h100 stay
independent:

    clusters:
      arc-cbr-production-uw1:
        nodepools-h100:
          capacity_reservation_ids:
            - cr-04d3d1d84e127a562
            - cr-09a53051589034fb8

This unblocks the multi-region prod design: one shared module def
file, different reservation IDs per region. The us-east-2 IDs in the
def file remain as the fallback when no cluster-level override is
set.

Implementation:

- cluster-config.py: print list values as comma-separated for shell
  consumption. Existing string/bool behaviors unchanged.
- modules/nodepools/deploy.sh: read clusters.<id>.<MODULE_NAME>.
  capacity_reservation_ids and pass as
  NODEPOOLS_CAPACITY_RESERVATION_IDS_OVERRIDE env var. MODULE_NAME
  comes from the nodepools-b200 / nodepools-h100 delegators, so the
  override key namespaces automatically.
- generate_nodepools.py: if the env var is set and non-empty, parse
  it (comma-separated) and override the def file's value. Empty
  string leaves the def value alone.

Adds 5 new tests:
- cluster-config.py list output format (comma-separated, empty list)
- Generator override wins over def value
- Override applies when def has no value set
- Empty override env var keeps def value intact

See osdc/docs/prod-cluster-ha-us-west-1.md "Phase 1 prerequisite 2"
for the broader context.