### PR TITLE
Make resume-runners respect region-excluded scale sets

### DIFF
--- a/osdc/modules/arc-runners/scripts/python/runner_max_map.py
+++ b/osdc/modules/arc-runners/scripts/python/runner_max_map.py
@@ -35,7 +35,7 @@ import yaml
 # generate_runners.py exactly or `resume-runners` will compute ARS names that
 # don't exist on the cluster. Both files live in the same directory so the
 # import is direct; pytest's testpaths puts this dir on sys.path too.
-from generate_runners import resolve_value
+from generate_runners import load_excluded_instance_types, resolve_value
 
 # The actions-runner-controller chart substitutes nil maxRunners with
 # math.MaxInt32 (controllers/actions.github.com/resourcebuilder.go:94-101 in
@@ -147,12 +147,13 @@ def compute_ars_name(prefix: str, runner_name: str) -> str:
     return (prefix + runner_name).replace("_", "-")
 
 
-def parse_def_file(def_file: Path) -> tuple[str, int | None]:
-    """Read a runner def YAML and return (runner_name, max_runners).
+def parse_def_file(def_file: Path) -> tuple[str, str | None, int | None]:
+    """Read a runner def YAML and return (runner_name, instance_type, max_runners).
 
     max_runners is None when the def omits it (caller substitutes MAX_INT32).
-    Raises ValueError if `runner.name` is missing or `max_runners` is invalid.
-    Mirrors generate_runners.py:152,158,162-164 validation rules.
+    instance_type is returned so the caller can apply the nodepool
+    exclude_regions guard. Raises ValueError if `runner.name` is missing or
+    `max_runners` is invalid. Mirrors generate_runners.py:152,158,162-164.
     """
     with open(def_file) as f:
         data = yaml.safe_load(f) or {}
@@ -162,10 +163,14 @@ def parse_def_file(def_file: Path) -> tuple[str, int | None]:
     if not isinstance(name, str) or not name:
         raise ValueError(f"Invalid def file {def_file}: missing required 'runner.name'")
 
+    instance_type = runner.get("instance_type")
+    if instance_type is not None and not isinstance(instance_type, str):
+        raise ValueError(f"Invalid def file {def_file}: instance_type must be a string, got {instance_type!r}")
+
     max_runners = runner.get("max_runners")
     if max_runners is not None and (not isinstance(max_runners, int) or max_runners < 1):
         raise ValueError(f"Invalid def file {def_file}: max_runners must be a positive integer, got {max_runners!r}")
-    return name, max_runners
+    return name, instance_type, max_runners
 
 
 def iter_def_files(repo_root: Path, module: str) -> list[Path]:
@@ -185,11 +190,20 @@ def build_max_runners_map(repo_root: Path, clusters_yaml: dict, cluster_id: str)
     """Build {ars_name: max_runners} for every def in every enabled arc-runners* module.
 
     Pure function (modulo file reads). Raises if cluster is unknown or any def
