### PR TITLE
Add two contextual panels to OSDC dashboard

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -307,7 +307,7 @@
             "transformations": []
           }
         },
-        "description": "Percent of assigned jobs that, based on historical peak runner start rate over the last 28 days, should already be running by now. Reads near 0% when the system is ramping at expected speed; climbs when jobs are accumulating faster than capacity has historically allowed.",
+        "description": "Percent of assigned jobs that, based on historical peak runner start rate over the last 28 days, should already be running by now. A 10-minute grace window is applied: jobs that fit within what the system could start in 10 minutes at peak observed throughput are not counted. Reads near 0% when the system is ramping at expected speed; climbs when jobs are accumulating faster than capacity has historically allowed.",
         "id": 9,
         "links": [],
         "title": "Startup Throughput Adjusted % of Assigned Jobs Not Running [cluster, scale_set]",
@@ -1097,7 +1097,7 @@
             "transformations": []
           }
         },
-        "description": "Rate at which new jobs are starting to run, in jobs/sec. Computed as the derivative of running jobs plus the completion rate (since running = started - completed). A flat or low value while jobs are queued indicates the system is not adding runners fast enough; a high value indicates active ramp-up.",
+        "description": "Number of new jobs starting to run per 5-minute bucket. Computed as the derivative of running jobs plus the completion rate (since running = started - completed), scaled to a 5-minute window. A flat or low value while jobs are queued indicates the system is not adding runners fast enough; a high value indicates active ramp-up.",
         "id": 8,
         "links": [],
         "title": "Runner Start Rate, Jobs per 5min [cluster, scale_set]",

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -976,10 +976,10 @@
             "transformations": []
           }
         },
-        "description": "Count of unique GitHub Actions workflow jobs picked up by OSDC production runners for the selected repositories and clusters.",
+        "description": "Count of unique GitHub Actions workflow jobs picked up by OSDC production runners for the selected repositories and clusters, aggregated in 5-minute buckets.",
         "id": 7,
         "links": [],
-        "title": "Jobs Submitted to OSDC Runners [cluster, repository]",
+        "title": "Jobs Submitted to OSDC Runners, per 5min [cluster, repository]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -181,7 +181,136 @@
         "description": "Percent of jobs assigned to the scale set that are not yet running on a runner.",
         "id": 2,
         "links": [],
-        "title": "Percent of Assigned Jobs Not Running [cluster, scale_set]",
+        "title": "% of Assigned Jobs Not Running [cluster, scale_set]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic",
+                  "seriesBy": "max"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.9,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed+area"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "rgba(255, 255, 255, 0)",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 10
+                    },
+                    {
+                      "color": "red",
+                      "value": 20
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-9": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "app": "grafana-assistant-app",
+                      "expr": "(100 * clamp_min(sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}) - sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}) - 600 * max_over_time((clamp_min(sum by(cluster) (deriv(gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])) + sum by(cluster) (rate(gha_completed_jobs_total{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])), 0))[28d:5m]), 0) / sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"})) and on(cluster) (sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}) > 0)",
+                      "instant": false,
+                      "legendFormat": "{{cluster}}",
+                      "queryType": "range",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of assigned jobs that, based on historical peak runner start rate over the last 28 days, should already be running by now. Reads near 0% when the system is ramping at expected speed; climbs when jobs are accumulating faster than capacity has historically allowed.",
+        "id": 9,
+        "links": [],
+        "title": "Startup Throughput Adjusted % of Assigned Jobs Not Running [cluster, scale_set]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -931,6 +1060,127 @@
           "version": "13.1.0-25668120414"
         }
       }
+    },
+    "panel-8": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "app": "grafana-assistant-app",
+                      "expr": "clamp_min(sum by(cluster) (deriv(gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])) + sum by(cluster) (rate(gha_completed_jobs_total{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])), 0)",
+                      "instant": false,
+                      "legendFormat": "{{cluster}}",
+                      "queryType": "range",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Rate at which new jobs are starting to run, in jobs/sec. Computed as the derivative of running jobs plus the completion rate (since running = started - completed). A flat or low value while jobs are queued indicates the system is not adding runners fast enough; a high value indicates active ramp-up.",
+        "id": 8,
+        "links": [],
+        "title": "Runner Start Rate [cluster, scale_set]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic",
+                  "seriesBy": "max"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.9,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
     }
   },
   "layout": {
@@ -983,10 +1233,36 @@
               "kind": "ElementReference",
               "name": "panel-2"
             },
