### PR TITLE
Add dashboard filter and Karpenter error metrics

### DIFF
--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1999,7 +1999,7 @@ simulate-cluster *args:
 
 # Publish Grafana dashboards to Grafana Cloud
 # Requires GRAFANA_API_TOKEN env var (service account token with dashboard write permission)
-publish-dashboards grafana_url="https://pytorchci.grafana.net" folder_uid="bfif0aqt8u800e" outdated_folder_uid="fvlk8m":
+publish-dashboards grafana_url="https://pytorchci.grafana.net" folder_uid="bfif0aqt8u800e" outdated_folder_uid="fvlk8m" filter="":
     #!/usr/bin/env bash
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
@@ -2013,6 +2013,7 @@ publish-dashboards grafana_url="https://pytorchci.grafana.net" folder_uid="bfif0
     GRAFANA_URL="{{grafana_url}}"
     FOLDER_UID="{{folder_uid}}"
     OUTDATED_FOLDER_UID="{{outdated_folder_uid}}"
+    FILTER="{{filter}}"
     API="${GRAFANA_URL}/api/dashboards/db"
 
     # Collect dashboard JSON files from upstream and consumer modules
@@ -2037,6 +2038,9 @@ publish-dashboards grafana_url="https://pytorchci.grafana.net" folder_uid="bfif0
         [[ -f "$file" ]] || continue
         TOTAL=$((TOTAL + 1))
         name=$(basename "$file" .json)
+        if [[ -n "$FILTER" && "$name" != *"$FILTER"* ]]; then
+          continue
+        fi
 
         # Wrap dashboard model in the Grafana API payload:
         # - set id to null (Grafana assigns it)

--- a/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/karpenter.yaml
+++ b/osdc/modules/monitoring/kubernetes/monitors/servicemonitors/karpenter.yaml
@@ -20,4 +20,4 @@ spec:
         # Drops all histogram buckets and low-value gauges (~400-500 series saved)
         - action: keep
           sourceLabels: [__name__]
-          regex: "karpenter_nodeclaims_created_total|karpenter_nodes_created_total|karpenter_nodes_terminated_total|karpenter_nodepools_usage|karpenter_nodepools_limit|karpenter_nodes_allocatable|karpenter_interruption_received_messages_total"
+          regex: "karpenter_nodeclaims_created_total|karpenter_nodes_created_total|karpenter_nodes_terminated_total|karpenter_nodepools_usage|karpenter_nodepools_limit|karpenter_nodes_allocatable|karpenter_interruption_received_messages_total|karpenter_cloudprovider_errors_total|controller_runtime_reconcile_errors_total"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #602
* #601

----

- Add optional filter param to publish-dashboards recipe to
  publish only dashboards matching a name substring
- Add karpenter_cloudprovider_errors_total and
  controller_runtime_reconcile_errors_total to Karpenter
  ServiceMonitor keep-list

The filter speeds up iteration when developing a single
dashboard — avoids republishing all dashboards each time.
The new Karpenter metrics surface cloud provider API failures
and controller reconciliation errors for oncall alerting.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>