-    is malformed. Logs to stderr (via warn callback) when a module has no defs
-    directory.
+    is malformed. Logs to stderr when a module has no defs directory.
+
+    Runners whose instance_type is in a nodepool/fleet def that excludes the
+    cluster's region render with max_runners=0 — mirrors the same guard in
+    generate_runners.py so `just resume-runners` does not patch excluded
+    scale sets back to MAX_INT32 after a drain.
     """
     prefix = resolve_runner_name_prefix(clusters_yaml, cluster_id)
     modules = enabled_arc_runner_modules(clusters_yaml, cluster_id)
+
+    cluster_cfg = get_cluster(clusters_yaml, cluster_id)
+    region = cluster_cfg.get("region", "")
+    nodepools_defs_dir = repo_root / "modules" / "nodepools" / "defs"
+    excluded_instance_types = load_excluded_instance_types(nodepools_defs_dir, region)
 
     result: dict[str, int] = {}
     for module in modules:
@@ -198,9 +212,12 @@ def build_max_runners_map(repo_root: Path, clusters_yaml: dict, cluster_id: str)
             print(f"warning: module '{module}' has no def files at modules/{module}/defs/", file=sys.stderr)
             continue
         for def_file in def_files:
-            name, max_runners = parse_def_file(def_file)
+            name, instance_type, max_runners = parse_def_file(def_file)
             ars_name = compute_ars_name(prefix, name)
-            result[ars_name] = max_runners if max_runners is not None else MAX_INT32
+            if instance_type in excluded_instance_types:
+                result[ars_name] = 0
+            else:
+                result[ars_name] = max_runners if max_runners is not None else MAX_INT32
     return result
 
 

--- a/osdc/modules/arc-runners/scripts/python/test_runner_max_map.py
+++ b/osdc/modules/arc-runners/scripts/python/test_runner_max_map.py
@@ -321,17 +321,31 @@ class TestIterDefFiles:
 
 
 class TestParseDefFile:
-    def test_returns_name_and_max_runners(self, tmp_path):
+    def test_returns_name_instance_type_and_max_runners(self, tmp_path):
         f = tmp_path / "r.yaml"
-        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu", "max_runners": 8}}))
-        assert parse_def_file(f) == ("linux-cpu", 8)
+        f.write_text(
+            yaml.safe_dump({"runner": {"name": "linux-cpu", "instance_type": "c7i.4xlarge", "max_runners": 8}})
+        )
+        assert parse_def_file(f) == ("linux-cpu", "c7i.4xlarge", 8)
 
     def test_max_runners_omitted_returns_none(self, tmp_path):
         f = tmp_path / "r.yaml"
-        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu"}}))
-        name, max_runners = parse_def_file(f)
+        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu", "instance_type": "c7i.4xlarge"}}))
+        name, instance_type, max_runners = parse_def_file(f)
         assert name == "linux-cpu"
+        assert instance_type == "c7i.4xlarge"
         assert max_runners is None
+
+    def test_instance_type_omitted_returns_none(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "linux-cpu", "max_runners": 4}}))
+        assert parse_def_file(f) == ("linux-cpu", None, 4)
+
+    def test_non_string_instance_type_raises(self, tmp_path):
+        f = tmp_path / "r.yaml"
+        f.write_text(yaml.safe_dump({"runner": {"name": "x", "instance_type": 42}}))
+        with pytest.raises(ValueError, match=r"instance_type must be a string"):
+            parse_def_file(f)
 
     def test_missing_runner_section_raises(self, tmp_path):
         f = tmp_path / "r.yaml"
@@ -440,6 +454,108 @@ class TestBuildMaxRunnersMap:
             "h100-1": 8,
             "b200-1": 1,
         }
+
+    def test_region_excluded_instance_forces_zero(self, tmp_path):
+        """Runner whose instance_type is region-excluded gets max_runners=0, not MAX_INT32."""
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-uw1": {
+                    "region": "us-west-1",
+                    "arc-runners": {"runner_name_prefix": "mt-"},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {
+                # Excluded in us-west-1 (g5 fleet) — must be zeroed even though def omits max_runners.
+                "a10g-8": {"name": "a10g-8", "instance_type": "g5.48xlarge"},
+                # Not excluded — preserves def-level value.
+                "t4": {"name": "t4", "instance_type": "g4dn.4xlarge", "max_runners": 2},
+            }
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        # Add a nodepool fleet def that excludes us-west-1 for g5.48xlarge.
+        nodepools_defs = repo / "modules" / "nodepools" / "defs"
+        nodepools_defs.mkdir(parents=True)
+        (nodepools_defs / "g5.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "fleet": {
+                        "name": "g5",
+                        "exclude_regions": ["us-west-1"],
+                        "instances": [{"type": "g5.48xlarge"}],
+                    }
+                }
+            )
+        )
+        result = build_max_runners_map(repo, clusters_yaml, "arc-uw1")
+        assert result == {"mt-a10g-8": 0, "mt-t4": 2}
+
+    def test_region_excluded_overrides_def_max_runners(self, tmp_path):
+        """A def-level max_runners is also overridden when instance_type is region-excluded."""
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-uw1": {
+                    "region": "us-west-1",
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {"a100": {"name": "a100", "instance_type": "p4d.24xlarge", "max_runners": 4}},
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        nodepools_defs = repo / "modules" / "nodepools" / "defs"
+        nodepools_defs.mkdir(parents=True)
+        (nodepools_defs / "p4d-24xlarge.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "nodepool": {
+                        "name": "p4d-24xlarge",
+                        "instance_type": "p4d.24xlarge",
+                        "exclude_regions": ["us-west-1"],
+                    }
+                }
+            )
+        )
+        result = build_max_runners_map(repo, clusters_yaml, "arc-uw1")
+        assert result == {"a100": 0}
+
+    def test_region_not_excluded_preserves_unbounded(self, tmp_path):
+        """In a region not on the exclusion list, capacity stays at MAX_INT32 when def omits max_runners."""
+        clusters_yaml = {
+            "defaults": {},
+            "clusters": {
+                "arc-ue2": {
+                    "region": "us-east-2",
+                    "arc-runners": {"runner_name_prefix": ""},
+                    "modules": ["arc-runners"],
+                }
+            },
+        }
+        modules = {
+            "arc-runners": {"a10g-8": {"name": "a10g-8", "instance_type": "g5.48xlarge"}},
+        }
+        repo = make_repo(tmp_path, clusters_yaml, modules)
+        nodepools_defs = repo / "modules" / "nodepools" / "defs"
+        nodepools_defs.mkdir(parents=True)
+        (nodepools_defs / "g5.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "fleet": {
+                        "name": "g5",
+                        "exclude_regions": ["us-west-1"],
+                        "instances": [{"type": "g5.48xlarge"}],
+                    }
+                }
+            )
+        )
+        result = build_max_runners_map(repo, clusters_yaml, "arc-ue2")
+        assert result == {"a10g-8": MAX_INT32}
 
     def test_normalization_underscores_in_def_name(self, tmp_path):
         clusters_yaml = {
@@ -689,6 +805,7 @@ class TestEndToEnd:
               max_burst_capacity: 2000
         """)
         (defs_dir / "l-x86iamx-8-16.yaml").write_text(full_def)
