### PR TITLE
Zero-out advertised capacity for region-excluded runners

### DIFF
--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -235,7 +235,7 @@ To exercise multiple runner types in parallel (e.g., CPU + GPU), repeat `--label
 just load-test arc-staging --label l-x86iamx-8-16:400 --label l-x86iavx512-29-115-t4:200
 ```
 
-**GPU labels in us-west-1**: g5 (A10G) and g6 (L4) fleets have `exclude_regions: [us-west-1]`. Only g4dn (T4) is available — pick from `l-x86iavx512-29-115-t4` (1×T4), `l-x86iavx512-45-172-t4-4` (4×T4), or `l-bx86iavx512-94-344-t4-8` (8×T4, bare-metal).
+**GPU labels in us-west-1**: g5 (A10G) and g6 (L4) fleets have `exclude_regions: [us-west-1]`. Only g4dn (T4) is available — pick from `l-x86iavx512-29-115-t4` (1×T4), `l-x86iavx512-45-172-t4-4` (4×T4), or `l-bx86iavx512-94-344-t4-8` (8×T4, bare-metal). Scale sets for excluded instance types still deploy but render with `maxRunners: 0`, so picking one of them in `--label` is a no-op.
 
 `--label` and `--jobs` are mutually exclusive. Without `--label`, `--jobs N` distributes proportionally across all available runner types.
 

--- a/osdc/docs/prod-cluster-ha-us-west-1.md
+++ b/osdc/docs/prod-cluster-ha-us-west-1.md
@@ -36,8 +36,10 @@ this design wouldn't work on staging (which is repo-scoped at
    AWS console; B200 is omitted because there's no B200 capacity in
    us-west-1.
 3. **us-west-1 service-quota raises** for the vCPU families this cluster
