### PR TITLE
Add cluster recreation runbook and fix docs

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -70,6 +70,7 @@ Reference documentation in `docs/`:
 | `docs/observability.md` | Three-Alloy observability architecture — monitoring + logging pipelines to Grafana Cloud |
 | `docs/observability-estimates.md` | Per-unit cost estimates for metrics cardinality and log volume (Grafana Cloud billing) |
 | `docs/operations.md` | Operational prerequisites — AWS CLI, mise, working directory setup for cluster management |
+| `docs/ipv6-cluster-recreation.md` | Operator runbook for destroying and recreating an OSDC cluster as IPv6-only (accepted data losses: Harbor S3, EFS pypi-cache) |
 | `docs/loki_query.md` | CLI queries against Grafana Cloud Loki when kubectl logs is unavailable |
 | `docs/mimir_query.md` | CLI queries against Grafana Cloud Mimir (Prometheus metrics, no in-cluster Prometheus) |
 | `docs/runner_naming_convention.md` | Runner label format and the ~42 character name limit (ARC/K8s/Cilium constraints) |

--- a/osdc/base/node-compactor/kubernetes/deployment.yaml
+++ b/osdc/base/node-compactor/kubernetes/deployment.yaml
@@ -57,11 +57,11 @@ spec:
               value: "COMPACTOR_CAPACITY_RESERVATION_NODES_PLACEHOLDER"
           resources:
             requests:
-              cpu: "2"
-              memory: "4Gi"
+              cpu: "50m"
+              memory: "2Gi"
             limits:
-              cpu: "10"
-              memory: "10Gi"
+              cpu: "200m"
+              memory: "4Gi"
           livenessProbe:
             exec:
               command:

--- a/osdc/base/node-compactor/kubernetes/deployment.yaml
+++ b/osdc/base/node-compactor/kubernetes/deployment.yaml
@@ -57,11 +57,11 @@ spec:
               value: "COMPACTOR_CAPACITY_RESERVATION_NODES_PLACEHOLDER"
           resources:
             requests:
-              cpu: "50m"
-              memory: "2Gi"
-            limits:
-              cpu: "200m"
+              cpu: "2"
               memory: "4Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
           livenessProbe:
             exec:
               command:

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -14,13 +14,17 @@
 
 ## Helm Chart
 
-Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image and publishes the chart to GHCR.
+Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image (multi-arch `linux/amd64` + `linux/arm64`) and publishes the chart to GHCR.
 
 - **OCI registry**: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
 - **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.10`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
-- **Image tags**: `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (set during workflow dispatch — pass `release_tag_name=0.14.1-jeanschmidt.10` to match the chart)
+- **Image tags**: the workflow publishes two tags per build:
+  - `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (the rolling release tag — pass `release_tag_name=0.14.1-jeanschmidt.10` to match the chart)
+  - `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>-<short_sha>` (immutable tag with the source commit baked in, useful for pinning and debugging)
 
 To publish a new chart version, trigger `gha-publish-chart.yaml` from the fork's GitHub Actions UI with `publish_gha_runner_scale_set_controller_chart: true`.
+
+**Exact-match enforcement on `release_tag_name`**: the workflow's first step runs `hack/check-gh-chart-versions.sh ${{ inputs.release_tag_name }}` and rejects the build unless `release_tag_name` matches **all four** chart fields exactly — `version` and `appVersion` of both `gha-runner-scale-set-controller` and `gha-runner-scale-set`. Partial matches (e.g., just major.minor) fail at build time. The major.minor allowance described in "Controller Version Check" below is a runtime-only behavior of `IsVersionAllowed`, not a build-time relaxation.
 
 ## Using the Local Chart (dev workflow)
 
@@ -92,22 +96,26 @@ docker buildx build \
   --platform linux/amd64 \
   --build-arg VERSION=0.14.1 \
   --build-arg COMMIT_SHA=$(git rev-parse HEAD) \
-  -t localhost:30002/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1 \
+  -t localhost:8081/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1 \
   -f Dockerfile \
   --load .
 
 # Save to tarball for crane push (faster than docker push over port-forward)
-docker save localhost:30002/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1 -o /tmp/arc-controller.tar
+docker save localhost:8081/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1 -o /tmp/arc-controller.tar
 
-# Port-forward to Harbor (if not already running)
-kubectl port-forward -n harbor-system svc/harbor 30002:80 &
+# Port-forward to Harbor (if not already running).
+# Port 8081 matches the project convention used by every other deploy.sh
+# (modules/arc, modules/harbor-cache-recovery, base/node-compactor, etc.) —
+# pick the same port so concurrent port-forwards from `just deploy-module`
+# do not collide.
+kubectl port-forward -n harbor-system svc/harbor 8081:80 &
 
 # Authenticate crane with Harbor
 HARBOR_PASS=$(kubectl get secret -n harbor-system harbor-admin-password -o jsonpath='{.data.password}' | base64 -d)
-mise exec -- crane auth login localhost:30002 -u admin -p "$HARBOR_PASS" --insecure
+mise exec -- crane auth login localhost:8081 -u admin -p "$HARBOR_PASS" --insecure
 
 # Push via crane (much faster than docker push — deduplicates existing blobs)
-mise exec -- crane push --insecure /tmp/arc-controller.tar localhost:30002/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1
+mise exec -- crane push --insecure /tmp/arc-controller.tar localhost:8081/osdc/gha-runner-scale-set-controller:0.14.1-capacity.1
 ```
 
 **Tagging**: always use the `<chart_version>-capacity.<N>` format. Bump `<N>` for every new build — `IfNotPresent` pull policy means the same tag won't be re-pulled. Never use a static mutable tag like `latest` or `proactive-capacity` in production. Never use a `v` prefix on `VERSION` — the controller's semver parser does not strip it and will fail the version check.
@@ -167,7 +175,8 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_RUNNER_CPU` | `750m` | `750m` | Runner placeholder CPU request — **must match the runner container's actual CPU request/limit** |
 | `CAPACITY_AWARE_RUNNER_MEMORY` | `512Mi` | `1Gi` | Runner placeholder memory request — **must match the runner container's actual memory request/limit**. The template value (`1Gi`) is the operative value; the code default (`512Mi`) would under-reserve and defeat the topology guarantee. |
 | `CAPACITY_AWARE_NODE_FLEET` | _(empty)_ | `{{NODE_FLEET}}` (from runner def) | Node fleet for placeholder-workflow scheduling (workflow pool, per-scale-set) |
-| `CAPACITY_AWARE_RUNNER_NODE_FLEET` | _(empty)_ | `c7i-runner` | **Required when `CAPACITY_AWARE_ENABLED=true`** — the dedicated runner-pool fleet for placeholder-runner scheduling. `Validate()` returns an error if missing. Cluster-wide value (currently `c7i-runner`). See "Dedicated Runner NodePool" in `PROACTIVE_CAPACITY.md`. |
+| `CAPACITY_AWARE_RUNNER_NODE_FLEET` | _(empty)_ | `c7i-runner` | **Required when `CAPACITY_AWARE_ENABLED=true`** — the cluster-wide runner-pool fleet for placeholder-runner scheduling (currently `c7i-runner`). `Validate()` returns an error if missing. Distinct from `CAPACITY_AWARE_NODE_FLEET` above: runner placeholders always land on the cluster-wide runner pool, while workflow placeholders land on the per-scale-set workflow pool. |
+| `CAPACITY_AWARE_HUD_FAILURE_MULTIPLIER` | `3` | _(unset — uses code default)_ | When the HUD API is unreachable, the capacity monitor over-provisions placeholders to `ProactiveCapacity * multiplier`. Outer caps (`MaxRunners` headroom, `MaxBurstCapacity`) bound the absolute blast radius. Clamped to a minimum of `1`. |
 | `CAPACITY_AWARE_RUNNER_CLASS` | _(empty)_ | `{{RUNNER_CLASS}}` (from runner def) | Runner class for placeholder node selector |
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
@@ -186,11 +195,11 @@ The template mounts this as optional (`optional: true`), so missing the secret d
 
 ## Adding maxRunners to a Runner Definition
 
-Add `max_runners: <value>` to the runner def YAML. Most existing defs also set `proactive_capacity` and `max_burst_capacity` — copy those too unless you specifically want to opt out of proactive capacity. Example:
+Add `max_runners: <value>` to the runner def YAML. Most existing defs also set `proactive_capacity` and `max_burst_capacity` — copy those too unless you specifically want to opt out of proactive capacity. Example (fictitious def, for illustration only):
 
 ```yaml
 runner:
-  name: l-x86iavx512-8-16
+  name: l-x86example-8-16
   instance_type: c7a.48xlarge
   vcpu: 8
   memory: 16Gi
