### PR TITLE
Bump node-compactor resource limits

### DIFF
--- a/osdc/base/node-compactor/kubernetes/deployment.yaml
+++ b/osdc/base/node-compactor/kubernetes/deployment.yaml
@@ -57,11 +57,11 @@ spec:
               value: "COMPACTOR_CAPACITY_RESERVATION_NODES_PLACEHOLDER"
           resources:
             requests:
-              cpu: "50m"
-              memory: "2Gi"
-            limits:
-              cpu: "200m"
+              cpu: "2"
               memory: "4Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
- Increase CPU request from 50m to 2 cores
- Increase memory request from 2Gi to 4Gi
- Increase CPU limit from 200m to 10 cores
- Increase memory limit from 4Gi to 10Gi

The previous resource allocation was too constrained for the node-compactor controller, which needs to query and manage node state across the cluster. The significant bump in both requests and limits gives it headroom to handle larger clusters without throttling or OOM kills.