### PR TITLE
Add us-east-1 to deploy and plan workflows

### DIFF
--- a/.github/workflows/osdc-deploy-prod.yml
+++ b/.github/workflows/osdc-deploy-prod.yml
@@ -6,10 +6,9 @@ name: "OSDC: Deploy production"
 # `environment:osdc-production` in the sub claim, so IAM enforces the gate too.
 #
 # Default behavior (target = all): sequential rollout.
-#   1. Deploy arc-cbr-production-uw1.
-#   2. Run the post-deploy smoke battery on uw1.
-#   3. Deploy arc-cbr-production
-#   4. Run the post-deploy smoke battery on ue2.
+#   1. Deploy arc-cbr-production-uw1 + smoke.
+#   2. Deploy arc-cbr-production (ue2) + smoke.
+#   3. Deploy arc-cbr-production-ue1 + smoke.
 #
 # Picking a specific cluster from the dropdown bypasses the sequencing and
 # deploys only that one — useful for hotfixes or to recover from a partial
@@ -28,6 +27,7 @@ on:
         default: all
         options:
           - all
+          - arc-cbr-production-ue1
           - arc-cbr-production-uw1
           - arc-cbr-production
       taint_nodes:
@@ -80,6 +80,26 @@ jobs:
     uses: ./.github/workflows/_osdc-deploy.yml
     with:
       cluster: arc-cbr-production
+      environment: osdc-production
+      taint_nodes: ${{ inputs.taint_nodes }}
+      restart_listeners: ${{ inputs.restart_listeners }}
+      skip_lint_test: ${{ inputs.skip_lint_test }}
+      run_smoke: true
+      run_compactor: false
+      run_janitor: false
+      run_load_test: false
+    secrets: inherit
+
+  deploy_ue1:
+    needs: deploy_ue2
+    if: |
+      !cancelled() && (
+        inputs.target == 'arc-cbr-production-ue1' ||
+        (inputs.target == 'all' && needs.deploy_ue2.result == 'success')
+      )
+    uses: ./.github/workflows/_osdc-deploy.yml
+    with:
+      cluster: arc-cbr-production-ue1
       environment: osdc-production
       taint_nodes: ${{ inputs.taint_nodes }}
       restart_listeners: ${{ inputs.restart_listeners }}

--- a/.github/workflows/osdc-plan-prod.yml
+++ b/.github/workflows/osdc-plan-prod.yml
@@ -36,3 +36,14 @@ jobs:
       cluster: arc-cbr-production-uw1
       pr_number: ${{ github.event.pull_request.number }}
     secrets: inherit
+
+  plan_ue1:
+    needs: plan_uw1
+    if: |
+      !cancelled() &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/_osdc-plan.yml
+    with:
+      cluster: arc-cbr-production-ue1
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -227,6 +227,51 @@ clusters:
       - monitoring
       - logging
 
+  # us-east-1 production cluster — initial canary validation phase.
+  # Runners register against pytorch-canary (repo-scoped) for safe E2E
+  # testing before switching to the pytorch org. See follow-up PR for
+  # production cutover.
+  arc-cbr-production-ue1:
+    cluster_name: pytorch-arc-cbr-production-ue1
+    region: us-east-1
+    state_bucket: ciforge-tfstate-arc-cbr-prod-ue1
+    access_config:
+      authentication_mode: API_AND_CONFIG_MAP
+      cluster_admin_role_names:
+        - osdc_gha_prod
+    base:
+      vpc_cidr: "10.16.0.0/16"
+    git_cache:
+      central_replicas: 15
+      central_cpu_request: "10"
+      central_cpu_limit: "15"
+      central_memory_request: "10Gi"
+      central_memory_limit: "50Gi"
+    node_compactor:
+      min_node_age_seconds: 900
+    buildkit:
+      arm64_instance_type: c7gd.16xlarge
+      amd64_instance_type: m6id.24xlarge
+      pods_per_node: 2
+    arc-runners:
+      github_config_url: "https://github.com/pytorch/pytorch-canary"
+      github_secret_name: pytorch-arc-staging
+      runner_name_prefix: "ue1-mt-"
+    pypi_cache:
+      replicas: 10
+    modules:
+      - karpenter
+      - arc
+      - nodepools
+      - arc-runners
+      - buildkit
+      - pypi-cache
+      - cache-enforcer
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
+
   arc-cbr-production:
     cluster_name: pytorch-arc-cbr-production
     region: us-east-2


### PR DESCRIPTION
Once state bucket is initialized, update workflows to account for the new cluster. us-east-1 is added to the end so that failures don't affect deployment of known-good clusters.