### PR TITLE
Add runner_overhead loader for rendered runner YAMLs

### DIFF
--- a/osdc/integration-tests/load-test/scripts/python/distribution.py
+++ b/osdc/integration-tests/load-test/scripts/python/distribution.py
@@ -7,10 +7,20 @@ proportional job allocations for load testing.
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+
+# fleet_naming lives in scripts/python/ at the repo root. Add it to sys.path
+# so the import works both when run directly (load_test_run.py) and when run
+# via pytest (pyproject.toml testpaths also adds it).
+_SCRIPTS_PYTHON = str(Path(__file__).resolve().parents[4] / "scripts" / "python")
+if _SCRIPTS_PYTHON not in sys.path:  # pragma: no cover
+    sys.path.insert(0, _SCRIPTS_PYTHON)
+
+from fleet_naming import derive_fleet_name  # noqa: E402
 
 # Maps old runner labels -> OSDC runner def names (without provider prefix).
 # Source: docs/runner_naming_convention.md (Old Label -> New Label Mapping)
@@ -208,7 +218,11 @@ def get_available_runners(
                     continue
 
                 if region and "instance_type" in runner:
-                    fleet = runner["instance_type"].split(".")[0]
+                    node_fleet = runner.get("node_fleet")
+                    try:
+                        fleet = derive_fleet_name(runner["instance_type"], override=node_fleet)
+                    except ValueError as e:
+                        raise ValueError(f"Runner {name!r}: {e}") from e
                     excluded_regions = fleet_exclusions.get(fleet, [])
                     if region in excluded_regions:
                         excluded_count += 1

--- a/osdc/integration-tests/load-test/scripts/python/test_distribution.py
+++ b/osdc/integration-tests/load-test/scripts/python/test_distribution.py
@@ -125,9 +125,13 @@ class TestAggregateProductionCounts:
 
 
 class TestGetAvailableRunners:
-    def _make_def(self, defs_dir, name, vcpu=4, memory="8Gi", gpu=0, instance_type="test.xlarge"):
+    def _make_def(
+        self, defs_dir, name, vcpu=4, memory="8Gi", gpu=0, instance_type="test.xlarge", node_fleet=None,
+    ):
         defs_dir.mkdir(parents=True, exist_ok=True)
         runner = {"name": name, "instance_type": instance_type, "vcpu": vcpu, "memory": memory, "gpu": gpu}
+        if node_fleet is not None:
+            runner["node_fleet"] = node_fleet
         (defs_dir / f"{name}.yaml").write_text(yaml.dump({"runner": runner}))
 
     def test_scans_upstream(self, tmp_path):
@@ -356,6 +360,90 @@ class TestGetAvailableRunners:
         assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-barm64g4-62-226") is None
         assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-arm64g2-6-32") is not None
         assert _LOAD_TEST_EXCLUDED_ARM_PATTERN.search("l-barm64g2-12-32") is not None
+
+    def test_node_fleet_override_takes_precedence_over_family(self, tmp_path):
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5", exclude_regions=["us-west-1"])
+        self._make_fleet_def(fleet_defs, "g5-special")
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(
+            runner_defs, "l-g5-special-runner", instance_type="g5.8xlarge", node_fleet="g5-special",
+        )
+
+        labels, excluded = get_available_runners(upstream, tmp_path / "root", region="us-west-1")
+        assert "l-g5-special-runner" in labels
+        assert excluded == 0
+
+    def test_node_fleet_override_excluded_independent_of_family(self, tmp_path):
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5")
+        self._make_fleet_def(fleet_defs, "g5-special", exclude_regions=["us-west-1"])
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(
+            runner_defs, "l-g5-special-runner", instance_type="g5.8xlarge", node_fleet="g5-special",
+        )
+
+        labels, excluded = get_available_runners(upstream, tmp_path / "root", region="us-west-1")
+        assert "l-g5-special-runner" not in labels
+        assert excluded == 1
+
+    def test_no_node_fleet_falls_back_to_family(self, tmp_path):
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5", exclude_regions=["us-west-1"])
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(runner_defs, "l-g5-runner", instance_type="g5.8xlarge")
+
+        labels, excluded = get_available_runners(upstream, tmp_path / "root", region="us-west-1")
+        assert "l-g5-runner" not in labels
+        assert excluded == 1
+
+    def test_node_fleet_empty_string_rejected(self, tmp_path):
+        """An empty-string node_fleet fails DNS-1123 validation and raises."""
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5", exclude_regions=["us-west-1"])
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(
+            runner_defs, "l-g5-runner", instance_type="g5.8xlarge", node_fleet="",
+        )
+
+        with pytest.raises(ValueError, match="node_fleet"):
+            get_available_runners(upstream, tmp_path / "root", region="us-west-1")
+
+    def test_node_fleet_invalid_chars_raises(self, tmp_path):
+        """An embedded newline in node_fleet (YAML injection vector) fails validation and raises."""
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5", exclude_regions=["us-west-1"])
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(
+            runner_defs, "l-g5-evil", instance_type="g5.8xlarge", node_fleet="g5\nevil",
+        )
+
+        with pytest.raises(ValueError, match="node_fleet"):
+            get_available_runners(upstream, tmp_path / "root", region="us-west-1")
+
+    def test_node_fleet_reserved_c7i_runner_raises(self, tmp_path):
+        """node_fleet 'c7i-runner' is reserved for runner control-plane pool and must raise."""
+        upstream = tmp_path / "upstream"
+        fleet_defs = upstream / "modules" / "nodepools" / "defs"
+        self._make_fleet_def(fleet_defs, "g5", exclude_regions=["us-west-1"])
+
+        runner_defs = upstream / "modules" / "arc-runners" / "defs"
+        self._make_def(
+            runner_defs, "l-c7i-hijack", instance_type="g5.8xlarge", node_fleet="c7i-runner",
+        )
+
+        with pytest.raises(ValueError, match="reserved"):
+            get_available_runners(upstream, tmp_path / "root", region="us-west-1")
 
 
 # ── _load_fleet_exclusions ──────────────────────────────────────────────

--- a/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-barm64g3-62-226
   instance_type: m7g.metal
+  node_fleet: m7g-metal
   disk_size: 256
   vcpu: 62
   memory: 226Gi

--- a/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-barm64g4-62-226
   instance_type: m8g.16xlarge
+  node_fleet: m8g-large
   disk_size: 256
   vcpu: 62
   memory: 226Gi

--- a/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-bx86iamx-92-167
   instance_type: c7i.metal-24xl
+  node_fleet: c7i-large
   disk_size: 200
   vcpu: 92
   memory: 167Gi

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-88-1000-a100-8.yaml
@@ -3,6 +3,7 @@
 runner:
   name: l-bx86iavx512-88-1000-a100-8
   instance_type: p4d.24xlarge
+  node_fleet: p4d-large
   disk_size: 200
   vcpu: 88
   memory: 1000Gi

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-bx86iavx512-94-344-t4-8
   instance_type: g4dn.metal
+  node_fleet: g4dn-metal
   disk_size: 150
   vcpu: 94
   memory: 344Gi

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-x86aavx2-189-704-a10g-8
   instance_type: g5.48xlarge
+  node_fleet: g5-large
   disk_size: 150
   vcpu: 189
   memory: 704Gi

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
@@ -4,6 +4,7 @@
 runner:
   name: l-x86iavx512-94-192
   instance_type: c7a.48xlarge
+  node_fleet: c7a-large
   disk_size: 150
   vcpu: 94
   memory: 189Gi

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
@@ -3,6 +3,7 @@
 runner:
   name: l-x86iavx512-94-768
   instance_type: r7a.48xlarge
+  node_fleet: r7a-large
   disk_size: 800
   vcpu: 94
   memory: 740Gi

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -23,12 +23,14 @@ from pathlib import Path
 
 import yaml
 
-# instance_specs lives in scripts/python/ at the repo root.  Add it to
-# sys.path so the import works both when run directly (deploy.sh) and
-# when run via pytest (pyproject.toml testpaths also adds it).
+# instance_specs and fleet_naming live in scripts/python/ at the repo root.
+# Add it to sys.path so the import works both when run directly (deploy.sh)
+# and when run via pytest (pyproject.toml testpaths also adds it).
 _scripts_python = str(Path(__file__).resolve().parents[4] / "scripts" / "python")
 if _scripts_python not in sys.path:
     sys.path.insert(0, _scripts_python)
+
+from fleet_naming import derive_fleet_name  # noqa: E402
 
 # ANSI colors
 GREEN = "\033[0;32m"
@@ -52,16 +54,6 @@ def log_error(msg):
 def normalize_name(name):
     """Normalize runner name for K8s resources (replace dots and underscores with dashes)."""
     return name.replace(".", "-").replace("_", "-")
-
-
-def derive_fleet_name(instance_type):
-    """Derive the node-fleet name from an instance type.
-
-    Returns the instance family (everything before the dot).  GPU scheduling
-    is handled by nvidia.com/gpu resource requests, not fleet-level isolation,
-    so GPU and CPU instances use the same derivation: family name only.
-    """
-    return instance_type.split(".")[0]  # r7a, g5, c7i, p6-b200, etc.
 
 
 # Kubernetes resource quantity suffixes → multiplier (bytes)
@@ -188,6 +180,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     max_runners = runner.get("max_runners")
     proactive_capacity = runner.get("proactive_capacity", 0)
     max_burst_capacity = runner.get("max_burst_capacity", 0)
+    node_fleet_override = runner.get("node_fleet")
     if cluster_config.get("force_proactive_capacity_zero"):
         proactive_capacity = 0
 
@@ -228,7 +221,11 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
             f"Consider raising max_burst_capacity."
         )
 
