### PR TITLE
grafana: replace mise tasks with `just` for orchestration

### DIFF
--- a/.github/workflows/grafana-publish.yml
+++ b/.github/workflows/grafana-publish.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           cd grafana
           # https://pytorchci.grafana.net/dashboards/f/fvnzj9
-          mise run push --folder fvnzj9
+          mise install
+          mise exec -- just push fvnzj9
         env:
           GRAFANA_TOKEN: ${{ secrets.PYTORCHCI_GRAFANA_API_TOKEN }}

--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -5,27 +5,33 @@ Required information from the user:
     * If the token provides more than viewer access, warn the user that this is highly discouraged and dangerous.
   * Folder UID. The folder UID to publish dashboards to. This is required for each publish session. If the user provides a Grafana URL see how to get the ID in publish.py.
 
-Use the mise-managed `gcx` workflow from this directory. `GRAFANA_SERVER` is set in `grafana/mise.toml`. How to validate and publish all `*.json` dashboards in the `grafana` folder:
+Use the `just` recipes from this directory; they run `gcx` via mise. `GRAFANA_SERVER` is set in `grafana/mise.toml`. How to validate and publish all `*.json` dashboards in the `grafana` folder:
 ```sh
 # Assume GRAFANA_TOKEN is set in the environment already.
 
 # Generate resource files
-mise run generate --folder "..."
+just generate "..."
 # Validate resource files
-mise run validate --folder "..."
+just validate "..."
 # Publish resource files
-mise run push --folder "..."
+just push "..."
 ```
 
 ## Rules & Guidelines
 
 * NEVER persist `GRAFANA_TOKEN` in files, shell profiles, logs, commits, or other durable storage; provide it only for the current publish session.
-* NEVER hardcode the Grafana folder UID in committed files. It must be provided with `--folder` for each session.
+* NEVER hardcode the Grafana folder UID in committed files. It must be provided as the recipe argument for each session.
 * When publishing, all top-level `*.json` dashboards under the `grafana` folder are pushed at once
   * The published dashboard can be found in https://pytorchci.grafana.net/d/ci-infra-<folder uid>-<file basename>/<kebab case dashboard title>
   * The folder can be found in https://pytorchci.grafana.net/dashboards/f/<folder uid>
 * Use gcx (`mise exec -- gcx`) to interact with Grafana
-  * NEVER make edits to any folders other than the folder UID provided with `--folder`
+  * NEVER make edits to any folders other than the folder UID provided to the recipe
+
+## Orchestration
+
+* `mise.toml` manages tool versions only (`gcx`, `just`). No tasks.
+* `justfile` defines the recipes (`generate`, `validate`, `push-dry-run`, `push`) and their dependency chain. `validate` depends on `generate`; `push` and `push-dry-run` depend on `validate`. Running `just push <folder>` runs the full chain.
+* CI (`.github/workflows/grafana-publish.yml`) installs mise via `jdx/mise-action`, which auto-installs `gcx` and `just`, then runs `just push <folder>`.
 
 ## Datasources
 

--- a/grafana/justfile
+++ b/grafana/justfile
@@ -1,0 +1,20 @@
+set shell := ["mise", "exec", "--", "bash", "-euo", "pipefail", "-c"]
+
+GRAFANA_URL := "https://pytorchci.grafana.net"
+
+# Generate dashboard resources for Grafana
+generate folder:
+    python3 generator.py --folder "{{folder}}"
+
+# Validate generated dashboard resources against Grafana
+validate folder: (generate folder)
+    gcx resources validate -p generated
+
+# Dry-run pushing generated dashboard resources to Grafana
+push-dry-run folder: (validate folder)
+    gcx resources push --dry-run -p generated -v
+
+# Push generated dashboard resources to Grafana
+push folder: (validate folder)
+    gcx resources push -p generated
+    @printf '\n✅ Published: {{GRAFANA_URL}}/dashboards/f/{{folder}}\n\n'

--- a/grafana/mise.toml
+++ b/grafana/mise.toml
@@ -1,39 +1,9 @@
 [tools]
 "github:grafana/gcx" = "0.2.16"
