### PR TITLE
Split pre-merge CI into fast and slow gates

### DIFF
--- a/.github/workflows/_osdc-slow-tests.yml
+++ b/.github/workflows/_osdc-slow-tests.yml
@@ -1,4 +1,12 @@
-name: "~ OSDC: Deploy (reusable)"
+name: "~ OSDC: Slow tests (reusable)"
+
+# NOTE: AWS region is hardcoded to us-west-1 in all jobs below, matching
+# _osdc-deploy.yml. This reusable is currently called only for the
+# arc-staging cluster (which lives in us-west-1). Re-using it for a
+# cluster in a different region requires either parameterizing the
+# region from `just region "${{ inputs.cluster }}"` or adding an
+# aws_region input. Do not call this reusable for non-us-west-1
+# clusters without first making that change.
 
 on:
   workflow_call:
@@ -12,48 +20,17 @@ on:
         required: false
         type: string
         default: ""
-      taint_nodes:
-        description: "Taint ARC runner nodes with NoSchedule before deploy for graceful refresh"
-        required: false
-        type: boolean
-        default: true
-      run_smoke:
-        description: "Run smoke tests after deploy"
-        required: false
-        type: boolean
-        default: true
-      run_integration:
-        description: "Run integration tests after deploy (requires CANARY_GITHUB_TOKEN)"
-        required: false
-        type: boolean
-        default: true
-      restart_listeners:
-        description: "Delete and recreate ARC listeners after deploy (required when controller image changes)"
-        required: false
-        type: boolean
-        default: false
-      skip_lint_test:
-        description: "Skip `just lint` and `just test` pre-flight checks (firefighting only)"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  deploy:
-    name: Deploy ${{ inputs.cluster }}
+  load-test:
+    name: Load tests
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    timeout-minutes: 60
-    # Serialize all tofu state-mutating work per cluster. Shared with
-    # _osdc-plan.yml so plan and deploy against the same cluster never
-    # race on the DynamoDB state lock.
-    concurrency:
-      group: osdc-tofu-${{ inputs.cluster }}
-      cancel-in-progress: false
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: osdc
@@ -73,14 +50,6 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
 
-      - name: Lint
-        if: ${{ !inputs.skip_lint_test }}
-        run: just lint
-
-      - name: Test
-        if: ${{ !inputs.skip_lint_test }}
-        run: just test
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
@@ -88,27 +57,15 @@ jobs:
           aws-region: us-west-1
           role-duration-seconds: 7200
 
-      # Register QEMU binfmt handlers so `docker build --platform linux/arm64`
-      # works on an amd64 runner. The base deploy builds image-cache-janitor
-      # (and node-compactor) for both archs; whenever the content-addressed
-      # tag changes (Dockerfile edit, etc.) the build branch runs and needs
-      # cross-arch emulation.
-      - name: Set up QEMU for cross-arch builds
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
-      - name: Deploy ${{ inputs.cluster }}
-        run: just deploy "${{ inputs.cluster }}"
+      - name: Run load tests
+        run: just load-test "${{ inputs.cluster }}"
         env:
-          OSDC_CONFIRM: "yes"
-          # smoke runs as a dedicated job below, skip the in-deploy step
-          OSDC_SMOKE: "no"
-          OSDC_TAINT_NODES: ${{ inputs.taint_nodes && 'yes' || 'no' }}
-          ARC_RESTART_LISTENERS: ${{ inputs.restart_listeners && 'yes' || 'no' }}
+          GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}
 
-  smoke:
-    name: Smoke tests
-    needs: deploy
-    if: ${{ inputs.run_smoke }}
+  compactor:
+    name: Compactor e2e tests
+    needs: load-test
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 30
@@ -138,16 +95,16 @@ jobs:
           aws-region: us-west-1
           role-duration-seconds: 7200
 
-      - name: Run smoke tests
-        run: just smoke "${{ inputs.cluster }}"
+      - name: Run compactor e2e tests
+        run: just test-compactor "${{ inputs.cluster }}"
 
-  integration:
-    name: Integration tests
-    needs: deploy
-    if: ${{ inputs.run_integration }}
+  janitor:
+    name: Janitor e2e tests
+    needs: load-test
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: osdc
@@ -167,11 +124,6 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
 
