### PR TITLE
Adds ci to publish dashboards

### DIFF
--- a/.github/workflows/osdc-publish-dashboards.yml
+++ b/.github/workflows/osdc-publish-dashboards.yml
@@ -7,10 +7,6 @@ on:
     paths:
       - "osdc/modules/monitoring/dashboards/**"
       - ".github/workflows/osdc-publish-dashboards.yml"
-  pull_request:
-    paths:
-      - "osdc/modules/monitoring/dashboards/**"
-      - ".github/workflows/osdc-publish-dashboards.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/osdc-publish-dashboards.yml
+++ b/.github/workflows/osdc-publish-dashboards.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "osdc/modules/monitoring/dashboards/**"
       - ".github/workflows/osdc-publish-dashboards.yml"
+  pull_request:
+    paths:
+      - "osdc/modules/monitoring/dashboards/**"
+      - ".github/workflows/osdc-publish-dashboards.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/osdc-publish-dashboards.yml
+++ b/.github/workflows/osdc-publish-dashboards.yml
@@ -1,0 +1,45 @@
+name: "OSDC: Publish dashboards"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "osdc/modules/monitoring/dashboards/**"
+      - ".github/workflows/osdc-publish-dashboards.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: osdc-publish-dashboards
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: osdc
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: "2026.5.11"
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Publish dashboards
+        run: just publish-dashboards
+        env:
+          GRAFANA_API_TOKEN: ${{ secrets.PYTORCHCI_GRAFANA_API_TOKEN }}


### PR DESCRIPTION
runs on:
```
on:
  workflow_dispatch:
  push:
    branches: [main]
    paths:
      - "osdc/modules/monitoring/dashboards/**"
      - ".github/workflows/osdc-publish-dashboards.yml"
```

run: https://github.com/pytorch/ci-infra/actions/runs/26312136517/job/77463161842?pr=615