### PR TITLE
Serialize tofu operations per cluster and add lock-timeout to prevent DynamoDB lock races

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -63,6 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 60
+    # Serialize all tofu state-mutating work per cluster. Shared with
+    # _osdc-plan.yml so plan and deploy against the same cluster never
+    # race on the DynamoDB state lock.
+    concurrency:
+      group: osdc-tofu-${{ inputs.cluster }}
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: osdc

--- a/.github/workflows/_osdc-plan.yml
+++ b/.github/workflows/_osdc-plan.yml
@@ -24,7 +24,13 @@ jobs:
     name: tofu plan (${{ inputs.cluster }})
     runs-on: ubuntu-latest
     environment: osdc-staging
-    timeout-minutes: 30
+    timeout-minutes: 45
+    # Serialize all tofu state-locking work per cluster. Shared with
+    # _osdc-deploy.yml so plan and deploy against the same cluster never
+    # race on the DynamoDB state lock.
+    concurrency:
+      group: osdc-tofu-${{ inputs.cluster }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -345,7 +345,7 @@ deploy-base cluster:
     # Suspend ERR trap — tofu plan returns exit code 2 for "changes detected"
     trap - ERR
     set +e
-    eval tofu plan $TFVARS -out=tfplan -detailed-exitcode
+    eval tofu plan -lock-timeout=15m $TFVARS -out=tfplan -detailed-exitcode
     PLAN_EXIT=$?
     set -e
     trap 'deploy_log_finish cmd "$CLUSTER" "deploy-base" "$DEPLOY_LOG_START" failed' ERR
@@ -371,7 +371,7 @@ deploy-base cluster:
                 exit 1
             fi
         fi
-        tofu apply tfplan
+        tofu apply -lock-timeout=15m tfplan
         rm -f tfplan
     else
         rm -f tfplan
@@ -486,7 +486,7 @@ deploy-module cluster module force="":
         # Suspend ERR trap — tofu plan returns exit code 2 for "changes detected"
         trap - ERR
         set +e
-        tofu plan \
+        tofu plan -lock-timeout=15m \
             -var="cluster_name=${CNAME}" \
             -var="aws_region=${REGION}" \
             -var="state_bucket=${BUCKET}" \
@@ -500,7 +500,7 @@ deploy-module cluster module force="":
             echo "  No changes. Skipping apply."
             rm -f tfplan
         elif [[ $PLAN_EXIT -eq 2 ]]; then
-            tofu apply tfplan
+            tofu apply -lock-timeout=15m tfplan
             rm -f tfplan
         else
             rm -f tfplan
@@ -560,7 +560,7 @@ plan cluster:
         -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
         -backend-config="region=${STATE_REGION}" \
         -backend-config="dynamodb_table=ciforge-terraform-locks" >/dev/null
-    eval tofu plan -input=false -no-color $TFVARS
+    eval tofu plan -lock-timeout=15m -input=false -no-color $TFVARS
 
     for MODULE in $(uv run {{CFG}} "$CLUSTER" modules); do
         if [[ -d "{{ROOT}}/modules/$MODULE" ]]; then
@@ -580,7 +580,7 @@ plan cluster:
             -backend-config="key=${CLUSTER}/${MODULE}/terraform.tfstate" \
             -backend-config="region=${STATE_REGION}" \
             -backend-config="dynamodb_table=ciforge-terraform-locks" >/dev/null
-        tofu plan -input=false -no-color \
+        tofu plan -lock-timeout=15m -input=false -no-color \
             -var="cluster_name=${CNAME}" \
             -var="aws_region=${REGION}" \
             -var="state_bucket=${BUCKET}" \

--- a/osdc/scripts/destroy-cluster.sh
+++ b/osdc/scripts/destroy-cluster.sh
@@ -148,7 +148,7 @@ destroy_module() {
   tofu_init "$module_dir" "$key"
   NO_PROXY="${NO_PROXY:-},.amazonaws.com" \
     no_proxy="${no_proxy:-},.amazonaws.com" \
-    tofu destroy -auto-approve \
+    tofu destroy -lock-timeout=15m -auto-approve \
     -var="cluster_name=$CNAME" \
     -var="aws_region=$REGION" \
     -var="state_bucket=$BUCKET" \
@@ -165,7 +165,7 @@ destroy_base() {
   tofu_init "$module_dir" "$key"
   NO_PROXY="${NO_PROXY:-},.amazonaws.com" \
     no_proxy="${no_proxy:-},.amazonaws.com" \
-    eval tofu destroy "$TFVARS" -auto-approve
+    eval tofu destroy -lock-timeout=15m "$TFVARS" -auto-approve
   cd - >/dev/null
   echo ""
 }


### PR DESCRIPTION
**Impact:** CI pipelines (plan + deploy workflows) and local just recipes **Risk:** low

## What
Adds GitHub Actions concurrency groups to serialize tofu plan and deploy jobs per cluster, and sets a 15-minute lock-timeout on every tofu plan/apply/destroy invocation to tolerate queued operations instead of failing immediately on a held DynamoDB state lock.

## Why
Parallel CI runs (e.g. concurrent PRs triggering plan, or a plan racing a deploy) against the same cluster contend on the shared DynamoDB state lock. Without serialization, the second job hits the lock and fails immediately. This creates flaky CI failures and requires manual reruns.

## How
- Used a shared concurrency group key (`osdc-tofu-${{ inputs.cluster }}`) across both reusable workflows so plan and deploy against the same cluster are mutually exclusive
- Set `cancel-in-progress: false` to queue rather than cancel waiting jobs
- Bumped plan workflow timeout from 30m to 45m to accommodate queuing delays
- Applied `-lock-timeout=15m` uniformly to all tofu plan, apply, and destroy calls rather than relying on instant lock acquisition

## Changes
- `.github/workflows/_osdc-deploy.yml`: add per-cluster concurrency group to the deploy job
- `.github/workflows/_osdc-plan.yml`: add matching concurrency group to the plan job; increase timeout from 30m to 45m
- `osdc/justfile`: add `-lock-timeout=15m` to all 6 tofu plan/apply invocations across `deploy-base`, `deploy-module`, and `plan` recipes
- `osdc/scripts/destroy-cluster.sh`: add `-lock-timeout=15m` to both `destroy_module` and `destroy_base` tofu destroy calls

## Testing
- Open two PRs targeting the same cluster and verify the plan jobs queue instead of racing
- Trigger a deploy while a plan is in progress and confirm the deploy waits for the plan to release the lock
- Verify `just plan <cluster>` and `just deploy <cluster>` pass locally with the new flag