-      - name: Verify gh CLI
-        run: gh --version
-        env:
-          GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
@@ -179,7 +131,5 @@ jobs:
           aws-region: us-west-1
           role-duration-seconds: 7200
 
-      - name: Run integration tests
-        run: just integration-test "${{ inputs.cluster }}" --skip-drain --skip-smoke --skip-compactor
-        env:
-          GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}
+      - name: Run janitor e2e tests
+        run: just test-janitor "${{ inputs.cluster }}"

--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -65,9 +65,6 @@ jobs:
       restart_listeners: ${{ inputs.restart_listeners }}
       skip_lint_test: ${{ inputs.skip_lint_test }}
       run_smoke: true
-      run_compactor: false
-      run_janitor: false
-      run_load_test: false
     secrets: inherit
 
   deploy_ue2:
@@ -85,7 +82,4 @@ jobs:
       restart_listeners: ${{ inputs.restart_listeners }}
       skip_lint_test: ${{ inputs.skip_lint_test }}
       run_smoke: true
-      run_compactor: false
-      run_janitor: false
-      run_load_test: false
     secrets: inherit

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -10,13 +10,20 @@ permissions:
   contents: read
   actions: write
 
+# Workflow-level concurrency. Serializes the ENTIRE battery (fast + slow)
+# per workflow invocation against arc-staging. cancel-in-progress: false
+# so a later run waits for the prior run's slow jobs to finish before
+# deploy/smoke/integration even start — protects test fixtures from
+# interleaving.
 concurrency:
-  group: osdc-pre-merge
+  group: osdc-staging
   cancel-in-progress: false
 
 jobs:
   # ------------------------------------------------------------------
-  # Path filter: skip expensive jobs when no OSDC files changed
+  # Path filter: skip expensive jobs when no OSDC files changed.
+  # The marker job (pre-merge-ok) still runs and reports green so the
+  # merge queue's required check resolves.
   # ------------------------------------------------------------------
   changes:
     runs-on: ubuntu-latest
@@ -41,13 +48,13 @@ jobs:
               - '.github/workflows/osdc-deploy-prod.yml'
               - '.github/workflows/osdc-pre-merge.yml'
               - '.github/workflows/_osdc-deploy.yml'
+              - '.github/workflows/_osdc-slow-tests.yml'
 
   # ------------------------------------------------------------------
-  # Deploy arc-staging + smoke / compactor / integration validation.
-  # All jobs live in the reusable workflow so staging and prod stay
-  # in sync.
+  # Fast set: deploy + smoke + integration. Gates the merge queue
+  # via the pre-merge-ok marker job below.
   # ------------------------------------------------------------------
-  deploy:
+  deploy-fast:
     needs: changes
     if: needs.changes.outputs.osdc == 'true'
     uses: ./.github/workflows/_osdc-deploy.yml
@@ -58,9 +65,62 @@ jobs:
       environment: osdc-staging
       taint_nodes: true
       restart_listeners: true
-      run_janitor: true
-      run_load_test: true
     # secrets: inherit is required for the reusable workflow to pick up
     # osdc-staging environment secrets (META_AWS_ACC_ID, META_AWS_DEPLOY_ROLE,
     # CANARY_GITHUB_TOKEN). Without it, secrets.* resolves to empty strings.
     secrets: inherit
