### PR TITLE
Fix arm64 silicon mismatches for t4g/m7g labels (incl. m7g.metal bare-metal)

### DIFF
--- a/osdc/docs/current_runner_load_distribution.md
+++ b/osdc/docs/current_runner_load_distribution.md
@@ -7,6 +7,7 @@ Job counts and peak concurrency by runner type over the last 30 days. Source: `d
 > - A100 runners (`l-x86iavx512-11-125-a100`, `…-2`, `…-4`, `l-bx86iavx512-88-1000-a100-8` on `nodepools/p4d-24xlarge`, added 2026-05-06).
 > - The `c7i-runner` Karpenter NodePool (proactive-capacity PoC; isolated from the shared `c7i` pool by the `node-fleet=c7i-runner` taint).
 > - Release runners (`rel-l-arm64g4-16-62`, `rel-l-x86iavx512-8-64`) on `m8g-48xlarge-release` / `r7a-48xlarge-release` nodepools — they have `proactive_capacity: 30` and consume real fleet capacity but are not modelled because they don't run pytorch/pytorch jobs.
+> - ARM64 silicon refinement (PR #591): `l-arm64g2-6-32` re-pointed from `m8g.48xlarge` to `t4g.2xlarge` (Graviton2), `l-arm64g3-16-62` to `m7g.8xlarge` (Graviton3), and `linux.arm64.m7g.metal` re-mapped from `l-barm64g4-62-226` to the new `l-barm64g3-62-226` backed by `m7g.metal` (true Graviton3 bare-metal). The snapshot rows below still reference the pre-refinement label / backings.
 >
 > When this doc is refreshed, `scripts/python/pytorch_workload_data.py` (`PEAK_CONCURRENT` and `OLD_TO_NEW_LABEL`) must be updated in lockstep — the simulator reads from this doc.
 

--- a/osdc/docs/node-utilization-optimization.md
+++ b/osdc/docs/node-utilization-optimization.md
@@ -203,6 +203,13 @@ The only way to push these above 85% is to use instances where `N × runner_size
 
 **Not covered by this analysis** (added later): the dedicated **release runner class** (`rel-l-x86iavx512-8-64`, `rel-l-arm64g4-16-62`) introduced in commit `903d1d4`, and the A100 / H100 GPU runners (see GPU Nodepools table for instance details).
 
