### PR TITLE
Exclude Graviton-2 (arm64g2) runners from load tests

### DIFF
--- a/osdc/integration-tests/load-test/scripts/python/distribution.py
+++ b/osdc/integration-tests/load-test/scripts/python/distribution.py
@@ -63,8 +63,6 @@ OLD_TO_OSDC_LABEL: dict[str, str] = {
     "linux.g6.4xlarge.experimental.nvidia.gpu": "l-x86aavx2-29-113-l4",
     "linux.g6.12xlarge.nvidia.gpu": "l-x86aavx2-45-172-l4-4",
     # ARM64 (Graviton)
-    "linux.arm64.2xlarge": "l-arm64g2-6-32",
-    "linux.arm64.2xlarge.ephemeral": "l-arm64g2-6-32",
     "linux.arm64.m7g.4xlarge": "l-arm64g3-16-62",
     "linux.arm64.m7g.4xlarge.ephemeral": "l-arm64g3-16-62",
     "linux.arm64.m8g.4xlarge": "l-arm64g4-16-62",
@@ -98,12 +96,10 @@ PRODUCTION_JOB_COUNTS: dict[str, int] = {
     "linux.24xl.spr-metal": 6_983,
     "linux.r7i.2xlarge": 5_173,
     "linux.arm64.r7g.12xlarge.memory": 5_046,
-    "linux.arm64.2xlarge": 4_552,
     "linux.24xlarge.memory": 3_652,
     "linux.g4dn.4xlarge.nvidia.gpu": 3_651,
     "linux.g5.48xlarge.nvidia.gpu": 3_465,
     "linux.g6.12xlarge.nvidia.gpu": 3_261,
-    "linux.arm64.2xlarge.ephemeral": 1_536,
     "linux.8xlarge.memory": 1_522,
     "linux.r7i.4xlarge": 1_449,
     "linux.10xlarge.avx2": 1_290,
@@ -123,6 +119,8 @@ _OSDC_GPU_PATTERN = re.compile(r"-(t4|a10g|l4)(?:-(\d+))?$")
 # multi-hour queue waits, low capacity in staging). Suffix may have an optional
 # trailing "-<count>" for multi-GPU defs (e.g. "-a100-4", "-h100-8").
 _LOAD_TEST_EXCLUDED_GPU_PATTERN = re.compile(r"-(a100|h100|b200|h200|mi300|mi325)(?:-\d+)?$")
+
+_LOAD_TEST_EXCLUDED_ARM_PATTERN = re.compile(r"arm64g2(?:-|$)")
 
 
 @dataclass
@@ -184,8 +182,9 @@ def get_available_runners(
 
     Returns (labels, excluded_count). ``excluded_count`` covers both
     region-based exclusions (fleets unavailable in the target region) and
-    specialized-hardware exclusions (high-end GPU defs matching
-    ``_LOAD_TEST_EXCLUDED_GPU_PATTERN``).
+    hardware-based exclusions (high-end GPU defs matching
+    ``_LOAD_TEST_EXCLUDED_GPU_PATTERN`` and ARM Graviton-2 defs matching
+    ``_LOAD_TEST_EXCLUDED_ARM_PATTERN``).
     """
     labels: set[str] = set()
     excluded_count = 0
@@ -204,7 +203,7 @@ def get_available_runners(
                 runner = data["runner"]
                 name = runner["name"]
 
-                if _LOAD_TEST_EXCLUDED_GPU_PATTERN.search(name):
+                if _LOAD_TEST_EXCLUDED_GPU_PATTERN.search(name) or _LOAD_TEST_EXCLUDED_ARM_PATTERN.search(name):
                     excluded_count += 1
                     continue
 

--- a/osdc/integration-tests/load-test/scripts/python/test_distribution.py
+++ b/osdc/integration-tests/load-test/scripts/python/test_distribution.py
@@ -3,6 +3,7 @@
 import pytest
 import yaml
 from distribution import (
+    _LOAD_TEST_EXCLUDED_ARM_PATTERN,
     _LOAD_TEST_EXCLUDED_GPU_PATTERN,
     OLD_TO_OSDC_LABEL,
     PRODUCTION_JOB_COUNTS,
@@ -323,6 +324,38 @@ class TestGetAvailableRunners:
             assert name in labels, f"{name} should NOT have been excluded"
             assert _LOAD_TEST_EXCLUDED_GPU_PATTERN.search(name) is None
         assert excluded == 0
+
+    def test_excludes_arm64g2_runner(self, tmp_path):
+        """g2 (Graviton 2) runners are excluded from load tests."""
+        upstream = tmp_path / "upstream"
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(runner_defs, "l-arm64g2-6-32")
+        self._make_def(runner_defs, "l-arm64g3-16-62")
+        self._make_def(runner_defs, "l-arm64g4-16-62")
+
+        labels, excluded = get_available_runners(upstream, tmp_path / "root")
+        assert "l-arm64g2-6-32" not in labels
+        assert "l-arm64g3-16-62" in labels
+        assert "l-arm64g4-16-62" in labels
+        assert excluded == 1
+
+    def test_excludes_arm64g2_baremetal_variant(self, tmp_path):
+        """Hypothetical baremetal g2 runner (l-barm64g2-*) is also excluded."""
+        upstream = tmp_path / "upstream"
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(runner_defs, "l-barm64g2-12-32")
+
+        labels, excluded = get_available_runners(upstream, tmp_path / "root")
+        assert "l-barm64g2-12-32" not in labels
+        assert excluded == 1
+
+    def test_arm_pattern_does_not_match_g3_g4(self):
+        """The g2 exclusion pattern must NOT match g3 or g4 runners."""
+        assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-arm64g3-16-62") is None
+        assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-arm64g4-16-62") is None
+        assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-barm64g4-62-226") is None
+        assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-arm64g2-6-32") is not None
+        assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-barm64g2-12-32") is not None
 
 
 # ── _load_fleet_exclusions ──────────────────────────────────────────────


### PR DESCRIPTION
**Impact:** Load test distribution only — no production runner changes **Risk:** low

## What
Removes Graviton-2 (`arm64g2`) ARM runners from load test job distribution due to persistent capacity issues on those instance types.

## Why
Graviton-2 instances (`linux.arm64.2xlarge` / `linux.arm64.2xlarge.ephemeral`) constantly hit capacity limits, causing load test failures. Newer Graviton generations (g3, g4) remain available and cover the ARM64 workload.

## How
- Rather than just removing the g2 entries from the label map, adds a regex-based exclusion pattern (`_LOAD_TEST_EXCLUDED_ARM_PATTERN`) that filters g2 runners at scan time — same approach used for high-end GPU exclusions
- This catches any g2 runner definition (including hypothetical baremetal variants) without needing to maintain an explicit denylist

## Changes
- Remove `linux.arm64.2xlarge` and `linux.arm64.2xlarge.ephemeral` from `OLD_TO_OSDC_LABEL` mapping and `PRODUCTION_JOB_COUNTS`
- Add `_LOAD_TEST_EXCLUDED_ARM_PATTERN` regex matching `arm64g2` runner names
- Apply the new pattern alongside the existing GPU exclusion in `get_available_runners()`
- Add 3 tests: g2 exclusion, baremetal g2 exclusion, and a negative test confirming g3/g4 are not affected

## Testing
- `pytest test_distribution.py` — all existing and new tests pass