+
+  # ------------------------------------------------------------------
+  # Slow set: load-test + compactor + janitor. Informational only —
+  # NOT a merge queue gate. Runs after the fast set succeeds on the
+  # same already-deployed staging cluster. The workflow-level
+  # concurrency group ensures no other workflow touches staging
+  # until these finish.
+  # ------------------------------------------------------------------
+  slow-tests:
+    needs: deploy-fast
+    if: needs.changes.outputs.osdc == 'true' && needs.deploy-fast.result == 'success'
+    uses: ./.github/workflows/_osdc-slow-tests.yml
+    with:
+      cluster: arc-staging
+      environment: osdc-staging
+    secrets: inherit
+
+  # ------------------------------------------------------------------
+  # Marker job: the SOLE required status check on the merge queue.
+  # Reports green when either:
+  #   (a) no osdc changes (path filter excluded), OR
+  #   (b) deploy-fast succeeded.
+  # slow-tests result is NOT considered — they're informational.
+  # if: always() is required so this job still runs (and reports) when
+  # deploy-fast is skipped by the path filter; otherwise the required
+  # check never reports and the merge queue times out.
+  # ------------------------------------------------------------------
+  pre-merge-ok:
+    needs: [changes, deploy-fast]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Evaluate gate
+        run: |
+          set -euo pipefail
+          changes_result="${{ needs.changes.result }}"
+          deploy_result="${{ needs.deploy-fast.result }}"
+          osdc="${{ needs.changes.outputs.osdc }}"
+
+          if [[ "$changes_result" != "success" ]]; then
+            echo "::error::changes job did not succeed (result: $changes_result). Cannot evaluate gate."
+            exit 1
+          fi
+
+          if [[ "$osdc" != "true" ]]; then
+            echo "No osdc changes — gate passes trivially."
+            exit 0
+          fi
+          if [[ "$deploy_result" == "success" ]]; then
+            echo "Fast jobs passed (deploy + smoke + integration)."
+            exit 0
+          fi
+          echo "::error::deploy-fast result was '$deploy_result' (expected 'success')."
+          exit 1

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -100,7 +100,7 @@ jobs:
     needs: [changes, deploy-fast]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 15
     steps:
       - name: Evaluate gate
         run: |
@@ -114,9 +114,13 @@ jobs:
             exit 1
           fi
 
-          if [[ "$osdc" != "true" ]]; then
+          if [[ "$osdc" == "false" ]]; then
             echo "No osdc changes — gate passes trivially."
             exit 0
+          fi
+          if [[ "$osdc" != "true" ]]; then
+            echo "::error::unexpected osdc filter output: '$osdc' (expected 'true' or 'false'). Failing closed."
+            exit 1
           fi
           if [[ "$deploy_result" == "success" ]]; then
             echo "Fast jobs passed (deploy + smoke + integration)."

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -78,7 +78,7 @@ jobs:
   # until these finish.
   # ------------------------------------------------------------------
   slow-tests:
-    needs: deploy-fast
+    needs: [changes, deploy-fast]
     if: needs.changes.outputs.osdc == 'true' && needs.deploy-fast.result == 'success'
     uses: ./.github/workflows/_osdc-slow-tests.yml
     with:

--- a/osdc/docs/ci-pre-merge.md
+++ b/osdc/docs/ci-pre-merge.md
@@ -1,0 +1,127 @@
+# Pre-merge CI
+
+## What this is
+
+The pre-merge CI runs the OSDC validation battery against the `arc-staging` cluster when PRs enter the merge queue. It is the gate that determines whether a PR is allowed to merge into `main`.
+
+## Workflow shape
+
+The workflow is defined in `.github/workflows/osdc-pre-merge.yml` and triggers on `merge_group` and `workflow_dispatch`. It is composed of four jobs:
+
+1. `changes` — uses `dorny/paths-filter` to detect whether the PR touches osdc-related files. Outputs `osdc: true|false`.
+2. `deploy-fast` — calls reusable `_osdc-deploy.yml` (lint+test → deploy `arc-staging` → smoke + integration tests). Runs only when osdc files changed.
+3. `slow-tests` — calls reusable `_osdc-slow-tests.yml` (load-test → compactor + janitor). Runs after `deploy-fast` succeeds. Informational only.
+4. `pre-merge-ok` — marker job that always runs and reports SUCCESS when the gate is satisfied.
+
+Dependency chain:
+
+```
+┌─────────┐     ┌─────────────┐     ┌────────────┐
+│ changes │───▶ │ deploy-fast │───▶ │ slow-tests │
+└────┬────┘     └──────┬──────┘     └────────────┘
+     │                 │
+     │                 ▼
+     │          ┌──────────────┐
+     └────────▶ │ pre-merge-ok │
+                └──────────────┘
+```
+
+`pre-merge-ok` depends on `changes` and `deploy-fast`, but NOT on `slow-tests`.
+
+## Fast vs slow jobs
+
+| Aspect            | Fast (`deploy-fast`)                       | Slow (`slow-tests`)                  |
+|-------------------|--------------------------------------------|--------------------------------------|
+| What it runs      | lint + test, deploy arc-staging, smoke, integration | load-test, compactor e2e, janitor e2e |
+| Gates merge?      | Yes (via `pre-merge-ok`)                   | No (informational only)              |
+| Typical duration  | ~30-60 min                                 | ~2-3 h                               |
+| Failure effect    | Blocks merge                               | Surfaces red check, merge still allowed |
+
+## The marker job
+
+`pre-merge-ok` is the SOLE required check on the merge queue. It always runs (no path filter) and reports SUCCESS when either:
+
+- the path filter excluded the PR (no osdc changes), or
+- `deploy-fast` succeeded.
+
+It is independent of `slow-tests` — slow failures do not flip the marker red.
+
+Without this marker, the merge queue cannot distinguish "fast green, slow still running" from "all checks done". Required-status configuration would either wait forever on slow-tests or wait forever on a skipped job.
+
+## Atomicity guarantee
+
+The workflow declares a workflow-level concurrency group:
+
+```yaml
+concurrency:
+  group: osdc-staging
+  cancel-in-progress: false
+```
+
+The lock is held for the ENTIRE workflow run — fast AND slow. No other workflow that joins the `osdc-staging` group can touch staging mid-battery.
+
+Trade-off: PR2's `deploy-fast` will not START until PR1's `slow-tests` finish. Queue throughput is bounded by the slow path.
+
+## Required GitHub Settings configuration
+
+This is the section operators MUST read.
+
+### Required status checks
+
+Repo Settings → Rules → "main" ruleset → Merge queue → Required status checks. The list MUST contain ONLY:
+
+- `pre-merge-ok`
+
+It MUST NOT contain individual job names like `Deploy arc-staging`, `Smoke tests`, `Integration tests`, `Load tests`, `Compactor e2e tests`, `Janitor e2e tests`.
+
+Why: those individual jobs may be SKIPPED (path filter excluded the PR) and never report. The merge queue would wait forever for a check that never arrives. The `pre-merge-ok` marker always runs and always reports.
+
+### Status check timeout
+
+Repo Settings → Rules → "main" ruleset → Merge queue → Status check timeout. MUST be raised from the default 60 minutes to at least 240 minutes (4 hours).
+
+Why: the concurrency group `osdc-staging` is held for the entire battery (~2-3h worst case). When PR2 enters the queue while PR1's slow-tests are still running, PR2's `deploy-fast` cannot start. PR2's required check `pre-merge-ok` stays pending. With the default 60-minute timeout, GitHub ejects PR2 from the queue before it ever gets a chance to run. Raising the timeout absorbs the worst-case wait.
+
+### Build concurrency
+
+Repo Settings → Rules → "main" ruleset → Merge queue → Build concurrency. Can stay at default. The workflow-level concurrency group serializes regardless.
+
+## What to do when slow-tests fail
+
+Slow-test failures DO NOT block merges (by design). They surface as a red check in the PR's Actions tab but the PR can still merge. Treat slow-test failures as a regression report for someone to investigate post-merge.
+
+- If load-test fails: check that the canary GitHub token still works and that the runner controller is healthy in `arc-staging`.
+- If compactor fails: investigate node-compactor pod logs in `arc-staging`.
+- If janitor fails: investigate image-cache-janitor in `arc-staging`.
+
+No notification automation today — see follow-up section.
+
+## Path filter
+
+The `changes` job uses `dorny/paths-filter` against these patterns:
+
+- `osdc/**` (excluding test files under `tests/` and `*_test.py` / `test_*.py`)
+- `.github/workflows/osdc-pre-merge.yml`
+- `.github/workflows/osdc-deploy-prod.yml`
+- `.github/workflows/_osdc-deploy.yml`
+- `.github/workflows/_osdc-slow-tests.yml`
+
+When none of these change, `deploy-fast` and `slow-tests` are skipped. `pre-merge-ok` reports success trivially.
+
+## Manual re-run
+
+To force a re-run of the full battery without a PR: dispatch `osdc-pre-merge.yml` via the Actions UI. `workflow_dispatch` forces `osdc: true` regardless of file changes, so both fast and slow run.
+
+## Known trade-offs (already accepted)
+
+- Queue throughput drops to ~1 PR per 3 hours under sustained load — direct cost of the atomicity guarantee.
+- Slow-test failures produce no automated notification today. Future work could add a Slack ping or auto-issue on slow failure.
+- The required-checks configuration lives in repo Settings, not in YAML. New repo admins must read this doc to set it up correctly.
+
+## Files involved
+
+| File | Role |
+|------|------|
+| `.github/workflows/osdc-pre-merge.yml` | Entry point, orchestrates fast + slow + marker job |
+| `.github/workflows/_osdc-deploy.yml` | Reusable: deploy + smoke + integration |
+| `.github/workflows/_osdc-slow-tests.yml` | Reusable: load-test + compactor + janitor |


