### PR TITLE
Add us-east-1 OSDC cluster and workflows

### DIFF
--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -6,10 +6,9 @@ name: "OSDC: Deploy production"
 # `environment:osdc-production` in the sub claim, so IAM enforces the gate too.
 #
 # Default behavior (target = all): sequential rollout.
-#   1. Deploy arc-cbr-production-uw1.
-#   2. Run the post-deploy smoke battery on uw1.
-#   3. Deploy arc-cbr-production
-#   4. Run the post-deploy smoke battery on ue2.
+#   1. Deploy arc-cbr-production-uw1 + smoke.
+#   2. Deploy arc-cbr-production (ue2) + smoke.
+#   3. Deploy meta-prod-aws-ue1 + smoke.
 #
 # Picking a specific cluster from the dropdown bypasses the sequencing and
 # deploys only that one — useful for hotfixes or to recover from a partial
@@ -28,6 +27,7 @@ on:
         default: all
         options:
           - all
+          - meta-prod-aws-ue1
           - arc-cbr-production-uw1
           - arc-cbr-production
       taint_nodes:
@@ -77,6 +77,23 @@ jobs:
     uses: ./.github/workflows/_osdc-deploy.yml
     with:
       cluster: arc-cbr-production
+      environment: osdc-production
+      taint_nodes: ${{ inputs.taint_nodes }}
+      restart_listeners: ${{ inputs.restart_listeners }}
+      skip_lint_test: ${{ inputs.skip_lint_test }}
+      run_smoke: true
+    secrets: inherit
+
+  deploy_ue1:
+    needs: deploy_ue2
+    if: |
+      !cancelled() && (
+        inputs.target == 'meta-prod-aws-ue1' ||
+        (inputs.target == 'all' && needs.deploy_ue2.result == 'success')
+      )
+    uses: ./.github/workflows/_osdc-deploy.yml
+    with:
+      cluster: meta-prod-aws-ue1
       environment: osdc-production
       taint_nodes: ${{ inputs.taint_nodes }}
       restart_listeners: ${{ inputs.restart_listeners }}

--- a/.github/workflows/osdc-plan-prod.yml
+++ b/.github/workflows/osdc-plan-prod.yml
@@ -36,3 +36,14 @@ jobs:
       cluster: arc-cbr-production-uw1
       pr_number: ${{ github.event.pull_request.number }}
     secrets: inherit
+
+  plan_ue1:
+    needs: plan_uw1
+    if: |
+      !cancelled() &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/_osdc-plan.yml
+    with:
+      cluster: meta-prod-aws-ue1
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -227,6 +227,43 @@ clusters:
       - monitoring
       - logging
 
+  meta-prod-aws-ue1:
+    cluster_name: meta-prod-aws-ue1
+    region: us-east-1
+    state_bucket: ciforge-tfstate-arc-cbr-prod-ue1
+    access_config:
+      authentication_mode: API_AND_CONFIG_MAP
+      cluster_admin_role_names:
+        - osdc_gha_prod
+    base:
+      vpc_cidr: "10.4.0.0/16"
+    git_cache:
+      central_replicas: 15
+      central_cpu_request: "10"
+      central_cpu_limit: "15"
+      central_memory_request: "10Gi"
+      central_memory_limit: "50Gi"
+    node_compactor:
+      min_node_age_seconds: 900
+    arc-runners:
+      github_config_url: "https://github.com/pytorch"
+      github_secret_name: meta-prod-aws-ue1
+      runner_name_prefix: "mt-"
+      runner_group: "meta-prod-aws-ue1"
+    pypi_cache:
+      replicas: 10
+    modules:
+      - karpenter
+      - arc
+      - nodepools
+      - arc-runners
+      - pypi-cache
+      - cache-enforcer
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
+
   arc-cbr-production:
     cluster_name: pytorch-arc-cbr-production
     region: us-east-2


### PR DESCRIPTION
Adds `us-east-1` and associated workflows. For initial bootstrapping, we need to initialize the bucket and rerun the workflows.
```
just bootstrap arc-cbr-production-ue1
```
- Checked cidr can match current prod.
- Checked EC2 instance types are launchable. 

For deployment, from local machine, we'll be using the following setting to avoid diverting workflows while the region is initially provisioning. 
```
    region: us-east-1
    + pause_runners: true
    state_bucket: ciforge-tfstate-arc-cbr-prod-ue1
```