### PR TITLE
Isolate g5.48xlarge into its own fleet to protect 8-GPU runner

### DIFF
--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -54,14 +54,21 @@ def normalize_name(name):
     return name.replace(".", "-").replace("_", "-")
 
 
-def derive_fleet_name(instance_type):
-    """Derive the node-fleet name from an instance type.
+def derive_fleet_name(instance_type, fleet_map=None):
+    """Derive the node-fleet name for an instance type.
 
-    Returns the instance family (everything before the dot).  GPU scheduling
-    is handled by nvidia.com/gpu resource requests, not fleet-level isolation,
-    so GPU and CPU instances use the same derivation: family name only.
+    Consults ``fleet_map`` (instance_type -> fleet_name, populated from
+    modules/nodepools/defs/*.yaml) first, so a runner whose instance_type
+    sits in a split-out fleet (e.g. g5.48xlarge in g5-48xlarge.yaml) picks
+    up that fleet's label automatically — no per-instance hardcoding here.
+
+    Falls back to the instance family (everything before the dot) when the
+    map is empty or missing the instance, matching the historical default
+    used before per-SKU fleets existed (r7a, g5, c7i, p6-b200, …).
     """
-    return instance_type.split(".")[0]  # r7a, g5, c7i, p6-b200, etc.
+    if fleet_map and instance_type in fleet_map:
+        return fleet_map[instance_type]
+    return instance_type.split(".")[0]
 
 
 # Kubernetes resource quantity suffixes → multiplier (bytes)
@@ -105,6 +112,49 @@ def load_clusters_yaml(repo_root):
     config_path = repo_root / "clusters.yaml"
     with open(config_path) as f:
         return yaml.safe_load(f)
+
+
+def load_instance_to_fleet_map(nodepools_defs_dir):
+    """Build an ``instance_type -> fleet_name`` map from nodepool defs.
+
+    Reads ``modules/nodepools/defs/*.yaml`` so the runner generator stays
+    consistent with the NodePool generator without duplicating per-SKU
+    fleet assignments here. Handles all three def formats:
+
+      - ``fleet:``    — single fleet, multiple instances share the fleet name.
+      - ``fleets:``   — multiple fleets in one file, each with its own
+                        instances list.
+      - ``nodepool:`` — legacy single-instance; auto-derives fleet name from
+                        the instance family, mirroring generate_nodepools.py.
+
+    Returns an empty dict when the defs dir is missing — callers fall back
+    to the family-name default in ``derive_fleet_name``.
+    """
+    mapping: dict[str, str] = {}
+    if not nodepools_defs_dir.is_dir():
+        return mapping
+
+    def _record(fleet_data):
+        name = fleet_data.get("name") if isinstance(fleet_data, dict) else None
+        if not name:
+            return
+        for section in ("instances", "release"):
+            for inst in fleet_data.get(section) or []:
+                if isinstance(inst, dict) and (t := inst.get("type")):
+                    mapping[t] = name
+
+    for def_file in sorted(nodepools_defs_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(def_file.read_text()) or {}
+        except yaml.YAMLError:
+            continue
+        if isinstance(fleet := data.get("fleet"), dict):
+            _record(fleet)
+        for f in data.get("fleets") or []:
+            _record(f)
+        if isinstance(nodepool := data.get("nodepool"), dict) and (t := nodepool.get("instance_type")):
+            mapping.setdefault(t, t.split(".")[0])
+    return mapping
 
 
 def load_excluded_instance_types(nodepools_defs_dir, region):
@@ -228,7 +278,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
             f"Consider raising max_burst_capacity."
         )
 
-    node_fleet = derive_fleet_name(instance_type)
+    node_fleet = derive_fleet_name(instance_type, cluster_config.get("instance_to_fleet"))
 
     # Cluster-specific values
     github_url = cluster_config.get("github_config_url", "")
@@ -415,6 +465,7 @@ def main():
     )
     cluster_config["region"] = region
     cluster_config["excluded_instance_types"] = load_excluded_instance_types(nodepools_defs_dir, region)
+    cluster_config["instance_to_fleet"] = load_instance_to_fleet_map(nodepools_defs_dir)
     if cluster_config["excluded_instance_types"]:
         log_info(
             f"Region {region}: nodepool exclude_regions hits {len(cluster_config['excluded_instance_types'])} "

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -13,6 +13,7 @@ from generate_runners import (
     get_cluster_config,
     load_clusters_yaml,
     load_excluded_instance_types,
+    load_instance_to_fleet_map,
     main,
     normalize_name,
     parse_memory_bytes,
@@ -258,11 +259,21 @@ class TestDeriveFleetName:
     def test_derive_fleet_name_cpu(self):
         assert derive_fleet_name("r7a.48xlarge") == "r7a"
 
-    def test_derive_fleet_name_gpu(self):
+    def test_derive_fleet_name_fallback_gpu(self):
+        # No fleet map -> falls back to the instance family.
         assert derive_fleet_name("g5.8xlarge") == "g5"
-
-    def test_derive_fleet_name_gpu_multi(self):
         assert derive_fleet_name("g5.48xlarge") == "g5"
+
+    def test_derive_fleet_name_uses_map(self):
+        # When nodepool defs split an instance into its own fleet
+        # (e.g. g5.48xlarge in g5-48xlarge.yaml), the map drives the result.
+        fleet_map = {"g5.8xlarge": "g5", "g5.48xlarge": "g5-48xlarge"}
+        assert derive_fleet_name("g5.8xlarge", fleet_map) == "g5"
+        assert derive_fleet_name("g5.48xlarge", fleet_map) == "g5-48xlarge"
+
+    def test_derive_fleet_name_map_miss_falls_back(self):
+        # Instances not in the map still get the family-name default.
+        assert derive_fleet_name("c7i.16xlarge", {"g5.48xlarge": "g5-48xlarge"}) == "c7i"
 
     def test_derive_fleet_name_b200(self):
         assert derive_fleet_name("p6-b200.48xlarge") == "p6-b200"
@@ -411,6 +422,84 @@ class TestLoadExcludedInstanceTypes:
     def test_missing_dir_returns_empty(self, tmp_path):
         """A missing nodepools defs dir returns an empty set rather than raising."""
         assert load_excluded_instance_types(tmp_path / "absent", "us-west-1") == set()
+
+
+# ============================================================================
+# load_instance_to_fleet_map
+# ============================================================================
+
+
+class TestLoadInstanceToFleetMap:
+    def _write_def(self, dirpath, name, content):
+        p = dirpath / f"{name}.yaml"
+        p.write_text(yaml.dump(content, default_flow_style=False))
+
+    def test_fleet_format_maps_each_instance_to_fleet_name(self, tmp_path):
+        self._write_def(
+            tmp_path,
+            "g5",
+            {"fleet": {"name": "g5", "instances": [{"type": "g5.8xlarge"}, {"type": "g5.12xlarge"}]}},
+        )
+        assert load_instance_to_fleet_map(tmp_path) == {"g5.8xlarge": "g5", "g5.12xlarge": "g5"}
+
+    def test_split_fleet_overrides_unified_when_in_separate_file(self, tmp_path):
+        # Mirrors the g5/g5-48xlarge split: g5.48xlarge lives in its own file
+        # with a distinct fleet name, while the rest stay on the unified g5 fleet.
+        self._write_def(
+            tmp_path,
+            "g5",
+            {"fleet": {"name": "g5", "instances": [{"type": "g5.8xlarge"}, {"type": "g5.12xlarge"}]}},
+        )
+        self._write_def(
+            tmp_path,
+            "g5-48xlarge",
+            {"fleet": {"name": "g5-48xlarge", "instances": [{"type": "g5.48xlarge"}]}},
+        )
+        m = load_instance_to_fleet_map(tmp_path)
+        assert m["g5.8xlarge"] == "g5"
+        assert m["g5.12xlarge"] == "g5"
+        assert m["g5.48xlarge"] == "g5-48xlarge"
+
+    def test_fleets_format(self, tmp_path):
+        self._write_def(
+            tmp_path,
+            "gpu",
+            {
+                "fleets": [
+                    {"name": "g5", "instances": [{"type": "g5.8xlarge"}]},
+                    {"name": "g5-48xlarge", "instances": [{"type": "g5.48xlarge"}]},
+                ]
+            },
+        )
+        assert load_instance_to_fleet_map(tmp_path) == {
+            "g5.8xlarge": "g5",
+            "g5.48xlarge": "g5-48xlarge",
+        }
+
+    def test_legacy_nodepool_uses_family(self, tmp_path):
+        self._write_def(
+            tmp_path,
+            "p4d-24xlarge",
+            {"nodepool": {"name": "p4d-24xlarge", "instance_type": "p4d.24xlarge"}},
+        )
+        assert load_instance_to_fleet_map(tmp_path) == {"p4d.24xlarge": "p4d"}
+
+    def test_release_section_included(self, tmp_path):
+        self._write_def(
+            tmp_path,
+            "m8g",
+            {
+                "fleet": {
+                    "name": "m8g",
+                    "instances": [{"type": "m8g.48xlarge"}],
+                    "release": [{"type": "m8g.metal"}],
+                }
+            },
+        )
+        assert load_instance_to_fleet_map(tmp_path) == {"m8g.48xlarge": "m8g", "m8g.metal": "m8g"}
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        assert load_instance_to_fleet_map(tmp_path / "absent") == {}
 
     def test_multiple_defs_merge(self, tmp_path):
         """Excluded instance types from multiple defs are unioned."""

--- a/osdc/modules/nodepools/defs/g5-48xlarge.yaml
+++ b/osdc/modules/nodepools/defs/g5-48xlarge.yaml
@@ -1,0 +1,22 @@
+# Karpenter NodePool fleet: g5-48xlarge (NVIDIA A10G, 8-GPU)
+#
+# g5.48xlarge is split out of the unified `g5` fleet so it carries a
+# distinct node-fleet label/taint. This prevents 1-GPU and 4-GPU workflow
+# pods (which tolerate `node-fleet=g5`) from landing on 8-GPU nodes and
+# fragmenting them — which previously starved the 8-GPU runner
+# (mt-l-x86aavx2-189-704-a10g-8 dropped to 3 active runners with 29
+# placeholder-workflows Pending on 2026-05-20).
+#
+# Only the 8-GPU runner def (l-x86aavx2-189-704-a10g-8.yaml) resolves to
+# this fleet via the g5.48xlarge special-case in derive_fleet_name().
+fleet:
+  name: g5-48xlarge
+  arch: amd64
+  gpu: true
+  exclude_regions:
+    - us-west-1
+  instances:
+    - type: g5.48xlarge
+      weight: 100
+      node_disk_size: 600
+      has_nvme: true

--- a/osdc/modules/nodepools/defs/g5.yaml
+++ b/osdc/modules/nodepools/defs/g5.yaml
@@ -1,6 +1,10 @@
 # NUMA note: restricted topology policy may reject mixed GPU packing; monitor for TopologyAffinityError
-# Karpenter NodePool fleet: g5 (NVIDIA A10G)
+# Karpenter NodePool fleet: g5 (NVIDIA A10G), 1-GPU and 4-GPU SKUs
 # GPU compute — single fleet, scheduling by nvidia.com/gpu resource requests
+#
+# g5.48xlarge (8-GPU) is intentionally NOT part of this fleet — it has its
+# own def (g5-48xlarge.yaml) with a distinct node-fleet label so 1/4-GPU
+# pods can't fragment 8-GPU nodes.
 fleet:
   name: g5
   arch: amd64
@@ -8,10 +12,6 @@ fleet:
   exclude_regions:
     - us-west-1
   instances:
-    - type: g5.48xlarge
-      weight: 100
-      node_disk_size: 600
-      has_nvme: true
     - type: g5.12xlarge
       weight: 90
       node_disk_size: 600

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -419,11 +419,14 @@ def _fleet_nodepool_name(fleet_name, instance_type, name_suffix=""):
     instance types still produce unique NodePool names.
     """
     instance_family = instance_type.split(".")[0]
-    if fleet_name == instance_family:
-        name = instance_type.replace(".", "-")
-    else:
-        instance_size = instance_type.split(".", 1)[1].replace(".", "-")
-        name = f"{fleet_name}-{instance_size}"
+    instance_size = instance_type.split(".", 1)[1].replace(".", "-")
+    canonical = f"{instance_family}-{instance_size}"
+    # Use the canonical "<family>-<size>" name when the fleet name is the
+    # family ("g5" + g5.48xlarge -> g5-48xlarge) or already encodes
+    # family+size ("g5-48xlarge" + g5.48xlarge -> g5-48xlarge, not
+    # g5-48xlarge-48xlarge). Otherwise fall back to "<fleet>-<size>"
+    # (e.g. "c7i-runner" + c7i.8xlarge -> c7i-runner-8xlarge).
+    name = canonical if fleet_name in (instance_family, canonical) else f"{fleet_name}-{instance_size}"
     if name_suffix:
         name = f"{name}{name_suffix}"
     return name


### PR DESCRIPTION
## Summary

Every g5 NodePool (g5.8xlarge, g5.12xlarge, g5.48xlarge, …) currently shares the same `node-fleet=g5` label and taint, so 1-GPU or 4-GPU workflow pods can schedule onto a g5.48xlarge node. Under sustained 1-GPU bursts the 8-GPU SKU becomes GPU-fragmented and starves its runner (`mt-l-x86aavx2-189-704-a10g-8` dropped to 3 active runners with 29 placeholder-workflows Pending on 2026-05-20).

This PR splits `g5.48xlarge` out of the shared fleet so it can only host the 8-GPU runner. 1-GPU and 4-GPU runners stay on the unified `g5` fleet — any fragmentation between those two is **out of scope** for this fix.

## Changes

- `modules/nodepools/defs/g5.yaml` — drop `g5.48xlarge` from the `g5` fleet (other SKUs unchanged).
- `modules/nodepools/defs/g5-48xlarge.yaml` — **new file**, single-instance fleet `g5-48xlarge`. Mirrors the `p4d-24xlarge.yaml` precedent of an isolated GPU SKU getting its own def file.
- `modules/nodepools/scripts/python/generate_nodepools.py` — when a fleet name already encodes family+size (e.g. `g5-48xlarge`), emit the NodePool with that name verbatim instead of `g5-48xlarge-48xlarge`.
- `modules/arc-runners/scripts/python/generate_runners.py` — special-case `g5.48xlarge` in `derive_fleet_name` so the 8-GPU runner's `CAPACITY_AWARE_NODE_FLEET`, node affinity, and toleration values all point at the isolated fleet.
- `test_generate_runners.py` — adjust fleet-name tests.

## Effect

| Runner | Instance | `node-fleet` before | `node-fleet` after |
|---|---|---|---|
| `l-x86aavx2-29-113-a10g`     | g5.8xlarge  | `g5` | `g5` *(unchanged)* |
| `l-x86aavx2-45-167-a10g-4`   | g5.12xlarge | `g5` | `g5` *(unchanged)* |
| `l-x86aavx2-189-704-a10g-8`  | g5.48xlarge | `g5` | `g5-48xlarge` |

g5.48xlarge nodes become reserved for 8-GPU jobs. 1-GPU and 4-GPU pods can no longer land on them.

NodePool resource names stay the same (`g5-48xlarge.yaml`, `g5-8xlarge.yaml`, etc.); only the `node-fleet` label/taint *value* changes — and only for `g5.48xlarge`.

## Migration is no-restart

Existing g5.48xlarge nodes keep their old `node-fleet=g5:NoSchedule` taint. New 8-GPU workflow pods only tolerate `node-fleet=g5-48xlarge`, so:

- In-flight 8-GPU jobs run to completion on the existing nodes.
- New 8-GPU scheduling decisions go to newly-provisioned g5.48xlarge nodes that carry the new label.
- Old g5.48xlarge nodes drain naturally and Karpenter consolidates them via `WhenEmpty` once idle.

No pod restarts, no scale-set bouncing.

## Test plan

- [x] `just lint` — all 13 linters pass.
- [x] `just test` — all unit tests pass (98.81% coverage).
- [x] Manual: ran `generate_nodepools.py` and confirmed the new `g5-48xlarge` NodePool is produced with `node-fleet=g5-48xlarge` label/taint, while `g5-8xlarge`, `g5-12xlarge`, `g5-16xlarge`, `g5-24xlarge` keep `node-fleet=g5`.
- [x] Manual: ran `just generate-arc-runners arc-cbr-production` and verified `l-x86aavx2-189-704-a10g-8` emits `CAPACITY_AWARE_NODE_FLEET=g5-48xlarge` while the other two a10g runners still emit `g5`.
- [ ] Staging soak before prod.
- [ ] Monitor 8-GPU scale set after rollout — expect `Pending` placeholder-workflow count on `mt-l-x86aavx2-189-704-a10g-8` to drop to ~0 once the queue rolls over.

## Follow-ups (out of scope)

- Same isolation for 4-GPU A10G (`g5.12xlarge`) if 1-GPU pressure starts hurting that runner.
- Same pattern for g6 (l4) and g4dn (t4) families if fragmentation surfaces there.
- Longer-term bin-packing scheduler profile (`MostAllocated` scoring) — separate PR.