+**ARM64 silicon refinement** (post-snapshot, PR #591): the Phase 2 decision to run all small ARM64 runners on `m8g.48xlarge` silently substituted Graviton4 for the Graviton2/3 silicon the EC2 labels promised, and the bare-metal `l-barm64g4-62-226` runs on a virtualized `m8g.16xlarge` dedicated node rather than true AWS bare-metal (see pytorch/pytorch#184284). Backings were corrected to match the EC2-promised silicon:
+- `l-arm64g2-6-32` → `t4g.2xlarge` (Graviton2, 1 pod/node)
+- `l-arm64g3-16-62` → `m7g.8xlarge` (Graviton3, 2 pods/node — `.8xlarge` needed because the 62Gi pod doesn't fit on `m7g.4xlarge` after kubelet overhead)
+- `l-barm64g3-62-226` (new pool) → `m7g.metal` (true Graviton3 bare-metal); replaces `l-barm64g4-62-226` as the backing for `linux.arm64.m7g.metal`
+
+This trades the heavy `m8g.48xlarge` bin-packing for honest silicon — per-pod cost on `l-arm64g3-16-62` rises ~30-50% at peak burst, and the standing bare-metal pool carries a fixed cost. See PR #591 for the full rationale.
+
 ### Phase 3: Retire Old Nodepools (DONE — merged into Phase 2)
 No ARC runners use r5.24xlarge anymore. The nodepool is retained solely for RE job-assigner workloads. r7g.16xlarge kept for the single memory-heavy ARM64 runner. Karpenter will drain underutilized r5 nodes naturally after redeployment.
 

--- a/osdc/docs/runner_naming_convention.md
+++ b/osdc/docs/runner_naming_convention.md
@@ -206,7 +206,7 @@ Additional AMX runners (no direct old-label mapping; provisioned for OSDC CI wor
 | linux.arm64.m8g.4xlarge | m8g.4xlarge | mt-l-arm64g4-16-62 |
 | linux.arm64.m8g.4xlarge.ephemeral | m8g.4xlarge | mt-l-arm64g4-16-62 |
 | linux.arm64.r7g.12xlarge.memory | r7g.16xlarge | mt-l-arm64g3-61-463 |
-| linux.arm64.m7g.metal | m8g.16xlarge | mt-l-barm64g4-62-226 |
+| linux.arm64.m7g.metal | m7g.metal | mt-l-barm64g3-62-226 |
 
 ## Many-to-One: Old Labels That Collapse Into a Single New Label
 

--- a/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
@@ -1,6 +1,5 @@
 # ARC runner definition: l-arm64g2-6-32
-# Instance type: t4g.2xlarge (AWS Graviton2, 8 vCPU / 32 GiB)
-# Backs linux.arm64.2xlarge[.ephemeral]. One job per node.
+# Instance type: t4g.2xlarge (pool: t4g)
 runner:
   name: l-arm64g2-6-32
   instance_type: t4g.2xlarge

--- a/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g2-6-32.yaml
@@ -1,8 +1,9 @@
 # ARC runner definition: l-arm64g2-6-32
-# Instance type: m8g.48xlarge (pool: arm-cpu)
+# Instance type: t4g.2xlarge (AWS Graviton2, 8 vCPU / 32 GiB)
+# Backs linux.arm64.2xlarge[.ephemeral]. One job per node.
 runner:
   name: l-arm64g2-6-32
-  instance_type: m8g.48xlarge
+  instance_type: t4g.2xlarge
   disk_size: 256
   vcpu: 6
   memory: 29Gi

--- a/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
@@ -1,8 +1,5 @@
 # ARC runner definition: l-arm64g3-16-62
-# Instance type: m7g.8xlarge (AWS Graviton3, 32 vCPU / 128 GiB)
-# Backs linux.arm64.m7g.4xlarge. Bin-packs 2 pods per m7g.8xlarge node;
-# using .8xlarge instead of .4xlarge because the 62 GiB pod request does
-# not fit on m7g.4xlarge (59 GiB allocatable after kubelet overhead).
+# Instance type: m7g.8xlarge (pool: m7g) — .8xlarge needed because 62 GiB pod doesn't fit on m7g.4xlarge
 runner:
   name: l-arm64g3-16-62
   instance_type: m7g.8xlarge

--- a/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
@@ -1,8 +1,11 @@
 # ARC runner definition: l-arm64g3-16-62
-# Instance type: m8g.48xlarge (pool: arm-cpu)
+# Instance type: m7g.8xlarge (AWS Graviton3, 32 vCPU / 128 GiB)
+# Backs linux.arm64.m7g.4xlarge. Bin-packs 2 pods per m7g.8xlarge node;
+# using .8xlarge instead of .4xlarge because the 62 GiB pod request does
+# not fit on m7g.4xlarge (59 GiB allocatable after kubelet overhead).
 runner:
   name: l-arm64g3-16-62
-  instance_type: m8g.48xlarge
+  instance_type: m7g.8xlarge
   disk_size: 256
   vcpu: 16
   memory: 62Gi

--- a/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
@@ -1,5 +1,5 @@
 # ARC runner definition: l-barm64g3-62-226
-# Instance type: m7g.metal (true bare-metal — AWS Graviton3, 64 vCPU / 256 GiB)
+# Instance type: m7g.metal (dedicated node — bare-metal runner)
 # Used for: inductor CPU perf benchmarks (needs bare-metal for noise isolation)
 runner:
   name: l-barm64g3-62-226

--- a/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
@@ -1,0 +1,12 @@
+# ARC runner definition: l-barm64g3-62-226
+# Instance type: m7g.metal (true bare-metal — AWS Graviton3, 64 vCPU / 256 GiB)
+# Used for: inductor CPU perf benchmarks (needs bare-metal for noise isolation)
+runner:
+  name: l-barm64g3-62-226
+  instance_type: m7g.metal
+  disk_size: 256
+  vcpu: 62
+  memory: 226Gi
+  gpu: 0
+  proactive_capacity: 10
+  max_burst_capacity: 250

--- a/osdc/modules/nodepools/defs/m7g.yaml
+++ b/osdc/modules/nodepools/defs/m7g.yaml
@@ -1,5 +1,10 @@
 # Karpenter NodePool fleet: m7g
-# AWS Graviton3 — balanced, ARM64, bare-metal (for inductor CPU perf benchmarks)
+# AWS Graviton3 — balanced, ARM64.
+# Hosts both the bin-packed l-arm64g3-16-62 label (on m7g.8xlarge) and the
+# bare-metal l-barm64g3-62-226 label for inductor CPU perf benchmarks (on
+# m7g.metal). Bare-metal exclusivity is achieved by the high resource
+# request (62 vCPU / 226 GiB) nearly maxing out the m7g.metal node, leaving
+# no room for additional pods.
 fleet:
   name: m7g
   arch: arm64
@@ -8,3 +13,7 @@ fleet:
     - type: m7g.metal
       weight: 100
       node_disk_size: 1000
+      baremetal: true
+    - type: m7g.8xlarge
+      weight: 50
+      node_disk_size: 500

--- a/osdc/modules/nodepools/defs/m7g.yaml
+++ b/osdc/modules/nodepools/defs/m7g.yaml
@@ -1,10 +1,5 @@
 # Karpenter NodePool fleet: m7g
-# AWS Graviton3 — balanced, ARM64.
-# Hosts both the bin-packed l-arm64g3-16-62 label (on m7g.8xlarge) and the
-# bare-metal l-barm64g3-62-226 label for inductor CPU perf benchmarks (on
-# m7g.metal). Bare-metal exclusivity is achieved by the high resource
-# request (62 vCPU / 226 GiB) nearly maxing out the m7g.metal node, leaving
-# no room for additional pods.
+# AWS Graviton3 — balanced, ARM64, ~4 GiB/core ratio
 fleet:
   name: m7g
   arch: arm64

--- a/osdc/modules/nodepools/defs/m7g.yaml
+++ b/osdc/modules/nodepools/defs/m7g.yaml
@@ -1,0 +1,10 @@
+# Karpenter NodePool fleet: m7g
+# AWS Graviton3 — balanced, ARM64, bare-metal (for inductor CPU perf benchmarks)
+fleet:
+  name: m7g
+  arch: arm64
+  gpu: false
+  instances:
+    - type: m7g.metal
+      weight: 100
+      node_disk_size: 1000

--- a/osdc/modules/nodepools/defs/t4g.yaml
+++ b/osdc/modules/nodepools/defs/t4g.yaml
@@ -1,6 +1,5 @@
 # Karpenter NodePool fleet: t4g
-# AWS Graviton2 — burstable, ARM64, ~4 GiB/core ratio.
-# Hosts the small linux.arm64.2xlarge[.ephemeral] labels (one job per node).
+# AWS Graviton2 — burstable, ARM64, ~4 GiB/core ratio
 fleet:
   name: t4g
   arch: arm64

--- a/osdc/modules/nodepools/defs/t4g.yaml
+++ b/osdc/modules/nodepools/defs/t4g.yaml
@@ -1,0 +1,11 @@
+# Karpenter NodePool fleet: t4g
+# AWS Graviton2 — burstable, ARM64, ~4 GiB/core ratio.
+# Hosts the small linux.arm64.2xlarge[.ephemeral] labels (one job per node).
+fleet:
+  name: t4g
+  arch: arm64
+  gpu: false
+  instances:
+    - type: t4g.2xlarge
+      weight: 100
+      node_disk_size: 500

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -70,9 +70,7 @@ INSTANCE_SPECS: dict[str, dict] = {
     "m8g.24xlarge": {"vcpu": 96, "memory_gib": 384, "memory_mi": 363724, "gpu": 0, "arch": "arm64"},
     "m8g.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 0, "arch": "arm64"},
     "r7g.16xlarge": {"vcpu": 64, "memory_gib": 512, "memory_mi": 485081, "gpu": 0, "arch": "arm64"},
-    # Graviton2 burstable (small arm64 jobs — linux.arm64.2xlarge[.ephemeral])
     "t4g.2xlarge": {"vcpu": 8, "memory_gib": 32, "memory_mi": 30310, "gpu": 0, "arch": "arm64"},
-    # Graviton3 balanced (linux.arm64.m7g.4xlarge bin-packed; bare-metal SKU for inductor CPU perf benchmarks)
     "m7g.8xlarge": {"vcpu": 32, "memory_gib": 128, "memory_mi": 121241, "gpu": 0, "arch": "arm64"},
     "m7g.metal": {"vcpu": 64, "memory_gib": 256, "memory_mi": 242540, "gpu": 0, "arch": "arm64"},
     # GPU instances — 1-GPU
@@ -162,9 +160,6 @@ ENI_MAX_PODS: dict[str, int] = {
     "m8g.24xlarge": 737,
     "m8g.48xlarge": 737,
     "r7g.16xlarge": 737,
-    # Graviton2 / Graviton3 arm64 runner pools (added with m7g.metal bare-metal fix)
-    # ENI max-pods values are estimates from family/size pattern; verify against
-    # eni-max-pods.txt for the deployed EKS AMI if precise values are needed.
     "t4g.2xlarge": 58,
     "m7g.8xlarge": 234,
     "m7g.metal": 737,

--- a/osdc/scripts/python/instance_specs.py
+++ b/osdc/scripts/python/instance_specs.py
@@ -70,6 +70,11 @@ INSTANCE_SPECS: dict[str, dict] = {
     "m8g.24xlarge": {"vcpu": 96, "memory_gib": 384, "memory_mi": 363724, "gpu": 0, "arch": "arm64"},
     "m8g.48xlarge": {"vcpu": 192, "memory_gib": 768, "memory_mi": 727449, "gpu": 0, "arch": "arm64"},
     "r7g.16xlarge": {"vcpu": 64, "memory_gib": 512, "memory_mi": 485081, "gpu": 0, "arch": "arm64"},
+    # Graviton2 burstable (small arm64 jobs — linux.arm64.2xlarge[.ephemeral])
+    "t4g.2xlarge": {"vcpu": 8, "memory_gib": 32, "memory_mi": 30310, "gpu": 0, "arch": "arm64"},
+    # Graviton3 balanced (linux.arm64.m7g.4xlarge bin-packed; bare-metal SKU for inductor CPU perf benchmarks)
+    "m7g.8xlarge": {"vcpu": 32, "memory_gib": 128, "memory_mi": 121241, "gpu": 0, "arch": "arm64"},
+    "m7g.metal": {"vcpu": 64, "memory_gib": 256, "memory_mi": 242540, "gpu": 0, "arch": "arm64"},
     # GPU instances — 1-GPU
     "g4dn.8xlarge": {"vcpu": 32, "memory_gib": 128, "memory_mi": 121241, "gpu": 1, "arch": "amd64"},
     # Fleet fallback sizes
@@ -157,6 +162,12 @@ ENI_MAX_PODS: dict[str, int] = {
     "m8g.24xlarge": 737,
     "m8g.48xlarge": 737,
     "r7g.16xlarge": 737,
+    # Graviton2 / Graviton3 arm64 runner pools (added with m7g.metal bare-metal fix)
+    # ENI max-pods values are estimates from family/size pattern; verify against
+    # eni-max-pods.txt for the deployed EKS AMI if precise values are needed.
+    "t4g.2xlarge": 58,
+    "m7g.8xlarge": 234,
+    "m7g.metal": 737,
     "g4dn.8xlarge": 58,
     # Fleet fallback sizes — g4dn
     "g4dn.16xlarge": 234,

--- a/osdc/scripts/python/pytorch_workload_data.py
+++ b/osdc/scripts/python/pytorch_workload_data.py
@@ -74,7 +74,7 @@ OLD_TO_NEW_LABEL: dict[str, str] = {
     "linux.arm64.m7g.4xlarge": "l-arm64g3-16-62",
     "linux.arm64.m8g.4xlarge": "l-arm64g4-16-62",
     "linux.arm64.r7g.12xlarge.memory": "l-arm64g3-61-463",
-    "linux.arm64.m7g.metal": "l-barm64g4-62-226",
+    "linux.arm64.m7g.metal": "l-barm64g3-62-226",
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the OSDC backings for every arm64 label in `pytorch/pytorch` `.github/arc.yaml` whose advertised silicon (`t4g` = Graviton2, `m7g` = Graviton3) is silently substituted by `m8g.48xlarge` (Graviton4) today.

See pytorch/pytorch#184284 — the m7g.metal report was the visible tip; the t4g and m7g.4xlarge labels have the same bug.

## Mismatch inventory (before this PR)

| arc.yaml source label | OSDC label name says | Actual OSDC backing | Silicon delivered |
|---|---|---|---|
| `linux.arm64.2xlarge` | g2 (Graviton2) | m8g.48xlarge | **Graviton4** |
| `linux.arm64.2xlarge.ephemeral` | g2 (Graviton2) | m8g.48xlarge | **Graviton4** |
| `linux.arm64.m7g.4xlarge` | g3 (Graviton3) | m8g.48xlarge | **Graviton4** |
| `linux.arm64.m7g.metal` | g4 (Graviton4) | m8g.16xlarge dedicated | **Graviton4** + not true bare-metal |
| `linux.arm64.m8g.4xlarge` | g4 | m8g.48xlarge | Graviton4 (OK) |
| `linux.arm64.r7g.12xlarge.memory` | g3 | r7g.16xlarge | Graviton3 (OK, just upsized) |

## Changes in this PR

**Karpenter fleets (`osdc/modules/nodepools/defs/`):**
- New `t4g.yaml` — Graviton2 fleet with `t4g.2xlarge` (only).
- New `m7g.yaml` — Graviton3 fleet with two SKUs: `m7g.metal` (bare-metal for inductor CPU perf benchmarks) and `m7g.8xlarge` (bin-packed for the m7g.4xlarge label — see sizing note below).

**Runner defs (`osdc/modules/arc-runners/defs/`):**
- New `l-barm64g3-62-226.yaml` → `m7g.metal` (64 vCPU / 256 GiB, true Graviton3 bare-metal).
- `l-arm64g2-6-32.yaml` re-pointed: `m8g.48xlarge` → `t4g.2xlarge` (Graviton2, 1 pod/node).
- `l-arm64g3-16-62.yaml` re-pointed: `m8g.48xlarge` → `m7g.8xlarge` (Graviton3, 2 pods/node). Cannot use `m7g.4xlarge` because its 59 GiB allocatable doesn't fit the def's 62 GiB pod request.

**Specs (`osdc/scripts/python/instance_specs.py`):**
- Added `t4g.2xlarge`, `m7g.8xlarge`, `m7g.metal` to `INSTANCE_SPECS` and `ENI_MAX_PODS`. ENI max-pods values are estimates from family/size patterns; please verify against `eni-max-pods.txt` for the deployed EKS AMI before relying on them for kubelet reservations.

## What changes for arc.yaml consumers after this lands + deploys

- **`linux.arm64.m7g.metal`** (`pytorch/pytorch` `.github/arc.yaml:83`): needs a follow-up one-line PR to point at `l-barm64g3-62-226`. That's the only arc.yaml change required.
- **`linux.arm64.2xlarge[.ephemeral]`, `linux.arm64.m7g.4xlarge`**: no arc.yaml change. The existing OSDC labels keep their names and just start delivering the correct silicon.

## Cost / scheduling implications (please review)

- **`l-arm64g2-6-32`**: switches from bin-packed `m8g.48xlarge` (~32 pods/node) to dedicated `t4g.2xlarge` (1 pod/node). At spot-price parity (~$0.10/hr per t4g.2xlarge vs ~$3/hr per m8g.48xlarge / 32 pods ≈ $0.094/hr per pod), this is roughly cost-neutral.
- **`l-arm64g3-16-62`**: switches from bin-packed `m8g.48xlarge` (~6-12 pods/node) to `m7g.8xlarge` (2 pods/node). **Per-pod cost goes up roughly 30-50%** at peak burst. Acceptable if Graviton3 fidelity matters; let me know if you'd rather keep the m8g bin-packing and just fix the label names instead.
- **`l-barm64g3-62-226`**: new pool, ~$2.5/hr on-demand × `proactive_capacity: 10` = ~$18K/month standing cost if no capacity reservation. Please check whether bare-metal m7g.metal needs an ODCR in `clusters.yaml` to avoid `InsufficientInstanceCapacity` at burst.
- `proactive_capacity: 30` and `max_burst_capacity: 2000` on the mutated defs are unchanged. Those values were sized for shared-pool bin-packing on m8g.48xlarge; you may want to tune now that each unit of burst capacity is a smaller node.

## Sibling issue not addressed here

`linux.arm64.r7g.12xlarge.memory` is upsized: it advertises `r7g.12xlarge` (48c/384Gi) but `l-arm64g3-61-463` runs on `r7g.16xlarge` (64c/512Gi). Same Graviton3 silicon, just bigger. Generally harmless — flagging only, no change in this PR.

## Test plan

- [ ] `osdc/modules/nodepools/scripts/python/generate_nodepools.py` produces Karpenter NodePools for the new t4g and m7g fleets.
- [ ] `osdc/modules/arc-runners/scripts/python/generate_runners.py` regenerates the three affected runners and produces the new `generated/l-barm64g3-62-226.yaml`.
- [ ] CI smoke tests in this repo pass (`osdc/modules/nodepools/tests/smoke/`, `osdc/modules/arc-runners/scripts/python/test_*.py`).
- [ ] Staging deploy: confirm a job dispatched to each of `l-arm64g2-6-32`, `l-arm64g3-16-62`, `l-barm64g3-62-226` lands on the expected instance family (visible in `kubectl get node -l node.kubernetes.io/instance-type`).
- [ ] Spot/ODCR coverage validated before flipping prod traffic.

Authored by Claude.