### PR TITLE
Drop BuildKit module from arc-cbr-production-uw1

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -196,10 +196,6 @@ clusters:
       central_memory_limit: "50Gi"
     node_compactor:
       min_node_age_seconds: 900
-    buildkit:
-      arm64_instance_type: c7gd.16xlarge
-      amd64_instance_type: m6id.24xlarge
-      pods_per_node: 2
     arc-runners:
       github_config_url: "https://github.com/pytorch"
       github_secret_name: pytorch-arc-cbr-production
@@ -224,7 +220,6 @@ clusters:
       - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
       - arc-runners
       - arc-runners-h100
-      - buildkit
       - pypi-cache
       - cache-enforcer
       - zombie-cleanup


### PR DESCRIPTION
## Summary

Remove the `buildkit` module (and its config block) from `arc-cbr-production-uw1`. us-west-1's ARC runner group (`arc-cbr-prod-uw1`) is not targeted by any `pytorch/pytorch` workflow today (notably the docker-builds migration in https://github.com/pytorch/pytorch/pull/184664 routes to the default group → us-east-2), so the us-west-1 BuildKit pool sits idle.

Companion PR #608 bumps `defaults.buildkit.replicas_per_arch` 5 → 12; without this PR that bump would idle ~$1k/day of `m6id.24xlarge` + `c7gd.16xlarge` capacity in us-west-1. These two PRs are independent and can land in either order.

## Post-merge cleanup

After this lands, future `just deploy` runs on `arc-cbr-production-uw1` will no longer reconcile BuildKit. The currently-deployed resources need a one-time manual cleanup against the us-west-1 cluster:

```
kubectl -n buildkit delete deploy,svc,cm,networkpolicy --all
kubectl delete namespace buildkit
kubectl delete nodepool buildkit-amd64 buildkit-arm64   # Karpenter
```

Karpenter will then consolidate the idle BuildKit nodes away.

## Test plan

- [ ] After merge, run the cleanup above on `arc-cbr-production-uw1`.
- [ ] Confirm no pods or nodes remain in `buildkit` namespace.
- [ ] Subsequent `just deploy` on us-west-1 does not re-create BuildKit resources.

Authored by Claude.