@@ -203,7 +212,12 @@ runner:
 
 This flows through the template as `maxRunners:` in the generated Helm values (the chart's standard scaling field — `gha_max_runners` at `runner.yaml.tpl:73` is an unrelated Prometheus metric). The capacity monitor reads `config.MaxRunners` (set from the listener config) and uses it as the ceiling for `X-ScaleSetMaxCapacity`. Without `max_runners`, the value is empty/unlimited.
 
-H100 (`modules/arc-runners-h100/defs/`) and B200 (`modules/arc-runners-b200/defs/`) runners all set `max_runners` (1, 2, 4, or 8 depending on GPU split). CPU/T4/A10G/L4/A100 runner defs currently do not set `max_runners`.
+H100 (`modules/arc-runners-h100/defs/`) and B200 (`modules/arc-runners-b200/defs/`) runners all set `max_runners`, computed as `(reserved GPUs / GPUs per runner)`:
+
+- H100 has 1 reserved 8-GPU node (8 total GPUs). Per-split values: `8 / 4 / 2 / 1` for 1× / 2× / 4× / 8× splits.
+- B200 has 2 reserved 8-GPU nodes (16 total GPUs). Per-split values: `16 / 8 / 4 / 2` for 1× / 2× / 4× / 8× splits.
+
+CPU/T4/A10G/L4/A100 runner defs currently do not set `max_runners`.
 
 ## Load Testing the Capacity Monitor
 
@@ -244,7 +258,7 @@ If the capacity monitor is NOT starting despite `CAPACITY_AWARE_ENABLED=true`, t
 
 On ARC upgrades:
 1. Check if `cmd/ghalistener/main.go` changed (the entry point wiring -- our changes are in the capacity monitor errgroup block)
-2. Check if `github.com/actions/scaleset` changed (specifically `listener.SetMaxRunners()` and `listener.Config`)
+2. Check if `github.com/actions/scaleset/listener` changed (specifically `listener.SetMaxRunners()` and `listener.Config` — that sub-package is the API surface we depend on)
 3. Rebase the fork's `master` branch onto upstream master
 4. Rebuild and push the image to Harbor
 

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -10,12 +10,12 @@ OSDC (Open Source Dev Cloud) is a modular platform for deploying Kubernetes-base
 
 Every cluster gets the same base infrastructure:
 
-- **VPC** — dual-stack (IPv4 + IPv6) public/private subnets, NAT gateways for IPv4, Egress-Only Internet Gateway for IPv6 outbound from private subnets, route tables
-- **EKS** — managed Kubernetes cluster with OIDC, addons (vpc-cni, coredns, kube-proxy, ebs-csi), fixed-size base node group
+- **VPC** — dual-stack (IPv4 + IPv6) public/private subnets, NAT gateways for IPv4, Egress-Only Internet Gateway for IPv6 outbound from private subnets, route tables. AZ-aware `private_subnets_by_az` output feeds the ENIConfig deploy step.
+- **EKS** — managed Kubernetes cluster with **IPv6-only pod networking** (`kubernetes_network_config.ip_family = "ipv6"`, immutable after cluster creation — see `docs/ipv6-cluster-recreation.md`). The Service CIDR is auto-assigned by EKS to a ULA in `fd00:ec2::/108`; pods receive IPv6 IPs from a `/80` prefix per node via VPC CNI prefix delegation (`ENABLE_PREFIX_DELEGATION=true`); IPv4 egress is enabled via SNAT (`ENABLE_V4_EGRESS=true`) so pods can reach IPv4-only external services (github.com, ghcr.io, nvcr.io). Includes OIDC for IRSA, addons (vpc-cni, coredns, kube-proxy, ebs-csi), KMS envelope encryption for secrets at rest (auto-rotated), CloudWatch control-plane logging (`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`), EKS access entries for cluster admin roles, pinned CoreDNS topology (replica count set per-cluster, autoscaling disabled, zone/hostname spread, PDB), and a fixed-size base node group tainted `CriticalAddonsOnly=true:NoSchedule`.
 - **Harbor** — S3 bucket, IAM roles/user for pull-through container image cache
-- **Base k8s resources** — gp3 StorageClass, NVIDIA device plugin, node performance tuning DaemonSet, git-cache (two-tier: central StatefulSet + rsync DaemonSet), Harbor namespace, image-cache-janitor (prunes stale image content from node disks), NodeLocal DNSCache (per-node CoreDNS DaemonSet that intercepts pod DNS via iptables-mode NOTRACK)
-- **Node compactor** — Taints underutilized Karpenter nodes for workload consolidation (configurable via `clusters.yaml`)
-- **Karpenter** — installed as a module but required for the autoscaling story; deployed before any compute-provisioning module
+- **Base k8s resources** — `osdc-system` namespace (used by deploy audit ConfigMaps), gp3 StorageClass, NVIDIA device plugin, node performance tuning DaemonSet, registry mirror config, git-cache (two-tier: central StatefulSet + rsync DaemonSet), Harbor namespace, image-cache-janitor (prunes stale image content from node disks), NodeLocal DNSCache (per-node CoreDNS DaemonSet binding `fd00::10`, intercepts pod DNS via iptables-mode NOTRACK), ENIConfigs (one per AZ; currently inert pending VPC CNI Custom Networking enablement), and two transient CVE-mitigation DaemonSets (`algif-mitigation` for CVE-2026-31431, `dirtyfrag-mitigation` for CVE-2026-43284) that will be removed once a kernel-patched AMI is in use.
+- **Node compactor** — taints underutilized Karpenter nodes for workload consolidation; enabled by default and can be disabled per-cluster via `clusters.yaml`.
+- **Karpenter** — packaged as a module under `modules/karpenter/` but is a prerequisite for any compute-provisioning module; clusters list it first in their `modules:` block.
 
 The base terraform is a single parameterized root that lives at `modules/eks/terraform/` (the `base/terraform/` directory contains no `.tf` files — it is leftover state cruft and should be ignored). Variables flow from `clusters.yaml` through the justfile as `-var` flags.
 
@@ -34,7 +34,7 @@ Current modules:
 
 | Module | Purpose |
 |--------|---------|
-| `karpenter` | Karpenter controller — IAM roles, SQS interruption queue, EventBridge rules, Helm install (deployed first; required by all compute modules) |
+| `karpenter` | Karpenter controller — IAM roles, SQS interruption queue, EventBridge rules, Helm install. Required by all compute modules; clusters list it first in their `modules:` block. |
 | `arc` | GitHub Actions Runner Controller — installs the ARC Helm chart |
 | `nodepools` | Karpenter NodePools generated from `defs/` — multi-flavor compute provisioning (CPU/GPU, runner vs build, metal variants) |
 | `nodepools-b200` | B200 GPU NodePools — delegates to upstream nodepools deploy with B200-specific definitions |
@@ -63,13 +63,22 @@ clusters:
     base:
       vpc_cidr: "10.0.0.0/16"
       single_nat_gateway: true
-      base_node_count: 5
+      base_node_count: 2
     modules:
+      - karpenter
       - arc
       - nodepools
       - arc-runners
       - buildkit
+      - pypi-cache
+      - cache-enforcer
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
 ```
+
+The above is abbreviated for illustration; see `clusters.yaml` for the full per-cluster blocks (CoreDNS sizing, Harbor replicas, ARC tuning, runner config, etc.).
 
 Adding a cluster = adding an entry. Adding a module to a cluster = appending to the `modules` list.
 
@@ -81,19 +90,26 @@ just deploy <cluster-id>
 ├── deploy-base
 │   ├── tofu apply (modules/eks/terraform/)         ← VPC, EKS, Harbor S3
 │   ├── mirror-images                               ← Harbor images to ECR
-│   ├── kubectl apply -k base/kubernetes/           ← StorageClass, NVIDIA, image-cache-janitor, etc.
+│   ├── kubectl apply -k base/kubernetes/           ← StorageClass, NVIDIA, CVE-mitigation DaemonSets, etc.
 │   ├── git-cache/deploy.sh                         ← Git cache central StatefulSet
-│   ├── eniconfigs/deploy.sh                          ← AZ-named ENIConfig CRs (one per AZ from terraform output)
+│   ├── eniconfigs/deploy.sh                        ← AZ-named ENIConfig CRs (one per AZ from terraform output; currently inert)
 │   ├── deploy-harbor                               ← Helm install Harbor (pull-through cache)
 │   ├── node-compactor/deploy.sh                    ← if enabled in clusters.yaml
 │   ├── image-cache-janitor/deploy.sh               ← prunes stale image content from node disks
 │   └── nodelocaldns/deploy.sh                      ← per-node CoreDNS cache (resolves kube-dns ClusterIP at apply time)
 │
-└── deploy-module (for each module in order)
-    ├── tofu apply (modules/<mod>/terraform/)        ← if exists
-    ├── kubectl apply -k (modules/<mod>/kubernetes/) ← if exists
-    └── modules/<mod>/deploy.sh                      ← if exists
+├── deploy-module (for each module in order)
+│   ├── tofu apply (modules/<mod>/terraform/)        ← if exists
+│   ├── kubectl apply -k (modules/<mod>/kubernetes/) ← if exists
+│   └── modules/<mod>/deploy.sh                      ← if exists
+│
+└── post-deploy (driven by clusters.yaml + env vars)
+    ├── recycle-nodes      ← if recycle_karpenter_nodes=true (staging default; replaces all Karpenter nodes for fresh userData/AMI)
+    ├── taint-nodes        ← unless recycling; OSDC_TAINT_NODES=yes|no|ask (default: ask; production default)
+    └── smoke              ← OSDC_SMOKE=yes|no|ask (default: ask)
 ```
+
+Every `deploy`, `deploy-base`, and `deploy-module` invocation also writes start/finish ConfigMaps to the `osdc-system` namespace; surface them via `just deploy-history <cluster>` and `just deploy-status <cluster>`.
 
 ## Terraform State Architecture
 

--- a/osdc/docs/cluster-recreation.md
+++ b/osdc/docs/cluster-recreation.md
@@ -1,0 +1,487 @@
+# Cluster Recreation Runbook
+
+## What this is and when to use it
+
+Operator-facing runbook for destroying and recreating an existing OSDC cluster. Use this whenever a planned change touches a property of `aws_eks_cluster` (or one of its directly-dependent resources) that is **immutable after cluster creation** and that AWS rejects in-place with a ForceNew plan.
+
+Common triggers:
+
+- IP family change (`kubernetes_network_config.ip_family`: `ipv4` ↔ `ipv6`)
+- Service CIDR change (`kubernetes_network_config.service_ipv4_cidr` / `service_ipv6_cidr`)
+- KMS encryption added to a previously-unencrypted cluster (`encryption_config`)
+- Any other field on `aws_eks_cluster` (or the VPC it lives in) that the AWS API refuses to mutate
+
+Per-cluster: do `arc-staging` (us-west-1) first, then `arc-cbr-production` (us-east-2) once staging has soaked. Never pipeline both clusters.
+
+**The code change that enables the new cluster shape MUST already be merged to `main` and CI must be green.** `just deploy <cluster>` after destroy is what brings up the new cluster — there is no manual override path.
+
+Accepted data losses (default; audit per migration):
+
+- **Harbor S3 bucket** (`<cluster_name>-harbor-registry`) is destroyed. All cached image layers are gone. Re-cached lazily from upstream over weeks as runners pull images.
+- **EFS pypi-cache wheelhouse** is destroyed. Wheels rebuild from the upstream S3 wheel pipeline over days.
+- Any other in-cluster state that is not preserved by terraform (cluster-local PVCs, in-cluster secrets created at runtime, ConfigMaps written by controllers, etc.).
+
+**Operator action**: before scheduling the maintenance window, audit every module being destroyed for data the operator does not want to lose. Surface anything ambiguous to stakeholders. If anything unacceptable surfaces, design preservation steps and add them to this runbook (or a migration-specific addendum) BEFORE proceeding.
+
+Out of scope for this runbook:
+
+- The migration-specific code changes themselves — those must be merged before following this runbook
+- Harbor S3 / EFS data preservation (design separately if the migration cannot tolerate the default loss)
+- Dependency / tool / image version bumps
+
+---
+
+## Pre-flight checklist
+
+### Pre-flight commands
+
+Read-only sanity checks. Run these BEFORE destroying anything. If any do not match expectations, STOP.
+
+```bash
+# Verify AWS account
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws sts get-caller-identity --query 'Account' --output text
+# Expected: 308535385114
+
+# Verify kubectl context (after just kubeconfig <cluster>)
+NO_PROXY="$NO_PROXY,.eks.amazonaws.com" no_proxy="$no_proxy,.eks.amazonaws.com" \
+  mise exec -- kubectl config current-context
+# Expected: arn:aws:eks:<region>:308535385114:cluster/<cluster_name>
+
+# Verify mise tools
+mise doctor
+
+# Verify just/uv/tofu versions
+just --version
+uv --version
+tofu version
+```
+
+### Checklist
+
+Complete every item before scheduling the maintenance window.
+
+- [ ] All migration code merged to `main` and CI green (`just lint`, `just test`)
+- [ ] Any out-of-band image / hook bumps required by the migration are deployed (handled outside this runbook)
+- [ ] Grafana dashboards verified: cluster-name labels match what the recreated cluster will use (`pytorch-arc-staging`, `pytorch-arc-cbr-production`) so panels stay continuous across recreation
+- [ ] AWS quotas in the target region:
+  - `L-FE5A380F` (NAT GWs / AZ): ≥ 1 per AZ (current default of 5 is plenty)
+  - Any AWS quotas the migration-specific changes introduce — operator must enumerate per migration
+- [ ] Data audit complete (see "Accepted data losses" above) — preservation steps in place for anything not safe to lose
+- [ ] Maintenance window communicated to pytorch/pytorch on-call and any stakeholders consuming the cluster
+- [ ] On-call reviewer paired for the cutover (2 people on the bridge)
+- [ ] State-bucket backup directory created locally: `mkdir -p ${HOME}/.osdc-cutover/${CLUSTER}`
+
+---
+
+## Per-cluster sequence
+
+Run the steps below per cluster, in order. Do NOT pipeline staging and production — staging must complete its soak before production starts.
+
+> **Shell prerequisite — set `CLUSTER` once, up front.** Every code block below references `${CLUSTER}` (e.g. `uv run scripts/cluster-config.py ${CLUSTER} cluster_name`, `just deploy ${CLUSTER}`, S3 keys under `s3://$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)/...`). If it's unset, commands either no-op confusingly or — worse — target the wrong bucket/region. Export it at the start of the session and keep working in the same shell.
+>
+> Also source `scripts/state-config.sh` so `STATE_REGION` is in scope for the state-bucket and DynamoDB commands below.
+>
+> ```bash
+> export CLUSTER=arc-staging          # or arc-cbr-production
+> source scripts/state-config.sh      # exports STATE_REGION
+> ```
+>
+> If you open a new shell mid-cutover, re-export it before resuming.
+
+### 1. Disable OSDC traffic
+
+Flip the OSDC experiment / GK that gates user traffic into the cluster. New jobs stop being routed; in-flight jobs continue until drained in step 2.
+
+### 2. Drain runners
+
+```bash
+just drain-runners ${CLUSTER}
+```
+
+This patches every `AutoScalingRunnerSet` to `maxRunners=0`, taints runner nodes, and polls until pod count is zero or the timeout (default 1h) hits.
+
+For stragglers: operator decides whether to wait (re-run with `OSDC_DRAIN_TIMEOUT_SECS=<larger>`) or force-terminate via `kubectl delete pod -n arc-runners --grace-period=0 --force <pod>`. Force-termination leaks job state at the GitHub side — coordinate with pytorch/pytorch on-call.
+
+Verify:
+
+```bash
+kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner --no-headers | wc -l   # must be 0
+```
+
+Once runner pods are gone, tear down Karpenter-managed compute so the destroy doesn't stall on lingering EC2.
+
+**Order matters.** Delete NodePools FIRST — Karpenter cascade-deletes the owned NodeClaims and gracefully terminates the EC2 instances via its `karpenter.sh/termination` finalizer. Deleting NodeClaims first leaves orphans Karpenter cannot reconcile (see Recovery below).
+
+```bash
+kubectl delete nodepools --all
+```
+
+This also stops re-provisioning: `drain-runners` only zeroes out ARC `AutoScalingRunnerSet` capacity, but non-ARC workloads (buildkit, pypi-cache, monitoring DaemonSets) keep requesting nodes. With no NodePool spec left, Karpenter has nothing to provision from. Buildkit / pypi-cache pods sit Pending until `tofu destroy` removes their controllers — that's fine.
+
+Wait for NodeClaims to drain:
+
+```bash
+kubectl get nodeclaims    # expect: No resources found
+```
+
+If they hang in `Terminating` (status: `Ready=False`, non-empty `metadata.deletionTimestamp`), see Recovery below.
+
+#### Recovery: stuck NodeClaim finalizers
+
+Symptom: `kubectl get nodeclaims` keeps showing the same NodeClaims with the same names, and `kubectl delete --wait=false` "deletes" them but they reappear. Karpenter controller logs spam `NodePool.karpenter.sh "<name>" not found (nodeclaim=<x>, nodepool=<name>)`. The `karpenter.sh/termination` finalizer never clears because the controller's reconciler errors out before it gets to the finalizer-removal step.
+
+Fix: terminate the orphan EC2 instances directly, then force-clear the finalizers.
+
+```bash
+# 1) Find Karpenter-managed instances for this cluster.
+#    Tag for cluster scoping is `eks:eks-cluster-name` (NOT `karpenter.sh/cluster`,
+#    which doesn't exist).
+CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
+REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
+INSTANCES=$(NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws ec2 describe-instances --region "${REGION}" \
+    --filters "Name=tag-key,Values=karpenter.sh/nodepool" \
+              "Name=tag:eks:eks-cluster-name,Values=${CNAME}" \
+              "Name=instance-state-name,Values=running,pending,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+echo "$INSTANCES"
+
+# 2) Terminate them. Without this the VPC destroy in step 6 will fail
+#    because the instances still hold ENIs in the soon-to-be-destroyed subnets.
+[[ -n "$INSTANCES" ]] && NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws ec2 terminate-instances --region "${REGION}" --instance-ids $INSTANCES
+
+# 3) Force-strip the finalizers so the k8s objects clean up.
+kubectl get nodeclaims -o name | xargs -r -I{} \
+  kubectl patch {} --type=merge -p '{"metadata":{"finalizers":null}}'
+```
+
+Steps 1+2 are the load-bearing ones — they kill the actual AWS resources. Step 3 just unblocks the k8s objects so `kubectl get nodeclaims` returns empty.
+
+### 3. Capture pre-cutover state
+
+```bash
+export STATE_DIR=${HOME}/.osdc-cutover/${CLUSTER}
+mkdir -p ${STATE_DIR}
+
+BUCKET=$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)
+
+# Tofu state for every module (in case of partial-recovery debugging)
+for mod in $(uv run scripts/cluster-config.py ${CLUSTER} modules) base; do
+  KEY="${CLUSTER}/${mod}/terraform.tfstate"
+  NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+    aws s3 cp "s3://${BUCKET}/${KEY}" \
+      "${STATE_DIR}/${mod}.tfstate" --region ${STATE_REGION} || true
+done
+
+# ConfigMap snapshot (deploy history, harbor secrets, etc.)
+kubectl get cm -A -o yaml > ${STATE_DIR}/configmaps-pre-cutover.yaml
+
+# CronJob suspend state (so step 9 only un-suspends entries originally false)
+kubectl get cronjobs -A -o json \
+  | jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name) \(.spec.suspend // false)"' \
+  > ${STATE_DIR}/cronjob-state-pre-cutover.txt
+
+# Grafana baseline metrics
+# Capture the dashboard URLs you want to compare post-cutover. Suggested:
+#   - pod startup time P50/P99
+#   - kube-apiserver p99 latency
+#   - CoreDNS QPS, node-local DNS health
+#   - NAT GW egress bytes
+#   - Any migration-specific panels
+echo "Capture baseline panel screenshots / CSVs from Grafana now." >&2
+```
+
+Treat `${STATE_DIR}` as sensitive — do not commit, keep on operator workstation.
+
+### 4. Suspend CronJobs
+
+```bash
+kubectl get cronjobs -A -o json \
+  | jq -r '.items[] | select(.spec.suspend != true) |
+           "kubectl -n \(.metadata.namespace) patch cronjob \(.metadata.name) -p '\''{\"spec\":{\"suspend\":true}}'\''"' \
+  | bash
+```
+
+This prevents scheduled work (zombie-cleanup, harbor-cache-recovery, image-cache-janitor) from racing the destroy.
+
+### 5. Empty Harbor S3 bucket
+
+`aws_s3_bucket.harbor_registry` is declared **without `force_destroy = true`** — `tofu destroy` will refuse on a non-empty bucket. Drain the bucket first:
+
+```bash
+CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
+REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3 rm "s3://${CNAME}-harbor-registry" --recursive --region ${REGION}
+
+# If versioning is on, also delete versions + delete-markers (paginated)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3api list-object-versions --bucket ${CNAME}-harbor-registry --region ${REGION} \
+    --output json | jq -r '
+      [.Versions // [], .DeleteMarkers // []] | flatten |
+      .[] | "\(.Key)\t\(.VersionId)"' \
+  | while IFS=$'\t' read -r k v; do
+      aws s3api delete-object --bucket ${CNAME}-harbor-registry --key "$k" --version-id "$v" --region ${REGION}
+    done
+```
+
+The pypi-cache module uses EFS (not S3), so no equivalent step is needed there — `aws_efs_file_system` destroys cleanly even when populated.
+
+### 6. Tofu destroy modules in dependency order
+
+#### Recommended: run the helper script
+
+```bash
+./scripts/destroy-cluster.sh ${CLUSTER}
+```
+
+The script encodes the dependency order, picks the right `-var` set per module (modules need `cluster_name` / `aws_region` / `state_bucket` / `cluster_id`; the base needs the full `tfvars` string from `scripts/cluster-config.py ${CLUSTER} tfvars`), uses the cluster's actual `state_bucket` (production is `ciforge-tfstate-arc-cbr-prod`, not `…-arc-cbr-production`), and gates the base destroy behind a second confirmation prompt. It does NOT empty the Harbor S3 bucket — step 5 must be run first.
+
+Env-var overrides:
+
+- `OSDC_CONFIRM=yes` — skip the up-front "type the cluster name" prompt
+- `OSDC_CONFIRM_BASE=destroy` — skip the final "type 'destroy <cluster>'" prompt before the base destroy
+
+Only modules that have a `terraform/main.tf` (`karpenter`, `pypi-cache`, and the base `modules/eks`) are tofu-destroyed. Every other module is k8s-only and dies with the EKS cluster — the script lists them under "k8s-only modules" but does not act on them.
+
+If the script fails partway through, fix the underlying issue and re-run — `tofu destroy` is idempotent against already-destroyed state.
+
+#### Manual procedure (use only when bypassing the script)
+
+Destroy in **reverse-deploy order**: leaf modules first, base last. `tofu init -reconfigure` in each module directory before `destroy`; pass the same `-var` flags the deploy uses.
+
+Compute the base tfvars string once:
+
+```bash
+TFVARS=$(uv run scripts/cluster-config.py ${CLUSTER} tfvars)
+BUCKET=$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)
+CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
+REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
+```
+
+`TFVARS` matches the **base** schema only — module destroys reject the extra vars; pass just `-var="cluster_name=${CNAME}" -var="aws_region=${REGION}" -var="state_bucket=${BUCKET}" -var="cluster_id=${CLUSTER}"` for those.
+
+Destroy order (reverse of the cluster's `modules` list in `clusters.yaml`, ending at the base):
+
+1. **Leaf cron / enforcement modules** (no dependents):
+   - `modules/harbor-cache-recovery`
+   - `modules/zombie-cleanup`
+   - `modules/cache-enforcer`
+2. **Observability**:
+   - `modules/logging`
+   - `modules/monitoring`
+3. **Workload modules** (depend on arc / nodepools):
+   - `modules/buildkit`
+   - `modules/arc-runners-h100` (production only)
+   - `modules/arc-runners-b200` (production only)
+   - `modules/arc-runners`
+   - `modules/arc`
+4. **Compute provisioning**:
+   - `modules/nodepools-h100` (production only)
+   - `modules/nodepools-b200` (production only)
+   - `modules/nodepools`
+   - `modules/karpenter`
+5. **PyPI cache** — **WARNING**: EFS file system + wheelhouse data is destroyed.
+   - `modules/pypi-cache`
+6. **Base / EKS** — **WARNING**: Harbor S3 bucket (already emptied in step 5), VPC, EKS control plane, base node group, IAM roles, KMS keys all destroyed.
+   - `modules/eks` (state key `${CLUSTER}/base/terraform.tfstate`)
+
+Per-module command pattern:
+
+```bash
+cd modules/<mod>/terraform
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  tofu init -reconfigure \
+    -backend-config="bucket=${BUCKET}" \
+    -backend-config="key=${CLUSTER}/<mod>/terraform.tfstate" \
+    -backend-config="region=${STATE_REGION}" \
+    -backend-config="dynamodb_table=ciforge-terraform-locks"
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  tofu destroy -auto-approve \
+    -var="cluster_name=${CNAME}" \
+    -var="aws_region=${REGION}" \
+    -var="state_bucket=${BUCKET}" \
+    -var="cluster_id=${CLUSTER}"
+cd -
+```
+
+For the base, the key is `${CLUSTER}/base/terraform.tfstate` (not `${CLUSTER}/eks/...`), and the destroy must use the full base var set:
+
+```bash
+cd modules/eks/terraform
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  tofu init -reconfigure \
+    -backend-config="bucket=${BUCKET}" \
+    -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
+    -backend-config="region=${STATE_REGION}" \
+    -backend-config="dynamodb_table=ciforge-terraform-locks"
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  eval tofu destroy ${TFVARS} -auto-approve
+cd -
+```
+
+Hangs to expect:
+
+- `aws_eks_cluster` destroy can stall ~10 min while EKS deletes the control plane
+- `aws_nat_gateway` destroy waits ~5 min for the NAT to drain
+- `aws_efs_file_system` destroy fails if mount targets aren't gone — `tofu destroy` deletes them in the same plan, but a half-applied destroy may need a retry
+- `aws_eks_addon.vpc_cni` may stall if it can't reach the API server because the cluster is half-gone — re-run destroy
+
+### 7. Verify survivors
+
+After base destroy completes, spot-check that NON-cluster resources are untouched:
+
+```bash
+# ECR mirrors (separate from Harbor S3 — these survive)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws ecr describe-repositories --region ${REGION} | jq '.repositories | length'
+
+# Tofu state bucket (lives in us-west-2 regardless of cluster region)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3 ls "s3://${BUCKET}/" --region ${STATE_REGION}
+
+# DynamoDB lock table (shared across all clusters)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws dynamodb describe-table --table-name ciforge-terraform-locks --region ${STATE_REGION} \
+    --query 'Table.TableStatus'
+
+# S3 wheel pipeline bucket (external to OSDC, feeds pypi-cache)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3 ls "s3://pytorch-pypi-wheel-cache/" --region us-east-2 | head -5
+
+# Grafana Cloud — verify dashboards still respond (browser check)
+```
+
+If anything cluster-related is left over (orphaned ENIs, NAT GW, EIP, security groups stuck on `cluster_security_group`), clean up by hand before redeploying — leftovers can collide with the recreated cluster.
+
+### 8. Bootstrap state (only if state bucket was destroyed) and redeploy
+
+The state bucket persists across recreation because it is bootstrapped via `scripts/bootstrap-state.sh` (not part of `modules/eks`). Skip the bootstrap step unless you also nuked the state bucket on purpose. If you did:
+
+```bash
+just bootstrap ${CLUSTER}
+```
+
+Then full deploy:
+
+```bash
+just deploy ${CLUSTER}
+```
+
+This applies base (VPC, EKS, Harbor S3/IAM, base k8s resources), then every module in the order defined in `clusters.yaml`.
+
+### 9. Smoke tests
+
+```bash
+just smoke ${CLUSTER}
+```
+
+Runs the per-base and per-module smoke suite under `modules/eks/tests/smoke/` and each module's `tests/smoke/`. All must pass before resuming traffic. Migrations that introduce new invariants should add assertions to the relevant smoke test before merging — those assertions then become a deploy-time gate here.
+
+### 10. Restore CronJobs
+
+Only un-suspend CronJobs that were `false` originally (preserves any CronJob suspended for unrelated reasons):
+
+```bash
+awk '$2=="false"{print $1}' ${STATE_DIR}/cronjob-state-pre-cutover.txt \
+  | while IFS=/ read -r ns name; do
+      kubectl -n "$ns" patch cronjob "$name" -p '{"spec":{"suspend":false}}'
+    done
+```
+
+### 11. Re-enable runner traffic
+
+`just deploy` already re-synced every `AutoScalingRunnerSet` from `modules/arc-runners/defs/`, so `maxRunners` is back at the def value. Re-enable the OSDC experiment / GK and watch the queue drain.
+
+`just resume-runners` is NOT used in standard cutover — it's out-of-band recovery only.
+
+---
+
+## Validation gates
+
+Per cluster, all gates must pass within the maintenance window before declaring cutover complete and starting the soak.
+
+| Gate | Check | Pass criterion |
+|---|---|---|
+| Cluster up | `kubectl get nodes -o wide` | All `Ready`; node count matches `base_node_count` for the cluster |
+| Pod-to-internet egress | `kubectl run -it --rm --image=curlimages/curl curl-test -- curl -sI https://github.com/` | HTTP 200 |
+| Harbor proxy | `kubectl run -it --rm --image=<harbor>/dockerhub-proxy/library/alpine:latest pull-test -- echo ok` | Image pulls — proxy fetches from upstream (cold cache) |
+| pypi-cache | `kubectl exec <runner-class pod> -- pip install --index-url http://pypi-cache.pypi-cache.svc/simple/cuda-12.6.3/ requests` | Wheel fetched via pypi-cache (proxy-fetches from upstream on miss) |
+| Distributed test (production only) | NCCL / `torch.distributed` 2-node smoke test on H100 or B200 fleet | Job completes; no socket errors |
+| Smoke suite | `just smoke ${CLUSTER}` | Exit 0 |
+| Migration-specific gates | Operator adds checks specific to the migration (e.g., new IP family addressing, new addon behavior, changed network policy semantics, KMS-backed secret round-trip) | Per-migration |
+
+If any gate fails: stop, do not advance to soak. Investigate; either fix in place or roll back per the rollback section.
+
+### IRSA refresh check
+
+Cluster recreation produces a new OIDC issuer URL. All IRSA-using ServiceAccounts get re-bound automatically by terraform on `just deploy` (modules read OIDC ARN from `terraform_remote_state.base.outputs.oidc_provider_arn`). Verify post-deploy:
+
+```bash
+NO_PROXY="$NO_PROXY,.eks.amazonaws.com" no_proxy="$no_proxy,.eks.amazonaws.com" \
+  mise exec -- kubectl get sa -A -o json | \
+  jq -r '.items[] | select(.metadata.annotations."eks.amazonaws.com/role-arn") | "\(.metadata.namespace)/\(.metadata.name) \(.metadata.annotations."eks.amazonaws.com/role-arn")"'
+# Spot-check that role ARNs reference roles bound to the NEW OIDC provider URL
+```
+
+---
+
+## Soak window
+
+Run for **≥ 3 days, preferably 7 days at production load** before declaring success and moving to the next cluster.
+
+Watch list (Grafana panels, alerts, and ad-hoc kubectl):
+
+- **NAT GW data egress trend** — compare bytes-out vs the pre-cutover baseline. Spike > 2x baseline indicates an unexpected destination set; investigate via VPC flow logs.
+- **conntrack table fill** — `node_nf_conntrack_entries / node_nf_conntrack_entries_limit` per node. > 80% fill is concerning; > 95% will start dropping connections (`nf_conntrack: table full, dropping packet`).
+- **kube-apiserver p99 latency** — should match pre-cutover baseline. Drift > 2x is a red flag (etcd / control plane sizing issue).
+- **CoreDNS QPS** — should be flat vs baseline. Spike means node-local DNS is missing.
+- **Node-local DNS health** — `coredns_nodecache_setup_errors_total` must remain 0. Any non-zero value means NLD failed to set up its iptables intercept on a node; the dummy interface bind will still work but liveness can flap.
+- **Pod startup time P50 / P99** — vs pre-cutover baseline. Drift > 2x P99 needs investigation (likely VPC CNI prefix warm-pool tuning or scheduler pressure).
+- **GitHub Actions runner success rate** — pull from ClickHouse / pytorch HUD. Should match pre-cutover within ± 1 percentage point.
+- **Harbor 5xx rate / cache miss rate** — expected to be elevated for the first ~ 2 weeks as the cold S3 backend re-fills. Watch for 5xx spikes that are NOT cache misses.
+- **pypi-cache cold-start errors** — wheel fetches from upstream may temporarily exceed the network policy budget; tune as needed. Re-population from the wheel-pipeline S3 takes days.
+- **Migration-specific watch items** — operator enumerates per migration (new metrics introduced, behaviors the migration changes, regressions specific to the property being mutated).
+
+Daily check-in: read the watch list, decide go/no-go for the next 24h. Promote `arc-staging` → `arc-cbr-production` only when staging has been clean for the full soak window.
+
+---
+
+## Rollback
+
+Cluster recreation is one-way. Once destroyed, you commit to recreate — there is no per-step rollback within a single cutover.
+
+"Rollback" means: revert the migration code change on a hotfix branch, get it merged to `main`, then destroy + recreate the cluster a second time (same procedure as this runbook). Costs:
+
+- One additional maintenance window per cluster
+- Harbor S3 / EFS / any other accepted-loss data is lost a second time (rebuilds again over weeks)
+- IRSA refresh again
+- Any state you captured in step 3 is now two cutovers stale
+
+Some migrations may design an explicit safety net (e.g., keeping inert fallback infrastructure in the codebase that can be activated post-recreation without another destroy). If the migration provides one, document the activation procedure in a migration-specific addendum to this runbook. For migrations without a safety net, plan one maintenance window per cluster for the rollback.
+
+If the validation gates fail and a hotfix is small (parameter tweak, addon version), prefer fixing forward over rolling back — a forward fix is `just deploy ${CLUSTER}` after the hotfix is merged, no destroy needed.
+
+---
+
+## Post-cutover follow-ups
+
+After both clusters are stable for several weeks:
+
+- **Per-cluster tuning** — update `clusters.yaml` if the migration introduces any per-cluster overrides (e.g. component memory, replica counts).
+- **Dashboard fixes** — fix any panels that hardcoded patterns affected by the migration (e.g. IP regexes, addon names, label keys). Use ClickHouse / Loki / Mimir to find dashboards still referencing the old patterns.
+- **Monitoring / alerting additions** — consider whether the migration introduces new failure modes worth alerting on. Add the rules with the migration's PR if possible, or as a follow-up PR.
+- **Codebase cleanup** — if the migration left behind transitional code (feature flags, dual-path conditionals, fallback infrastructure), schedule its removal once the new path has been stable long enough that rollback is no longer plausible. Treat as a separate PR.
+
+---
+
+## References
+
+- `docs/architecture.md` — cluster architecture, base vs modules, deploy flow
+- `docs/operations.md` — day-to-day ops; bootstrap and deploy recipes
+- `scripts/destroy-cluster.sh` — the destroy helper invoked in step 6
+- `scripts/cluster-config.py` — resolves cluster-name / region / state-bucket / tfvars / module list from `clusters.yaml`
+- `clusters.yaml` — per-cluster module list and overrides (source of truth for destroy order)
+- `modules/eks/tests/smoke/` — base smoke assertions; add migration-specific assertions here

--- a/osdc/docs/current_runner_load_distribution.md
+++ b/osdc/docs/current_runner_load_distribution.md
@@ -1,5 +1,7 @@
 # Runner Load Distribution (pytorch/pytorch)
 
+**Data as of 2026-03-18 (load tables) / 2026-03-24 (fleet simulation). Not refreshed since.** See the staleness note below for what is missing from this snapshot.
+
 Job counts and peak concurrency by runner type over the last 30 days. Source: `default.workflow_job` ClickHouse table, queried 2026-03-18.
 
 > **Staleness note:** The load tables below are a point-in-time snapshot from 2026-03-18. They do **not** reflect changes made since then, including:
@@ -141,8 +143,10 @@ Job counts and peak concurrency by runner type over the last 30 days. Source: `d
 |---|---|---|
 | l-x86iamx-8-16 | 89 | 15 |
 | l-x86iavx512-2-4 | 18 | 3 |
-| l-x86iavx512-16-64-t4 | 9 | 2 |
+| l-x86iavx512-16-64-t4 [^1] | 9 | 2 |
 | l-x86iavx512-8-16 | 9 | 2 |
+
+[^1]: `l-x86iavx512-16-64-t4` was removed in the right-sizing PR #402 (commit `fcc4df1`, 2026-03-19) and no longer exists in `modules/arc-runners/defs/`. Listed here because it received traffic during the 2026-03-18 snapshot window.
 
 ---
 

--- a/osdc/docs/loki_query.md
+++ b/osdc/docs/loki_query.md
@@ -77,11 +77,12 @@ Three log sources flow into the same Loki tenant: **pod logs**, **system journal
 | `cluster` | all | `pytorch-arc-cbr-production` | Cluster name from clusters.yaml (external label on the writer) |
 | `namespace` | pod logs | `arc-runners`, `kube-system`, `harbor-system` | Kubernetes namespace |
 | `container` | pod logs | `runner`, `coredns`, `kube-proxy` | Container name |
-| `app` | pod logs | `coredns`, `karpenter`, `harbor` | From `app.kubernetes.io/name` pod label |
-| `level` | pod + journal logs | `error`, `warn`, `info`, `debug`, `fatal` | Normalized log level (lowercase) |
+| `app` | pod logs | `karpenter`, `harbor`, `pypi-cache` | From `app.kubernetes.io/name` pod label only — pods labeled only with `k8s-app` (EKS-managed CoreDNS, kube-proxy, NodeLocal DNS) do NOT have this label; filter by `container=` instead |
+| `level` | pod + journal logs | `error`, `warn`, `info`, `fatal` | Normalized log level (lowercase). `debug` lines are dropped at ingestion (DEBUG/TRACE text-drop in pod pipeline, priority-7 drop in journal pipeline) so `level="debug"` returns few or no results |
 | `unit` | journal logs | `kubelet.service`, `containerd.service`, `kernel`, `nvidia-fabricmanager.service`, `nvidia-persistenced.service` | Systemd unit |
 | `kind` | k8s events | `Pod`, `Node`, `Deployment` | Event involved-object kind |
 | `type` | k8s events | `Normal`, `Warning` | Event type |
+| `namespace` | k8s events | `kube-system`, `arc-runners`, `harbor-system` | Namespace of the involved object (set automatically by `loki.source.kubernetes_events`) |
 
 ### Structured Metadata (go after `{}` with pipe `|` syntax)
 
@@ -186,11 +187,13 @@ curl -s -u "$LOKI_USER:$LOKI_READ_KEY" \
 
 ### NodeLocal DNSCache logs
 
+NodeLocal DNSCache pods are labeled `k8s-app: node-local-dns` only (no `app.kubernetes.io/name`), so filter by container name instead:
+
 ```bash
 # ... (credential extraction) ... && \
 curl -s -u "$LOKI_USER:$LOKI_READ_KEY" \
     "$LOKI_URL/loki/api/v1/query_range" \
-    --data-urlencode 'query={cluster="pytorch-arc-cbr-production", namespace="kube-system", app="node-local-dns"}' \
+    --data-urlencode 'query={cluster="pytorch-arc-cbr-production", namespace="kube-system", container="node-cache"}' \
     --data-urlencode "limit=50" \
     --data-urlencode "start=$(date -u -v-1H +%s)000000000" \
     --data-urlencode "end=$(date -u +%s)000000000" | jq .
@@ -256,7 +259,7 @@ To include timestamps:
 
 ## Notes on what's collected
 
-- **Pod logs** are collected from every node by the Alloy DaemonSet (`loki.source.file` reading CRI logs from `/var/log/pods/`). Pods in the `logging` namespace are excluded to prevent feedback loops; pods in `Succeeded` or `Failed` phase are dropped at discovery; lines matching `DEBUG`/`TRACE` levels and lines longer than 16KB are dropped; per-pod rate limit is 1000 lines/s sustained / 5000 burst.
+- **Pod logs** are collected from every node by the Alloy DaemonSet (`loki.source.file` reading CRI logs from `/var/log/pods/`). Pods in the `logging` namespace are excluded to prevent feedback loops; pods in `Succeeded` or `Failed` phase are dropped at discovery; lines matching `DEBUG`/`TRACE` levels and lines longer than 16KB are dropped; lines containing `kube-probe/` are dropped (HTTP readiness/liveness probe noise from any pod with HTTP access logging); per-pod rate limit is 1000 lines/s sustained / 5000 burst.
 - **Journal logs** are collected for `kubelet.service`, `containerd.service`, `kernel`, `nvidia-fabricmanager.service`, and `nvidia-persistenced.service` only. Debug-priority entries (syslog priority 7) are dropped.
 - **Kubernetes events** are collected by a separate Alloy Deployment (`alloy-events`, single replica) via the K8s Events API. Events from the `logging` namespace are dropped.
 - Some module pipelines apply additional sampling (e.g. `arc-runners` non-error logs are sampled at 10%, `buildkit` non-error logs at 50%, `harbor-system` non-error logs are throttled to 100 lines/s burst 500).

--- a/osdc/docs/mimir_query.md
+++ b/osdc/docs/mimir_query.md
@@ -8,7 +8,7 @@ The OSDC clusters ship metrics to Grafana Cloud Mimir via Grafana Alloy. There i
 
 - `kubectl` access to the target cluster (managed by mise in the `osdc/` directory)
 - `jq` for parsing responses
-- The `grafana-cloud-read-credentials` secret must exist in the `monitoring` namespace
+- The `grafana-cloud-read-credentials` secret must exist in the `monitoring` namespace (see "Creating the read-credentials secret" below)
 
 ## Step 1 — Extract Credentials
 
@@ -30,7 +30,20 @@ MIMIR_URL="https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom"
 
 **Note**: There are two secrets — `grafana-cloud-credentials` (write, used by Alloy) and `grafana-cloud-read-credentials` (read, for queries). Always use the **read** secret for queries.
 
-The Mimir URL comes from `clusters.yaml` under `monitoring.grafana_cloud_mimir_read_url`.
+The Mimir URL comes from `clusters.yaml` under `monitoring.grafana_cloud_read_url`.
+
+### Creating the read-credentials secret
+
+The write-side `grafana-cloud-credentials` secret is documented in `docs/observability.md` ("Credential setup (monitoring)"). The read-side secret is created the same way but with a read-scope API key:
+
+```bash
+kubectl create secret generic grafana-cloud-read-credentials \
+  -n monitoring \
+  --from-literal=username='<GRAFANA_CLOUD_METRICS_USER_ID>' \
+  --from-literal=password='<API_KEY_WITH_METRICS_READ_SCOPE>'
+```
+
+Neither secret is created by `deploy.sh` — both are operator-provided per cluster.
 
 ## Step 2 — Query
 
@@ -94,32 +107,37 @@ These are the scrape jobs configured in the cluster. **Most jobs apply tight `ke
 
 Target counts vary continuously with cluster size and are not listed here — query `count(up{cluster="...", job="<job>"})` for live counts.
 
-| Job | Description | Filter notes |
-|-----|-------------|--------------|
-| `node-exporter` | Node-level memory metrics only | Only `node_memory_MemAvailable_bytes` and `node_memory_MemTotal_bytes` are kept; CPU/disk/network are dropped at scrape |
-| `kubelet` | Running pod/container counts only | Only `kubelet_running_(pods\|containers)` and `kubelet_node_name` are kept |
-| `kubelet` (cAdvisor port) | Pod-level memory only | Only `container_memory_working_set_bytes` and `container_memory_rss` are kept; CPU/network/filesystem dropped. Alloy further restricts to control-plane namespaces (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`) |
-| `kube-state-metrics` | Filtered KSM allowlist | Keeps `kube_pod_info`, `kube_pod_container_status_*`, `kube_pod_status_reason`, `kube_deployment_status_*`, daemonset/namespace/node/statefulset/pv/hpa/job metrics |
-| `apiserver` | API server health | Only `apiserver_request_total` and `apiserver_request_terminations_total` are kept |
-| `coredns` | DNS resolution metrics | All `coredns_*` except buckets, plus `go_*`/`process_*` dropped |
-| `monitoring/nodelocaldns` | Per-node NodeLocal DNSCache (NLD) DaemonSet metrics; scrapes both ports `9253` (CoreDNS plugin) and `9353` (binary `coredns_nodecache_setup_errors_total`) at 60s | All `coredns_*` except `coredns_*_request_duration_seconds_bucket`, plus `go_*`/`process_*` dropped |
-| `karpenter` | Autoscaler counters and capacity | Only `karpenter_nodeclaims_created_total`, `karpenter_nodes_created_total`, `karpenter_nodes_terminated_total`, `karpenter_nodepools_usage`, `karpenter_nodepools_limit`, `karpenter_nodes_allocatable`, `karpenter_interruption_received_messages_total` |
-| `git-cache-central-metrics` | Git cache central service metrics | No filter — all `git_cache_central_*` flow through |
-| Git cache daemonset | Per-node git cache metrics (PodMonitor) | No filter — all `git_cache_node_*` flow through |
-| `arc-listeners` | ARC runner-scale-set listener metrics (PodMonitor) | Keeps `gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, `gha_job_*_duration_seconds_(sum\|count)`, `gha_capacity_*` |
-| `arc-controller` | ARC controller metrics | See ServiceMonitor for filter |
-| `harbor` | Harbor registry exporter | All metrics except `go_*`/`process_*`/`promhttp_*` |
-| `buildkit` / `buildkit-haproxy` | BuildKit pods + LB metrics | See ServiceMonitors for filter |
-| `node-compactor` | Node consolidation/compactor metrics | No filter |
-| `pushgateway` | Prometheus Pushgateway (ad-hoc job metrics) | No filter |
-| `pypi-cache` | PyPI cache nginx metrics | Only `nginx_up`, `nginx_http_requests_total`, `nginx_connections_active` |
-| `dcgm-exporter` | NVIDIA GPU metrics (only on GPU nodes) | See ServiceMonitor for filter |
+> **Kubelet / cAdvisor metrics are unavailable.** Under IPv6-only EKS, the kubelet ServiceMonitor (`kubelet.enabled: false` in `modules/monitoring/helm/values.yaml`) is disabled — Prometheus Operator's kubelet Endpoints picker returns the IPv4 NodeInternalIP, which Alloy (IPv6-only pod) cannot reach. **All of `kubelet_running_pods`, `kubelet_running_containers`, `container_memory_working_set_bytes`, and `container_memory_rss` return empty in current clusters.** See `docs/observability.md` ("Disabled scrapers (IPv6 migration)") for the re-enable plan. Until a custom IPv6-aware kubelet ServiceMonitor ships, treat any query against these metric names as broken-by-design — not as a Mimir failure.
+
+The table below lists the **ServiceMonitor / PodMonitor name** alongside the **actual `job=` label** that appears in Mimir. They differ because ServiceMonitors inherit the `job` label from the target *Service* name, not the monitor name.
+
+| Monitor name | Actual `job=` label | Description | Filter notes |
+|--------------|---------------------|-------------|--------------|
+| `node-exporter` (built-in) | `node-exporter` | Node-level memory + conntrack only | Only `node_memory_MemAvailable_bytes`, `node_memory_MemTotal_bytes`, `node_nf_conntrack_entries`, and `node_nf_conntrack_entries_limit` are kept; CPU/disk/network are dropped at scrape. Conntrack metrics power `NodeConntrackHigh{Warn,Critical}` alerts (critical under IPv6-only EKS where pod-IPv4-internet egress hits VPC CNI SNAT). |
+| `kubelet` (built-in) | — (DISABLED) | Would emit `kubelet_running_(pods\|containers)` and `kubelet_node_name` | ServiceMonitor disabled on IPv6-only EKS — queries return empty. |
+| `kubelet` cAdvisor (built-in) | — (DISABLED) | Would emit `container_memory_working_set_bytes` and `container_memory_rss` | ServiceMonitor disabled on IPv6-only EKS — queries return empty. (Alloy's `cost_control` two-step replace+drop targeting these metrics is still configured but has no source data to filter.) |
+| `kube-state-metrics` (built-in) | `kube-state-metrics` | Filtered KSM allowlist | Keeps `kube_pod_info`, `kube_pod_container_status_*` (both `last_terminated_reason` AND `terminated_reason` — the non-`last_` variant fires for Job/CronJob containers with `restartPolicy: Never`), `kube_pod_status_reason`, `kube_deployment_status_*`, daemonset/namespace/node/statefulset/pv/hpa/job metrics. `Completed` reason and exit code `0` are dropped from both terminated variants. |
+| `apiserver` | `kubernetes` | API server health | Only `apiserver_request_total` and `apiserver_request_terminations_total` are kept |
+| `coredns` PodMonitor | `monitoring/coredns` | DNS resolution metrics | All `coredns_*` except buckets, plus `go_*`/`process_*` dropped |
+| `nodelocaldns` PodMonitor | `monitoring/nodelocaldns` | Per-node NodeLocal DNSCache (NLD) DaemonSet metrics; scrapes both ports `9253` (CoreDNS plugin) and `9353` (binary `coredns_nodecache_setup_errors_total`) at 60s | All `coredns_*` except `coredns_*_request_duration_seconds_bucket`, plus `go_*`/`process_*` dropped |
+| `karpenter` | `karpenter` | Autoscaler counters and capacity | Only `karpenter_nodeclaims_created_total`, `karpenter_nodes_created_total`, `karpenter_nodes_terminated_total`, `karpenter_nodepools_usage`, `karpenter_nodepools_limit`, `karpenter_nodes_allocatable`, `karpenter_interruption_received_messages_total` |
+| `git-cache-central` | `git-cache-central-metrics` | Git cache central service metrics | No filter — all `git_cache_central_*` flow through |
+| `git-cache-daemonset` PodMonitor | `monitoring/git-cache-daemonset` | Per-node git cache metrics | No filter — all `git_cache_node_*` flow through |
+| `arc-listeners` PodMonitor | `monitoring/arc-listeners` | ARC runner-scale-set listener metrics | Keeps `gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, `gha_job_*_duration_seconds_(sum\|count)`, `gha_capacity_*` |
+| `arc-controller` | (varies — Service name depends on ARC chart version) | ARC controller metrics | Keeps `gha_controller_.*` and `controller_runtime_reconcile_errors_total` only |
+| `harbor` | (varies — Harbor exporter emits per-component job labels: `core`, `registry`, `jobservice`, etc.) | Harbor registry exporter | All metrics except `go_*`/`process_*`/`promhttp_*` |
+| `buildkit` | `buildkitd-pods` | BuildKit pod metrics | Drops `go_*`, `process_*`, `promhttp_*`, `target_info`, AND `.*_bucket` (all histogram buckets). For latency, use `rate(metric_sum)/rate(metric_count)` — `histogram_quantile(...)` will not work. |
+| `buildkit-haproxy` | `buildkitd-lb-metrics` | BuildKit LB metrics | (See ServiceMonitor for filter) |
+| `node-compactor` | `node-compactor` | Node consolidation/compactor metrics | No filter |
+| `pushgateway` | `pushgateway` | Prometheus Pushgateway (ad-hoc job metrics) | No filter; `honorLabels: true` — pushed metrics' `job`/`instance` labels are preserved instead of overwritten by scrape target |
+| `pypi-cache` | (one job per Service per CUDA slug — e.g. `pypi-cache-cpu`, `pypi-cache-cu126`, `pypi-cache-cu128`, `pypi-cache-cu130` per `clusters.yaml` `cuda_versions`) | PyPI cache nginx metrics | Only `nginx_up`, `nginx_http_requests_total`, `nginx_connections_active` |
+| `dcgm-exporter` | `dcgm-exporter` | NVIDIA GPU metrics (only on GPU nodes) | All `DCGM_FI_*` metrics flow through (no metric drops); label drops only: `UUID`, `modelName`, `DCGM_FI_DRIVER_VERSION`, `pci_bus_id` |
 
 In addition, the `kube-prometheus-stack-operator` job exists but Alloy's `cost_control` drops every `prometheus_operator_*` metric (and `go_*`/`process_*`/`promhttp_*`), so only the `up` metric is queryable in practice.
 
 Job naming follows two conventions:
 
-- **ServiceMonitors**: the `job` label is the target Service name (e.g. `karpenter`, `kubernetes` for the API server, `buildkitd-pods`).
+- **ServiceMonitors**: the `job` label is the target Service name (e.g. `karpenter`, `kubernetes` for the API server, `buildkitd-pods` for BuildKit). This is why the "Monitor name" and "Actual `job=` label" columns above often differ.
 - **PodMonitors**: the `job` label is `<namespace>/<podmonitor-name>` (e.g. `monitoring/arc-listeners`, `monitoring/coredns`, `monitoring/git-cache-daemonset`).
 
 Confirm exact job names by running `count(up{cluster="..."}) by (job)`.
@@ -134,7 +152,7 @@ All metrics include `cluster="pytorch-arc-cbr-production"` (set by Alloy as an e
 | `pod` | `runner-xyz-abc` | Pod name |
 | `container` | `runner`, `git-cache` | Container name |
 | `node` | `ip-10-4-154-0.us-east-2.compute.internal` | Node hostname (use `kube_pod_info` to map pod → node) |
-| `instance` | `10.4.154.0:9100` | Scrape target address |
+| `instance` | `[fd00:ec2::xxx]:9100` | Scrape target address. **IPv6 under IPv6-only EKS** — node-exporter binds the node's IPv6 hostIP via Downward API (`listenOnAllInterfaces: false`). |
 | `job` | `node-exporter`, `karpenter` | Scrape job name |
 | `nodepool` | `c7i-12xlarge`, `g5-48xlarge` | **Only present on Karpenter and node-compactor metrics**, NOT a global label |
 
@@ -161,7 +179,7 @@ sum(node_memory_MemAvailable_bytes{cluster="pytorch-arc-cbr-production"})
 count(up{cluster="pytorch-arc-cbr-production"}) by (job)
 ```
 
-> **Note**: CPU, disk, and network metrics from `node_exporter` are dropped at scrape (only `node_memory_MemAvailable_bytes` and `node_memory_MemTotal_bytes` are kept). For per-pod CPU you need a different source (e.g. KSM pod resource metrics) — `node_cpu_seconds_total`, `node_filesystem_*`, and `node_network_*` will return empty.
+> **Note**: CPU, disk, and most network metrics from `node_exporter` are dropped at scrape. Only `node_memory_MemAvailable_bytes`, `node_memory_MemTotal_bytes`, `node_nf_conntrack_entries`, and `node_nf_conntrack_entries_limit` are kept. For per-pod CPU you need a different source (e.g. KSM pod resource metrics) — `node_cpu_seconds_total`, `node_filesystem_*`, and `node_network_*` will return empty.
 
 ### Node Metrics
 
@@ -172,12 +190,14 @@ node_memory_MemAvailable_bytes{cluster="pytorch-arc-cbr-production"}
 # Memory usage per node (%)
 100 * (1 - node_memory_MemAvailable_bytes{cluster="pytorch-arc-cbr-production"} / node_memory_MemTotal_bytes{cluster="pytorch-arc-cbr-production"})
 
-# Running pod count per node
-kubelet_running_pods{cluster="pytorch-arc-cbr-production"}
+# Conntrack table utilization per node (%)
+100 * node_nf_conntrack_entries{cluster="pytorch-arc-cbr-production"} / node_nf_conntrack_entries_limit{cluster="pytorch-arc-cbr-production"}
 
-# Running container count per node
-kubelet_running_containers{cluster="pytorch-arc-cbr-production"}
+# Nodes with conntrack pressure (matches NodeConntrackHigh alert threshold)
+node_nf_conntrack_entries{cluster="pytorch-arc-cbr-production"} / node_nf_conntrack_entries_limit{cluster="pytorch-arc-cbr-production"} > 0.80
 ```
+
+> **Kubelet metrics unavailable**: `kubelet_running_pods` and `kubelet_running_containers` return empty in current clusters — the kubelet ServiceMonitor is disabled under IPv6-only EKS. See the warning at the top of "Available Scrape Jobs".
 
 ### Pod / Container Health
 
@@ -197,13 +217,9 @@ kube_pod_container_status_last_terminated_exitcode{cluster="pytorch-arc-cbr-prod
 
 # Pod status reasons (Evicted, NodeLost, UnexpectedAdmissionError — routine reasons are dropped)
 kube_pod_status_reason{cluster="pytorch-arc-cbr-production"} == 1
-
-# Container memory (working set) — control-plane namespaces only
-# (Alloy drops container_memory_working_set_bytes for non-control-plane namespaces)
-container_memory_working_set_bytes{cluster="pytorch-arc-cbr-production", namespace="monitoring"}
 ```
 
-> **Note**: `kube_pod_status_phase` is NOT in the KSM keep allowlist — phase-based queries return nothing. Use `kube_pod_info` joined with `kube_pod_container_status_*` instead. Container CPU (`container_cpu_usage_seconds_total`) is dropped at scrape — only the two memory metrics survive cAdvisor filtering.
+> **Note**: `kube_pod_status_phase` is NOT in the KSM keep allowlist — phase-based queries return nothing. Use `kube_pod_info` joined with `kube_pod_container_status_*` instead. `container_memory_working_set_bytes`, `container_memory_rss`, and `container_cpu_usage_seconds_total` all return empty in current clusters — the kubelet/cAdvisor ServiceMonitor is disabled under IPv6-only EKS. The Alloy `cost_control` two-step replace+drop pattern that previously scoped cAdvisor memory to control-plane namespaces is still configured but has no source data to filter; queries against these metrics will be empty until a custom IPv6-aware kubelet ServiceMonitor ships.
 
 ### Karpenter (Autoscaling)
 
@@ -293,6 +309,8 @@ Per-node DaemonSet — each pod emits CoreDNS plugin metrics on port `9253` (zon
 
 > **Metric name gotcha**: the binary's setup-error counter is **`coredns_nodecache_setup_errors_total`** (namespace `coredns`, subsystem `nodecache`), **NOT** `nodelocaldns_setup_errors_total`. Some upstream/internal docs and PR drafts use the wrong name. Queries against `nodelocaldns_setup_errors_total` will silently return zero results — always use the `coredns_nodecache_*` form.
 
+> **Two CoreDNS request-count metric names exist** and the choice depends on which CoreDNS you're querying. NLD ships `k8s-dns-node-cache:1.26.8` which embeds an older CoreDNS that emits the legacy **`coredns_dns_request_count_total`**. The cluster CoreDNS (AWS-managed addon) is newer and emits **`coredns_dns_requests_total`** (used in the Control Plane section above and in `dashboards/cluster-health.json`). Do not "normalize" these to a single name — each is correct for its source.
+
 ```promql
 # Cluster-wide NLD QPS across all zones (one pod per node)
 sum(rate(coredns_dns_request_count_total{cluster="pytorch-arc-cbr-production", job="monitoring/nodelocaldns"}[5m]))
@@ -334,6 +352,24 @@ rate(nginx_http_requests_total{cluster="pytorch-arc-cbr-production"}[5m])
 
 # Active connections
 nginx_connections_active{cluster="pytorch-arc-cbr-production"}
+```
+
+### GPU (DCGM)
+
+The DCGM ServiceMonitor doesn't drop any metric names — only labels (`UUID`, `modelName`, `DCGM_FI_DRIVER_VERSION`, `pci_bus_id`) — so the full `DCGM_FI_*` set is queryable on GPU nodes:
+
+```promql
+# GPU temperature per GPU (Celsius) — used by GPUTemperatureCritical alert (>95C for 5m)
+DCGM_FI_DEV_GPU_TEMP{cluster="pytorch-arc-cbr-production"}
+
+# GPU utilization per GPU (%)
+DCGM_FI_DEV_GPU_UTIL{cluster="pytorch-arc-cbr-production"}
+
+# Uncorrectable (double-bit) ECC errors — used by GPUDoublebitECCError alert
+DCGM_FI_DEV_ECC_DBE_VOL_TOTAL{cluster="pytorch-arc-cbr-production"}
+
+# XID critical errors (48/79/94/95) — used by GPUXIDCriticalError alert
+DCGM_FI_DEV_XID_ERRORS{cluster="pytorch-arc-cbr-production"}
 ```
 
 ### Bad Node Detection (Join Pattern)

--- a/osdc/docs/modules.md
+++ b/osdc/docs/modules.md
@@ -36,6 +36,12 @@ REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
 UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
 ```
 
+**Module resolution (consumer override).** Before running the three phases, `deploy-module` resolves the module directory as: if `$OSDC_ROOT/modules/<name>/` exists, use it; otherwise fall back to `$OSDC_UPSTREAM/modules/<name>/`. This is how a downstream consumer repo replaces a shared upstream module with a local variant — drop a module of the same name under your own `modules/` and it wins.
+
+**Audit logging.** `deploy-module` wraps each invocation with `scripts/deploy-log.sh` calls (`deploy_log_start` / `deploy_log_finish`) at both `cmd` and `module` scope. Successes and failures are recorded and surfaced by `just deploy-history` and `just deploy-status`.
+
+**`force` argument.** `deploy-module` accepts an optional third positional `force` argument; setting it to any non-empty value (e.g. `just deploy-module my-cluster monitoring force`) exports `HELM_FORCE_UPGRADE=1` for the duration of the run, which the shared `helm-upgrade.sh` helper honours to force a Helm upgrade even when no diff is detected.
+
 ## Creating a new module
 
 1. Create directory:
@@ -93,7 +99,7 @@ variable "state_bucket" { type = string }
 variable "cluster_id"   { type = string }
 ```
 
-Add more variables as needed. If they need cluster-specific values, extend `clusters.yaml` with module-specific config — `scripts/cluster-config.py` is generic (it walks dotted paths against the YAML with deep-merged defaults), so no code change is required to read new keys.
+Add more variables as needed. If they need cluster-specific values, extend `clusters.yaml` with module-specific config — `scripts/cluster-config.py` is generic (it walks dotted paths against the YAML with per-path fallback: the cluster's own value wins, otherwise the same path is looked up under `defaults`), so no code change is required to read new keys.
 
 ## Adding kubernetes resources to a module
 
@@ -154,11 +160,11 @@ The `logging` module's `assemble_config.py` discovers these via `--modules-dir` 
 
 ## Tests
 
-Every module has a `tests/` directory; pytest tests are auto-collected by `just test`. Modules that own deployable behaviour can additionally provide a `tests/smoke/` directory — `just smoke <cluster>` walks every enabled module and runs whichever `tests/smoke` it finds (`arc/`, `eks/`, `karpenter/` currently have one).
+Most non-delegate modules have a `tests/` directory; pytest tests are auto-collected by `just test`. Exceptions: the four delegate modules (`arc-runners-h100`, `arc-runners-b200`, `nodepools-h100`, `nodepools-b200`) have no `tests/` of their own, and `zombie-cleanup` keeps its tests alongside the script under `scripts/python/test_*.py`. Modules that own deployable behaviour can additionally provide a `tests/smoke/` directory — `just smoke <cluster>` walks every enabled module and runs whichever `tests/smoke` it finds. Every non-delegate module currently has one.
 
 ## Delegate modules (GPU variants)
 
-GPU SKUs (`arc-runners-h100`, `arc-runners-b200`, `nodepools-h100`, `nodepools-b200`) are pure delegate modules: they ship only their own `defs/` (and `generated/`) and a 14-line `deploy.sh` that `exec`s the parent module's deploy script after exporting a few env vars:
+GPU SKUs (`arc-runners-h100`, `arc-runners-b200`, `nodepools-h100`, `nodepools-b200`) are pure delegate modules: they ship only their own `defs/` (and `generated/`), optionally a `scripts/` directory (the `nodepools-*` delegates carry a per-SKU node-setup script), and a 13-line `deploy.sh` that `exec`s the parent module's deploy script after exporting a few env vars:
 
 ```bash
 #!/usr/bin/env bash
@@ -215,9 +221,10 @@ ARC runner scale sets for GitHub Actions self-hosted runners. Requires `arc` (co
 - **defs/**: Runner definitions (source of truth) — instance type, CPU, memory, GPU, default max runners
 - **templates/runner.yaml.tpl**: Multi-doc template: Helm values + job pod hook ConfigMap
 - **generated/**: Auto-generated ARC runner configs (from defs + template)
+- **kubernetes/**: `arc-runners` namespace, `hooks-warmer` Deployment (warms the runner-container-hooks image on every node), `kustomization.yaml` — auto-applied in Phase 2 because `kustomization.yaml` is present
 - **scripts/python/generate_runners.py**: Reads `defs/` + template + `clusters.yaml` → writes `generated/`
 - **scripts/python/validate_runner_qos.py**: Pre-deploy validation (Guaranteed QoS, requests == limits) — invoked via `uv run`
-- **deploy.sh**: Generates configs, validates QoS, applies ConfigMaps + Helm releases (enforces `arc` module presence)
+- **deploy.sh**: Generates configs, validates QoS, applies the per-runner hook ConfigMaps and Helm releases (enforces `arc` module presence)
 
 ### logging
 
@@ -234,8 +241,9 @@ Dual-architecture container build service with HAProxy load balancing.
 
 - **kubernetes/base/**: BuildKit namespace, Deployments (arm64 + amd64), Services, HAProxy (least-connections LB), NetworkPolicy
 - **scripts/python/generate_buildkit.py**: Generates Deployments + NodePools from instance type specs and `clusters.yaml` config
-- **scripts/node-setup.sh**: NVMe RAID0, registry mirrors, CPU tuning for build nodes
 - **deploy.sh**: Generates manifests, applies k8s resources, deploys Karpenter NodePools, waits for rollout
+
+Build-node tuning (NVMe RAID0, registry mirrors, CPU tuning) is not a separate script in this module — it comes from the Karpenter EC2NodeClass userData baked into the generated `nodepools.yaml` and from cluster-wide DaemonSets in `base/kubernetes/`.
 
 ### harbor-cache-recovery
 
@@ -251,10 +259,10 @@ Automated recovery from Harbor proxy cache corruption (stale manifests, size mis
 Grafana Alloy in metrics mode, scraping cluster + module endpoints and remote-writing to Grafana Cloud Mimir.
 
 - **helm/**: Alloy values for the metrics pipeline
-- **kubernetes/**: ServiceMonitor / PodMonitor / additional scrape configs
+- **kubernetes/**: namespace, DCGM exporter DaemonSet + custom-metrics ConfigMap (`dcgm-exporter/`), PrometheusRule alert CRDs (`alerts/` — ARC, GPU, infra, network-pressure, node-compactor, nodelocaldns, harbor-cache-recovery, zombie-cleanup), and ServiceMonitor / PodMonitor manifests (`monitors/`)
 - **dashboards/**: Grafana dashboard JSON sources
 - **logging/pipeline.alloy**: Log routing rules for the monitoring module's own pods
-- **deploy.sh**: Secret-gated Alloy install, dashboard sync
+- **deploy.sh**: Installs `kube-prometheus-stack` (CRDs, node-exporter, kube-state-metrics, Prometheus Operator — Prometheus/Grafana/AlertManager are disabled), Prometheus Pushgateway, the `monitors/` kustomize (ServiceMonitors / PodMonitors / `alerts/` PrometheusRules) after the CRDs land, and — gated on the `grafana-cloud-credentials` secret — Grafana Alloy as the metrics push pipeline to Grafana Cloud
 
 ### pypi-cache
 
@@ -282,8 +290,8 @@ CronJob that reaps orphaned ARC runner pods left behind by aborted GitHub Action
 
 ### arc-runners-h100, arc-runners-b200
 
-Delegate modules for H100 / B200 GPU runner scale sets. Ship only `defs/`, `generated/`, and a 14-line `deploy.sh` that exports `ARC_RUNNERS_DEFS_DIR` / `ARC_RUNNERS_OUTPUT_DIR` / `ARC_RUNNERS_MODULE_NAME` then `exec`s the parent `arc-runners/deploy.sh`. See "Delegate modules" above.
+Delegate modules for H100 / B200 GPU runner scale sets. Ship only `defs/`, `generated/`, and a 13-line `deploy.sh` that exports `ARC_RUNNERS_DEFS_DIR` / `ARC_RUNNERS_OUTPUT_DIR` / `ARC_RUNNERS_MODULE_NAME` then `exec`s the parent `arc-runners/deploy.sh`. See "Delegate modules" above.
 
 ### nodepools-h100, nodepools-b200
 
-Delegate modules for H100 / B200 GPU NodePools. Same pattern as the arc-runners delegates but exporting `NODEPOOLS_*` env vars and delegating to `nodepools/deploy.sh`.
+Delegate modules for H100 / B200 GPU NodePools. Same pattern as the arc-runners delegates but with an extra `scripts/` directory holding a per-SKU node-setup script, exporting `NODEPOOLS_*` env vars and delegating to `nodepools/deploy.sh`.

--- a/osdc/docs/node-utilization-optimization.md
+++ b/osdc/docs/node-utilization-optimization.md
@@ -18,11 +18,11 @@ OSDC uses Kubernetes Guaranteed QoS pods (requests == limits) for all runner wor
 
 Each node's allocatable resources are reduced by:
 
-1. **Kubelet reserved CPU**: 60m (first core) + 10m/core (cores 2-4) + 5m/core (cores 5-8) + 2.5m/core (cores 9+)
+1. **Kubelet reserved CPU**: 60m (core 1) + 10m (core 2) + 5m/core (cores 3-4) + 2.5m/core (cores 5+)
 2. **Kubelet reserved memory**: 255Mi + 11Mi per max_pod (ENI-based) + 100Mi eviction threshold
-3. **DaemonSet overhead**: 270m CPU / 740Mi memory (non-GPU), 370m CPU / 996Mi memory (GPU nodes). Includes NodeLocal DNSCache (NLD) at 25m CPU / 100Mi memory per node, deployed on every node via DaemonSet.
+3. **DaemonSet overhead**: 460m CPU / 1158Mi memory (non-GPU), 560m CPU / 1414Mi memory (GPU nodes). Includes NodeLocal DNSCache (NLD) at 25m CPU / 100Mi memory per node, deployed on every node via DaemonSet.
 
-Each runner pod also includes a sidecar (750m CPU, 512Mi memory) on top of its job container resources.
+Each workflow pod also includes runner-container-hooks containers (320m CPU + 522Mi memory) on top of the job container's resources. The runner-orchestrator pod itself (750m CPU / 1Gi memory) lives on the dedicated `c7i-runner` NodePool and does not consume resources on the workflow node — see `c7i-runner` notes below.
 
 **Utilization** = `(pods_per_node * pod_resource) / allocatable_resource` for each dimension. The **minimum** across CPU and memory determines the packing efficiency — unused resources in the higher dimension are waste.
 
@@ -70,7 +70,7 @@ Runners have ISA (instruction set) requirements encoded in their names that cons
 | g4dn.12xlarge | 48c/192Gi @ $3.91/hr | 1 (T4) | **95.6%** | `l-x86iavx512-45-172-t4-4` fills the node (FIXED) |
 | g4dn.metal | 96c/384Gi @ $7.82/hr | 1 (T4) | 96.0% | Good — `l-bx86iavx512-94-344-t4-8` fills the node |
 | p6-b200.48xlarge | 192c/2048Gi @ $55.47/hr | 4 (B200) | 88.1% | Good — runners scale proportionally to GPU count |
-| p4d.24xlarge | 96c/1152Gi (8x A100) | 4 (A100) | n/a | Added after this snapshot — `l-x86iavx512-{11-125,22-250,44-500}-a100*` + `l-bx86iavx512-88-1000-a100-8`, 1/2/4/8 GPU splits |
+| p4d.24xlarge | 96c/1152Gi (8x A100 40GB SXM4) | 4 (A100) | n/a | Added after this snapshot — `l-x86iavx512-{11-125,22-250,44-500}-a100*` + `l-bx86iavx512-88-1000-a100-8`, 1/2/4/8 GPU splits |
 | p5.48xlarge | 192c/2048Gi (8x H100) | 4 (H100) | n/a | Added after this snapshot — `l-x86iamx-{22-225,44-450,88-900}-h100*` + `l-bx86iamx-176-1800-h100-8`, 1/2/4/8 GPU splits |
 
 ### Critical Issue: T4 Runner Cannot Schedule (RESOLVED)
@@ -87,13 +87,13 @@ The original 4-GPU T4 runner (`l-x86iavx512-48-192-t4-4`) requested 48 vCPU + 19
 
 **Proposed**: Split into 3 nodepools per ISA group, matched to CPU:memory ratio.
 
-#### AMX/AVX2 Group (10 runners → 3 nodepools)
+#### AMX/AVX2 Group (11 runners → 3 nodepools)
 
 These runners include `l-x86iamx-*` (AMX) and `l-x86iavx2-*` (AVX2). Since AMX runners require Intel, **all pools in this group must use Intel instances** (c7i, m7i, r7i — not AMD c7a, m7a, r7a).
 
 | Pool | Instance | Runners | Worst Util | Cost/hr |
 |------|----------|---------|-----------|---------|
-| Compute | **c7i.12xlarge** (48c/96Gi) + **c7i.metal-24xl** (96c/192Gi) | 5 shared + 1 bare-metal (2:1 ratio) | ~92-99% | $2.14 / $4.28 |
+| Compute | **c7i.12xlarge** (48c/96Gi) + **c7i.metal-24xl** (96c/192Gi) | 4 shared + 1 bare-metal (2:1 ratio) | ~92-99% | $2.14 / $4.28 |
 | Balanced | **m7i.48xlarge** (192c/768Gi) | 4 runners (4:1 ratio) | ~84% | $9.68 |
 | Memory | **r7i.48xlarge** (192c/1536Gi) | 2 runners (8:1 ratio) | ~88% | $12.70 |
 
@@ -142,13 +142,17 @@ AVX-512 runners can use either Intel or AMD instances with AVX-512 support.
 
 ### Recommendation 3: Fix T4 Runner Scheduling (DONE)
 
-`l-x86iavx512-48-192-t4-4` was renamed to `l-x86iavx512-45-172-t4-4` with reduced vCPU (45) and memory (172Gi) to leave headroom for the runner pod (750m/512Mi) and system overhead on g4dn.12xlarge.
+`l-x86iavx512-48-192-t4-4` was renamed to `l-x86iavx512-45-172-t4-4` with reduced vCPU (45) and memory (172Gi) to leave headroom for the runner pod and system overhead on g4dn.12xlarge. (Per-workflow-pod overhead is now 320m CPU + 522Mi memory from the runner-container-hooks containers; at the time this fix was made it was the 750m / 1Gi runner-orchestrator sidecar — see "How Packing Works" for the current model.)
 
-### Recommendation 4: GPU Nodepool Right-Sizing (LOW PRIORITY)
+### Recommendation 4: GPU Nodepool Right-Sizing (DONE)
 
-GPU nodepools are constrained by GPU count, limiting instance options. The current g5.48xlarge and g6.48xlarge assignments are suboptimal for 1-GPU and 4-GPU runners (50-67% utilization), but there are no smaller GPU instances that fit all runners in a single pool.
+GPU nodepools are constrained by GPU count, limiting instance options. The original g5.48xlarge and g6.48xlarge assignments were suboptimal for 1-GPU and 4-GPU runners (50-67% utilization), with no smaller GPU instance that fit all runners in a single pool.
 
-**Potential optimization for A10G**: Use g5.8xlarge (32c/128Gi, 1 GPU, $2.45/hr) for the 1-GPU runner and g5.12xlarge (48c/192Gi, 4 GPU, $5.67/hr) for the 4-GPU runner instead of g5.48xlarge ($16.29/hr). This adds 2 nodepools but each node is 3-7x cheaper. Worth evaluating if A10G runners are used frequently.
+**A10G/L4 fleet expansion (implemented)**: The g5 and g6 fleets now include the smaller `g5.8xlarge` / `g5.12xlarge` and `g6.8xlarge` / `g6.12xlarge` sizes as weighted fleet members. 1-GPU and 4-GPU runners are pinned to those smaller instances:
+- `l-x86aavx2-29-113-a10g` → `g5.8xlarge` (32c/128Gi, 1 GPU)
+- `l-x86aavx2-45-167-a10g-4` → `g5.12xlarge` (48c/192Gi, 4 GPU)
+- `l-x86aavx2-189-704-a10g-8` → `g5.48xlarge` (192c/768Gi, 8 GPU)
+- `l-x86aavx2-29-113-l4` → `g6.8xlarge`, `l-x86aavx2-45-172-l4-4` → `g6.12xlarge`
 
 **B200 nodepools**: Already well-optimized at 88% utilization. No changes needed — the runners are designed to scale proportionally to GPU count on p6-b200.48xlarge.
 
@@ -157,13 +161,13 @@ GPU nodepools are constrained by GPU count, limiting instance options. The curre
 | State | CPU Nodepools | GPU Nodepools | Total |
 |-------|--------------|---------------|-------|
 | Pre-Phase 2 | 2 (r5.24xlarge, r7g.16xlarge) | 6 (g4dn.8xl, g4dn.12xl, g4dn.metal, g5.48xl, g6.48xl, p6-b200) | 8 |
-| Phase 2 (proposed at the time) | 8 (3×amx/avx2 + 3×avx512 + 2×arm64) | 6 (unchanged) | 14 |
+| Phase 2 (proposed at the time) | 9 (3×amx/avx2 + 3×avx512 + 3×arm64) | 6 (unchanged) | 15 |
 
-This increased from 8 to 14 nodepool defs in the original Phase 2 plan. Each nodepool is a Karpenter NodePool CRD — lightweight, no ongoing cost. The infrastructure impact is minimal.
+This increased from 8 to 15 nodepool defs in the original Phase 2 plan (9 CPU pools — including the dedicated bare-metal m8g.16xlarge for `l-barm64g4-62-226` — plus 6 GPU pools). Each nodepool is a Karpenter NodePool CRD — lightweight, no ongoing cost. The infrastructure impact is minimal.
 
 **Post-snapshot state**: After commit `fa950b4` ("Migrate nodepool defs from single-instance to fleet format"), the per-instance-size nodepool defs were collapsed into family-level **fleet** files. Each fleet lists multiple weighted instance sizes (`c7i.48xlarge`, `c7i.24xlarge`, …) and Karpenter picks an appropriate size per workload. The current `modules/nodepools/defs/` directory holds 14 fleet files (`c7a`, `c7i`, `c7i-runner`, `g4dn`, `g5`, `g6`, `m6i`, `m7i`, `m8g`, `p4d-24xlarge`, `r5`, `r7a`, `r7g`, `r7i`), plus separate `nodepools-h100/defs/p5-48xlarge.yaml` and `nodepools-b200/defs/p6-b200-48xlarge.yaml`. The runner-to-instance-size pinning shown above is now a soft preference (fleet weights), not a hard one-pool-per-size split.
 
-**Dedicated runner pool (`c7i-runner`)**: Added after this snapshot for the proactive-capacity / preemption design. It is a name-only clone of the `c7i` fleet, separated by the `node-fleet=c7i-runner` taint, and hosts the lightweight ARC runner pods (placeholders) — workflow pods continue to land on c7a/c7i/m7i/etc. See `PROACTIVE_CAPACITY.md`.
+**Dedicated runner pool (`c7i-runner`)**: Added after this snapshot for the proactive-capacity / preemption design. It is a name-only clone of the `c7i` fleet, separated by the `node-fleet=c7i-runner` taint, and hosts the lightweight ARC runner-orchestrator pods plus placeholders — workflow pods continue to land on c7a/c7i/m7i/etc. The split is enforced by the `node-fleet=c7i-runner` NodePool taint + matching toleration on runner pods, plus the `CAPACITY_AWARE_RUNNER_NODE_FLEET=c7i-runner` env var on each AutoscalingListener (which pins placeholder-runner and runner-orchestrator pods to that fleet). Because the orchestrator no longer lives on the workflow node, the per-workflow-pod overhead dropped from `750m/1Gi sidecar + hooks` to just the hooks containers (320m/522Mi). See `docs/arc-fork-build-deploy.md` for the full env-var reference.
 
 ## Cost Analysis
 
@@ -182,9 +186,9 @@ The savings compound: nodes with better packing serve more concurrent runners, r
 
 Some runners (46c/85Gi, 94c/192Gi, 48c/384Gi) consistently achieve only 74-76% utilization even on perfectly-matched instance types. This is because:
 
-1. **Overhead is fixed**: Kubelet + DaemonSet overhead (~525m CPU, ~1.6Gi memory; includes NLD at 25m CPU / 100Mi memory per node) is constant regardless of instance size
+1. **Overhead is fixed**: Kubelet + DaemonSet overhead (~700m CPU, ~1.6Gi memory non-GPU / ~1.9Gi GPU; includes NLD at 25m CPU / 100Mi memory per node) is constant regardless of instance size
 2. **Large runners don't divide evenly**: A 94c runner on a 128c node leaves 34c unused — only 1 pod fits
-3. **Sidecar tax**: Each pod adds 750m CPU + 512Mi memory, which compounds at large sizes
+3. **Hooks tax**: Each workflow pod adds 320m CPU + 522Mi memory for runner-container-hooks, which compounds at large sizes (the runner-orchestrator pod itself lives on `c7i-runner`, so workflow nodes are no longer charged the 750m/1Gi orchestrator)
 
 The only way to push these above 85% is to use instances where `N × runner_size ≈ allocatable` — and no standard instance hits that for every runner. The proposed 74% worst-case is the practical optimum.
 
@@ -213,8 +217,8 @@ The original Phase 2 analysis used `scripts/python/analyze_node_utilization.py` 
 The throwaway script has since been superseded by the simulation tooling now in the repo:
 
 - **`scripts/python/analyze_node_utilization.py`** (`just analyze-utilization`): per-node-type packing efficiency, CPU/memory waste, best/worst mixed combos
-- **`scripts/python/simulate_cluster.py`** (`just simulate-cluster`): full cluster simulation — maps peak concurrency targets to runners, bin-packs onto nodes, reports fleet size and per-runner deployment accuracy
-- **`scripts/python/simulate_cluster_cli.py`**: Monte Carlo stability runner (`just simulate-cluster --rounds N`)
+- **`scripts/python/simulate_cluster_cli.py`** (`just simulate-cluster`): CLI wrapper that drives full cluster simulation — maps peak concurrency targets to runners, bin-packs onto nodes, reports fleet size and per-runner deployment accuracy; supports Monte Carlo stability runs (`just simulate-cluster --rounds N`)
+- **`scripts/python/simulate_cluster.py`**: library backing the CLI (imported by `simulate_cluster_cli.py`)
 
 All scripts model EKS kubelet reserves, DaemonSet overhead, runner sidecars, and ISA/GPU compatibility constraints. See `docs/current_runner_load_distribution.md` for current reproduction commands.
 

--- a/osdc/docs/node-warmup-and-scheduling-gates.md
+++ b/osdc/docs/node-warmup-and-scheduling-gates.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-When Karpenter provisions a new runner node, several initialization steps must complete before the node can accept GitHub Actions workflow jobs. These steps are orchestrated through Kubernetes-native mechanisms — startup taints, DaemonSets, and init containers — with no reliance on EC2 userdata or bootstrap scripts.
+When Karpenter provisions a new runner node, several initialization steps must complete before the node can accept GitHub Actions workflow jobs. These steps are orchestrated primarily through Kubernetes-native mechanisms — startup taints, DaemonSets, and init containers. The standard nodepools (g4dn, g5, g6, p4d, c7i, c7a, m8g, etc.) require no per-node EC2 userdata scripts; the H100 (p5.48xlarge) and B200 (p6-b200.48xlarge) pools are the exception — both ship a per-fleet bash script referenced by `user_data_script:` in their def (`modules/nodepools-h100/scripts/h100-node-setup.sh`, `modules/nodepools-b200/scripts/b200-node-setup.sh`) that resolves the node's primary IPv6 from IMDS and writes the `<NODE_IPV6> harbor` /etc/hosts entry from cloud-init, before the registry-mirror-config DaemonSet would otherwise do it.
+
+The cluster is end-to-end IPv6-only for pod networking (EKS `ip_family = "ipv6"`, kube-proxy IPv6, NLD binds the IPv6 ULA `fd00::10`, kube-dns ClusterIP is IPv6) — many of the conventions below (per-node /etc/hosts rewrites for `harbor:30002`, NLD bind addresses, `case "$KUBE_DNS_CLUSTER_IP" in *:*` validation) follow from that.
 
 The system guarantees that every runner node has a warm git cache, patched runner-container-hooks, containerd registry mirrors, and optimized CPU/GPU settings before any workflow job is dispatched to it.
 
@@ -52,15 +54,17 @@ Every Karpenter NodePool applies this startup taint via the `startupTaints` fiel
 
 **Flow**:
 1. DaemonSet pod starts on the new node (tolerates the taint)
-2. Resolves the headless service DNS for the central git-cache StatefulSet (multi-replica — e.g. 5 replicas for arc-cbr-production, configured via `git_cache.central_replicas` in `clusters.yaml`), queries each replica's metrics endpoint, and picks the one with the fewest active connections
-3. Waits for the chosen central replica's rsyncd to accept TCP connections (600s timeout)
-4. Rsyncs bare git repos from that replica to local NVMe at `/mnt/git-cache` using dual-slot rotation (cache-a / cache-b with atomic symlink swap)
+2. Waits for the central git-cache ClusterIP Service (`git-cache-central.kube-system.svc.cluster.local`, port 873) to accept TCP connections (600s timeout) via `wait_for_central()`
+3. Migrates any pre-existing single-directory cache layout into slot-a (one-time, if `/mnt/git-cache` exists as a plain directory)
+4. Runs the initial sync: `rsync_from_central()` resolves the headless Service DNS for the central StatefulSet (multi-replica — `central_replicas: 15` for arc-cbr-production, cluster default `2`, configured via `git_cache.central_replicas` in `clusters.yaml`), queries each replica's metrics endpoint, picks the one with the fewest active connections, and rsyncs bare git repos from that replica to local NVMe at `/mnt/git-cache` using dual-slot rotation (cache-a / cache-b with atomic symlink swap)
 5. On successful initial sync, removes the taint via Kubernetes API JSON Patch (RFC 6902 `test` + `remove` — atomic, race-safe)
-6. Enters periodic refresh loop (every 300s)
+6. Enters periodic refresh loop (every 300s — `FETCH_INTERVAL`), re-running `rsync_from_central()` (replica discovery happens fresh each cycle)
 
 **If sync fails**: Retries with exponential backoff (30s, 60s, 120s... capped at 300s). The node stays tainted indefinitely until a successful sync. Runner pods will not schedule.
 
 **RBAC**: The `git-cache-warmer` ServiceAccount has `get` + `patch` on `nodes` (`base/kubernetes/git-cache/rbac.yaml`).
+
+**c7i-runner note**: The git-cache-warmer's nodeAffinity selects `workload-type In [github-runner, buildkit]`, and c7i-runner NodePools label nodes `workload-type: github-runner`. The warmer therefore schedules on c7i-runner nodes and removes the `git-cache-not-ready` taint there, even though runner pods on c7i-runner do not consume the `/mnt/git-cache` mount. The runner pod's explicit toleration on `git-cache-not-ready` (in `modules/arc-runners/templates/runner.yaml.tpl`) is belt-and-suspenders: it allows runner pods to schedule during the brief warmup window before the warmer clears the startup taint. A code comment in `runner.yaml.tpl` claims the warmer does NOT run on c7i-runner — that comment is contradicted by the actual nodeAffinity selector and should be treated as stale.
 
 ### Gate 2: Patched Hooks (Init Container Poll)
 
@@ -117,6 +121,10 @@ Per-node CoreDNS cache running as a DaemonSet on **every** node. Reduces cluster
 
 **Tolerations**: explicit list (NOT `operator: Exists`) — `CriticalAddonsOnly`, `nvidia.com/gpu`, `node-fleet`, `instance-type`, `git-cache-not-ready`. Covers all standard runner/buildkit/GPU taints so it schedules at provisioning time.
 
+**Deploy ordering — Service BEFORE DaemonSet** (`base/kubernetes/nodelocaldns/deploy.sh`): kubelet snapshots Service env into pods at pod-create time, so the `kube-dns-upstream` Service must exist before the DaemonSet pods are scheduled or the binary will not see `KUBE_DNS_UPSTREAM_SERVICE_HOST/PORT`. The deploy script enforces this in seven steps: (1) verify any existing `kube-dns-upstream` Service has the correct `k8s-app=kube-dns` selector (refuses to overwrite a foreign one), (2) resolve the live kube-dns ClusterIP and fail-fast if it is IPv4 (NLD is IPv6-only on OSDC), (3) render manifests with `kubectl kustomize` and sed-substitute the `__KUBE_DNS_CLUSTER_IP__` placeholder, (4) split into a Services file and the rest, (5) `kubectl apply` Services first, (6) sleep 3s for ClusterIP allocation, (7) `kubectl apply` ConfigMap + ServiceAccount + DaemonSet. Then if the upstream Service was freshly created in THIS run (first-time deploy or out-of-band deletion + redeploy), the script runs `kubectl rollout restart ds node-local-dns` so pods re-pick the Service env on the next pod-create.
+
+**Two metrics ports**: NLD exposes both `metrics` on port 9253 (CoreDNS plugin metrics — cache hits, forward latency, etc.) and `metrics-binary` on port 9353 (k8s-dns-node-cache binary metrics — setup errors, `coredns_nodecache_*`). The headless `node-local-dns-metrics` Service publishes both ports; both must be scraped to see the full picture.
+
 ### NVIDIA Device Plugin (GPU nodes only)
 
 **File**: `base/kubernetes/nvidia-device-plugin.yaml`
@@ -128,6 +136,8 @@ Exposes `nvidia.com/gpu` resources to the Kubernetes scheduler. Without this Dae
 **File**: `base/kubernetes/registry-mirror-config.yaml`
 
 Configures containerd's `certs.d/` on every node to route image pulls through Harbor's proxy cache at `harbor:30002`. Covers six registries: docker.io, ghcr.io, public.ecr.aws, nvcr.io, registry.k8s.io, quay.io. Uses a marker file for idempotency. If Harbor is unavailable, containerd falls through to upstream registries automatically.
+
+**Also writes `<NODE_IP> harbor` to /etc/hosts** — this is what makes the `harbor:30002` hostname in `certs.d/` resolvable from each node. Under IPv6-only kube-proxy, NodePort listeners on `[::]:30002` are NOT reachable via `::1` or `localhost`; only the node's own primary IP is routable. `NODE_IP` is supplied via the Downward API (`status.hostIP`). The DaemonSet rewrites /etc/hosts via a tmpfile + `cat > /etc/hosts` (preserves the kubelet bind-mount inode that `sed -i` and rename(2) editors cannot swap). The /etc/hosts write and the `certs.d/` config are equally load-bearing — modifying one without the other will break image pulls.
 
 Runs on ALL nodes (no nodeSelector, tolerates everything).
 
@@ -153,6 +163,14 @@ Runs on ALL nodes (no nodeSelector, tolerates everything). Idempotent via `/var/
 
 **TODO — REMOVE this DaemonSet** once all nodes are running an AL2023 AMI with kernel 6.12.85+. Watch https://explore.alas.aws.amazon.com/CVE-2026-31431.html and the AMI pinnings tagged with the same TODO marker (`clusters.yaml`, `modules/nodepools/scripts/python/generate_nodepools.py`, `modules/buildkit/scripts/python/generate_buildkit.py`, `modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl`).
 
+### DirtyFrag Mitigation (TEMPORARY — CVE-2026-43284 + CVE-2026-43500)
+
+**File**: `base/kubernetes/dirtyfrag-mitigation.yaml`
+
+Sibling DaemonSet to `algif-mitigation`, same shape (privileged `nsenter` into PID 1's namespaces, modprobe.d blacklist, marker file at `/var/lib/dirtyfrag-mitigation/.configured`, runs on EVERY node). Writes `/etc/modprobe.d/disable-dirtyfrag.conf` blacklisting three modules — `esp4`, `esp6`, `rxrpc` — then defensively `modprobe -r`'s any that have already loaded, then drops the page cache (`echo 3 > /proc/sys/vm/drop_caches`) to evict DirtyFrag-poisoned pages of read-only files. Mitigates two related Linux kernel write-LPEs in the IPv4/IPv6 datagram zero-copy path (xfrm-ESP and RxRPC variants) — both cross container boundaries via the shared page cache.
+
+**TODO — REMOVE this DaemonSet** once all nodes are running an AL2023 AMI with kernel 6.1.170+ or 6.12.83+ (separate kernel-version gate from algif-mitigation's 6.12.85+). Watch AWS Security Bulletin 2026-027-AWS, ALAS2023-2026-1694, and ALAS2023-2026-1695.
+
 ## Taint Summary
 
 | Taint Key | Type | Effect | Scope | Removed By |
@@ -161,7 +179,7 @@ Runs on ALL nodes (no nodeSelector, tolerates everything). Idempotent via `/var/
 | `instance-type={type}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (scheduling constraint) |
 | `node-fleet={fleet}` | Permanent | `NoSchedule` | ARC runner NodePools | Never (fleet-based scheduling) |
 | `workload/buildkit-{arch}=true` | Permanent | `NoSchedule` | BuildKit NodePools | Never (scheduling constraint) |
-| `nvidia.com/gpu=true` | Permanent | `NoSchedule` | GPU NodePools only — applied by both the standard `generate_nodepools.py` (g4dn, g5, g6, p4d) and the specialized H100 (`modules/nodepools-h100`) and B200 (`modules/nodepools-b200`) generators. H100/B200 pools also pin `topology_manager_policy: single-numa-node` (scope `pod`) instead of the runner default (`best-effort`/`container`). | Never (scheduling constraint) |
+| `nvidia.com/gpu=true` | Permanent | `NoSchedule` | GPU NodePools only — applied by both the standard `generate_nodepools.py` (g4dn, g5, g6, p4d) and the specialized H100 (`modules/nodepools-h100`) and B200 (`modules/nodepools-b200`) generators. The `topology_manager_policy: single-numa-node` (scope `pod`) override is a per-def opt-in (set in the fleet YAML) and is used by p4d in the standard generator AND by H100/B200 in the specialized generators; other GPU pools inherit the runner default (`best-effort`/`container`). | Never (scheduling constraint) |
 | `node-compactor.osdc.io/consolidating=true` | Runtime (dynamic) | `NoSchedule` | Applied by node-compactor | node-compactor controller (protected by `min_node_age`: 900s) |
 | `CriticalAddonsOnly=true` | Permanent | `NoSchedule` | Base infrastructure nodes (EKS-managed) | Never |
 
@@ -215,4 +233,5 @@ This ensures DaemonSet pods schedule on nodes immediately at provisioning time, 
 | `base/kubernetes/registry-mirror-config.yaml` | Containerd registry mirror DaemonSet |
 | `base/kubernetes/node-performance-tuning.yaml` | CPU/GPU tuning DaemonSet |
 | `base/kubernetes/algif-mitigation.yaml` | TEMPORARY: blacklists algif_aead module to mitigate CVE-2026-31431 (remove when AL2023 AMI has kernel 6.12.85+) |
+| `base/kubernetes/dirtyfrag-mitigation.yaml` | TEMPORARY: blacklists esp4/esp6/rxrpc + drops page cache to mitigate CVE-2026-43284 + CVE-2026-43500 (remove when AL2023 AMI has kernel 6.1.170+ or 6.12.83+) |
 | `modules/arc-runners/scripts/python/validate_runner_qos.py` | Deploy-time validation (checks hooks init container exists) |

--- a/osdc/docs/observability-estimates.md
+++ b/osdc/docs/observability-estimates.md
@@ -2,7 +2,14 @@
 
 Per-unit cost estimates for metrics cardinality and log volume. For architecture, pipeline descriptions, deploy order, gotchas, and troubleshooting, see [observability.md](observability.md).
 
-> **Stale estimates warning (2026-05-06)**: The numerical cardinality estimates in the "Estimated Metrics Load for arc-cbr-production" section below predate the comprehensive metric whitelisting work landed in PR #418 / #428 (commits b59f269, 18dcf3b). Per-source descriptions have been updated to reflect the current whitelists, but the aggregate totals and percentages have **not** been recomputed. They are likely overstated by 1–2 orders of magnitude for sources like node-exporter (now 2 series per node, was estimated at 200–400) and cAdvisor (now 2 series per container restricted to control-plane namespaces, was estimated at 30–50 cluster-wide). Re-validate against live Grafana Cloud Mimir before relying on these numbers (e.g. `count by (__name__) ({cluster="pytorch-arc-cbr-production"})`).
+> **Stale estimates warning**: The numerical cardinality estimates in the "Estimated Metrics Load for arc-cbr-production" section below are stale for multiple reasons and should not be relied on without re-validation:
+> - **Per-source whitelists landed after the original calculation.** node-exporter is now ~4 series per node (was estimated at 200–400) and cAdvisor is restricted to control-plane namespaces (was estimated at 30–50 cluster-wide).
+> - **The kubelet ServiceMonitor is currently disabled** on IPv6-only EKS (`modules/monitoring/helm/values.yaml` `kubelet.enabled: false`). Both cAdvisor and `kubelet_*` series produce **zero** today. The per-source descriptions below describe the planned post-IPv6 state, not current behavior. See `observability.md` "Disabled scrapers (IPv6 migration)".
+> - **`arc-cbr-production` sizing inputs in this doc are out of date.** Current `clusters.yaml` defaults give: base nodes 6 (`m7i.12xlarge`), CoreDNS 6, Karpenter 4, ARC controller 4, Harbor nginx/core/registry 6/4/4, git-cache-central 15, BuildKit 10 (5/arch × 2), pypi-cache 40 (4 deployments × 10 replicas). The input-data table below has been refreshed; subtotals downstream may still reflect the older numbers.
+> - **Scale-set count is 50**, not 40 (42 upstream + 4 B200 + 4 H100).
+> - **`gha_capacity_*` family count is 16**, not 15.
+>
+> Re-validate against live Grafana Cloud Mimir before relying on aggregate numbers (e.g. `count by (__name__) ({cluster="pytorch-arc-cbr-production"})`).
 
 > **Maintenance note**: When adding, removing, or modifying any ServiceMonitor, PodMonitor, metricRelabelings, logging pipeline, sampling rate, or filtering rule, the estimates in this document **MUST be updated** to reflect the change. Stale estimates are misleading and can lead to unexpected Grafana Cloud costs.
 
@@ -16,8 +23,8 @@ Runner pods are ephemeral — they run a single GitHub Actions job and terminate
 
 | Source | What's collected | ~Series |
 |--------|-----------------|---------|
-| **cAdvisor** (kubelet) | Whitelisted to `container_memory_working_set_bytes` and `container_memory_rss` only at the kubelet ServiceMonitor level. Further restricted by Alloy `cost_control` to control-plane namespaces only (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`). Runner pods contribute zero cAdvisor series. | 0 per runner pod (filtered out at Alloy) |
-| **ARC listener** (per scale set, not per pod) | `gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, `gha_job_execution_duration_seconds_{sum,count}`, `gha_job_startup_duration_seconds_{sum,count}`, plus the 15 `gha_capacity_*` metric families (proactive-capacity monitor) | ~85-90 per scale set |
+| **cAdvisor** (kubelet) | **Currently 0 series — kubelet ServiceMonitor is disabled** (`modules/monitoring/helm/values.yaml` `kubelet.enabled: false`, IPv6 migration). Planned post-IPv6 state: whitelisted to `container_memory_working_set_bytes` and `container_memory_rss` only at the kubelet ServiceMonitor level, then further restricted by Alloy `cost_control` to control-plane namespaces only (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`). Runner pods will contribute zero cAdvisor series even after re-enablement. | 0 per runner pod (kubelet SM off) |
+| **ARC listener** (per scale set, not per pod) | `gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, `gha_job_execution_duration_seconds_{sum,count}`, `gha_job_startup_duration_seconds_{sum,count}`, plus the 16 `gha_capacity_*` metric families (proactive-capacity monitor) | ~85-90 per scale set |
 
 **What's NOT collected per runner pod**: No application-level metrics from inside the runner. No per-job Prometheus endpoint. Runner pods do not expose a `/metrics` port. All runner-level telemetry is limited to what kubelet/cAdvisor observes externally.
 
@@ -27,20 +34,22 @@ Every node managed by Karpenter runs several DaemonSets that produce metrics. Th
 
 | Source | Deployment | What's collected | ~Series per node |
 |--------|-----------|-----------------|-----------------|
-| **node-exporter** | DaemonSet (all nodes) | Whitelisted to memory only: `node_memory_MemAvailable_bytes` and `node_memory_MemTotal_bytes`. All other collectors (CPU, disk, fs, network, load, OS info) are dropped at ServiceMonitor level. | ~2 per node |
-| **kubelet** | Built-in (kubelet ServiceMonitor) | Whitelisted to `kubelet_running_pods`, `kubelet_running_containers`, `kubelet_node_name`. `/metrics/probes` disabled. | small fixed set per node |
-| **cAdvisor** | Built-in (kubelet) | Whitelisted to `container_memory_working_set_bytes` and `container_memory_rss`, then restricted by Alloy `cost_control` to control-plane namespaces only (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`). Runner nodes contribute zero cAdvisor series. | ~2 per control-plane container; 0 per runner pod |
+| **node-exporter** | DaemonSet (all nodes) | Whitelisted to 4 metrics: `node_memory_MemAvailable_bytes`, `node_memory_MemTotal_bytes`, `node_nf_conntrack_entries`, `node_nf_conntrack_entries_limit`. Conntrack metrics power `ipv6-network-pressure` alerts (`NodeConntrackHighWarn/Critical/MetricMissing`); other collectors (CPU, disk, fs, network, load, OS info) are dropped at ServiceMonitor level. | ~4 per node |
+| **kubelet** | Built-in (kubelet ServiceMonitor) | **Currently 0 series — `kubelet.enabled: false`** in `modules/monitoring/helm/values.yaml` (IPv6 migration). Planned post-IPv6 state: whitelisted to `kubelet_running_pods`, `kubelet_running_containers`, `kubelet_node_name`; `/metrics/probes` disabled. | 0 per node (kubelet SM off) |
+| **cAdvisor** | Built-in (kubelet) | **Currently 0 series — kubelet ServiceMonitor disabled** (see kubelet row above). Planned post-IPv6 state: whitelisted to `container_memory_working_set_bytes` and `container_memory_rss`, then restricted by Alloy `cost_control` to control-plane namespaces only (`arc-systems\|karpenter\|harbor-system\|monitoring\|logging\|buildkit`). Runner nodes will contribute zero cAdvisor series even after re-enablement. | 0 per node (kubelet SM off) |
+| **kube-proxy** | DaemonSet (all nodes, EKS-managed) | Not scraped — no ServiceMonitor for `kube-proxy` metrics; logs collected via base pipeline. | 0 per node |
+| **aws-node (VPC-CNI)** | DaemonSet (all nodes, EKS-managed) | Not scraped — no ServiceMonitor; logs collected via base pipeline. | 0 per node |
 | **git-cache-warmer** | DaemonSet (all nodes) | Clone/fetch durations, cache sizes, rsync stats | ~10-20 |
 | **nodelocaldns** | DaemonSet (all nodes) | Two scrape ports: `:9253` exposes CoreDNS plugin metrics per zone (4 zones — `cluster.local`, `in-addr.arpa`, `ip6.arpa`, `.`) — request counts by type/proto/family, response codes, cache hits/misses/entries, forward stats, plus `_sum`/`_count` for duration histograms. `:9353` exposes the binary's `coredns_nodecache_setup_errors_total` (single series). Drops `go_*`, `process_*`, and `coredns_*_request_duration_seconds_bucket` at PodMonitor level (matches `coredns.yaml` convention). | ~40-60 per node (~10-15 per zone × 4 zones, plus 1 setup-errors series) |
 | **DCGM exporter** | DaemonSet (GPU nodes only) | 25 curated GPU metrics per GPU (Tier 1: 22, Tier 2: 3): utilization, memory, temp, power, ECC, XID errors, NVLink, PCIe, clocks, throttling | 25 per GPU |
 
-**Per-node totals** (varies by node type — see the stale-estimates warning at the top of this doc; the numbers below are pre-whitelist and overstate cardinality by 1–2 orders of magnitude):
+**Per-node totals** (varies by node type — see the stale-estimates warning at the top of this doc; the numbers below are pre-whitelist and overstate cardinality by 1–2 orders of magnitude. cAdvisor column is **currently 0 everywhere** because the kubelet ServiceMonitor is disabled for the IPv6 migration):
 
 | Node type | node-exporter | cAdvisor | git-cache-warmer | nodelocaldns | DCGM | Total per node |
 |-----------|:---:|:---:|:---:|:---:|:---:|:---:|
-| CPU runner node (~10 containers) | ~300 | ~400 | ~15 | ~50 | 0 | ~765 |
-| GPU node (8x GPUs, ~10 containers) | ~300 | ~400 | ~15 | ~50 | ~208 | ~973 |
-| Base infra node (~30 containers) | ~300 | ~1200 | ~15 | ~50 | 0 | ~1565 |
+| CPU runner node (~10 containers) | ~300 | 0 (SM off) | ~15 | ~50 | 0 | ~365 |
+| GPU node (8x GPUs, ~10 containers) | ~300 | 0 (SM off) | ~15 | ~50 | ~208 | ~573 |
+| Base infra node (~30 containers) | ~300 | 0 (SM off) | ~15 | ~50 | 0 | ~365 |
 
 ### Cluster-Wide (Fixed per Source)
 
@@ -49,8 +58,8 @@ These metrics come from centralized Deployments or StatefulSets. Series counts b
 | Source | What's collected | ~Series per replica |
 |--------|-----------------|---------------------|
 | **K8s API server** (EKS-managed) | Whitelisted to `apiserver_request_total` and `apiserver_request_terminations_total` only. | small fixed set (whitelist of 2 metric families) |
-| **CoreDNS** (EKS-managed) | Request/response counts, latency (sum/count), cache hits/misses/entries, forward request stats. go_*/process_* and histogram buckets dropped at monitor level | ~30-50 per replica |
-| **kube-state-metrics** | K8s object state: pod/deployment/node/daemonset/statefulset/PV/HPA/job/namespace status. Allowlist scope: `daemonset|deployment|pod|namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job` (replicaset NOT included). Heavily filtered via allowlist + cost-control drops. | ~200-500 total (single replica) |
+| **CoreDNS** (EKS-managed) | kube-prometheus-stack built-in `coreDns` ServiceMonitor is disabled (`coreDns.enabled: false`); custom PodMonitor (`modules/monitoring/kubernetes/monitors/podmonitors/coredns.yaml`) scrapes the pods directly. Keeps: request/response counts, latency (sum/count), cache hits/misses/entries, forward request stats. Drops: `go_*`, `process_*`, and `coredns_dns_request_duration_seconds_bucket|coredns_forward_request_duration_seconds_bucket` at the PodMonitor level. | ~30-50 per replica |
+| **kube-state-metrics** | K8s object state: pod/deployment/node/daemonset/statefulset/PV/HPA/job/namespace status. Two-layer filter: (1) `--metric-allowlist=kube_(daemonset\|deployment\|pod\|namespace\|node\|statefulset\|persistentvolume\|horizontalpodautoscaler\|job)_.+` extraArg controls which resource groups KSM generates; (2) per-monitor `keep` allowlist further narrows daemonset/deployment/pod metrics (e.g. only `kube_daemonset_status_(desired_number_scheduled\|number_ready\|number_available\|number_unavailable)`, `kube_deployment_status_(replicas_ready\|replicas_available\|replicas_unavailable\|condition)`, `kube_pod_info\|kube_pod_container_status_*\|kube_pod_status_reason`) plus three `drop` rules for benign Completed terminations and routine pod status reasons. replicaset NOT included. | ~200-500 total (single replica) |
 | **Karpenter controller** | Whitelisted to 7 metric families: `karpenter_nodeclaims_created_total`, `karpenter_nodes_created_total`, `karpenter_nodes_terminated_total`, `karpenter_nodepools_usage`, `karpenter_nodepools_limit`, `karpenter_nodes_allocatable`, `karpenter_interruption_received_messages_total`. No latency, histograms, or disruption counts. | small fixed set per replica |
 | **ARC controller** | Whitelisted to `gha_controller_.*` and `controller_runtime_reconcile_errors_total`. | ~10-25 per replica |
 | **Harbor exporter** | No positive whitelist — only `go_*\|process_*\|promhttp_*` are dropped at the ServiceMonitor level. Actual cardinality is the full Harbor metric set; estimate is approximate. | ~50-100 per replica (unverified upper bound) |
@@ -63,7 +72,7 @@ These metrics come from centralized Deployments or StatefulSets. Series counts b
 
 ### Scaling Formula (Metrics)
 
-> **NOTE:** the per-node and per-pod multipliers below are stale (see warning at top of doc). They predate the metric whitelisting work — node-exporter is now ~2 series per node (not ~300) and runner-pod cAdvisor is now 0 series (not 40). The DCGM term should use 25, not 26 (the curated metrics CSV defines exactly 25 metrics). The nodelocaldns term (~50 per node) is post-whitelist and stable. Use the formula structure but expect totals to be 1–2 orders of magnitude lower in practice.
+> **NOTE:** the per-node and per-pod multipliers below are stale (see warning at top of doc). They predate the metric whitelisting work — node-exporter is now ~4 series per node (not ~300; memory 2 + conntrack 2) and runner-pod cAdvisor is currently 0 series (kubelet ServiceMonitor disabled for IPv6 migration). The DCGM term should use 25, not 26 (the curated metrics CSV defines exactly 25 metrics). The nodelocaldns term (~50 per node) is post-whitelist and stable. Use the formula structure but expect totals to be 1–2 orders of magnitude lower in practice.
 
 ```
 Total series ≈ C_fixed
@@ -77,7 +86,7 @@ Total series ≈ C_fixed
 Where:
 - `C_fixed` = sum of all cluster-wide sources × their replica counts
 - `N_total_GPUs` = total GPUs across all GPU nodes (handles heterogeneous fleets where GPU count varies by instance type)
-- The `N_scale_sets × 85` term reflects the listener's full per-scale-set series count: ~5-10 baseline (`gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, job-duration sum/count) plus ~77 from the 15 `gha_capacity_*` families (the two histograms — `gha_capacity_reconcile_duration_seconds` and `gha_capacity_hud_request_duration_seconds` — contribute ~22 each via 9 buckets + sum + count across two label values; `gha_capacity_placeholder_pods` contributes 10 via the `role`(2)×`phase`(5) cross-product; the remaining gauges/counters add the rest)
+- The `N_scale_sets × 85` term reflects the listener's full per-scale-set series count: ~5-10 baseline (`gha_assigned_jobs`, `gha_completed_jobs_total`, `gha_started_jobs_total`, `gha_running_jobs`, job-duration sum/count) plus ~77 from the 16 `gha_capacity_*` families (the two histograms — `gha_capacity_reconcile_duration_seconds` and `gha_capacity_hud_request_duration_seconds` — contribute ~22 each via 9 buckets + sum + count across two label values; `gha_capacity_placeholder_pods` contributes 10 via the `role`(2)×`phase`(5) cross-product; the remaining gauges/counters add the rest). Note: only the job-duration histograms (`gha_job_(execution|startup)_duration_seconds_bucket`) are dropped by Alloy `cost_control`; the two capacity histograms above survive and contribute their full bucket × label cross-products.
 
 ### What's NOT Collected (Metrics)
 
@@ -86,7 +95,7 @@ Where:
 | etcd metrics | Not collected | EKS manages etcd; not exposed |
 | CloudWatch / VPC / EBS metrics | Not collected | No CloudWatch exporter. Control plane logs go to CloudWatch (see Terraform) |
 | kube-proxy metrics | Not scraped | Low signal-to-noise for CI workloads. Logs collected via logging pipeline |
-| kubelet metrics (non-cAdvisor) | Partial | Whitelisted to `kubelet_running_pods`, `kubelet_running_containers`, `kubelet_node_name`. `/metrics/probes` disabled. |
+| kubelet metrics (non-cAdvisor) | Disabled (IPv6 migration) | kube-prometheus-stack `kubelet.enabled: false`. Planned post-IPv6 state: whitelisted to `kubelet_running_pods`, `kubelet_running_containers`, `kubelet_node_name`; `/metrics/probes` disabled. See `observability.md` "Disabled scrapers (IPv6 migration)". |
 | kube-controller-manager metrics | Not collected | EKS does not expose controller-manager endpoints |
 | kube-scheduler metrics | Not collected | EKS does not expose scheduler endpoints |
 
@@ -125,13 +134,20 @@ Every Karpenter-managed node runs DaemonSets that produce logs. This is the per-
 | **kernel** (journal) | System | 1-10 | OOM kills, hardware errors |
 | **git-cache-warmer** | Pod log | 2-10 | rsync from central every 300s |
 | **node-performance-tuning** | Pod log | ~0 | Init container only, main sleeps |
-| **runner-hooks-warmer** | Pod log | ~0 | Downloads once, main sleeps |
 | **registry-mirror-config** | Pod log | ~0 | Init container, main sleeps |
+| **kube-proxy** | Pod log | 1-5 | EKS-managed DaemonSet — runs on every node. klog format, level extracted. |
+| **aws-node (VPC-CNI)** | Pod log | 1-5 | EKS-managed DaemonSet — runs on every node. JSON, level extracted. |
 | **GPU: nvidia-fabricmanager** (journal) | System | 1-5 | GPU nodes only |
 | **GPU: nvidia-persistenced** (journal) | System | 0-2 | GPU nodes only |
 | **cache-enforcer** | Pod log | 1-5 | DaemonSet on `arc-cbr-production` (`modules/cache-enforcer/kubernetes/daemonset.yaml`) |
 | **image-cache-janitor** | Pod log | 1-5 | DaemonSet in base — runs on every node (`base/kubernetes/image-cache-janitor/daemonset.yaml`) |
 | **nodelocaldns** | Pod log | <1 | DaemonSet in base — runs on every node (`base/kubernetes/nodelocaldns/`). CoreDNS plugin reports + "Setup OK" messages only; near-silent at steady state |
+
+Subset-scoped DaemonSets (not on every Karpenter node):
+
+| Source | Type | Scope | ~Lines/min per node | Notes |
+|--------|------|-------|:---:|-------|
+| **runner-hooks-warmer** | Pod log | `arc-runners` namespace, `nodeSelector: node-fleet=c7i-runner` (CPU runner pool only — not GPU, not BuildKit) | ~0 | Downloads runner-container-hooks zip once, main sleeps. Because it lives in `arc-runners`, its logs are sampled at 10% per the ARC pipeline. |
 
 **Per-node totals**:
 
@@ -162,8 +178,6 @@ These run on tainted `CriticalAddonsOnly` base nodes. Rates are **per replica** 
 | **ARC controller** | 5-25 | Runner scale set reconciliation |
 | **ARC listener** | 1-5 | GitHub API polling (1 listener per runner scale set definition) |
 | **CoreDNS** | 10-50 | DNS query logs |
-| **kube-proxy** | 1-5 | Connection tracking (DaemonSet — 1 per base node) |
-| **aws-node (VPC-CNI)** | 1-5 | Network allocation, JSON, level extracted (DaemonSet — 1 per base node) |
 | **kube-state-metrics** | 2-10 | Object state change logs (single replica) |
 | **Prometheus Operator** | 2-10 | CRD reconciliation (single replica) |
 | **BuildKit HAProxy** | 5-20 | TCP connection access logs |
@@ -254,28 +268,28 @@ From the fleet simulation:
 | CPU-only runner nodes | 680 | c7a.48xlarge (267) + c7i.metal-24xl (36) + m6i.32xlarge (27) + m7i.48xlarge (48) + m8g.16xlarge (29) + m8g.48xlarge (15) + r7a.48xlarge (138) + r7g.16xlarge (120) |
 | GPU runner nodes | 1,433 | g4dn.12xlarge (157) + g4dn.8xlarge (89) + g4dn.metal (79) + g5.12xlarge (58) + g5.48xlarge (40) + g5.8xlarge (596) + g6.12xlarge (26) + g6.8xlarge (388). H100 (`p5.48xlarge`) and B200 nodes are not in the fleet simulation and are not counted here. |
 | Total GPUs | 2,989 | Across all GPU node types in the fleet simulation (excludes H100/B200) |
-| Base infra nodes | 5 | `clusters.yaml` → `base_node_count` (m7i.4xlarge, fixed) |
+| Base infra nodes | 6 | `clusters.yaml` defaults → `base_node_count: 6` (m7i.12xlarge per `base_node_instance_type`; `arc-cbr-production` has no override) |
 | Runner scale sets | 50 | 42 upstream (`modules/arc-runners/defs/`) + 4 B200 (`modules/arc-runners-b200/defs/`) + 4 H100 (`modules/arc-runners-h100/defs/`) |
 
-From `clusters.yaml` defaults for `arc-cbr-production`:
+From `clusters.yaml` defaults plus `arc-cbr-production` overrides:
 
-| Service | Replicas |
-|---|---|
-| Karpenter | 2 |
-| ARC controller | 2 |
-| Harbor nginx | 3 |
-| Harbor core | 2 |
-| Harbor registry | 2 |
-| Harbor exporter / jobservice / portal / db / redis | 1 each |
-| git-cache-central | 5 |
-| node-compactor | 1 |
+| Service | Replicas | Source |
+|---|---|---|
+| Karpenter | 4 | `defaults.karpenter.replicas: 4` |
+| ARC controller | 4 | `defaults.arc.replica_count: 4` |
+| Harbor nginx | 6 | `defaults.harbor.nginx_replicas: 6` |
+| Harbor core | 4 | `defaults.harbor.core_replicas: 4` |
+| Harbor registry | 4 | `defaults.harbor.registry_replicas: 4` |
+| Harbor exporter / jobservice / portal / db / redis | 1 each | chart defaults |
+| git-cache-central | 15 | `arc-cbr-production.git_cache.central_replicas: 15` (default is 2) |
+| node-compactor | 1 | single replica |
 | Monitoring Alloy | 2 | Hard-coded in `modules/monitoring/helm/alloy-values.yaml` (`controller.replicas: 2`, `clustering.enabled: true`) — there is no `monitoring.alloy_replicas` config knob |
-| BuildKit daemon | 8 (4 per arch — `buildkit.replicas_per_arch: 4` × 2 archs) |
-| BuildKit HAProxy | 1 |
-| CoreDNS | 2 (EKS default) |
-| kube-state-metrics | 1 |
-| Prometheus Operator | 1 |
-| pypi-cache nginx | 20 (4 deployments per CUDA slug × 5 replicas — `pypi_cache.replicas: 5`) |
+| BuildKit daemon | 10 | `defaults.buildkit.replicas_per_arch: 5` × 2 archs |
+| BuildKit HAProxy | 1 | single replica |
+| CoreDNS | 6 | `defaults.coredns.replicas: 6` (`arc-cbr-production` has no override) |
+| kube-state-metrics | 1 | single replica |
+| Prometheus Operator | 1 | single replica |
+| pypi-cache nginx | 40 | 4 deployments per CUDA slug (`cpu`, `cu126`, `cu128`, `cu130`) × `arc-cbr-production.pypi_cache.replicas: 10` |
 
 ### Cluster-wide fixed overhead (C_fixed)
 
@@ -284,16 +298,17 @@ Using midpoint of per-replica ranges from the [cluster-wide reference table](#cl
 | Source | ~Series/replica (mid) | Replicas | Subtotal |
 |---|---|---|---|
 | K8s API server | ~300 | 1 | ~300 |
-| CoreDNS | ~40 | 2 | ~80 |
+| CoreDNS | ~40 | 6 | ~240 |
 | kube-state-metrics | ~350 | 1 | ~350 |
-| Karpenter | ~38 | 2 | ~76 |
-| ARC controller | ~18 | 2 | ~36 |
+| Karpenter | ~38 | 4 | ~152 |
+| ARC controller | ~18 | 4 | ~72 |
 | Harbor exporter | ~75 | 1 | ~75 |
-| BuildKit daemon | ~9 | 8 | ~72 |
+| BuildKit daemon | ~9 | 10 | ~90 |
 | BuildKit HAProxy | ~23 | 1 | ~23 |
-| git-cache-central | ~7 | 5 | ~35 |
+| git-cache-central | ~7 | 15 | ~105 |
 | node-compactor | ~15 | 1 | ~15 |
-| **Total C_fixed** | | | **~1,062** |
+| pypi-cache nginx (per-pod) | ~5 | 40 | ~200 |
+| **Total C_fixed** | | | **~1,622** |
 
 ### Peak cardinality calculation
 
@@ -307,11 +322,11 @@ Total series ≈ C_fixed
              + N_base_nodes × 1515
              + N_scale_sets × 85
 
-           ≈ 1,062
-             + 7,367 × 40               =    294,680   (stale: per-pod cAdvisor now 0)
-             + 680 × 715                =    486,200   (stale: per-node node-exporter now ~2)
-             + 1,433 × 715 + 25 × 2,989 =  1,099,320   (stale: per-node node-exporter now ~2; H100 GPUs not counted)
-             + 5 × 1,515               =      7,575   (stale: per-node multiplier overstated)
+           ≈ 1,622                              (refreshed C_fixed)
+             + 7,367 × 40               =    294,680   (stale: per-pod cAdvisor currently 0 — kubelet SM disabled)
+             + 680 × 715                =    486,200   (stale: per-node node-exporter now ~4; cAdvisor currently 0)
+             + 1,433 × 715 + 25 × 2,989 =  1,099,320   (stale: per-node node-exporter now ~4; cAdvisor currently 0; H100 GPUs not counted)
+             + 6 × 1,515               =      9,090   (stale: per-node multiplier overstated; base node count refreshed 5 → 6)
              + 50 × 85                  =      4,250   (was 40 × 85 = 3,400 before H100 module + 6 added scale sets)
 
            ≈ stale; do not rely on aggregate totals
@@ -362,9 +377,9 @@ From the load distribution data:
 | Peak fleet | 2,113 nodes | Fleet simulation |
 | Weekday avg fleet | ~1,355 nodes | Derived from [node churn estimates](current_runner_load_distribution.md#fleet-size-by-time-of-day): weighted average of peak (2,113), trough (597), and transition periods |
 | Weekend avg fleet | ~249 nodes | [Node churn estimates](current_runner_load_distribution.md#fleet-size-by-time-of-day) |
-| BuildKit pods | 8 (4 per arch) | `clusters.yaml` → `buildkit.replicas_per_arch: 4` × 2 archs |
-| BuildKit nodes | 4 (2 per arch) | `clusters.yaml` arc-cbr-production override → `buildkit.pods_per_node: 2` |
-| Base nodes | 5 | `clusters.yaml` → `base_node_count` |
+| BuildKit pods | 10 (5 per arch) | `clusters.yaml` defaults → `buildkit.replicas_per_arch: 5` × 2 archs |
+| BuildKit nodes | 5 (≈ 10 pods / 2 per node) | `clusters.yaml` arc-cbr-production override → `buildkit.pods_per_node: 2` |
+| Base nodes | 6 | `clusters.yaml` defaults → `base_node_count: 6` (no override in `arc-cbr-production`) |
 
 ### Component breakdown (weekday average)
 
@@ -385,12 +400,14 @@ Fixed overhead from centralized services. Uses service rates from the [base infr
 
 | Service | Lines/min (mid × replicas) | GB/day |
 |---|---|---|
-| Harbor (all components) | 3×93 + 2×15 + 2×28 + 1×6 + 1×3 + 1×3 + 1×3 + 1×3 = ~380 | ~0.11 |
+| Harbor (all components) | 6×93 + 4×15 + 4×28 + 1×6 + 1×3 + 1×3 + 1×3 + 1×3 = ~748 | ~0.22 |
 | ARC listeners (50 scale sets) | 50 × 3 = ~150 | ~0.04 |
-| ARC controller + Karpenter + CoreDNS | 2×15 + 2×15 + 2×30 = ~120 | ~0.03 |
-| git-cache-central (5 replicas) | 5 × 6 = ~30 | ~0.01 |
-| Other (node-compactor, kube-proxy, aws-node, KSM, Prom Operator, Alloy, HAProxy) | ~90 | ~0.03 |
-| **Total base services** | **~740** | **~0.21** |
+| ARC controller + Karpenter + CoreDNS | 4×15 + 4×15 + 6×30 = ~300 | ~0.09 |
+| git-cache-central (15 replicas) | 15 × 6 = ~90 | ~0.03 |
+| Other (node-compactor, KSM, Prom Operator, Alloy, HAProxy) | ~50 | ~0.01 |
+| **Total base services** | **~1,338** | **~0.39** |
+
+kube-proxy and aws-node (EKS-managed) are excluded here — they run as DaemonSets on every node and are accounted for in the per-node DaemonSet overhead.
 
 #### Runner job logs
 
@@ -409,12 +426,12 @@ At ~53,300 jobs/day average:
 
 #### BuildKit logs
 
-8 pods at `max-parallelism=1`. Volume depends on build activity (not in the load data).
+10 pods at `max-parallelism=1`. Volume depends on build activity (not in the load data).
 
 | Build activity | GB/day |
 |---|---|
-| Mostly idle | ~0.08 (8 × 0.01) |
-| Fully active | ~4.0 (8 × 0.5) |
+| Mostly idle | ~0.10 (10 × 0.01) |
+| Fully active | ~5.0 (10 × 0.5) |
 
 #### Kubernetes events
 
@@ -431,9 +448,9 @@ Using midpoint per-unit rates and ~1 MB/job as the runner job estimate:
 
 | Component | GB/day | % of Total |
 |---|---|---|
-| Node DaemonSet + journal overhead | ~61 | 52.8% |
-| Runner job logs (at 1 MB/job) | ~53 | 45.9% |
-| Base infrastructure services | ~0.2 | 0.2% |
+| Node DaemonSet + journal overhead | ~61 | 52.5% |
+| Runner job logs (at 1 MB/job) | ~53 | 45.6% |
+| Base infrastructure services | ~0.4 | 0.3% |
 | BuildKit (mixed idle/active) | ~1 | 0.9% |
 | Events | ~0.2 | 0.2% |
 | **Total** | **~116** | |

--- a/osdc/docs/observability.md
+++ b/osdc/docs/observability.md
@@ -76,7 +76,7 @@ The chart (v82.10.3) is used **only as a CRD + exporter bundle**:
 
 | Type | Name | Target Namespace | What it monitors |
 |------|------|-----------------|-----------------|
-| ServiceMonitor | apiserver | default | K8s API server request rate, latency, inflight requests, etcd latency |
+| ServiceMonitor | apiserver | default | K8s API server request counters (`apiserver_request_total`, `apiserver_request_terminations_total`) — latency, inflight, and etcd metrics are filtered out |
 | ServiceMonitor | arc-controller | arc-systems | ARC controller metrics |
 | ServiceMonitor | harbor | harbor-system | Harbor exporter metrics |
 | ServiceMonitor | karpenter | karpenter | Karpenter controller metrics |
@@ -139,10 +139,11 @@ Per-source `keep` whitelists or targeted `drop` rules — most filtering lives h
 
 | Source | Filter |
 |--------|--------|
-| `apiserver` ServiceMonitor | `keep`: `apiserver_request_total\|apiserver_request_terminations_total` only |
+| `apiserver` ServiceMonitor | `keep`: `apiserver_request_total\|apiserver_request_terminations_total` only — request rate and termination counts only; latency, inflight, and etcd metrics are dropped |
 | `coredns` PodMonitor | `drop`: `go_.*`, `process_.*`, `coredns_dns_request_duration_seconds_bucket\|coredns_forward_request_duration_seconds_bucket` |
 | `pypi-cache` ServiceMonitor | `keep`: `nginx_up\|nginx_http_requests_total\|nginx_connections_active` only |
-| node-exporter (built-in) | `keep`: `node_memory_MemAvailable_bytes\|node_memory_MemTotal_bytes` only — drops everything else including all CPU, disk I/O, filesystem, network, and load metrics |
+| node-exporter (built-in) | `keep`: `node_memory_MemAvailable_bytes\|node_memory_MemTotal_bytes\|node_nf_conntrack_entries\|node_nf_conntrack_entries_limit` only — drops everything else including all CPU, disk I/O, filesystem, network, and load metrics. Conntrack metrics are kept because they power the `ipv6-network-pressure` alerts (pod-to-IPv4 egress via VPC CNI SNAT is conntrack-heavy under IPv6-only EKS). |
+| `buildkit` ServiceMonitor | `drop`: `go_.*`, `process_.*`, `promhttp_.*\|target_info`, `.*_bucket` — drop-list pattern (not keep-list); buckets are dropped wholesale, only `_sum`/`_count` survive for latency tracking |
 | DCGM ServiceMonitor | label drops: `UUID`, `modelName`, `DCGM_FI_DRIVER_VERSION`, `pci_bus_id` |
 
 #### Layer 3: Alloy `cost_control` (safety net)
@@ -161,7 +162,7 @@ Final drops applied to anything that escapes layers 1–2:
 
 ### Alerting
 
-PrometheusRule CRDs are defined locally and synced to Grafana Cloud Mimir via Alloy's `mimir.rules.kubernetes` component for remote evaluation. Six alert groups across six PrometheusRule files in `kubernetes/alerts/`:
+PrometheusRule CRDs are defined locally and synced to Grafana Cloud Mimir via Alloy's `mimir.rules.kubernetes` component for remote evaluation. Eight alert groups across eight PrometheusRule files in `kubernetes/alerts/`:
 
 | Group | Alert | Condition |
 |-------|-------|-----------|
@@ -176,12 +177,15 @@ PrometheusRule CRDs are defined locally and synced to Grafana Cloud Mimir via Al
 | infrastructure | `KarpenterNodeClaimNotReady` | NodeClaim created but no node joins for 15m |
 | node-compactor | `NodeCompactorReconcileErrors` | Continuous reconciliation errors for 15m (burst-absorption offline) |
 | zombie-cleanup | `ZombieCleanupCapReached` | Per-round cap reached — zombie pods deferred to next run |
-| harbor-cache-recovery | `HarborCacheRecoveryFailing` | Cache-recovery CronJob failing for 15m (≥3 consecutive runs at */5) |
-| harbor-cache-recovery | `HarborCacheRecoveryOOM` | Recovery pod OOMKilled (most common root cause — listing pods cluster-wide) |
-| harbor-cache-recovery | `HarborCacheRecoveryStale` | No successful recovery run in >30m (CronJob suspended/stuck) |
+| harbor-cache-recovery | `HarborCacheRecoveryFailing` | Cache-recovery CronJob failing for 15m (≥3 consecutive runs at */5). Targets `kube_job_status_failed` — each scheduled run is a fresh Job object, no long-lived pod to watch. |
+| harbor-cache-recovery | `HarborCacheRecoveryOOM` | Recovery pod OOMKilled (most common root cause — listing pods cluster-wide). Uses `kube_pod_container_status_terminated_reason` (no `_last_`) because recovery pods have `restartPolicy=Never`; KSM only populates `_last_terminated_reason` after a container restart. |
+| harbor-cache-recovery | `HarborCacheRecoveryStale` | No successful recovery run in >30m (CronJob suspended/stuck). Targets `kube_job_status_completion_time` for the same Job-vs-Pod reason. |
 | nodelocaldns | `NodeLocalDNSSetupErrors` | `increase(coredns_nodecache_setup_errors_total[5m]) > 0` — iptables NOTRACK rule install failed |
 | nodelocaldns | `NodeLocalDNSPodRestarting` | NLD container restarting (per-node DNS interception briefly degrades to fallthrough) |
 | nodelocaldns | `NodeLocalDNSDaemonSetDegraded` | DaemonSet has unavailable pods for >15m |
+| ipv6-network-pressure | `NodeConntrackHighWarn` | `node_nf_conntrack_entries / node_nf_conntrack_entries_limit > 0.80` for 5m — pod-to-IPv4 egress on IPv6-only EKS goes via VPC CNI's IPv4 SNAT, which is conntrack-heavy |
+| ipv6-network-pressure | `NodeConntrackHighCritical` | Same ratio > 0.95 for 2m — new connections will start failing imminently; raise `nf_conntrack_max` or drain the node |
+| ipv6-network-pressure | `NodeConntrackMetricMissing` | `absent(node_nf_conntrack_entries)` for 10m — catches silent loss of node-exporter scraping (e.g. IPv6 endpoint regression); without it the conntrack alerts above would be inert |
 
 ### Adding a new ServiceMonitor/PodMonitor
 
@@ -193,7 +197,9 @@ Monitors are applied by `deploy.sh` after kube-prometheus-stack Helm install (CR
 
 ### Credential setup (monitoring)
 
-The Grafana Cloud URL comes from `clusters.yaml` (`monitoring.grafana_cloud_url`), not from the secret. The secret only contains authentication credentials:
+The Grafana Cloud URL comes from `clusters.yaml` (`monitoring.grafana_cloud_url`), not from the secret. Two separate secrets are used in the `monitoring` namespace — one for Alloy's write path, one for the smoke tests' Mimir read queries.
+
+**Write credentials** — required for Alloy. The `monitoring/deploy.sh` script gates Alloy install on this secret existing:
 
 ```bash
 kubectl create namespace monitoring
@@ -201,6 +207,15 @@ kubectl create secret generic grafana-cloud-credentials \
   -n monitoring \
   --from-literal=username='<GRAFANA_CLOUD_METRICS_USER_ID>' \
   --from-literal=password='<API_KEY_WITH_METRICS_WRITE_SCOPE>'
+```
+
+**Read credentials** — required for `just smoke` to verify metrics actually arrived in Mimir. Without it, the remote-verification tests in `modules/monitoring/tests/smoke/test_monitoring.py` skip silently, leaving `remote_write` regressions undetected:
+
+```bash
+kubectl create secret generic grafana-cloud-read-credentials \
+  -n monitoring \
+  --from-literal=username='<GRAFANA_CLOUD_METRICS_USER_ID>' \
+  --from-literal=password='<API_KEY_WITH_METRICS_READ_SCOPE>'
 ```
 
 ### Configuration (clusters.yaml)
@@ -337,7 +352,7 @@ See [observability-estimates.md](observability-estimates.md#log-volume-estimatio
 2. `deploy.sh` installs kube-prometheus-stack (CRDs + exporters), chart `v82.10.3`
 3. `deploy.sh` installs Prometheus Pushgateway (chart `v3.6.0`, runs on base-infrastructure, scraped by the `pushgateway` ServiceMonitor)
 4. `deploy.sh` applies `kubernetes/monitors/` (ServiceMonitors, PodMonitors, and PrometheusRules — alerts are included via kustomization, requires CRDs from step 2)
-5. `deploy.sh` conditionally installs Alloy (chart version from `clusters.yaml` `alloy_chart_version`, currently `1.6.2`) if `grafana-cloud-credentials` secret exists
+5. `deploy.sh` conditionally installs Alloy (chart version from `clusters.yaml` `alloy_chart_version`, currently `1.6.2`) if `grafana-cloud-credentials` secret exists. After every successful `helm upgrade`, `deploy.sh` runs `kubectl rollout restart deployment/alloy` followed by `rollout status` — this picks up secret rotations and external config changes that Helm doesn't trigger naturally (the secret keys are referenced via `valueFrom.secretKeyRef`, so Kubernetes won't restart pods when the secret value changes).
 
 ### Logging (module — runs during `deploy-module`)
 
@@ -375,6 +390,15 @@ CI nodes can have 100+ concurrent runner pods each producing logs. The logging A
 ### Module pipeline ordering
 
 The `// MODULE_PIPELINES` marker in `base.alloy` is placed **before** `stage.structured_metadata` and `stage.label_drop`. This means module `stage.match` blocks can select on `{pod=~"..."}` and `{node=~"..."}` labels. After the module pipelines run, pod and node are moved to structured metadata and dropped from indexed labels.
+
+### IPv6 binding overrides (IPv6-only EKS)
+
+Under IPv6-only EKS the kubelet readiness probe targets the pod's IPv6 address. Several upstream Helm chart defaults bind to `0.0.0.0` (IPv4-only) and would leave pods stuck `NotReady` and metrics silently missing:
+
+- **`alloy-logging` and `alloy-events`** — both set `alloy.listenAddr: "[::]"` (in `modules/logging/helm/alloy-logging-values.yaml` and `alloy-events-values.yaml`). Without this the DaemonSet/Deployment never passes readiness.
+- **`node-exporter`** — `prometheus-node-exporter.listenOnAllInterfaces: false` (in `modules/monitoring/helm/values.yaml`), which makes node-exporter bind the node's primary IP from Downward API `status.hostIP` instead of `0.0.0.0:9100`. Without it Alloy (IPv6-only pod) cannot scrape node-exporter and `node_nf_conntrack_entries` silently disappears — which would in turn make the `ipv6-network-pressure` alerts inert (the `NodeConntrackMetricMissing` alert exists precisely to catch this regression).
+
+These overrides are easy to miss when adding a new Alloy chart instance or another `:0.0.0.0`-binding exporter — anything that needs to be scraped or probed from the IPv6 pod network must bind IPv6.
 
 ## Troubleshooting
 

--- a/osdc/docs/operations.md
+++ b/osdc/docs/operations.md
@@ -2,12 +2,25 @@
 
 ## Prerequisites
 
-- AWS CLI configured with appropriate credentials
+- AWS CLI configured with credentials for an IAM principal mapped to one of the roles in the target cluster's `access_config.cluster_admin_role_names` (e.g. `osdc_gha_staging` for `arc-staging`, `osdc_gha_prod` for `arc-cbr-production`). How those credentials are acquired (SSO, role assumption, static keys) is left to the operator's organization — the project does not prescribe a profile or login flow.
 - `mise` installed ([mise.jdx.dev](https://mise.jdx.dev))
 - `just` installed (not managed by `mise` — install separately)
 - Working directory: `osdc/`
 
 `mise` auto-installs all other tools (tofu, kubectl, helm, crane, awscli, packer, `uv`, plus linters) on first run. Run `just setup` once to create the Python virtualenv (`uv sync`) used by `cluster-config.py` and other helpers.
+
+`mise` also exports `AWS_REGION=us-west-2` for every shell rooted at the project. This is the state-bucket region (state and the lock table always live in `us-west-2`) and the default for `aws` calls; override `AWS_REGION` explicitly when running ad-hoc `aws` commands against another cluster's region (e.g. `arc-cbr-production` lives in `us-east-2`).
+
+### Corporate proxy (Meta and similar)
+
+In environments behind an HTTP proxy that does not whitelist `*.eks.amazonaws.com`, `aws eks ...`, `kubectl`, and `helm` calls will hang or time out. Extend the bypass list:
+
+```bash
+export NO_PROXY="${NO_PROXY:-},.eks.amazonaws.com"
+export no_proxy="${no_proxy:-},.eks.amazonaws.com"
+```
+
+Every `just` recipe that touches the EKS API inlines this bypass for you. The export above is only needed when invoking `aws`, `kubectl`, or `helm` directly — for example during the read-only debugging session below.
 
 ## First-time setup
 
@@ -50,19 +63,68 @@ The full per-cluster module list lives in `clusters.yaml` under `clusters.<id>.m
 
 ## Day-to-day operations
 
+For the module contract (directory layout, deploy phases, adding a new module) see [`modules.md`](modules.md).
+
 ### Deploy a specific module
 
 ```bash
 just deploy-module arc-staging nodepools
 just deploy-module arc-staging arc-runners
+
+# Force a Helm upgrade even when the release looks unchanged
+just deploy-module arc-staging arc force
+```
+
+### Preview changes without applying
+
+`just plan <cluster>` runs `tofu plan` for the base and every terraform-backed module. Read-only: no apply, no Kubernetes side effects, safe to run from CI on PRs.
+
+```bash
+just plan arc-staging
 ```
 
 ### Inspect cluster state
 
 ```bash
-just show arc-staging        # shows config, modules, tofu vars
+just show arc-staging        # config, modules, tofu vars
 just list                    # all clusters and their modules
 ```
+
+### Inspect what was deployed
+
+The deploy commands write an audit log into ConfigMaps in the `osdc-system` namespace.
+
+```bash
+just deploy-history arc-staging              # list of deploy entries (oldest → newest)
+just deploy-status arc-staging               # current versions + recent history (all)
+just deploy-status arc-staging arc-runners   # narrow to a single module/command
+```
+
+### Post-deploy validation
+
+```bash
+just smoke arc-staging              # pytest-based smoke suite (per-module)
+just integration-test arc-staging   # full integration suite
+just load-test arc-staging          # synthetic load
+just workload-test arc-staging      # production workload replay
+```
+
+`just deploy` itself prompts to run smoke at the end (skipped when `OSDC_SMOKE=no`).
+
+### Graceful runner refresh
+
+To roll new runner configurations or AMIs without aborting in-flight CI jobs:
+
+```bash
+just drain-runners arc-staging      # patch maxRunners=0, taint nodes, wait for in-flight pods
+just resume-runners arc-staging     # restore maxRunners from def files, remove the taint
+```
+
+`drain-runners` waits up to `OSDC_DRAIN_TIMEOUT_SECS` (default `3600`) for runner pods to finish before declaring stragglers. The default 1h matches typical PyTorch suite duration — raise it for longer test windows.
+
+`taint-nodes` / `untaint-nodes` add or remove the `deploy.osdc.io/refresh-pending=true:NoSchedule` taint on every node labelled `workload-type=github-runner` — useful when you want to mark nodes stale without also draining the AutoscalingRunnerSets.
+
+`recycle-nodes` deletes all Karpenter `NodeClaims`, forcing Karpenter to reprovision on demand. Use after AMI/userData changes when you do not need to preserve in-flight jobs. Staging runs this automatically at the end of `just deploy` (driven by `recycle_karpenter_nodes: true` in `clusters.yaml`).
 
 ### Read-only debugging
 
@@ -73,6 +135,17 @@ kubectl get nodepools                                # requires the karpenter mo
 kubectl get autoscalingrunnersets -n arc-runners
 helm list -A
 ```
+
+### Environment variables for `just deploy`
+
+Set these to suppress the interactive prompts in `just deploy` — required for CI/automation use:
+
+| Variable | Values | Default | Effect |
+|----------|--------|---------|--------|
+| `OSDC_CONFIRM` | `yes` / `no` / `ask` | `ask` | Confirm before applying the full deploy and each tofu plan. `no` cancels immediately. |
+| `OSDC_TAINT_NODES` | `yes` / `no` / `ask` | `ask` | Taint ARC runner nodes after the deploy completes (skipped when nodes are being recycled). |
+| `OSDC_SMOKE` | `yes` / `no` / `ask` | `ask` | Run `just smoke <cluster>` after the deploy. |
+| `OSDC_DRAIN_TIMEOUT_SECS` | seconds | `3600` | How long `just drain-runners` waits for in-flight runner pods before listing stragglers. |
 
 ## Adding a new cluster
 

--- a/osdc/docs/pypi-package-cache.md
+++ b/osdc/docs/pypi-package-cache.md
@@ -18,9 +18,12 @@ deployment that:
   uploading a wants list to S3, where an out-of-cluster builder consumes it
 
 The cache is paired with the `cache-enforcer` DaemonSet, which iptables-blocks
-direct egress from runner nodes to `pypi.org`, `files.pythonhosted.org`, and
-`download.pytorch.org` — so all pip/uv traffic on runners is routed through
-pypi-cache by force, not by env var alone.
+direct egress from runner nodes to `pypi.org` and `files.pythonhosted.org` —
+so all pip/uv traffic to those two hosts is routed through pypi-cache by force,
+not by env var alone. `download.pytorch.org` is intentionally NOT blocked by
+cache-enforcer (it is listed in the enforcer's `ALLOWED_DOMAINS`); the URL
+rewriting on the `/whl/` path keeps cache hits consistent but is not a runtime
+correctness requirement for that host.
 
 > Detailed operational notes (slug naming, NVMe sizing math, IRSA roles, log
 > rotation, etc.) live in the `osdc-pypi-cache` skill. This document covers the
@@ -51,17 +54,27 @@ Each pod runs three containers:
   caches the `/simple/<pkg>/` response for 30 minutes upstream, so the per-request
   listdir cost is negligible.
 - **nginx-prometheus-exporter** (`docker.io/nginx/nginx-prometheus-exporter:1.4.1`)
-  on port 9113 scraping `/stub_status` for monitoring.
+  on port 9113 scraping `/stub_status` for monitoring. The exporter scrapes
+  via `http://[::1]:8080/stub_status` (IPv6 loopback) — nginx listens on both
+  `8080` and `[::]:8080` so this works under IPv6-only EKS. Reverting to a
+  single-stack IPv4 deployment would require changing the scrape URL.
 
 Replicas: default 2, override per-cluster (`arc-staging: 1`,
-`arc-cbr-production: 5`). Pods spread across nodes via `podAntiAffinity` on
-`kubernetes.io/hostname`.
+`arc-cbr-production: 10`). Pods spread across nodes via `podAntiAffinity` on
+`kubernetes.io/hostname`. A per-slug `PodDisruptionBudget` with `minAvailable: 1`
+guards each Deployment, so voluntary disruptions (node drain, rolling update)
+block until a replacement pod is ready — on `arc-staging` with `replicas: 1`
+this means drains stall until the new pod schedules.
 
 Pods are scheduled on dedicated Karpenter nodes (`workload=pypi-cache:NoSchedule`
 taint, default `r5d.12xlarge`). Per-pod CPU/memory is computed from instance
 specs in `compute_pod_resources()` for Guaranteed QoS — nginx gets a fixed
 `4 vCPU / 64 GiB` slice (sized for njs subrequest buffers under load) and
-pypiserver gets the remainder.
+pypiserver gets the remainder. The formula subtracts `kubelet_reserved`,
+`DAEMONSET_OVERHEAD_CPU_M = 300m`, and `DAEMONSET_OVERHEAD_MEM_MI = 440`,
+then applies `MARGIN = 0.90` before dividing by `pods_per_node`. If
+DaemonSets land on these nodes or kubelet reserved changes, these constants
+need to be updated to keep Guaranteed QoS reservations admissible.
 
 ### 2. `pypi-wants-collector` Deployment (1 replica)
 
@@ -86,7 +99,14 @@ The collector is the **only S3 writer** in the loop.
 Long-lived pod running `scripts/python/wheel_syncer.py`. Each cycle (default
 every 60s) lists `s3://pytorch-pypi-wheel-cache/{slug}/*.whl` for every
 configured slug, downloads anything missing from the local EFS wheelhouse using
-atomic rename for safe placement.
+atomic rename for safe placement (download to `<filename>.tmp`, then
+`os.rename` to the final path). A path-traversal guard rejects any S3 key
+whose resolved path escapes the slug directory — defense-in-depth against
+malicious keys arriving from the external builder bucket.
+
+Runs with `AWS_USE_DUALSTACK_ENDPOINT=true` so boto3 reaches
+`s3.dualstack.<region>.amazonaws.com` and `sts.dualstack...` over IPv6 from
+the IPv6-only pod (boto3's default endpoints are IPv4-only).
 
 This is the **only S3 reader for wheels** in the cluster — pods do not pull
 wheels from S3 directly.
@@ -103,11 +123,15 @@ them on EFS within ~60s.
 `modules/cache-enforcer/` runs on `workload-type: github-runner` nodes (NOT on
 pypi-cache nodes). Loads the `xt_string` kernel module and installs iptables
 REJECT rules in OUTPUT and FORWARD chains that match domain strings in TLS
-ClientHello SNI fields and HTTP Host headers for `pypi.org`,
-`files.pythonhosted.org`, and `download.pytorch.org`.
+ClientHello SNI fields and HTTP Host headers for `pypi.org` and
+`files.pythonhosted.org`. `download.pytorch.org` is explicitly NOT blocked
+(see `ALLOWED_DOMAINS` in the cache-enforcer smoke test) — direct egress to
+it from runners is permitted.
 
-This is what forces pip/uv traffic through pypi-cache. **If pypi-cache is
-unhealthy, all pip installs on runners fail — there is no bypass.**
+This is what forces pip traffic to PyPI/pythonhosted through pypi-cache.
+**If pypi-cache is unhealthy, every pip install that resolves anything from
+`pypi.org` or `files.pythonhosted.org` fails — there is no bypass for those
+two hosts.**
 
 ## Storage Layout
 
@@ -120,7 +144,13 @@ Two distinct storage layers with different semantics:
 
 The EFS PVC is `ReadWriteMany` with StorageClass `efs-pypi-cache` (provisioner
 `efs.csi.aws.com`, `basePath: /pypi-cache`, `reclaimPolicy: Retain`). It's
-mounted by every pypi-cache pod, plus the wants-collector and wheel-syncer.
+mounted by every pypi-cache pod, plus the wants-collector and wheel-syncer —
+but not identically across containers. The pypiserver, wants-collector, and
+wheel-syncer containers mount the entire PVC at `/data` (no subPath), so they
+see `/data/wheelhouse/{slug}/` and `/data/logs/`. The nginx container only
+mounts `subPath: logs/upstream` at `/data/logs/upstream`, which is all it
+needs to write `@pypi_fallback` access logs. Operators debugging EFS
+permission/ownership issues should keep this asymmetry in mind.
 
 NVMe size per pod is computed as `floor(nvme_gib * 0.95 / pods_per_node)`. For
 `r5d.12xlarge` (~1,800 GiB NVMe RAID0) with 4 slugs that's ~427 GiB per pod.
@@ -168,8 +198,11 @@ returned 200 for some packages with wrong-variant wheels, which short-circuited
 nginx's `proxy_intercept_errors` fallback to PyPI. Merging guarantees both
 sources are always considered.
 
-The root listing `/simple/` is passed through to upstream (pypiserver's root
-listing is incomplete by design).
+For the root listing `/simple/`, the handler still issues both subrequests
+in parallel but prefers the upstream response (pypiserver's root listing is
+incomplete by design) and falls back to the local response only if upstream
+fails. Both subrequests run on every root request — the local one is paid
+for even when upstream is healthy.
 
 ### `/whl/...` — PyTorch wheel index
 
@@ -185,8 +218,10 @@ Two notable rewrites on this path:
   returns 403 for packages it doesn't carry (e.g. `/whl/cpu/six/`); uv treats
   403 as auth error and aborts resolution. Rewriting to 404 makes uv fall
   through to the default index. **Don't change this.**
-- `proxy_redirect https://download.pytorch.org/ /` — clients can't follow
-  HTTPS redirects from the proxy (cache-enforcer blocks the destination).
+- `proxy_redirect https://download.pytorch.org/ /` — keeps clients on this
+  proxy so cached responses stay consistent. cache-enforcer does NOT block
+  `download.pytorch.org`, so the proxy_redirect is for cache cohesion, not
+  for connectivity.
 
 ### `/packages/{2-hex}/...` — pythonhosted file downloads
 
@@ -221,10 +256,15 @@ match PyTorch's `download.pytorch.org/whl/cu128/` convention.
 
 ## CI Integration
 
-There is **no composite GitHub Action** for index selection. Routing is baked
-into the runner pod itself by the `arc-runners` module: each runner type is
-generated per CUDA slug, and the runner ConfigMap sets these env vars on the
-workflow container:
+Routing is baked into the runner pod itself by the `arc-runners` module: each
+runner type is generated per CUDA slug, and the runner ConfigMap sets these
+env vars on the workflow container as defaults. CI jobs that need a different
+slug (typically: a CUDA wheel index that doesn't match the runner's default
+slug) override these with the `setup-pypi-cache` composite action at
+`pytorch/test-infra/.github/actions/setup-pypi-cache@jeanschmidt/define_pip_cuda`
+— this is what the integration tests and workload tests use, and the action
+is injected as the first step into every instrumented job. The pod-level env
+vars below are the defaults; the composite action layers on top.
 
 ```
 PIP_INDEX_URL          = http://pypi-cache-{slug}.pypi-cache.svc.cluster.local:8080/simple/
@@ -238,8 +278,11 @@ PYPI_CACHE_SIMPLE_URL  = http://pypi-cache-{slug}.pypi-cache.svc.cluster.local:8
 PYPI_CACHE_WHL_URL     = http://pypi-cache-{slug}.pypi-cache.svc.cluster.local:8080/whl/{slug}/
 ```
 
-CI authors don't need to do anything — pip/uv pick up these env vars
-automatically. cache-enforcer prevents anyone from bypassing them.
+CI authors who are happy with the default slug don't need to do anything —
+pip/uv pick up these env vars automatically, and cache-enforcer prevents
+anyone from bypassing the proxy for `pypi.org` / `files.pythonhosted.org`.
+Authors who need a different CUDA slug invoke `setup-pypi-cache` (see above)
+to point pip/uv at the right `pypi-cache-{slug}` Service.
 
 The PYPI_CACHE_* variables are exposed for workflow scripts that build their own
 URLs (e.g. for `--find-links`).
@@ -286,16 +329,20 @@ serving HTML to JSON-expecting clients and vice versa. Hard to debug.
 nginx `sub_filter` rewrites `https://files.pythonhosted.org` and
 `https://download.pytorch.org` to relative paths in upstream index responses.
 `merge_indexes.js` does the same in subrequest results (sub_filter does not
-apply to njs subrequest responses). Without this rewriting, pip would receive
-absolute URLs that cache-enforcer blocks at the iptables level — every install
-would fail.
+apply to njs subrequest responses). For `files.pythonhosted.org` this is
+load-bearing: cache-enforcer blocks direct egress to that host, so any
+absolute URL would fail. For `download.pytorch.org` the rewrite is for cache
+cohesion — direct egress to it is allowed, but routing through the proxy
+keeps cached entries reachable.
 
 ### `proxy_redirect` rewrites also matter
 
 `proxy_redirect https://pypi.org/ /` and
 `proxy_redirect https://download.pytorch.org/ /` strip absolute hosts from
-`Location` headers in 301/302 responses. Same reasoning as sub_filter — clients
-can't reach the destination directly.
+`Location` headers in 301/302 responses. The `pypi.org` rewrite is required
+for connectivity (cache-enforcer blocks the destination); the
+`download.pytorch.org` rewrite keeps clients on this proxy for cache
+cohesion (egress to that host is allowed but discouraged).
 
 ### `subrequest_output_buffer_size 100m` is load-bearing
 
@@ -330,16 +377,64 @@ deploy script after editing `clusters.yaml`.
 
 ### pypi-cache health is a hard runtime dependency
 
-cache-enforcer blocks all direct egress to PyPI/pythonhosted/download.pytorch
-on runner nodes. If the pypi-cache pods are unhealthy or the Service has no
-endpoints, every `pip install` on every runner pod fails with a connection
-error. Treat pypi-cache rollouts during business hours as risky.
+cache-enforcer blocks direct egress to `pypi.org` and
+`files.pythonhosted.org` on runner nodes. If the pypi-cache pods are
+unhealthy or the Service has no endpoints, every `pip install` that resolves
+anything from those two hosts fails with a connection error. Treat
+pypi-cache rollouts during business hours as risky.
 
 ### NetworkPolicy: ingress restricted to `arc-runners` namespace
 
 `networkpolicy.yaml` allows ingress only from pods in namespace
 `kubernetes.io/metadata.name: arc-runners`. Pods in other namespaces (e.g.
 `buildkit`, `kube-system`) cannot reach pypi-cache directly.
+
+### nginx resolver is substituted at deploy time
+
+`deploy.sh` reads the `kube-dns` ClusterIP from the cluster and substitutes
+it into the nginx `resolver` directive at ConfigMap creation time (IPv6
+ClusterIPs are wrapped in brackets for nginx syntax). This is what lets
+nginx resolve `pypi.org`, `files.pythonhosted.org`, and `download.pytorch.org`
+for the upstream proxy locations. Any change to cluster DNS — for example
+cutting over to NodeLocal DNSCache or back — requires redeploying pypi-cache
+so the resolver IP is current.
+
+### IPv6-only EKS: dual-stack listen, IPv6 loopback scrape, dualstack S3
+
+These clusters are IPv6-only at the pod level, which affects several
+pypi-cache details that look surprising in isolation:
+
+- nginx listens on both `8080` and `[::]:8080` so the nginx-prometheus-exporter
+  sidecar can scrape `http://[::1]:8080/stub_status` over the IPv6 side of
+  loopback.
+- pypiserver is bound to `127.0.0.1` intentionally even on IPv6-only EKS —
+  pypiserver's bottle gunicorn adapter formats `--host` with `"%s:%d"`, which
+  mangles `::` into a malformed bind string. The kernel always brings `lo`
+  up with both `127.0.0.1/8` and `::1/128`, so IPv4 loopback works inside an
+  IPv6-only pod.
+- wants-collector and wheel-syncer set `AWS_USE_DUALSTACK_ENDPOINT=true` so
+  boto3 reaches `s3.dualstack.<region>.amazonaws.com` over IPv6 (default S3
+  endpoints are IPv4-only).
+- The resolver substitution above wraps IPv6 ClusterIPs in brackets.
+
+See the `osdc-pypi-cache` skill for additional IPv6-specific details.
+
+### `proxy_max_temp_file_size 2048m` enables caching of large CUDA wheels
+
+The top-level `http` block sets `proxy_max_temp_file_size 0` (stream, don't
+buffer). The `/whl/...`, `/packages/{hash}/...`, and generic
+`*.whl|*.tar.gz|*.zip` locations each override this to `2048m` so CUDA wheels
+(~900 MB) actually land in the cache. Removing these overrides would crater
+cache hit rate on the largest, slowest-to-fetch artifacts.
+
+### End-to-end health probe path
+
+pypiserver runs with `--health-endpoint /health`. nginx proxies `/health`
+through to pypiserver uncached, and the nginx container's `livenessProbe`
+hits that path. This means a livenessProbe failure exercises the full
+nginx → pypiserver chain (not just nginx). The `readinessProbe` hits
+`/nginx-health` which returns a static 200 with no backend dependency, so a
+slow pypiserver does not flap readiness.
 
 ### `docker/Dockerfile` is unused legacy
 

--- a/osdc/docs/runner_naming_convention.md
+++ b/osdc/docs/runner_naming_convention.md
@@ -2,18 +2,21 @@ Runner labels encode hardware capabilities directly in the name, so a workflow a
 
 ## Why the Names Are So Compact
 
-Runner labels must stay under **~42 characters**. This limit comes from three stacking constraints in how ARC (Actions Runner Controller) uses the scale set name:
+Runner labels stay under **~42 characters** to leave headroom under several stacking constraints in how ARC (Actions Runner Controller) derives names from the scale set name:
 
-1. **ARC Helm chart** enforces a **45-character** maximum on scale set names. With ARC, the scale set name *is* the `runs-on` label — you cannot add extra labels to target ARC runners.
-2. **Kubernetes label values** are capped at **63 characters**. ARC derives resource names by appending suffixes (e.g. `-gha-rs-no-permission`, 21 chars) to the scale set name. 45 + 18 (fullname infix) = 63, exactly at the K8s ceiling.
-3. **Cilium/Istio CNI** plugins create `CiliumIdentity` resources using the ServiceAccount name as a label value. Derived SA names from a 45-char scale set name can reach ~66 chars, exceeding the 63-char limit. Keeping names at **~42 characters** avoids this entirely.
-This is why every field is abbreviated (`l` not `linux`, `avx512` not `avx-512`, no units on vCPU/memory). The longest label from our current runner catalog is 33 characters (`c-mt-l-bx86iavx512-88-1000-a100-8`) — well within the ceiling.
+1. **ARC Helm chart** enforces a **45-character** maximum on scale set names. With ARC, the scale set name *is* the `runs-on` label — you cannot add extra labels to target ARC runners. See `charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml` lines 6-8 in the [actions-runner-controller fork](https://github.com/jeanschmidt/actions-runner-controller).
+2. **Kubernetes label values** are capped at **63 characters**. The ARC chart derives resource names as `{scale-set-name}-gha-rs` (7-char infix) plus a per-resource suffix; the longest suffix is `-no-permission` (14 chars), giving a derived ServiceAccount name of `{scale-set-name}-gha-rs-no-permission` — 21 chars added in total. A 45-char scale-set name therefore produces a 66-char derived name, which the chart truncates to 63 via `trunc 63 | trimSuffix "-"` (see `_helpers.tpl` lines 22-25 and 83-85). Truncation works for the chart's internal references but breaks any downstream consumer that mirrors the un-truncated derived name as a label value.
+3. **Future CNI-based network policy** (planned migration to Cilium for `toFQDNs` enforcement in cache-enforcer) would create `CiliumIdentity` resources using the ServiceAccount name as a label value, re-exposing the 63-char cap. OSDC does not run Cilium today, so this is not a today-blocking limit; the ~42-character target is headroom that keeps the option open without renaming runners later.
+
+Every field is abbreviated (`l` not `linux`, `avx512` not `avx-512`, no units on vCPU/memory). The longest label in any deployed cluster is 33 characters: `c-mt-l-bx86iavx512-88-1000-a100-8` on staging (which uses the `c-mt-` canary prefix). Production (`mt-` prefix) tops out at 31 characters (`mt-l-bx86iavx512-88-1000-a100-8`). Both are well within the ceiling.
 
 Reference: [actions/actions-runner-controller#2697](https://github.com/actions/actions-runner-controller/issues/2697)
 
 ## Format
 
 `[c-]{provider}-[rel-]{os}-[b]{arch}{vendor}{features}-{vcpu}-{memory}[-{gpu_type}[-{gpu_count}]]`
+
+Defs live in `modules/arc-runners/defs/` (CPU runners + A100 GPU + release defs), `modules/arc-runners-h100/defs/` (H100 GPU), and `modules/arc-runners-b200/defs/` (B200 GPU). The naming convention is identical across all three modules — the split is operational (per-module capacity reservation handling), not semantic.
 
 ## Fields
 

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -208,8 +208,7 @@ template:
 
     # Pin runner pods to the dedicated c7i-runner pool (separate from the
     # workflow pool defined by {{NODE_FLEET}} on the ConfigMap below). This
-    # topology split is what makes preemption victim selection deterministic
-    # — see PROACTIVE_CAPACITY.md "Dedicated Runner NodePool".
+    # topology split is what makes preemption victim selection deterministic.
     # Runner-class isolation (osdc.io/runner-class) is a workflow-pool
     # concern only; c7i-runner nodes carry no runner-class label.
     nodeSelector:
@@ -218,11 +217,11 @@ template:
 
     # Tolerate node-fleet + instance-type taints. The c7i-runner NodePool
     # inherits the git-cache-not-ready startupTaint from the unconditional
-    # generator emission; the git-cache-warmer DaemonSet does not run on
-    # this pool, so the taint is never cleared. Tolerating it lets runner
-    # pods schedule despite the persistent taint. The runner pod itself
-    # does NOT use the git-cache mount — only the toleration is required
-    # for scheduling.
+    # generator emission. The git-cache-warmer DaemonSet runs on this pool
+    # (its nodeAffinity matches workload-type: github-runner) and clears
+    # the taint once the local cache is hydrated, but runner pods don't
+    # use the git-cache mount and tolerate the taint to schedule
+    # immediately without waiting for warmer hydration.
     tolerations:
       - key: node-fleet
         operator: Equal

--- a/osdc/modules/pypi-cache/kubernetes/nginx.conf
+++ b/osdc/modules/pypi-cache/kubernetes/nginx.conf
@@ -229,7 +229,8 @@ http {
         # (.whl, .tar.gz, .zip) with long-term caching (immutable packages).
         # Runners set PIP_EXTRA_INDEX_URL to
         #   http://pypi-cache-{slug}:8080/whl/{cuda}/
-        # and cache-enforcer blocks direct access to download.pytorch.org.
+        # so all download.pytorch.org traffic is routed through the cache
+        # (cache-enforcer does NOT block download.pytorch.org).
         #
         # ORDERING: This regex MUST appear before the generic \.(whl|tar\.gz|zip)$
         # location below.  nginx evaluates regex locations in declaration order

--- a/osdc/scripts/destroy-cluster.sh
+++ b/osdc/scripts/destroy-cluster.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Destroy every tofu-managed module and the base for a cluster, in
+# reverse-deploy order. Automation for step 6 of
+# `docs/cluster-recreation.md`.
+#
+# Usage:
+#   ./scripts/destroy-cluster.sh <cluster-id>
+#
+# Env vars:
+#   OSDC_CONFIRM=yes   Skip the interactive confirmation prompts. The
+#                      final base-destroy still requires the prompt unless
+#                      you also set OSDC_CONFIRM_BASE=destroy.
+#
+# Prereqs (NOT enforced — operator must run them first):
+#   1. just drain-runners <cluster>      (runner pods drained; NodeClaims gone)
+#   2. Harbor S3 bucket emptied          (step 5 of the runbook)
+#
+# What this destroys:
+#   - tofu-managed modules: karpenter, pypi-cache  (state keys
+#     <cluster>/<module>/terraform.tfstate)
+#   - base / eks: VPC, EKS control plane, Harbor S3, IAM, KMS
+#     (state key <cluster>/base/terraform.tfstate)
+#
+# What this does NOT destroy:
+#   - k8s-only modules (arc, arc-runners*, buildkit, cache-enforcer,
+#     harbor-cache-recovery, logging, monitoring, nodepools*,
+#     zombie-cleanup) — these have no terraform state; the resources
+#     die with the EKS cluster.
+#   - Tofu state bucket and DynamoDB lock table (shared, intentionally
+#     preserved across recreations).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
+
+CONFIG_PY="$SCRIPT_DIR/cluster-config.py"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOCK_TABLE="ciforge-terraform-locks"
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <cluster-id>" >&2
+  echo "" >&2
+  echo "Available clusters:" >&2
+  uv run "$CONFIG_PY" --list | sed 's/^/  /' >&2
+  exit 2
+fi
+CLUSTER="$1"
+
+CNAME=$(uv run "$CONFIG_PY" "$CLUSTER" cluster_name)
+REGION=$(uv run "$CONFIG_PY" "$CLUSTER" region)
+BUCKET=$(uv run "$CONFIG_PY" "$CLUSTER" state_bucket)
+TFVARS=$(uv run "$CONFIG_PY" "$CLUSTER" tfvars)
+
+# ── Compute destroy order ──────────────────────────────────────────────────
+# Reverse of the cluster's `modules` list, filtered to entries that actually
+# have a terraform/ root. Anything else is k8s-only and dies with the cluster.
+
+MODULES=()
+while IFS= read -r m; do MODULES+=("$m"); done < <(uv run "$CONFIG_PY" "$CLUSTER" modules)
+
+TF_MODULES=()
+K8S_ONLY_MODULES=()
+for ((i = ${#MODULES[@]} - 1; i >= 0; i--)); do
+  m="${MODULES[i]}"
+  if [[ -f "$ROOT/modules/$m/terraform/main.tf" ]]; then
+    TF_MODULES+=("$m")
+  else
+    K8S_ONLY_MODULES+=("$m")
+  fi
+done
+
+# ── Plan summary ───────────────────────────────────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "DESTROY plan for cluster: $CLUSTER ($CNAME) in $REGION"
+echo "  State bucket: $BUCKET (region: $STATE_REGION)"
+echo "  Lock table:   $LOCK_TABLE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "tofu destroy (in order):"
+for m in "${TF_MODULES[@]}"; do
+  echo "  - modules/$m         (state key: $CLUSTER/$m/terraform.tfstate)"
+done
+echo "  - modules/eks (base)  (state key: $CLUSTER/base/terraform.tfstate)"
+echo ""
+if [[ ${#K8S_ONLY_MODULES[@]} -gt 0 ]]; then
+  echo "k8s-only modules (no terraform — die with the EKS cluster):"
+  for m in "${K8S_ONLY_MODULES[@]}"; do echo "  - $m"; done
+  echo ""
+fi
+
+# ── Preflight: NodeClaim drain warning ─────────────────────────────────────
+# Best-effort only — if kubectl can't reach the cluster we silently skip.
+
+if command -v kubectl >/dev/null 2>&1; then
+  NC_COUNT=$(
+    NO_PROXY="${NO_PROXY:-},.eks.amazonaws.com" \
+      no_proxy="${no_proxy:-},.eks.amazonaws.com" \
+      kubectl get nodeclaims --no-headers 2>/dev/null | wc -l | tr -d ' '
+  )
+  if [[ "$NC_COUNT" != "0" ]]; then
+    echo "WARNING: $NC_COUNT Karpenter NodeClaim(s) still exist on this cluster."
+    echo "         Run 'just drain-runners $CLUSTER' first — continuing may leak EC2."
+    echo ""
+  fi
+fi
+
+# ── Confirmation gate (overall) ────────────────────────────────────────────
+
+CONFIRM="${OSDC_CONFIRM:-ask}"
+if [[ "$CONFIRM" != "yes" ]]; then
+  read -rp "Proceed with destroy? (type the cluster name to confirm): " CONFIRM_INPUT
+  if [[ "$CONFIRM_INPUT" != "$CLUSTER" ]]; then
+    echo "Mismatch — aborting."
+    exit 1
+  fi
+fi
+echo ""
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+tofu_init() {
+  local module_dir="$1"
+  local key="$2"
+  cd "$module_dir"
+  NO_PROXY="${NO_PROXY:-},.amazonaws.com" \
+    no_proxy="${no_proxy:-},.amazonaws.com" \
+    tofu init -reconfigure -input=false -no-color \
+    -backend-config="bucket=$BUCKET" \
+    -backend-config="key=$key" \
+    -backend-config="region=$STATE_REGION" \
+    -backend-config="dynamodb_table=$LOCK_TABLE" >/dev/null
+}
+
+destroy_module() {
+  local module="$1"
+  local module_dir="$ROOT/modules/$module/terraform"
+  local key="$CLUSTER/$module/terraform.tfstate"
+
+  echo "━━━ DESTROY: $module ━━━"
+  tofu_init "$module_dir" "$key"
+  NO_PROXY="${NO_PROXY:-},.amazonaws.com" \
+    no_proxy="${no_proxy:-},.amazonaws.com" \
+    tofu destroy -auto-approve \
+    -var="cluster_name=$CNAME" \
+    -var="aws_region=$REGION" \
+    -var="state_bucket=$BUCKET" \
+    -var="cluster_id=$CLUSTER"
+  cd - >/dev/null
+  echo ""
+}
+
+destroy_base() {
+  local module_dir="$ROOT/modules/eks/terraform"
+  local key="$CLUSTER/base/terraform.tfstate"
+
+  echo "━━━ DESTROY: base (modules/eks) ━━━"
+  tofu_init "$module_dir" "$key"
+  NO_PROXY="${NO_PROXY:-},.amazonaws.com" \
+    no_proxy="${no_proxy:-},.amazonaws.com" \
+    eval tofu destroy "$TFVARS" -auto-approve
+  cd - >/dev/null
+  echo ""
+}
+
+# ── Phase 1: destroy tofu-managed modules ──────────────────────────────────
+
+for m in "${TF_MODULES[@]}"; do
+  destroy_module "$m"
+done
+
+# ── Phase 2: destroy base (extra confirmation) ─────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "FINAL STEP: tofu destroy modules/eks (the base)"
+echo ""
+echo "This destroys: VPC, EKS control plane, base node group, Harbor S3,"
+echo "  IAM roles, KMS keys, OIDC provider."
+echo ""
+echo "The Harbor S3 bucket ($CNAME-harbor-registry) MUST be empty."
+echo "  Step 5 of docs/cluster-recreation.md handles this."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+CONFIRM_BASE="${OSDC_CONFIRM_BASE:-ask}"
+if [[ "$CONFIRM_BASE" != "destroy" ]]; then
+  read -rp "Type 'destroy $CLUSTER' to proceed: " CONFIRM_INPUT
+  if [[ "$CONFIRM_INPUT" != "destroy $CLUSTER" ]]; then
+    echo "Mismatch — aborting before base destroy. Modules already destroyed; re-run to resume."
+    exit 1
+  fi
+fi
+echo ""
+
+destroy_base
+
+# ── Done ───────────────────────────────────────────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Done. Cluster $CLUSTER ($CNAME) destroyed."
+echo ""
+echo "Next steps per runbook:"
+echo "  7. Verify survivors (ECR mirrors, state bucket, wheel-pipeline)"
+echo "  8. just deploy $CLUSTER  (recreates with current main shape)"
+echo "  9. just smoke $CLUSTER"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
- Add cluster-recreation.md runbook covering drain, destroy, redeploy, validation gates, soak window, and rollback procedures
- Add scripts/destroy-cluster.sh automating tofu destroy in reverse-deploy order with confirmation gates
- Update 14 docs to fix stale info: IPv6-only EKS state, disabled kubelet ServiceMonitor, current replica counts, conntrack metrics, cache-enforcer scope, pypi-cache IPv6 details, Harbor port 8081
- Fix runner.yaml.tpl comment about git-cache-warmer scheduling on c7i-runner and pypi-cache nginx.conf comment about cache-enforcer

The doc refresh aligns descriptions with the current IPv6-only cluster shape (disabled kubelet scraping, NLD IPv6 bind, node-exporter conntrack metrics, dualstack S3 endpoints) and corrects sizing inputs in observability-estimates.md to match current clusters.yaml defaults.