### PR TITLE
Create a common Grafana dashboard

### DIFF
--- a/.github/workflows/grafana-publish.yml
+++ b/.github/workflows/grafana-publish.yml
@@ -1,0 +1,37 @@
+name: "Grafana: Publish dashboards"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - grafana/**
+      - .github/workflows/grafana-publish.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: grafana-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2026.5.11
+          install: true
+
+      - name: Publish dashboards
+        run: |
+          cd grafana
+          # https://pytorchci.grafana.net/dashboards/f/fvnzj9
+          mise run push --folder fvnzj9
+        env:
+          GRAFANA_TOKEN: ${{ secrets.PYTORCHCI_GRAFANA_API_TOKEN }}

--- a/grafana/.gitignore
+++ b/grafana/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -1,0 +1,25 @@
+# Grafana Dashboard Resources
+
+Required information from the user:
+  * Environment variable `GRAFANA_TOKEN`. A private API token to access Grafana. NEVER print the value of environment variable. Only confirm if it's set.
+  * Folder UID. The folder UID to publish dashboards to. This is required for each publish session. If the user provides a Grafana URL see how to get the ID in publish.py.
+
+Use the mise-managed `gcx` workflow from this directory. `GRAFANA_SERVER` is set in `grafana/mise.toml`. How to validate and publish all `*.json` dashboards in the `grafana` folder:
+```sh
+# Assume GRAFANA_TOKEN is set in the environment already.
+
+# Generate resource files
+mise run generate --folder "..."
+# Validate resource files
+mise run validate --folder "..."
+# Publish resource files
+mise run push --folder "..."
+```
+
+* NEVER persist `GRAFANA_TOKEN` in files, shell profiles, logs, commits, or other durable storage; provide it only for the current publish session.
+* NEVER hardcode the Grafana folder UID in committed files. It must be provided with `--folder` for each session.
+* When publishing, all top-level `*.json` dashboards under the `grafana` folder are pushed at once
+  * The published dashboard can be found in https://pytorchci.grafana.net/d/ci-infra-<folder uid>-<file basename>/<kebab case dashboard title>
+  * The folder can be found in https://pytorchci.grafana.net/dashboards/f/<folder uid>
+* Use gcx (`mise exec -- gcx`) to interact with Grafana
+  * NEVER make edits to any folders other than the folder UID provided with `--folder`

--- a/grafana/generator.py
+++ b/grafana/generator.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+import shutil
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Grafana dashboard resources."
+    )
+    parser.add_argument("--folder", required=True, help="Grafana folder UID")
+    return parser.parse_args(argv)
+
+
+def wrap_dashboard(
+    dashboard: object,
+    folder_uid: str,
+    dashboard_name: str,
+) -> Dict[str, object]:
+    return {
+        "apiVersion": "dashboard.grafana.app/v2",
+        "kind": "Dashboard",
+        "metadata": {
+            "name": f"ci-infra-{folder_uid}-{dashboard_name}",
+            "annotations": {
+                "grafana.app/folder": folder_uid,
+            },
+        },
+        "spec": dashboard,
+    }
+
+
+def reset_generated_dir(generated_dir: Path) -> None:
+    if generated_dir.is_symlink() or generated_dir.is_file():
+        generated_dir.unlink()
+    elif generated_dir.exists():
+        shutil.rmtree(generated_dir)
+
+    generated_dir.mkdir(parents=True, exist_ok=True)
+
+
+def main(argv: List[str]) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stderr
+    )
+
+    args = parse_args(argv)
+
+    dashboard_files = sorted(Path(".").glob("*.json"))
+    if not dashboard_files:
+        logging.error("No dashboard JSON files found.")
+        return 1
+
+    generated_dir = Path("generated")
+    reset_generated_dir(generated_dir)
+
+    for dashboard_file in dashboard_files:
+        with dashboard_file.open(encoding="utf-8") as source:
+            dashboard = json.load(source)
+        resource = wrap_dashboard(dashboard, args.folder, dashboard_file.stem)
+        output_file = generated_dir / dashboard_file.name
+        with output_file.open("w", encoding="utf-8") as output:
+            json.dump(resource, output, indent=2, ensure_ascii=False)
+            output.write("\n")
+
+    logging.info(
+        "Generated %s dashboard resource(s) in %s",
+        len(dashboard_files),
+        generated_dir.resolve(),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/grafana/mise.toml
+++ b/grafana/mise.toml
@@ -1,0 +1,36 @@
+[tools]
+"github:grafana/gcx" = "0.2.16"
+
+[env]
+GRAFANA_SERVER = "https://pytorchci.grafana.net"
+
+[tasks.generate]
+description = "Generate dashboard resources for Grafana"
+usage = '''
+flag "--folder <folder>" help="Grafana folder UID" required=#true
+'''
+run = 'python3 generator.py --folder "{{usage.folder}}"'
+
+[tasks.validate]
+description = "Validate generated dashboard resources against Grafana"
+usage = '''
+flag "--folder <folder>" help="Grafana folder UID" required=#true
+'''
+depends = [{ task = "generate", args = ["--folder", "{{usage.folder}}"] }]
+run = "gcx resources validate -p generated"
+
+[tasks.push-dry-run]
+description = "Dry-run pushing generated dashboard resources to Grafana"
+usage = '''
+flag "--folder <folder>" help="Grafana folder UID" required=#true
+'''
+depends = [{ task = "validate", args = ["--folder", "{{usage.folder}}"] }]
+run = "gcx resources push --dry-run -p generated -v"
+
+[tasks.push]
+description = "Push generated dashboard resources to Grafana"
+usage = '''
+flag "--folder <folder>" help="Grafana folder UID" required=#true
+'''
+depends = [{ task = "validate", args = ["--folder", "{{usage.folder}}"] }]
+run = "gcx resources push -p generated"

--- a/grafana/pytorch_devx.json
+++ b/grafana/pytorch_devx.json
@@ -1,0 +1,659 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Off",
+  "editable": true,
+  "elements": {
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "builderOptions": {
+                        "columns": [],
+                        "database": "default",
+                        "filters": [
+                          {
+                            "condition": "AND",
+                            "filterType": "custom",
+                            "hint": "time",
+                            "key": "",
+                            "operator": "WITH IN DASHBOARD TIME RANGE",
+                            "type": "datetime"
+                          }
+                        ],
+                        "limit": 1000,
+                        "meta": {},
+                        "mode": "list",
+                        "orderBy": [
+                          {
+                            "default": true,
+                            "dir": "ASC",
+                            "hint": "time",
+                            "name": ""
+                          }
+                        ],
+                        "queryType": "timeseries",
+                        "table": "_clickhouse_internal_analyzer_broken_queries"
+                      },
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "default",
+                          "filters": [
+                            {
+                              "condition": "AND",
+                              "filterType": "custom",
+                              "hint": "time",
+                              "key": "",
+                              "operator": "WITH IN DASHBOARD TIME RANGE",
+                              "type": "datetime"
+                            }
+                          ],
+                          "limit": 1000,
+                          "meta": {},
+                          "mode": "list",
+                          "orderBy": [
+                            {
+                              "default": true,
+                              "dir": "ASC",
+                              "hint": "time",
+                              "name": ""
+                            }
+                          ],
+                          "queryType": "timeseries",
+                          "table": "_clickhouse_internal_analyzer_broken_queries"
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    fromUnixTimestamp(repository.pushed_at) AS pushed_time,\n    dateDiff(\n        'minutes', \n        arraySort(commits.timestamp)[1] AS commit_time, -- SQL is 1-indexed\n        pushed_time\n    ) AS drift_minutes,\n    avg(drift_minutes) OVER (ORDER BY toUnixTimestamp(pushed_time) ASC RANGE BETWEEN 7 * 24 * 60 * 60 PRECEDING AND CURRENT ROW) AS trend_7d_avg\nFROM push\nWHERE\n    repository.full_name = 'pytorch/pytorch'\n    AND ref = 'refs/heads/viable/strict'\n    AND length(commits) > 0\n    AND $__timeFilter(pushed_time)\nORDER BY pushed_time DESC"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "Drift"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 4,
+        "links": [],
+        "title": "viable/strict Drift Minutes",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds",
+                  "seriesBy": "last"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 27,
+                  "gradientMode": "scheme",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 240
+                    },
+                    {
+                      "color": "red",
+                      "value": 1440
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "trend_7d_avg",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineInterpolation",
+                      "value": "smooth"
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    revert_day,\n    prs_reverted,\n    sum(prs_reverted) OVER (\n        ORDER BY toUnixTimestamp(revert_day) ASC\n        RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW\n    ) / least(7.0, toFloat64(count() OVER (\n        ORDER BY toUnixTimestamp(revert_day) ASC\n        RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW\n    ))) AS trend_7d_avg\nFROM (\n    SELECT\n        toStartOfDay(event_time) AS revert_day,\n        COUNT() AS prs_reverted\n    FROM pull_label_event\n    WHERE\n        repo_name = 'pytorch/pytorch'\n        AND label_name = 'Reverted'\n        AND action = 'labeled'\n        AND $__timeFilter(event_time)\n    GROUP BY revert_day\n)\nORDER BY revert_day DESC\nLIMIT 100"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 5,
+        "links": [],
+        "title": "Daily PR Reverts",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds",
+                  "seriesBy": "last"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.5,
+                  "drawStyle": "bars",
+                  "fillOpacity": 50,
+                  "gradientMode": "scheme",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "trend_7d_avg",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineInterpolation",
+                      "value": "smooth"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "  WITH commits AS (\n      SELECT\n          commit.id AS commit_sha,\n          commit.timestamp AS commit_time\n      FROM default.push\n      ARRAY JOIN commits AS commit\n      WHERE\n          repository.full_name = 'pytorch/pytorch'\n          AND ref = 'refs/heads/main'\n  ),\n  blocking_runs AS (\n      SELECT id\n      FROM default.workflow_run\n      WHERE\n          head_branch = 'main'\n          AND event = 'push'\n          AND path IN (\n              -- Core\n              '.github/workflows/lint.yml',\n              '.github/workflows/pull.yml',\n              '.github/workflows/trunk.yml',\n              '.github/workflows/inductor.yml',\n              '.github/workflows/inductor-periodic.yml',\n              '.github/workflows/inductor-unittest.yml',\n              '.github/workflows/periodic.yml',\n              '.github/workflows/slow.yml',\n              '.github/workflows/dynamo-unittest.yml',\n              -- Modern hardware\n              '.github/workflows/rocm-mi300.yml',\n              '.github/workflows/rocm-mi355.yml',\n              '.github/workflows/xpu.yml',\n              '.github/workflows/mac-mps.yml',\n              '.github/workflows/tsan.yml',\n              '.github/workflows/inductor-rocm-mi300.yml',\n              '.github/workflows/inductor-rocm-mi355.yml',\n              -- Distributed\n              '.github/workflows/b200-distributed.yml',\n              '.github/workflows/h100-distributed.yml',\n              -- Adjacent / integrations\n              '.github/workflows/dtensor.yml',\n              '.github/workflows/inductor-pallas.yml',\n              '.github/workflows/vllm.yml',\n              '.github/workflows/torchtitan.yml'\n          )\n  )\n  \nSELECT\n    commits.commit_time AS commit_time,\n    round((countIf(default.workflow_job.conclusion = 'failure') / count()) * 100.0, 2) AS failure_percent,\n    avg(failure_percent) OVER (ORDER BY toUnixTimestamp(commits.commit_time) ASC RANGE BETWEEN 7 * 24 * 60 * 60 PRECEDING AND CURRENT ROW) AS trend_7d_avg\nFROM default.workflow_job\nINNER JOIN commits ON commits.commit_sha = default.workflow_job.head_sha\nINNER JOIN blocking_runs ON blocking_runs.id = default.workflow_job.run_id\nWHERE\n    default.workflow_job.run_attempt = 1\n    AND $__timeFilter(commits.commit_time)\nGROUP BY commits.commit_sha, commits.commit_time\nORDER BY commit_time ASC"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 6,
+        "links": [],
+        "title": "Workflow Failure Percent / Main Commit",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "rgba(242, 73, 92, 0.75)",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 50,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "trend_7d_avg",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineInterpolation",
+                      "value": "smooth"
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "GridLayout",
+    "spec": {
+      "items": [
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-4"
+            },
+            "height": 10,
+            "width": 8,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-5"
+            },
+            "height": 10,
+            "width": 8,
+            "x": 8,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-6"
+            },
+            "height": 10,
+            "width": 8,
+            "x": 16,
+            "y": 0
+          }
+        }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preload": false,
+  "tags": [],
+  "timeSettings": {
+    "autoRefresh": "",
+    "autoRefreshIntervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-30d",
+    "hideTimepicker": false,
+    "timezone": "browser",
+    "to": "now"
+  },
+  "title": "PyTorch DevX",
+  "variables": []
+}


### PR DESCRIPTION
* Creates a common area for all Grafana dashboards shared by the team. This will be published to: [fburl.com/pytorch-metrics](https://fburl.com/pytorch-metrics)
   * Allows a way to test changes in a custom folder
   * Workflow on main will push to the real folder
* Include the initial dashboard to track key developer experience metrics


## Test Plan

Pushed to my test folder: https://pytorchci.grafana.net/dashboards/f/flrhzs

```sh
$ cd grafana
$ GRAFANA_TOKEN=... mise run publish --folder flrhzs
```