-   uses (c7i, m7i, r7i, m7g, m8g, g4dn, g5, g6, p5). File early —
-   GPU families can have long lead times.
+   uses (c7i, m7i, r7i, m7g, m8g, g4dn, p5). File early — GPU families
+   can have long lead times. `g5`, `g6`, `c7a`, `r7a`, and `p4d` are
+   not offered in us-west-1; the matching scale sets render with
+   `maxRunners: 0` automatically (see [Region-excluded runners](#region-excluded-runners)).
 4. **PyPI wheel S3 feeder reachable from us-west-1.** Verify or add
    replication.
 
@@ -142,9 +144,26 @@ prod traffic in the failover case, not just steady-state share.
 - **Monitoring/logging** — Grafana Cloud tenant is shared; clusters
   distinguished by `cluster_name` label.
 
+## Region-excluded runners
+
+us-west-1 lacks several instance families AWS offers in us-east-2:
+`g5` (A10G), `g6` (L4), `p4d` (A100), `c7a`, and `r7a`. The matching
+nodepool defs in `modules/nodepools/defs/` carry `exclude_regions: [us-west-1]`,
+so no NodePool is rendered.
+
+The arc-runners generator reads the same `exclude_regions` lists and
+forces `maxRunners: 0` and `proactive_capacity: 0` for any runner whose
+`instance_type` is in an excluded def. This keeps the scale set present
+(so the runner group still exists on GitHub) but prevents jobs from
+being routed to a cluster that cannot schedule them. To add or remove
+a region exclusion, edit the relevant nodepool def — the runner side
+follows automatically.
+
 ## Not in scope
 
 - B200 in us-west-1 (no capacity reservation available).
+- A10G / L4 / A100 / AMD-CPU runners in us-west-1 (AWS does not offer
+  these instance families in the region — see above).
 - Cross-region Harbor / PyPI / git-cache sharing — failure-domain
   isolation is the design intent.
 - Workflow changes in `pytorch/pytorch`. The whole point of the

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -107,6 +107,42 @@ def load_clusters_yaml(repo_root):
         return yaml.safe_load(f)
 
 
+def load_excluded_instance_types(nodepools_defs_dir, region):
+    """Return the set of instance_types whose backing nodepool/fleet excludes ``region``.
+
+    Reads ``modules/nodepools/defs/*.yaml`` — handles both the multi-instance
+    ``fleet:`` format and the legacy single-instance ``nodepool:`` format. An
+    instance_type is considered excluded when its containing def lists
+    ``region`` in ``exclude_regions``. Defs without ``exclude_regions`` (or
+    without ``region`` in the list) contribute nothing.
+
+    Returning an empty set when ``region`` is falsy or the dir is missing keeps
+    the caller backward-compatible: existing scripts that do not pass a region
+    behave exactly as before.
+    """
+    excluded: set[str] = set()
+    if not region or not nodepools_defs_dir.is_dir():
+        return excluded
+    for def_file in sorted(nodepools_defs_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(def_file.read_text()) or {}
+        except yaml.YAMLError:
+            continue
+        fleet = data.get("fleet")
+        nodepool = data.get("nodepool")
+        if isinstance(fleet, dict) and region in (fleet.get("exclude_regions") or []):
+            for inst in fleet.get("instances") or []:
+                if isinstance(inst, dict) and (t := inst.get("type")):
+                    excluded.add(t)
+        elif (
+            isinstance(nodepool, dict)
+            and region in (nodepool.get("exclude_regions") or [])
+            and (t := nodepool.get("instance_type"))
+        ):
+            excluded.add(t)
+    return excluded
+
+
 def get_cluster_config(clusters_yaml, cluster_id):
     """Get cluster config with defaults applied."""
     defaults = clusters_yaml.get("defaults", {})
@@ -165,6 +201,18 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
 
     if cluster_config.get("pause_runners"):
         max_runners = 0
+
+    # Region-exclusion guard: if the backing nodepool/fleet excludes the
+    # cluster's region (no underlying capacity), force advertised capacity to
+    # zero so GitHub does not route jobs that would pend forever.
+    if instance_type in (cluster_config.get("excluded_instance_types") or set()):
+        log_warning(
+            f"{runner_name}: instance_type {instance_type} excluded in region "
+            f"{cluster_config.get('region', '?')} via modules/nodepools/defs/ "
+            f"— forcing max_runners=0, proactive_capacity=0"
+        )
+        max_runners = 0
+        proactive_capacity = 0
 
     if max_burst_capacity is not None and (not isinstance(max_burst_capacity, int) or max_burst_capacity < 0):
         log_error(
@@ -355,6 +403,23 @@ def main():
     cluster_config["pause_runners"] = bool(cluster_cfg.get("pause_runners"))
     if cluster_config["pause_runners"]:
         log_warning(f"pause_runners=true for cluster '{cluster_id}' — all scale sets will render with maxRunners: 0")
+
+    # Mirror the nodepools generator's exclude_regions handling: zero out
+    # advertised capacity for any runner whose instance_type is in a fleet/
+    # nodepool def that excludes this cluster's region.
+    region = cluster_cfg.get("region", "")
+    nodepools_defs_dir = (
+        Path(os.environ["NODEPOOLS_DEFS_DIR"])
+        if "NODEPOOLS_DEFS_DIR" in os.environ
+        else repo_root / "modules" / "nodepools" / "defs"
+    )
+    cluster_config["region"] = region
+    cluster_config["excluded_instance_types"] = load_excluded_instance_types(nodepools_defs_dir, region)
+    if cluster_config["excluded_instance_types"]:
+        log_info(
+            f"Region {region}: nodepool exclude_regions hits {len(cluster_config['excluded_instance_types'])} "
+            f"instance type(s); matching runners will render with maxRunners: 0"
+        )
 
     # Clean output dir so removed defs don't leave stale generated files
     if output_dir.exists():

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -12,6 +12,7 @@ from generate_runners import (
     generate_runner,
     get_cluster_config,
     load_clusters_yaml,
+    load_excluded_instance_types,
     main,
     normalize_name,
     parse_memory_bytes,
@@ -326,6 +327,121 @@ class TestLoadClustersYaml:
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             load_clusters_yaml(tmp_path)
+
+
+# ============================================================================
+# load_excluded_instance_types
+# ============================================================================
+
+
+class TestLoadExcludedInstanceTypes:
+    def _write_def(self, dirpath, name, content):
+        p = dirpath / f"{name}.yaml"
+        p.write_text(yaml.dump(content, default_flow_style=False))
+
+    def test_fleet_format_excludes_all_listed_instances(self, tmp_path):
+        """A fleet def with exclude_regions returns every instance type it declares."""
+        self._write_def(
+            tmp_path,
+            "g5",
+            {
+                "fleet": {
+                    "name": "g5",
+                    "exclude_regions": ["us-west-1"],
+                    "instances": [{"type": "g5.48xlarge"}, {"type": "g5.12xlarge"}],
+                }
+            },
+        )
+        assert load_excluded_instance_types(tmp_path, "us-west-1") == {"g5.48xlarge", "g5.12xlarge"}
+
+    def test_legacy_nodepool_format(self, tmp_path):
+        """A legacy single-instance nodepool def returns its instance_type."""
+        self._write_def(
+            tmp_path,
+            "p4d-24xlarge",
+            {
+                "nodepool": {
+                    "name": "p4d-24xlarge",
+                    "instance_type": "p4d.24xlarge",
+                    "exclude_regions": ["us-west-1"],
+                }
+            },
+        )
+        assert load_excluded_instance_types(tmp_path, "us-west-1") == {"p4d.24xlarge"}
+
+    def test_non_matching_region_returns_empty(self, tmp_path):
+        """An exclude_regions list that does not contain the target region contributes nothing."""
+        self._write_def(
+            tmp_path,
+            "g5",
+            {
+                "fleet": {
+                    "name": "g5",
+                    "exclude_regions": ["us-west-1"],
+                    "instances": [{"type": "g5.48xlarge"}],
+                }
+            },
+        )
+        assert load_excluded_instance_types(tmp_path, "us-east-2") == set()
+
+    def test_no_exclude_regions_returns_empty(self, tmp_path):
+        """A def without exclude_regions contributes nothing."""
+        self._write_def(
+            tmp_path,
+            "c7i",
+            {"fleet": {"name": "c7i", "instances": [{"type": "c7i.24xlarge"}]}},
+        )
+        assert load_excluded_instance_types(tmp_path, "us-west-1") == set()
+
+    def test_empty_region_returns_empty(self, tmp_path):
+        """A falsy region short-circuits to an empty set (backward-compatible)."""
+        self._write_def(
+            tmp_path,
+            "g5",
+            {
+                "fleet": {
+                    "name": "g5",
+                    "exclude_regions": ["us-west-1"],
+                    "instances": [{"type": "g5.48xlarge"}],
+                }
+            },
+        )
+        assert load_excluded_instance_types(tmp_path, "") == set()
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        """A missing nodepools defs dir returns an empty set rather than raising."""
+        assert load_excluded_instance_types(tmp_path / "absent", "us-west-1") == set()
+
+    def test_multiple_defs_merge(self, tmp_path):
+        """Excluded instance types from multiple defs are unioned."""
+        self._write_def(
+            tmp_path,
+            "g5",
+            {
+                "fleet": {
+                    "name": "g5",
+                    "exclude_regions": ["us-west-1"],
+                    "instances": [{"type": "g5.48xlarge"}],
+                }
+            },
+        )
+        self._write_def(
+            tmp_path,
+            "p4d-24xlarge",
+            {
+                "nodepool": {
+                    "name": "p4d-24xlarge",
+                    "instance_type": "p4d.24xlarge",
+                    "exclude_regions": ["us-west-1"],
+                }
+            },
+        )
+        self._write_def(
+            tmp_path,
+            "c7i",
+            {"fleet": {"name": "c7i", "instances": [{"type": "c7i.24xlarge"}]}},
+        )
+        assert load_excluded_instance_types(tmp_path, "us-west-1") == {"g5.48xlarge", "p4d.24xlarge"}
 
 
 # ============================================================================
@@ -662,6 +778,68 @@ class TestGenerateRunner:
 
         docs = list(yaml.safe_load_all((output_dir / "kept-runner.yaml").read_text()))
         assert docs[0]["maxRunners"] == 8
+
+    def test_region_excluded_instance_forces_max_runners_zero(self, tmp_path):
+        """Runners whose instance_type matches a nodepool exclude_regions entry render with maxRunners: 0."""
+        def_file = make_def_file(
+            tmp_path, "uw1-a10g", "g5.48xlarge", 189, 704, gpu=8, proactive_capacity=5, max_burst_capacity=30
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "region": "us-west-1",
+            "excluded_instance_types": {"g5.48xlarge", "g5.12xlarge"},
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "uw1-a10g.yaml").read_text()))
+        assert docs[0]["maxRunners"] == 0
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "0"
+
+    def test_region_excluded_instance_overrides_def_max_runners(self, tmp_path):
+        """A def-level max_runners is overridden when the instance_type is region-excluded."""
+        def_file = make_def_file(tmp_path, "uw1-fixed", "p4d.24xlarge", 88, 1000, gpu=8, max_runners=4)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "region": "us-west-1",
+            "excluded_instance_types": {"p4d.24xlarge"},
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "uw1-fixed.yaml").read_text()))
+        assert docs[0]["maxRunners"] == 0
+
+    def test_region_not_excluded_preserves_capacity(self, tmp_path):
+        """When the instance_type is not in the excluded set, capacity is unchanged."""
+        def_file = make_def_file(
+            tmp_path, "ue2-a10g", "g5.48xlarge", 189, 704, gpu=8, proactive_capacity=5, max_burst_capacity=30
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "region": "us-east-2",
+            "excluded_instance_types": set(),
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "ue2-a10g.yaml").read_text()))
+        assert "maxRunners" not in docs[0]
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "5"
 
     def test_pause_runners_unset_preserves_unbounded(self, tmp_path):
         """pause_runners unset leaves the RSS unbounded when the def also omits max_runners."""


