### PR TITLE
Bump runner-container-hooks to v0.8.14 (OOM protection for RPC server)

### DIFF
--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -2,7 +2,7 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.13
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.14
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -61,7 +61,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.13"
+              HOOKS_VERSION="0.8.14"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"


### PR DESCRIPTION
**Impact:** All runner pods on c7i-runner nodes (hooks-warmer DaemonSet) **Risk:** low

## What
Bumps the patched runner-container-hooks from v0.8.13 to v0.8.14 in the hooks-warmer DaemonSet.

## Why
When a user job consumes excessive memory, the Linux OOM killer can target the in-pod RPC server instead of the job, since both share the same cgroup. When the RPC server dies, the hook driver loses its communication channel, leaving the GitHub Actions runner hanging indefinitely with no status update. v0.8.14 makes the RPC server OOM-immune (`oom_score_adj=-1000`) so the kernel kills the user job first, allowing the server to survive and report a clean failure back to the runner.

## How
- The upstream fix sets `oom_score_adj=-1000` on the RPC server process at startup
- Child processes (user jobs) are reset to `oom_score_adj=0` via a `preexec_fn` after fork, so they remain normal OOM candidates
- Uses only async-signal-safe syscalls between fork/exec; degrades gracefully (no-op) on systems without `/proc`

## Changes
- Updated `HOOKS_VERSION` from `0.8.13` to `0.8.14` in hooks-warmer DaemonSet init script
- Updated release URL comment to point to v0.8.14 tag

## Testing
- The hooks-warmer DaemonSet will pull the new zip on next rollout; verify with `kubectl get ds runner-hooks-warmer -n arc-runners` and confirm pods restart cleanly
- Check `/mnt/runner-container-hooks/.version` on a node reads `0.8.14`
- Run a memory-heavy CI job to confirm the runner no longer hangs when the job OOMs