-        name, max_runners = parse_def_file(defs_dir / "l-x86iamx-8-16.yaml")
+        name, instance_type, max_runners = parse_def_file(defs_dir / "l-x86iamx-8-16.yaml")
         assert name == "l-x86iamx-8-16"
+        assert instance_type == "c7i.12xlarge"
         assert max_runners is None


### PR DESCRIPTION
## Summary

- PR #597 taught `generate_runners.py` to render `maxRunners: 0` and `proactive_capacity: 0` for runners whose nodepool excludes the cluster's region (e.g. `g5`, `g6`, `p4d`, `c7a`, `r7a` defs that carry `exclude_regions: [us-west-1]`).
- `runner_max_map.py` (used by `just resume-runners`) reads the same runner defs but did not consult the nodepool exclusions. After a `just drain-runners` cutover on `arc-cbr-production-uw1`, it would patch every excluded scale set back to `MAX_INT32`, silently undoing #597 until the next `just deploy`.
- This change imports `load_excluded_instance_types` (added in #597) and forces `max_runners=0` for any runner whose `instance_type` matches an excluded nodepool def. `parse_def_file` now also returns `instance_type` so the caller can apply the guard.

## Test plan

- [x] `just lint` — 13/13 pass
- [x] `just test` — full suite passes (78 tests in `test_runner_max_map.py`, including 3 new cases covering region-excluded behavior)
- [ ] Manual: run `uv run runner_max_map.py arc-cbr-production-uw1` after merge and confirm every region-excluded scale set (g5/g6/p4d/c7a/r7a) reports `0` in the JSON map.
- [ ] Manual: smoke-test `just drain-runners arc-cbr-production-uw1 && just resume-runners arc-cbr-production-uw1` and verify excluded scale sets remain at `maxRunners: 0`.