### PR DESCRIPTION
## Summary

- The arc-runners generator now reads `modules/nodepools/defs/*.yaml` and zeros out `maxRunners` (and `proactive_capacity`) for any runner whose `instance_type` is in a fleet/nodepool def with `exclude_regions` matching the cluster's region.
- Single source of truth stays in the nodepool defs — no per-runner-def or `clusters.yaml` edits needed when a region exclusion is added or removed.
- Docs updated: `docs/prod-cluster-ha-us-west-1.md` trims its quota-raise list to families AWS actually offers in us-west-1 and adds a short "Region-excluded runners" section; `docs/arc-fork-build-deploy.md` notes that excluded-instance labels are no-ops in load tests.

## Why

In `arc-cbr-prod-uw1`, the `g5`/`g6`/`p4d`/`c7a`/`r7a` defs carry `exclude_regions: [us-west-1]` because AWS does not offer those instance families in the region. Without this change, the matching runner scale sets register with GitHub and advertise unbounded capacity, so GitHub routes jobs (e.g. `mt-l-x86aavx2-189-704-a10g-8`) to a cluster where they pend forever — Karpenter cannot provision a node type AWS does not sell in us-west-1.

## Test plan

- [x] `just lint` — all 13 linters pass
- [x] `just test` — full suite passes (98.81% coverage)
- [x] New `TestLoadExcludedInstanceTypes` (7 cases): fleet format, legacy `nodepool` format, non-matching region, no `exclude_regions`, empty region, missing dir, multi-def union
- [x] New cases in `TestGenerateRunner`: excluded def → `maxRunners: 0` + `PROACTIVE_CAPACITY: 0`; excluded overrides a def-level `max_runners`; non-excluded region preserves capacity
- [ ] After merge: re-run `just deploy-module arc-cbr-production-uw1 arc-runners` and confirm A10G/L4/A100/c7a/r7a scale sets render `maxRunners: 0` in the cluster