### PR TITLE
Raise burst capacity on single-GPU ARC scale sets

### DIFF
--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -8,5 +8,5 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 5
-  max_burst_capacity: 30
+  proactive_capacity: 10
+  max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -8,5 +8,5 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 5
-  max_burst_capacity: 30
+  proactive_capacity: 10
+  max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -10,5 +10,5 @@ runner:
   vcpu: 29
   memory: 115Gi
   gpu: 1
-  proactive_capacity: 5
-  max_burst_capacity: 30
+  proactive_capacity: 10
+  max_burst_capacity: 60


### PR DESCRIPTION
## Summary

- Bump `proactive_capacity` 5 → 10 and `max_burst_capacity` 30 → 60 on three single-GPU defs (`a10g`, `l4`, `t4` on g5/g6/g4dn `.8xlarge`).
- Multi-GPU defs (94-vCPU / 189-vCPU GPU nodes) keep the 30/5 cap.

## Why

`CAPACITY_AWARE_MAX_BURST_CAPACITY` clamps `desiredPairs` in `cmd/ghalistener/capacity/monitor.go` L457-458 of the jeanschmidt fork:

```go
if m.config.MaxBurstCapacity > 0 {
    desiredPairs = min(desiredPairs, m.config.MaxBurstCapacity)
}
```

That clamp is on inventory (running + pending placeholder pairs), not on per-cycle creation rate. When `queuedJobs=795` on the `a10g` scale set with `burst=30`, `desiredPairs=30` every reconcile, forever; advertised `X-ScaleSetMaxCapacity` pins near `pickup_rate == arrival_rate` and the queue never drains until job arrivals slow.

Single-GPU defs were lumped in the same `30 / 5` bucket as 8x-GPU defs even though each runner pod occupies a `.8xlarge` (1 GPU, 32 vCPU) instead of a `.48xlarge` (8 GPU, 192 vCPU). Same cap, ~8x less per-runner blast radius — leaves ramp width pinned far below what the underlying capacity allows.

The 30 cap exists to bound cluster pressure (git-cache rsync, Harbor manifest fetches, pypi-cache). 60 is a conservative first step (2x the old cap) — well below the small-CPU tier's `2000` cap and the medium tier's `250` cap, leaves room to raise further once we observe downstream-service load.

## Investigation

Full root-cause writeup (incl. why `iavx512` was self-resolved by GitHub incident `g6ffrm0rfvz9`, and why this is the listener-side fix that's still worth shipping): see attached doc.

## Test plan

- [x] `just test` passes (98.81% coverage; 12/13 linters; `kube-linter` is OOM in local env unrelated to these YAML scalar changes)
- [ ] Deploy to `arc-cbr-production-uw1` first, observe `gha_capacity_desired_pairs` / `gha_capacity_pairs` ramp behavior
- [ ] Watch git-cache, Harbor, pypi-cache subsystem health for 1h after first burst
- [ ] Roll to `arc-cbr-production` if no regression
- [ ] If healthy at 60, consider follow-up bump to 100-150

## Reference

ARC code change to make `MaxBurstCapacity` a per-cycle creation-rate cap (so it bounds ramp slope without capping steady-state) tracked separately in jeanschmidt fork.