### PR TITLE
Bump ARC fork chart to 0.14.1-jeanschmidt.11 (fix listener startup race)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -61,7 +61,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.10"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.11"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 4
     log_level: info

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -17,9 +17,9 @@
 Published from the fork via the `gha-publish-chart.yaml` workflow (manual `workflow_dispatch`). The workflow builds the controller image (multi-arch `linux/amd64` + `linux/arm64`) and publishes the chart to GHCR.
 
 - **OCI registry**: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.10`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
+- **Chart version**: configured in `clusters.yaml` at `arc.chart_version` (currently `0.14.1-jeanschmidt.11`). Format is `<upstream-base>-jeanschmidt.<N>`; bump `<N>` for each fork publish. Valid as both Helm chart version and OCI image tag.
 - **Image tags**: the workflow publishes two tags per build:
-  - `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (the rolling release tag — pass `release_tag_name=0.14.1-jeanschmidt.10` to match the chart)
+  - `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>` (the rolling release tag — pass `release_tag_name=0.14.1-jeanschmidt.11` to match the chart)
   - `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<release_tag_name>-<short_sha>` (immutable tag with the source commit baked in, useful for pinning and debugging)
 
 To publish a new chart version, trigger `gha-publish-chart.yaml` from the fork's GitHub Actions UI with `publish_gha_runner_scale_set_controller_chart: true`.
@@ -137,14 +137,14 @@ This runs `modules/arc/deploy.sh`, which:
 3. **Applies RBAC** from `modules/arc/kubernetes/capacity-monitor-rbac.yaml`
 4. **Helm upgrade** of the fork chart:
    - Chart: `oci://ghcr.io/jeanschmidt/actions-runner-controller-charts/gha-runner-scale-set-controller`
-   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.10`)
+   - Version: from `clusters.yaml` `arc.chart_version` (default `0.14.1-jeanschmidt.11`)
    - Image: defaults to `ghcr.io/jeanschmidt/gha-runner-scale-set-controller:<chart_version>`. Override with `arc.image_repository` / `arc.image_tag` in `clusters.yaml` for local Harbor builds.
 
 Other deploy.sh config knobs (all from `clusters.yaml`):
 
 | Key | Default | What |
 |-----|---------|------|
-| `arc.chart_version` | `0.14.1-jeanschmidt.10` | Helm chart version (fork) |
+| `arc.chart_version` | `0.14.1-jeanschmidt.11` | Helm chart version (fork) |
 | `arc.image_repository` | `ghcr.io/jeanschmidt/gha-runner-scale-set-controller` | Controller image repo (override for local Harbor builds) |
 | `arc.image_tag` | _(chart_version)_ | Controller image tag (override for local Harbor builds) |
 | `arc.replica_count` | `2` | Controller replicas |


### PR DESCRIPTION
**Impact:** All ARC-managed runner scale sets across all OSDC clusters **Risk:** low

## What
Bumps the ARC fork chart version from `0.14.1-jeanschmidt.10` to `0.14.1-jeanschmidt.11` in `clusters.yaml` and updates all version references in the deploy docs.

## Why
The fork release `0.14.1-jeanschmidt.11` fixes a race condition where the listener goroutine starts advertising capacity to GitHub before the capacity monitor completes its initial reconcile. When `max_runners` is unset (capacity monitor mode), the listener would briefly advertise `math.MaxInt32` (~2.1 billion) as available capacity, causing GitHub to dispatch jobs the cluster cannot fulfill. The fix seeds the listener with zero capacity when the capacity monitor is enabled, so no phantom jobs are dispatched before the monitor reports real capacity.

See: https://github.com/jeanschmidt/actions-runner-controller/pull/6

## How
- Pure version bump — no behavioral changes in OSDC itself
- The fork PR hoists `capacity.ConfigFromEnv()` earlier in `main.go` and adds a `listenerInitialMaxRunners()` helper that returns `0` when the capacity monitor is enabled
- Chart must be published from the fork via `gha-publish-chart.yaml` before deploying

## Changes
- `clusters.yaml`: bump `arc.chart_version` from `0.14.1-jeanschmidt.10` to `0.14.1-jeanschmidt.11`
- `docs/arc-fork-build-deploy.md`: update all four references to the chart version to match

## Testing
- Publish the chart from the fork (`gha-publish-chart.yaml` with `release_tag_name=0.14.1-jeanschmidt.11`)
- Deploy the ARC module to a staging cluster: `just deploy-module <cluster> arc`
- Verify controller pods restart with the new image tag
- Confirm runner scale sets come up without phantom capacity bursts (check listener logs for initial `maxRunners=0` before the capacity monitor's first reconcile)