### PR DESCRIPTION
**Impact:** CI only — merge queue behavior for OSDC PRs
**Risk:** medium

## What

Splits the pre-merge CI battery into a fast gate (deploy + smoke + integration, ~30-60 min) that blocks merges, and a slow informational tier (load-test + compactor + janitor, ~2-3 h) that runs afterward but does not block. A new `pre-merge-ok` marker job is the sole required status check.

## Why

With the CI in a stable state for a good time, we are in a position now to gate PR merges with they succeeding deployment and test on staging. This PR is intended to break the checks into the critical ones that run sufficiently fast and the informational ones that also are slow tests.

The full pre-merge battery takes 2-3 hours end-to-end. Fast tests (smoke, integration) catch the vast majority of regressions, but a single slow-test failure (load-test, compactor, janitor) would block the merge queue for hours even when the core deploy is healthy. Splitting the gates lets fast failures block merges immediately while slow failures surface as informational red checks to investigate post-merge.

## How

- Introduced a `pre-merge-ok` marker job with `if: always()` as the sole required merge-queue check. It evaluates only the path filter and `deploy-fast` result, ignoring `slow-tests`.
- Extracted load-test, compactor, and janitor jobs from `_osdc-deploy.yml` into a new `_osdc-slow-tests.yml` reusable workflow. This keeps `_osdc-deploy.yml` focused on deploy + smoke + integration.
- Removed `run_compactor`, `run_janitor`, and `run_load_test` input toggles from `_osdc-deploy.yml` since those jobs no longer live there.
- Renamed the concurrency group from `osdc-pre-merge` to `osdc-staging` and scoped it to the entire workflow run (fast + slow) so no concurrent workflow can touch staging mid-battery.

## Changes

**`.github/workflows/osdc-pre-merge.yml`**
- Renamed `deploy` job to `deploy-fast` to clarify its role
- Added `slow-tests` job calling the new `_osdc-slow-tests.yml` reusable, dependent on `deploy-fast` success
- Added `pre-merge-ok` marker job as the sole merge-queue gate
- Changed concurrency group from `osdc-pre-merge` to `osdc-staging`
- Added `_osdc-slow-tests.yml` to the path filter

**`.github/workflows/_osdc-slow-tests.yml`** (new)
- Reusable workflow containing load-test, compactor e2e, and janitor e2e jobs (moved from `_osdc-deploy.yml`)
- Accepts `cluster` and `environment` inputs
- Compactor and janitor run after load-test, gated on `!cancelled() && !failure()`

**`.github/workflows/_osdc-deploy.yml`**
- Removed `run_compactor`, `run_janitor`, `run_load_test` inputs
- Removed `load-test`, `compactor`, and `janitor` jobs (moved to `_osdc-slow-tests.yml`)

**`.github/workflows/osdc-deploy-prod.yml`**
- Removed `run_compactor: false`, `run_janitor: false`, `run_load_test: false` overrides (inputs no longer exist)

**`osdc/docs/ci-pre-merge.md`** (new)
- Documents the workflow shape, fast vs slow split, marker job design, atomicity guarantee, required GitHub Settings configuration, and troubleshooting guidance

## Notes

- **Required GitHub Settings change:** the merge queue's required status check list must be updated to contain only `pre-merge-ok`. Individual job names (`Deploy arc-staging`, `Smoke tests`, etc.) must be removed. The status check timeout must be raised to at least 240 minutes to absorb worst-case queuing behind a slow run.
- Queue throughput under sustained load drops to ~1 PR per 3 hours because the concurrency group is held for the entire battery (fast + slow). This is an accepted trade-off for staging atomicity.
- No automated notification for slow-test failures today — failures surface only as red checks in the Actions tab.