+just = "1.45"
 
 [env]
 GRAFANA_SERVER = "https://pytorchci.grafana.net"
 
-[tasks.generate]
-description = "Generate dashboard resources for Grafana"
-usage = '''
-flag "--folder <folder>" help="Grafana folder UID" required=#true
-'''
-run = 'python3 generator.py --folder "{{usage.folder}}"'
-
-[tasks.validate]
-description = "Validate generated dashboard resources against Grafana"
-usage = '''
-flag "--folder <folder>" help="Grafana folder UID" required=#true
-'''
-depends = [{ task = "generate", args = ["--folder", "{{usage.folder}}"] }]
-run = "gcx resources validate -p generated"
-
-[tasks.push-dry-run]
-description = "Dry-run pushing generated dashboard resources to Grafana"
-usage = '''
-flag "--folder <folder>" help="Grafana folder UID" required=#true
-'''
-depends = [{ task = "validate", args = ["--folder", "{{usage.folder}}"] }]
-run = "gcx resources push --dry-run -p generated -v"
-
-[tasks.push]
-description = "Push generated dashboard resources to Grafana"
-usage = '''
-flag "--folder <folder>" help="Grafana folder UID" required=#true
-'''
-depends = [{ task = "validate", args = ["--folder", "{{usage.folder}}"] }]
-run = '''
-gcx resources push -p generated
-echo "\n✅ Published: https://pytorchci.grafana.net/dashboards/f/{{usage.folder}}\n"
-'''
+[settings]
+auto_install = true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #628
* __->__ #627

`grafana/mise.toml` was mixing two concerns: tool versions (`gcx`) **and** task orchestration (generate → validate → push). The task definitions failed to load:

```
mise ERROR TOML parse error at line 19, column 11
   |
19 | depends = [{ task = "generate", args = ["--folder", "{{usage.folder}}"] }]
data did not match any variant of untagged enum StringOrValue
```

The `depends = [{ task = ..., args = [...] }]` object form isn't accepted by multiple mise versions — it only accepts strings or arrays of strings.

Fixing the parse exposed a second problem: even with the array syntax `depends = [["generate", "--folder", "{{usage.folder}}"]]`, mise renders deps against a Tera context **before** the parent task's `usage` flags are populated, so `{{usage.folder}}` is unbound:

```
Failed to render '__tera_one_off'
Variable `usage.folder` not found in context
Location: src/task/task_dep.rs:22
```

This is a real limitation in mise's task model: forwarding a CLI flag from a parent task to a dependent task requires either an env-var indirection (`flag "--folder" env="GRAFANA_FOLDER"` + reference `$GRAFANA_FOLDER` in deps) or inlining the dep into the parent's `run` script. Both are awkward.

- **Two layers of templating, neither obvious**: `{{usage.folder}}` for templates, `$usage_folder` (snake-cased, lowercased) inside the shell `run`. Easy to get wrong.
- **`usage` mini-DSL** for flags (`flag "--folder <folder>" help="..." required=#true`) is a third syntax to learn, distinct from both TOML and shell.
- **Deps rendered before flags exist**: the very feature that would justify mise tasks (typed flag passing through a dep chain) is broken/footgunned in practice.
- **`depends` shape ambiguity**: strings, arrays, objects, env-prefixed shell-style — all valid in different combinations, none discoverable from the error messages.

For a four-step chain (`generate → validate → push-dry-run → push`) with one shared argument, this is far too much surface area.

- **One language, one templating model**: recipe args are just `{{name}}` substitutions in shell snippets. Same syntax everywhere.
- **Native dependency forwarding**: `validate folder: (generate folder)` — the parent's argument is passed to the dep declaratively, no templating, no env-var tricks.
- **Already established in this repo**: `osdc/justfile` uses the same pattern (`set shell := ["mise", "exec", "--", "bash", ...]`), so this aligns with existing convention.
- **Zero added install burden in CI**: `just` is added to `grafana/mise.toml`'s `[tools]`, so `mise install` (run from `grafana/`) pulls it in alongside `gcx`. Invocation uses `mise exec -- just push <folder>` so PATH resolution works without a global install.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>