### PR TITLE
Bump BuildKit replicas_per_arch from 5 to 12

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -82,7 +82,7 @@ defaults:
     gpu_disruption_budget: "20%"
     cpu_disruption_budget: "20%"
   buildkit:
-    replicas_per_arch: 5
+    replicas_per_arch: 12
   monitoring:
     grafana_cloud_url: "https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom/push"
     grafana_cloud_read_url: "https://prometheus-prod-36-prod-us-west-0.grafana.net/api/prom"


### PR DESCRIPTION
## Summary

Bump BuildKit pool size in the default `clusters.yaml` config (5 → 12 replicas per arch). All production clusters inherit this default, so this applies to `arc-cbr-production` (us-east-2) and `arc-cbr-production-uw1` (us-west-1). `arc-staging` keeps its explicit override of 2.

For context on why we want more capacity, see https://github.com/pytorch/pytorch/pull/184664 (migrating `docker-builds` to OSDC + remote BuildKit).

## Follow-ups (out of scope)

- Per-arch replica overrides in `generate_buildkit.py` if asymmetric sizing becomes useful.
- Registry-mode `--cache-to` / `--cache-from` on the buildx invocation in `pytorch/.ci/docker/build.sh` to shrink repeat-build cost.

## Test plan

- [ ] `just deploy buildkit` on a prod cluster (staging is unaffected since it overrides to 2).
- [ ] `kubectl -n buildkit get deploy buildkitd-amd64 -o jsonpath='{.spec.replicas}'` returns `12`.
- [ ] Karpenter spins up 3 additional amd64 BuildKit nodes (6 nodes total per arch).
- [ ] Re-run pytorch docker-builds on OSDC, compare wall-time / per-job duration to the 5-replica baseline.

Authored by Claude.