-            "height": 20,
+            "height": 7,
             "width": 8,
             "x": 16,
             "y": 10
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-9"
+            },
+            "height": 7,
+            "width": 8,
+            "x": 16,
+            "y": 17
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-8"
+            },
+            "height": 6,
+            "width": 8,
+            "x": 16,
+            "y": 24
           }
         },
         {

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -964,7 +964,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n  $__timeInterval(created_at) AS time,\n  uniqExact(id) AS jobs\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n  AND arrayExists(label -> match(label, '^mt-(rel-)?l-'), labels)\n  AND (\n    (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n    OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n  )\n  AND $__timeFilter(created_at)\nGROUP BY time\nORDER BY time ASC"
+                      "rawSql": "SELECT\n  toStartOfInterval(created_at, INTERVAL 5 MINUTE) AS time,\n  uniqExact(id) AS jobs\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n  AND arrayExists(label -> match(label, '^mt-(rel-)?l-'), labels)\n  AND (\n    (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n    OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n  )\n  AND $__timeFilter(created_at)\nGROUP BY time\nORDER BY time ASC"
                     },
                     "version": "v0"
                   },
@@ -1080,8 +1080,9 @@
                     "kind": "DataQuery",
                     "spec": {
                       "app": "grafana-assistant-app",
-                      "expr": "clamp_min(sum by(cluster) (deriv(gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])) + sum by(cluster) (rate(gha_completed_jobs_total{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])), 0)",
+                      "expr": "clamp_min(300 * (sum by(cluster) (deriv(gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m])) + sum by(cluster) (rate(gha_completed_jobs_total{cluster=~\"$cluster\", name=~\"$scale_set\"}[5m]))), 0)",
                       "instant": false,
+                      "interval": "5m",
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
                       "range": true
@@ -1099,7 +1100,7 @@
         "description": "Rate at which new jobs are starting to run, in jobs/sec. Computed as the derivative of running jobs plus the completion rate (since running = started - completed). A flat or low value while jobs are queued indicates the system is not adding runners fast enough; a high value indicates active ramp-up.",
         "id": 8,
         "links": [],
-        "title": "Runner Start Rate [cluster, scale_set]",
+        "title": "Runner Start Rate, Jobs per 5min [cluster, scale_set]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -1156,7 +1157,7 @@
                     }
                   ]
                 },
-                "unit": "ops"
+                "unit": "short"
               },
               "overrides": []
             },


### PR DESCRIPTION
Adds "Startup Throughput Adjusted % of Assigned Jobs Not Running [cluster, scale_set]" and "Runner Start Rate, Jobs per 5min [cluster, scale_set]" to OSDC dashboard.

### Jobs Submitted to OSDC Runners

Grouped to 5 minutes buckets interval, to maintain consistency with the rest of the dashboard, reduce the datapoints and make visualization easier.

### Startup Throughput Adjusted % of Assigned Jobs Not Running [cluster, scale_set]

Is more robust metric that 'hides' just regular peaks caused by the rapid burst of new jobs submitted to the infra as part of big stacked PRs or just regular webb-and-flow of daily peaks when compared to "Percent of Assigned Jobs Not Running [cluster, scale_set]". But, given its less sensitive nature, I rather have both and use this as a differential to help easily detect when issues are just regular spikes.

### Runner Start Rate, Jobs per 5min [cluster, scale_set]

This is a independent useful metric, that both add context and can help point to individual problems when the number of jobs are not starting in the rate we expected compared to submission rate.

The context can be seen in the false positive for 'Percent of Assigned Jobs Not Running'

<img width="561" height="779" alt="Screenshot 2026-05-26 at 15 34 26" src="https://github.com/user-attachments/assets/2bfe7438-72f1-4fd6-858a-524aa93a8514" />

## Testing
```
mise run push --folder f4vfmq
```

Link to deployed dashboard: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc?orgId=1&from=now-7d&to=now&timezone=browser&var-cluster=$__all&var-scale_set=$__all&var-repository=$__all

*Note:* link to dashboard will become stale as I hack stuff onto it.