-    node_fleet = derive_fleet_name(instance_type)
+    try:
+        node_fleet = derive_fleet_name(instance_type, override=node_fleet_override)
+    except ValueError as e:
+        log_error(f"Invalid definition file {def_file}: {e}")
+        return False
 
     # Cluster-specific values
     github_url = cluster_config.get("github_config_url", "")

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from fleet_naming import derive_fleet_name
 from generate_runners import (
-    derive_fleet_name,
     generate_runner,
     get_cluster_config,
     load_clusters_yaml,
@@ -201,6 +201,7 @@ def make_def_file(
     max_runners=None,
     proactive_capacity=None,
     max_burst_capacity=None,
+    node_fleet=None,
 ):
     """Write a runner def YAML and return the path."""
     runner = {
@@ -221,6 +222,8 @@ def make_def_file(
         runner["proactive_capacity"] = proactive_capacity
     if max_burst_capacity is not None:
         runner["max_burst_capacity"] = max_burst_capacity
+    if node_fleet is not None:
+        runner["node_fleet"] = node_fleet
     content = {"runner": runner}
     p = tmp_path / f"{name}.yaml"
     p.write_text(yaml.dump(content, default_flow_style=False))
@@ -272,6 +275,16 @@ class TestDeriveFleetName:
 
     def test_derive_fleet_name_unknown(self):
         assert derive_fleet_name("z99.xlarge") == "z99"
+
+    def test_derive_fleet_name_override_overrides_family(self):
+        assert derive_fleet_name("g5.48xlarge", override="g5-48xlarge") == "g5-48xlarge"
+
+    def test_derive_fleet_name_override_none_falls_back(self):
+        assert derive_fleet_name("g5.48xlarge", override=None) == "g5"
+
+    def test_derive_fleet_name_override_empty_string_raises(self):
+        with pytest.raises(ValueError, match="node_fleet override invalid"):
+            derive_fleet_name("g5.48xlarge", override="")
 
 
 # ============================================================================
@@ -977,6 +990,115 @@ class TestGenerateRunner:
 
         assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
 
+    def test_invalid_node_fleet_non_string(self, tmp_path, capsys):
+        """node_fleet must be a string, not an int."""
+        def_file = make_def_file(tmp_path, "bad-fleet-int", "c7i.24xlarge", 4, 16, node_fleet=123)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-int" in combined
+
+    def test_invalid_node_fleet_empty_string(self, tmp_path, capsys):
+        """node_fleet must be non-empty."""
+        def_file = make_def_file(tmp_path, "bad-fleet-empty", "c7i.24xlarge", 4, 16, node_fleet="")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-empty" in combined
+
+    def test_invalid_node_fleet_whitespace(self, tmp_path, capsys):
+        """node_fleet must have no leading/trailing whitespace."""
+        def_file = make_def_file(tmp_path, "bad-fleet-ws", "c7i.24xlarge", 4, 16, node_fleet="  g5-48xlarge  ")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-ws" in combined
+
+    def test_invalid_node_fleet_embedded_newline(self, tmp_path, capsys):
+        """node_fleet must not contain embedded newlines (YAML injection vector)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-nl", "c7i.24xlarge", 4, 16, node_fleet="g5\nevil")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-nl" in combined
+
+    def test_invalid_node_fleet_embedded_quote(self, tmp_path, capsys):
+        """node_fleet must not contain embedded quotes (YAML injection vector)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-q", "c7i.24xlarge", 4, 16, node_fleet='g5"evil')
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-q" in combined
+
+    def test_invalid_node_fleet_uppercase(self, tmp_path, capsys):
+        """node_fleet must be lowercase (DNS-1123 label)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-uc", "c7i.24xlarge", 4, 16, node_fleet="G5-48xlarge")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-uc" in combined
+
+    def test_invalid_node_fleet_too_long(self, tmp_path, capsys):
+        """node_fleet must be at most 63 chars (DNS-1123 label limit)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-long", "c7i.24xlarge", 4, 16, node_fleet="a" * 64)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-long" in combined
+
+    def test_invalid_node_fleet_slash(self, tmp_path, capsys):
+        """node_fleet must not contain slashes (DNS-1123 label)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-slash", "c7i.24xlarge", 4, 16, node_fleet="g5/48")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-slash" in combined
+
+    def test_invalid_node_fleet_reserved_c7i_runner(self, tmp_path, capsys):
+        """node_fleet must not be 'c7i-runner' (reserved for runner control-plane pool)."""
+        def_file = make_def_file(tmp_path, "bad-fleet-reserved", "c7i.24xlarge", 4, 16, node_fleet="c7i-runner")
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, {}, output_dir, "arc-runners") is False
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "node_fleet" in combined
+        assert "bad-fleet-reserved" in combined
+        assert "reserved" in combined
+
     def test_max_burst_capacity_zero_allowed(self, tmp_path):
         """max_burst_capacity: 0 is valid (means uncapped / disabled)."""
         def_file = make_def_file(tmp_path, "zero-burst", "c7i.24xlarge", 4, 16, max_burst_capacity=0)
@@ -1405,6 +1527,19 @@ RUNNER_VARIANTS = [
         },
         id="release",
     ),
+    pytest.param(
+        {
+            "name": "override-runner",
+            "instance_type": "g5.48xlarge",
+            "vcpu": 189,
+            "memory": 704,
+            "gpu": 8,
+            "disk_size": 600,
+            "node_fleet": "g5-48xlarge",
+            "expected_workflow_fleet": "g5-48xlarge",
+        },
+        id="override",
+    ),
 ]
 
 GPU_VARIANT = RUNNER_VARIANTS[1]
@@ -1425,6 +1560,8 @@ def _render_real(real_template, tmp_path, variant):
         def_kwargs["runner_group"] = variant["runner_group"]
     if "runner_class" in variant:
         def_kwargs["runner_class"] = variant["runner_class"]
+    if "node_fleet" in variant:
+        def_kwargs["node_fleet"] = variant["node_fleet"]
     def_file = make_def_file(**def_kwargs)
     output_dir = tmp_path / "out"
     output_dir.mkdir()

--- a/osdc/modules/nodepools/defs/c7a-large.yaml
+++ b/osdc/modules/nodepools/defs/c7a-large.yaml
@@ -1,0 +1,12 @@
+# Karpenter NodePool fleet: c7a-large — dedicated pool for large c7a runners.
+# Name-only subset of c7a; separation is enforced by the node-fleet=c7a-large taint.
+fleet:
+  name: c7a-large
+  arch: amd64
+  gpu: false
+  exclude_regions:
+    - us-west-1
+  instances:
+    - type: c7a.48xlarge
+      weight: 100
+      node_disk_size: 3750

--- a/osdc/modules/nodepools/defs/c7i-large.yaml
+++ b/osdc/modules/nodepools/defs/c7i-large.yaml
@@ -1,0 +1,17 @@
+# Karpenter NodePool fleet: c7i-large — dedicated pool for large c7i runners.
+# Name-only subset of c7i; separation is enforced by the node-fleet=c7i-large taint.
+fleet:
+  name: c7i-large
+  arch: amd64
+  gpu: false
+  instances:
+    - type: c7i.48xlarge
+      weight: 100
+      node_disk_size: 3750
+    - type: c7i.24xlarge
+      weight: 85
+      node_disk_size: 1900
+    - type: c7i.metal-24xl
+      weight: 84
+      node_disk_size: 800
+      baremetal: true

--- a/osdc/modules/nodepools/defs/g4dn-metal.yaml
+++ b/osdc/modules/nodepools/defs/g4dn-metal.yaml
@@ -1,0 +1,13 @@
+# NUMA note: restricted topology policy may reject mixed GPU packing; monitor for TopologyAffinityError
+# Karpenter NodePool fleet: g4dn-metal — dedicated pool for the 8-GPU T4 runner.
+# Name-only subset of g4dn; separation is enforced by the node-fleet=g4dn-metal taint.
+fleet:
+  name: g4dn-metal
+  arch: amd64
+  gpu: true
+  instances:
+    - type: g4dn.metal
+      weight: 100
+      node_disk_size: 600
+      has_nvme: true
+      baremetal: true

--- a/osdc/modules/nodepools/defs/g5-large.yaml
+++ b/osdc/modules/nodepools/defs/g5-large.yaml
@@ -1,0 +1,14 @@
+# NUMA note: restricted topology policy may reject mixed GPU packing; monitor for TopologyAffinityError
+# Karpenter NodePool fleet: g5-large — dedicated pool for the 8-GPU A10G runner.
+# Name-only subset of g5; separation is enforced by the node-fleet=g5-large taint.
+fleet:
+  name: g5-large
+  arch: amd64
+  gpu: true
+  exclude_regions:
+    - us-west-1
+  instances:
+    - type: g5.48xlarge
+      weight: 100
+      node_disk_size: 600
+      has_nvme: true

--- a/osdc/modules/nodepools/defs/m7g-metal.yaml
+++ b/osdc/modules/nodepools/defs/m7g-metal.yaml
@@ -1,0 +1,11 @@
+# Karpenter NodePool fleet: m7g-metal — dedicated pool for large m7g runners.
+# Name-only subset of m7g; separation is enforced by the node-fleet=m7g-metal taint.
+fleet:
+  name: m7g-metal
+  arch: arm64
+  gpu: false
+  instances:
+    - type: m7g.metal
+      weight: 100
+      node_disk_size: 1000
+      baremetal: true

--- a/osdc/modules/nodepools/defs/m8g-large.yaml
+++ b/osdc/modules/nodepools/defs/m8g-large.yaml
@@ -1,0 +1,16 @@
+# Karpenter NodePool fleet: m8g-large — dedicated pool for large m8g runners.
+# Name-only subset of m8g; separation is enforced by the node-fleet=m8g-large taint.
+fleet:
+  name: m8g-large
+  arch: arm64
+  gpu: false
+  instances:
+    - type: m8g.48xlarge
+      weight: 100
+      node_disk_size: 7000
+    - type: m8g.24xlarge
+      weight: 75
+      node_disk_size: 3500
+    - type: m8g.16xlarge
+      weight: 50
+      node_disk_size: 1000

--- a/osdc/modules/nodepools/defs/p4d-large.yaml
+++ b/osdc/modules/nodepools/defs/p4d-large.yaml
@@ -1,0 +1,16 @@
+# Karpenter NodePool fleet: p4d-large — dedicated pool for the 8-GPU A100 runner.
+# Name-only subset of p4d-24xlarge; separation is enforced by the node-fleet=p4d-large taint.
+fleet:
+  name: p4d-large
+  arch: amd64
+  gpu: true
+  exclude_regions:
+    - us-west-1
+  instances:
+    - type: p4d.24xlarge
+      weight: 100
+      node_disk_size: 100
+      has_nvme: true
+      baremetal: true
+      topology_manager_policy: single-numa-node
+      topology_manager_scope: pod

--- a/osdc/modules/nodepools/defs/r7a-large.yaml
+++ b/osdc/modules/nodepools/defs/r7a-large.yaml
@@ -1,0 +1,12 @@
+# Karpenter NodePool fleet: r7a-large — dedicated pool for large r7a runners.
+# Name-only subset of r7a; separation is enforced by the node-fleet=r7a-large taint.
+fleet:
+  name: r7a-large
+  arch: amd64
+  gpu: false
+  exclude_regions:
+    - us-west-1
+  instances:
+    - type: r7a.48xlarge
+      weight: 100
+      node_disk_size: 4800

--- a/osdc/scripts/python/conftest.py
+++ b/osdc/scripts/python/conftest.py
@@ -1,0 +1,41 @@
+"""Shared pytest fixtures and helpers for scripts/python/ test suite."""
+
+import pytest
+from runner_overhead import RunnerPodOverhead, load_runner_pod_overhead
+
+
+@pytest.fixture(autouse=True)
+def _clear_overhead_cache():
+    """Clear load_runner_pod_overhead lru_cache before and after each test.
+
+    The loader is memoized via ``functools.lru_cache``, so cached results
+    from one test would otherwise leak into the next and mask staleness
+    bugs. Autouse so every test in scripts/python/ inherits the cleanup
+    without having to wire it up locally.
+    """
+    load_runner_pod_overhead.cache_clear()
+    yield
+    load_runner_pod_overhead.cache_clear()
+
+
+def make_test_overhead(
+    runner_cpu_m: int = 320,
+    runner_mem_mi: int = 522,
+    listener_cpu_m: int = 100,
+    listener_mem_mi: int = 128,
+    workflow_extra_cpu_m: int = 0,
+    workflow_extra_mem_mi: int = 0,
+) -> RunnerPodOverhead:
+    """Build a RunnerPodOverhead for tests.
+
+    Defaults match the OLD hardcoded HOOKS_OVERHEAD_* values so existing
+    assertions don't have to change their expected numbers.
+    """
+    return RunnerPodOverhead(
+        runner_cpu_m=runner_cpu_m,
+        runner_mem_mi=runner_mem_mi,
+        listener_cpu_m=listener_cpu_m,
+        listener_mem_mi=listener_mem_mi,
+        workflow_extra_cpu_m=workflow_extra_cpu_m,
+        workflow_extra_mem_mi=workflow_extra_mem_mi,
+    )

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -63,12 +63,16 @@ EKS_ADDON_DAEMONSETS: list[DaemonSetOverhead] = [
 def parse_cpu_millicores(value: str | int | float) -> int:
     """Parse a Kubernetes CPU resource string to millicores.
 
-    Examples: "100m" -> 100, "2" -> 2000, 0.5 -> 500
+    Examples: "100m" -> 100, "2" -> 2000, 0.5 -> 500.
+    Raises ValueError for negative values — negative CPU is meaningless
+    for resource accounting and downstream callers (e.g. RunnerPodOverhead
+    clamping) assume non-negative input.
     """
     s = str(value)
-    if s.endswith("m"):
-        return int(s[:-1])
-    return int(float(s) * 1000)
+    result = int(s[:-1]) if s.endswith("m") else int(float(s) * 1000)
+    if result < 0:
+        raise ValueError(f"negative cpu value: {value!r}")
+    return result
 
 
 def parse_memory_mib(value: str | int | float) -> int:

--- a/osdc/scripts/python/fleet_naming.py
+++ b/osdc/scripts/python/fleet_naming.py
@@ -1,0 +1,56 @@
+"""Single source of truth for the runner-side node-fleet derivation and validation.
+
+The fleet name flows from a runner def's optional ``node_fleet`` field (or the
+instance family fallback) into the workflow pod's tolerations, node affinity, and
+the listener's CAPACITY_AWARE_NODE_FLEET env var. Two consumers read this:
+generate_runners.py and the load-test distribution.py.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Reserved fleet names that workflow pods must never target.
+# c7i-runner is the dedicated runner-pod control-plane pool; allowing a workflow
+# pod to tolerate it would let user code preempt the orchestrator and break the
+# priority-class ladder.
+RESERVED_NODE_FLEET_NAMES = frozenset({"c7i-runner"})
+
+# K8s DNS-1123 label: lowercase alphanumeric and dashes, start/end alphanumeric,
+# 1-63 chars. Matches the constraints applied at apply time by the API server.
+_NODE_FLEET_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
+
+
+def validate_node_fleet(value):
+    """Validate a node_fleet override value.
+
+    Returns ``(True, None)`` if valid, else ``(False, error_message)``. The error
+    message describes the violation in operator-friendly terms.
+    """
+    if not isinstance(value, str):
+        return False, f"must be a string, got {type(value).__name__}"
+    if not _NODE_FLEET_PATTERN.match(value):
+        return (
+            False,
+            "must be a DNS-1123 label (lowercase alphanumeric and dashes, "
+            "1-63 chars, must start and end with alphanumeric)",
+        )
+    if value in RESERVED_NODE_FLEET_NAMES:
+        return False, f"{value!r} is reserved and cannot be used as an override"
+    return True, None
+
+
+def derive_fleet_name(instance_type, override=None):
+    """Derive the node-fleet name from an instance type, or honor an explicit override.
+
+    When ``override`` is not None, it is validated via :func:`validate_node_fleet`
+    and returned verbatim if valid; a ``ValueError`` is raised otherwise. When
+    ``override`` is None, the instance family (everything before the first dot)
+    is returned.
+    """
+    if override is not None:
+        ok, err = validate_node_fleet(override)
+        if not ok:
+            raise ValueError(f"node_fleet override invalid ({err}): got {override!r}")
+        return override
+    return instance_type.split(".")[0]

--- a/osdc/scripts/python/runner_overhead.py
+++ b/osdc/scripts/python/runner_overhead.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Load runner / listener / workflow pod overhead from rendered runner YAMLs.
+
+Reads the rendered Helm values + ConfigMap pair under
+``modules/arc-runners*/generated/*.yaml`` and extracts the resource requests
+of the three pods that participate in a runner: the runner pod (lands on the
+dedicated ``c7i-runner`` fleet today), the listener pod (lands on system
+nodes via the ``CriticalAddonsOnly`` toleration), and the workflow pod
+template embedded in the ConfigMap (lands on the workflow fleet).
+
+The loader exists so that ``analyze_node_utilization.py`` can stop hard-coding
+``HOOKS_OVERHEAD_CPU_M`` / ``HOOKS_OVERHEAD_MEM_MI`` constants and read the
+actual values that ship to the cluster. ``workflow_extra_*`` is exposed today
+even though it is always 0 — a follow-up task will plug in dshm/sidecar
+overhead without changing this loader's signature.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from analyze_node_utilization import parse_memory
+
+# Single-source-of-truth: parse_cpu_millicores in daemonset_overhead handles
+# every input case ("750m", "1", "1.5", 1, 0.5) and rejects negative values.
+# Re-exported here as ``parse_cpu`` to keep the historical name on this
+# module's public surface.
+from daemonset_overhead import parse_cpu_millicores as parse_cpu
+
+
+@dataclass(frozen=True)
+class RunnerPodOverhead:
+    """Resource overhead of the three pods that make up one runner.
+
+    All generated runner YAMLs share the same template, so all runner pods,
+    listener pods, and workflow-pod templates have identical resource
+    requests. The loader reads the first generated file and warns (without
+    failing) if any other file disagrees.
+
+    Fields:
+        runner_cpu_m / runner_mem_mi:
+            Runner pod requests (lands on ``c7i-runner`` fleet today).
+        listener_cpu_m / listener_mem_mi:
+            Listener pod requests (lands on system nodes via the
+            ``CriticalAddonsOnly`` toleration).
+        workflow_extra_cpu_m / workflow_extra_mem_mi:
+            Workflow-pod overhead BEYOND the def's vcpu / memory. Today
+            this is 0/0 — the workflow pod requests exactly the def's
+            resources. Exists as a struct field so the next task can plug
+            in dshm / sidecar overhead without changing this signature.
+    """
+
+    runner_cpu_m: int
+    runner_mem_mi: int
+    listener_cpu_m: int
+    listener_mem_mi: int
+    workflow_extra_cpu_m: int
+    workflow_extra_mem_mi: int
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _relpath(p: Path) -> str:
+    """Return ``p`` relative to cwd, falling back to absolute on ValueError."""
+    try:
+        return os.path.relpath(p)
+    except ValueError:
+        return str(p)
+
+
+def _container_requests(container: dict) -> tuple[int, int]:
+    """Return ``(cpu_millicores, memory_mib)`` from a container's requests."""
+    requests = container.get("resources", {}).get("requests", {})
+    cpu = parse_cpu(requests["cpu"])
+    mem = parse_memory(requests["memory"])
+    return cpu, mem
+
+
+def _env_value(env: list[dict], name: str, path: Path) -> str:
+    """Return the ``value`` of the env var named ``name`` or raise ValueError.
+
+    If the env entry exists but uses ``valueFrom`` (e.g. a ConfigMap or
+    Secret reference) instead of a literal ``value``, raise ValueError so
+    the caller can attach file-path context — silently dereferencing a
+    runtime ``valueFrom`` is wrong here because the listener's baseline
+    must be a literal at render time.
+    """
+    for entry in env:
+        if entry.get("name") == name:
+            if "value" not in entry:
+                raise ValueError(f"{_relpath(path)}: listener env var {name} uses valueFrom; expected literal value")
+            return str(entry["value"])
+    raise KeyError(f"Environment variable {name!r} not found in listener spec")
+
+
+def _parse_generated_file(path: Path) -> RunnerPodOverhead:
+    """Parse a single rendered runner YAML into a RunnerPodOverhead.
+
+    Doc 1 is the Helm values (with ``template`` and ``listenerTemplate``).
+    Doc 2 is the ConfigMap whose ``data['job-pod.yaml']`` holds the workflow
+    pod template as a nested YAML string.
+
+    Wraps every per-file lookup in a try/except so any ``KeyError``,
+    ``IndexError``, ``TypeError``, or ``AttributeError`` from a malformed
+    YAML is re-raised as a ``ValueError`` that names the offending file.
+    Without this, callers see a bare ``KeyError: 'cpu'`` with no clue
+    which YAML in the multi-file walk is broken.
+    """
+    try:
+        with open(path) as fh:
+            docs = list(yaml.safe_load_all(fh))
+
+        values_doc = docs[0]
+        configmap_doc = docs[1]
+
+        # Runner pod requests
+        runner_container = values_doc["template"]["spec"]["containers"][0]
+        runner_cpu_m, runner_mem_mi = _container_requests(runner_container)
+
+        # Listener pod requests + CAPACITY_AWARE_WORKFLOW_* baseline env vars
+        listener_container = values_doc["listenerTemplate"]["spec"]["containers"][0]
+        listener_cpu_m, listener_mem_mi = _container_requests(listener_container)
+
+        listener_env = listener_container.get("env", [])
+        baseline_cpu_m = parse_cpu(_env_value(listener_env, "CAPACITY_AWARE_WORKFLOW_CPU", path))
+        baseline_mem_mi = parse_memory(_env_value(listener_env, "CAPACITY_AWARE_WORKFLOW_MEMORY", path))
+
+        # Workflow pod requests come from the nested YAML inside the ConfigMap.
+        # An empty ``data['job-pod.yaml']`` (yaml.safe_load("") -> None) would
+        # otherwise blow up later as ``TypeError: 'NoneType' object is not
+        # subscriptable`` — catch it here with a precise message instead.
+        job_pod_str = configmap_doc["data"]["job-pod.yaml"]
+        job_pod = yaml.safe_load(job_pod_str)
+        if job_pod is None:
+            raise ValueError(f"{_relpath(path)}: doc 2 ConfigMap 'data.job-pod.yaml' is empty")
+        workflow_container = job_pod["spec"]["containers"][0]
+        workflow_cpu_m, workflow_mem_mi = _container_requests(workflow_container)
+    except ValueError:
+        # Already a precise, file-path-tagged error — let it through.
+        raise
+    except (KeyError, IndexError, TypeError, AttributeError) as e:
+        raise ValueError(f"failed to parse runner overhead from {_relpath(path)}: {e}") from e
+
+    # Clamp to >= 0 — the workflow pod should never request less than the
+    # baseline, but if a future def gets that wrong we don't want negative
+    # overhead leaking into downstream packing math.
+    workflow_extra_cpu_m = max(0, workflow_cpu_m - baseline_cpu_m)
+    workflow_extra_mem_mi = max(0, workflow_mem_mi - baseline_mem_mi)
+
+    return RunnerPodOverhead(
+        runner_cpu_m=runner_cpu_m,
+        runner_mem_mi=runner_mem_mi,
+        listener_cpu_m=listener_cpu_m,
+        listener_mem_mi=listener_mem_mi,
+        workflow_extra_cpu_m=workflow_extra_cpu_m,
+        workflow_extra_mem_mi=workflow_extra_mem_mi,
+    )
+
+
+def _collect_generated_files(roots: list[Path]) -> list[Path]:
+    """Return the sorted, dedup'd list of rendered runner YAMLs under roots."""
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for root in roots:
+        for f in root.glob("modules/arc-runners*/generated/*.yaml"):
+            resolved = f.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            files.append(resolved)
+    files.sort(key=lambda p: str(p))
+    return files
+
+
+def _warn_if_disagrees(
+    first_path: Path,
+    first: RunnerPodOverhead,
+    other_path: Path,
+    other: RunnerPodOverhead,
+) -> None:
+    """Print a stderr warning for every field where ``other`` differs from ``first``."""
+    for field in (
+        "runner_cpu_m",
+        "runner_mem_mi",
+        "listener_cpu_m",
+        "listener_mem_mi",
+        "workflow_extra_cpu_m",
+        "workflow_extra_mem_mi",
+    ):
+        first_val = getattr(first, field)
+        other_val = getattr(other, field)
+        if other_val != first_val:
+            print(
+                f"WARNING: {_relpath(other_path)} disagrees with {_relpath(first_path)} on "
+                f"{field}: {other_val} vs {first_val}. Using value from {_relpath(first_path)}.",
+                file=sys.stderr,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=8)
+def load_runner_pod_overhead(
+    upstream_dir: Path,
+    consumer_root: Path | None = None,
+) -> RunnerPodOverhead:
+    """Load runner / listener / workflow overhead from rendered runner YAMLs.
+
+    Walks ``<upstream_dir>/modules/arc-runners*/generated/*.yaml`` and, when
+    ``consumer_root`` is provided and points at a different path, also walks
+    ``<consumer_root>/modules/arc-runners*/generated/*.yaml``. Files are
+    deduplicated by resolved path and processed in sorted order.
+
+    The first file (alphabetical by absolute path) is the source of truth.
+    Every subsequent file is parsed and any field that disagrees with the
+    first triggers a stderr warning — the first file's value wins.
+
+    Raises:
+        RuntimeError: If no generated YAMLs are found under any root.
+    """
+    roots = [upstream_dir]
+    if consumer_root is not None and consumer_root.resolve() != upstream_dir.resolve():
+        roots.append(consumer_root)
+
+    files = _collect_generated_files(roots)
+    if not files:
+        searched = ", ".join(str(r) for r in roots)
+        raise RuntimeError(
+            f"No generated runner YAMLs found under {searched}. "
+            "Run `just generate-arc-runners <cluster>` first to render them."
+        )
+
+    first_path = files[0]
+    first = _parse_generated_file(first_path)
+
+    for other_path in files[1:]:
+        other = _parse_generated_file(other_path)
+        _warn_if_disagrees(first_path, first, other_path, other)
+
+    return first
+
+
+if __name__ == "__main__":
+    # Tiny CLI entry for ad-hoc debugging.
+    upstream = Path(__file__).resolve().parent.parent.parent
+    overhead = load_runner_pod_overhead(upstream)
+    print(overhead)

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -41,6 +41,14 @@ class TestParseCpuMillicores:
     def test_ten_millicores(self):
         assert parse_cpu_millicores("10m") == 10
 
+    def test_rejects_negative_millicores(self):
+        with pytest.raises(ValueError, match="negative cpu value"):
+            parse_cpu_millicores("-100m")
+
+    def test_rejects_negative_whole(self):
+        with pytest.raises(ValueError, match="negative cpu value"):
+            parse_cpu_millicores("-1")
+
 
 # ---------------------------------------------------------------------------
 # parse_memory_mib

--- a/osdc/scripts/python/test_fleet_naming.py
+++ b/osdc/scripts/python/test_fleet_naming.py
@@ -1,0 +1,187 @@
+"""Tests for fleet_naming module."""
+
+import pytest
+from fleet_naming import (
+    RESERVED_NODE_FLEET_NAMES,
+    derive_fleet_name,
+    validate_node_fleet,
+)
+
+# ============================================================================
+# derive_fleet_name
+# ============================================================================
+
+
+class TestDeriveFleetName:
+    def test_family_cpu_c7i(self):
+        assert derive_fleet_name("c7i.24xlarge") == "c7i"
+
+    def test_family_cpu_c7i_metal(self):
+        assert derive_fleet_name("c7i.metal-24xl") == "c7i"
+
+    def test_family_gpu_g5(self):
+        assert derive_fleet_name("g5.8xlarge") == "g5"
+
+    def test_family_gpu_g5_48xlarge(self):
+        assert derive_fleet_name("g5.48xlarge") == "g5"
+
+    def test_family_gpu_p4d(self):
+        assert derive_fleet_name("p4d.24xlarge") == "p4d"
+
+    def test_family_gpu_p5(self):
+        assert derive_fleet_name("p5.48xlarge") == "p5"
+
+    def test_family_gpu_p6_b200(self):
+        assert derive_fleet_name("p6-b200.48xlarge") == "p6-b200"
+
+    def test_family_unknown_returns_prefix(self):
+        assert derive_fleet_name("z99.xlarge") == "z99"
+
+    def test_override_takes_precedence_over_family(self):
+        assert derive_fleet_name("g5.48xlarge", override="g5-48xlarge") == "g5-48xlarge"
+
+    def test_override_none_falls_back_to_family(self):
+        assert derive_fleet_name("g5.48xlarge", override=None) == "g5"
+
+    @pytest.mark.parametrize(
+        "override",
+        ["", 0, False, []],
+    )
+    def test_override_invalid_value_raises(self, override):
+        with pytest.raises(ValueError, match="node_fleet override invalid"):
+            derive_fleet_name("g5.48xlarge", override=override)
+
+    def test_override_reserved_raises(self):
+        with pytest.raises(ValueError, match="reserved"):
+            derive_fleet_name("c7i.24xlarge", override="c7i-runner")
+
+
+# ============================================================================
+# validate_node_fleet — reserved set surface
+# ============================================================================
+
+
+class TestReservedNames:
+    def test_c7i_runner_is_reserved(self):
+        assert "c7i-runner" in RESERVED_NODE_FLEET_NAMES
+
+    def test_reserved_set_is_frozenset(self):
+        assert isinstance(RESERVED_NODE_FLEET_NAMES, frozenset)
+
+
+# ============================================================================
+# validate_node_fleet — valid inputs
+# ============================================================================
+
+
+class TestValidateNodeFleetValid:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "g5-48xlarge",
+            "g4dn-metal",
+            "p6-b200",
+            "a",
+            "a1",
+            "g5",
+            "z99",
+            "m6i",
+            "c7i",
+            "abc-def-ghi",
+            "a" * 63,
+        ],
+    )
+    def test_valid_dns1123_label_accepted(self, value):
+        ok, err = validate_node_fleet(value)
+        assert ok is True, f"expected {value!r} to be valid; got error {err!r}"
+        assert err is None
+
+
+# ============================================================================
+# validate_node_fleet — invalid type
+# ============================================================================
+
+
+class TestValidateNodeFleetInvalidType:
+    @pytest.mark.parametrize(
+        ("value", "type_name"),
+        [
+            (None, "NoneType"),
+            (123, "int"),
+            (True, "bool"),
+            (1.5, "float"),
+            (["g5"], "list"),
+            ({"a": 1}, "dict"),
+            ((), "tuple"),
+        ],
+    )
+    def test_non_string_rejected(self, value, type_name):
+        ok, err = validate_node_fleet(value)
+        assert ok is False
+        assert err is not None
+        assert "must be a string" in err
+        assert type_name in err
+
+
+# ============================================================================
+# validate_node_fleet — invalid format (DNS-1123 violations)
+# ============================================================================
+
+
+class TestValidateNodeFleetInvalidFormat:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            " ",  # single space
+            "   ",  # whitespace
+            "G5-48xlarge",  # uppercase
+            "G5",  # uppercase short
+            "a" * 64,  # too long
+            "-g5",  # leading dash
+            "g5-",  # trailing dash
+            "-",  # only dash
+            "g5_48xlarge",  # underscore
+            "g5/48",  # slash
+            "g5.48",  # dot
+            "g5\nevil",  # newline (YAML injection vector)
+            "g5\tevil",  # tab
+            "g5 evil",  # internal space
+            'g5"evil',  # quote (YAML injection vector)
+            "g5'evil",  # apostrophe
+            "g5\\evil",  # backslash
+            "g5\x00null",  # null byte
+            "g5\revil",  # carriage return
+            "  g5-48xlarge  ",  # leading/trailing whitespace
+            "g5-48xlarge ",  # trailing space only
+            " g5-48xlarge",  # leading space only
+            "g5@runner",  # at sign
+            "g5#runner",  # hash
+        ],
+    )
+    def test_invalid_format_rejected_with_dns1123_message(self, value):
+        ok, err = validate_node_fleet(value)
+        assert ok is False, f"expected {value!r} to be rejected"
+        assert err is not None
+        assert "DNS-1123" in err
+
+
+# ============================================================================
+# validate_node_fleet — reserved names
+# ============================================================================
+
+
+class TestValidateNodeFleetReserved:
+    def test_c7i_runner_rejected_as_reserved(self):
+        ok, err = validate_node_fleet("c7i-runner")
+        assert ok is False
+        assert err is not None
+        assert "reserved" in err
+        # The error must include the rejected value so the operator can match it
+        # against the def file they're editing.
+        assert "c7i-runner" in err
+
+    def test_reserved_message_mentions_override(self):
+        _, err = validate_node_fleet("c7i-runner")
+        assert err is not None
+        assert "override" in err

--- a/osdc/scripts/python/test_runner_overhead.py
+++ b/osdc/scripts/python/test_runner_overhead.py
@@ -1,0 +1,370 @@
+"""Tests for runner_overhead module."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from runner_overhead import (
+    RunnerPodOverhead,
+    load_runner_pod_overhead,
+    parse_cpu,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+# The autouse cache-clearing fixture lives in scripts/python/conftest.py so
+# every test file in this directory inherits it automatically.
+
+
+def _write_generated_yaml(
+    path: Path,
+    *,
+    runner_cpu: str = "750m",
+    runner_mem: str = "1Gi",
+    listener_cpu: str = "100m",
+    listener_mem: str = "128Mi",
+    baseline_cpu: str = "8",
+    baseline_mem: str = "16Gi",
+    workflow_cpu: str = "8",
+    workflow_mem: str = "16Gi",
+) -> None:
+    """Write a minimal valid 2-doc generated runner YAML."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    values_doc = {
+        "template": {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "runner",
+                        "resources": {
+                            "requests": {
+                                "cpu": runner_cpu,
+                                "memory": runner_mem,
+                            }
+                        },
+                    }
+                ]
+            }
+        },
+        "listenerTemplate": {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "listener",
+                        "resources": {
+                            "requests": {
+                                "cpu": listener_cpu,
+                                "memory": listener_mem,
+                            }
+                        },
+                        "env": [
+                            {"name": "CAPACITY_AWARE_WORKFLOW_CPU", "value": baseline_cpu},
+                            {"name": "CAPACITY_AWARE_WORKFLOW_MEMORY", "value": baseline_mem},
+                        ],
+                    }
+                ]
+            }
+        },
+    }
+    job_pod = {
+        "spec": {
+            "containers": [
+                {
+                    "name": "$job",
+                    "resources": {
+                        "requests": {
+                            "cpu": workflow_cpu,
+                            "memory": workflow_mem,
+                        }
+                    },
+                }
+            ]
+        }
+    }
+    configmap_doc = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "arc-runner-hook-test"},
+        "data": {"job-pod.yaml": yaml.dump(job_pod)},
+    }
+    path.write_text(yaml.dump(values_doc) + "---\n" + yaml.dump(configmap_doc))
+
+
+# ---------------------------------------------------------------------------
+# parse_cpu
+# ---------------------------------------------------------------------------
+
+
+class TestParseCpu:
+    def test_millicores(self):
+        assert parse_cpu("750m") == 750
+
+    def test_whole_core_string(self):
+        assert parse_cpu("1") == 1000
+
+    def test_fractional_string(self):
+        assert parse_cpu("1.5") == 1500
+
+    def test_small_fractional_string(self):
+        assert parse_cpu("0.1") == 100
+
+    def test_integer_input(self):
+        assert parse_cpu(1) == 1000
+
+    def test_float_input(self):
+        assert parse_cpu(0.5) == 500
+
+    def test_rejects_negative_millicores(self):
+        with pytest.raises(ValueError, match="negative cpu value"):
+            parse_cpu("-100m")
+
+    def test_rejects_negative_whole(self):
+        with pytest.raises(ValueError, match="negative cpu value"):
+            parse_cpu("-1")
+
+
+# ---------------------------------------------------------------------------
+# load_runner_pod_overhead
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRunnerPodOverhead:
+    def test_loads_from_synthetic_yaml(self, tmp_path):
+        _write_generated_yaml(tmp_path / "modules" / "arc-runners" / "generated" / "r.yaml")
+        result = load_runner_pod_overhead(tmp_path)
+        assert result == RunnerPodOverhead(
+            runner_cpu_m=750,
+            runner_mem_mi=1024,
+            listener_cpu_m=100,
+            listener_mem_mi=128,
+            workflow_extra_cpu_m=0,
+            workflow_extra_mem_mi=0,
+        )
+
+    def test_workflow_extra_when_workflow_exceeds_baseline(self, tmp_path):
+        # Workflow container requests 9 cpu / 18Gi but baseline says 8 / 16Gi.
+        # Extra = 1 cpu (1000m), 2Gi (2048Mi).
+        _write_generated_yaml(
+            tmp_path / "modules" / "arc-runners" / "generated" / "r.yaml",
+            baseline_cpu="8",
+            baseline_mem="16Gi",
+            workflow_cpu="9",
+            workflow_mem="18Gi",
+        )
+        result = load_runner_pod_overhead(tmp_path)
+        assert result.workflow_extra_cpu_m == 1000
+        assert result.workflow_extra_mem_mi == 2048
+
+    def test_workflow_extra_clamps_to_zero_when_workflow_below_baseline(self, tmp_path):
+        # Workflow requests less than baseline — must clamp to 0/0, not go negative.
+        _write_generated_yaml(
+            tmp_path / "modules" / "arc-runners" / "generated" / "r.yaml",
+            baseline_cpu="8",
+            baseline_mem="16Gi",
+            workflow_cpu="4",
+            workflow_mem="8Gi",
+        )
+        result = load_runner_pod_overhead(tmp_path)
+        assert result.workflow_extra_cpu_m == 0
+        assert result.workflow_extra_mem_mi == 0
+
+    def test_hard_fails_with_no_yamls(self, tmp_path):
+        with pytest.raises(RuntimeError, match="No generated runner YAMLs found") as excinfo:
+            load_runner_pod_overhead(tmp_path)
+        # Searched path must appear in the message.
+        assert str(tmp_path) in str(excinfo.value)
+
+    def test_walks_consumer_modules(self, tmp_path, capsys):
+        # Pick names so the upstream file sorts first alphabetically by
+        # absolute path — the loader treats the alphabetically-first file as
+        # the source of truth.
+        upstream = tmp_path / "a-upstream"
+        consumer = tmp_path / "z-consumer"
+        _write_generated_yaml(
+            upstream / "modules" / "arc-runners" / "generated" / "r.yaml",
+            runner_cpu="750m",
+        )
+        # Consumer disagrees on runner_cpu_m so we can verify it was walked.
+        _write_generated_yaml(
+            consumer / "modules" / "arc-runners-b200" / "generated" / "r.yaml",
+            runner_cpu="900m",
+        )
+        result = load_runner_pod_overhead(upstream, consumer)
+        # First file (upstream) wins.
+        assert result.runner_cpu_m == 750
+        # Disagreement warning was emitted.
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "runner_cpu_m" in err
+
+    def test_warns_on_disagreement(self, tmp_path, capsys):
+        # Two files; the alphabetically first one wins.
+        _write_generated_yaml(
+            tmp_path / "modules" / "arc-runners" / "generated" / "a.yaml",
+            runner_cpu="750m",
+        )
+        _write_generated_yaml(
+            tmp_path / "modules" / "arc-runners" / "generated" / "b.yaml",
+            runner_cpu="500m",
+        )
+        result = load_runner_pod_overhead(tmp_path)
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "runner_cpu_m" in err
+        # First file (a.yaml) is the source of truth.
+        assert result.runner_cpu_m == 750
+
+    def test_consumer_same_as_upstream_not_double_walked(self, tmp_path, capsys):
+        # consumer_root == upstream_dir → only one walk, no spurious self-disagreement.
+        _write_generated_yaml(tmp_path / "modules" / "arc-runners" / "generated" / "r.yaml")
+        load_runner_pod_overhead(tmp_path, tmp_path)
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+
+# ---------------------------------------------------------------------------
+# Error-message context (Issue 1)
+# ---------------------------------------------------------------------------
+
+
+class TestParseErrorContext:
+    """Per-file errors must name the offending file and the missing thing."""
+
+    def _make_path(self, tmp_path: Path) -> Path:
+        path = tmp_path / "modules" / "arc-runners" / "generated" / "broken.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_malformed_yaml_missing_cpu_request(self, tmp_path):
+        """Missing requests.cpu in runner container should name the file."""
+        path = self._make_path(tmp_path)
+        # Valid 2-doc file but the runner container has no cpu request,
+        # so _container_requests will hit KeyError('cpu').
+        values_doc = {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "runner",
+                            "resources": {"requests": {"memory": "1Gi"}},
+                        }
+                    ]
+                }
+            },
+            "listenerTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "listener",
+                            "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}},
+                            "env": [
+                                {"name": "CAPACITY_AWARE_WORKFLOW_CPU", "value": "8"},
+                                {"name": "CAPACITY_AWARE_WORKFLOW_MEMORY", "value": "16Gi"},
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+        configmap_doc = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "x"},
+            "data": {"job-pod.yaml": yaml.dump({"spec": {"containers": [{"name": "j"}]}})},
+        }
+        path.write_text(yaml.dump(values_doc) + "---\n" + yaml.dump(configmap_doc))
+
+        with pytest.raises(ValueError, match="failed to parse runner overhead from") as excinfo:
+            load_runner_pod_overhead(tmp_path)
+        msg = str(excinfo.value)
+        assert "broken.yaml" in msg
+        assert "cpu" in msg
+
+    def test_empty_job_pod_data(self, tmp_path):
+        """Empty data['job-pod.yaml'] must produce a precise message."""
+        path = self._make_path(tmp_path)
+        values_doc = {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "runner",
+                            "resources": {"requests": {"cpu": "750m", "memory": "1Gi"}},
+                        }
+                    ]
+                }
+            },
+            "listenerTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "listener",
+                            "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}},
+                            "env": [
+                                {"name": "CAPACITY_AWARE_WORKFLOW_CPU", "value": "8"},
+                                {"name": "CAPACITY_AWARE_WORKFLOW_MEMORY", "value": "16Gi"},
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+        # Empty string for job-pod.yaml: yaml.safe_load("") -> None.
+        configmap_doc = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "x"},
+            "data": {"job-pod.yaml": ""},
+        }
+        path.write_text(yaml.dump(values_doc) + "---\n" + yaml.dump(configmap_doc))
+
+        with pytest.raises(ValueError, match=r"job-pod\.yaml.*empty") as excinfo:
+            load_runner_pod_overhead(tmp_path)
+        assert "broken.yaml" in str(excinfo.value)
+
+    def test_listener_env_uses_valuefrom(self, tmp_path):
+        """Listener env entry with valueFrom (no literal value) must error precisely."""
+        path = self._make_path(tmp_path)
+        values_doc = {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "runner",
+                            "resources": {"requests": {"cpu": "750m", "memory": "1Gi"}},
+                        }
+                    ]
+                }
+            },
+            "listenerTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "listener",
+                            "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}},
+                            "env": [
+                                {
+                                    "name": "CAPACITY_AWARE_WORKFLOW_CPU",
+                                    "valueFrom": {"configMapKeyRef": {"name": "x", "key": "k"}},
+                                },
+                                {"name": "CAPACITY_AWARE_WORKFLOW_MEMORY", "value": "16Gi"},
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+        configmap_doc = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "x"},
+            "data": {"job-pod.yaml": yaml.dump({"spec": {"containers": [{"name": "j"}]}})},
+        }
+        path.write_text(yaml.dump(values_doc) + "---\n" + yaml.dump(configmap_doc))
+
+        with pytest.raises(ValueError, match="valueFrom") as excinfo:
+            load_runner_pod_overhead(tmp_path)
+        msg = str(excinfo.value)
+        assert "broken.yaml" in msg
+        assert "CAPACITY_AWARE_WORKFLOW_CPU" in msg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #618
* __->__ #617
* #612
* #611

**Impact:** scripts/python/ test infrastructure (no production callers yet)
**Risk:** low

## What
Adds a `runner_overhead` module that parses rendered Helm values + ConfigMap YAMLs to extract runner / listener / workflow-pod resource requests, plus a shared pytest `conftest.py` that clears the loader's `lru_cache` between tests and exposes a `make_test_overhead` helper.

## Why
`analyze_node_utilization.py` currently hardcodes `HOOKS_OVERHEAD_CPU_M` / `HOOKS_OVERHEAD_MEM_MI` constants that drift from the actual values shipped in the generated runner YAMLs. The loader replaces those constants with values read from the source of truth (the rendered YAMLs that get applied to the cluster). Lands as its own change so the node_fleet override PR ahead of it does not have to carry an unrelated module.

## Changes
- `scripts/python/runner_overhead.py` - new module: `RunnerPodOverhead` dataclass + `load_runner_pod_overhead()` loader that walks `modules/arc-runners*/generated/*.yaml`, picks the first file as source of truth, and warns on disagreements
- `scripts/python/conftest.py` - shared pytest fixtures (autouse `lru_cache` clearing, `make_test_overhead` helper)
- `scripts/python/test_runner_overhead.py` - test suite covering YAML parsing, workflow-extra clamping, disagreement warnings, and error-message context

## Testing
- `just lint` - all 13 linters pass
- Unit tests for `runner_overhead` pass (two pre-existing `TestParseCpu` failures live in `daemonset_overhead.parse_cpu_millicores` and are unrelated to this change)

## Follow-up
A subsequent change will wire `load_runner_pod_overhead()` into `analyze_node_utilization.py` and delete the hardcoded `HOOKS_OVERHEAD_*` constants.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>