### PR TITLE
cluster-config: add runner-image-modules subcommand and just recipes

### DIFF
--- a/osdc/justfile
+++ b/osdc/justfile
@@ -168,6 +168,14 @@ deploy-status cluster name='':
         -o json \
     | python3 "{{SCRIPTS}}/deploy-status.py" "${ARGS[@]}"
 
+# Print the AWS region for a cluster (single source of truth: clusters.yaml)
+region cluster:
+    @export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; uv run {{CFG}} {{cluster}} region
+
+# Print the enabled modules that consume runner_image_tag (comma-separated)
+runner-image-modules cluster:
+    @export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; uv run {{CFG}} {{cluster}} runner-image-modules
+
 # Update kubeconfig for a cluster (aws eks update-kubeconfig)
 kubeconfig cluster:
     @export CLUSTERS_YAML="{{CLUSTERS_YAML}}"; \

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -18,6 +18,10 @@ Usage:
     # Check if a module is enabled
     cluster-config.py arc-staging has-module arc      -> exits 0 (true) or 1 (false)
 
+    # List the enabled modules that consume runner_image_tag (comma-separated)
+    cluster-config.py arc-cbr-production runner-image-modules
+        -> arc-runners,arc-runners-b200,arc-runners-h100
+
     # List all cluster IDs
     cluster-config.py --list
 """
@@ -29,6 +33,13 @@ from pathlib import Path
 import yaml
 
 CONFIG_PATH = Path(os.environ.get("CLUSTERS_YAML", Path(__file__).resolve().parent.parent / "clusters.yaml"))
+
+# Modules whose generated manifests embed `runner_image_tag` from clusters.yaml.
+# Authoritative source: modules/arc-runners/scripts/python/generate_runners.py is
+# re-used by the arc-runners-{b200,h100} delegates via their deploy.sh wrappers.
+# If a new module starts reading `runner_image_tag`, add it here so the
+# Renovate auto-update pipeline redeploys it on every bump.
+RUNNER_IMAGE_CONSUMER_MODULES = ("arc-runners", "arc-runners-b200", "arc-runners-h100")
 
 
 def load_config():
@@ -111,6 +122,10 @@ def main():
     elif cmd == "modules":
         for m in cluster_cfg.get("modules", []):
             print(m)
+    elif cmd == "runner-image-modules":
+        enabled = cluster_cfg.get("modules", []) or []
+        consumers = [m for m in enabled if m in RUNNER_IMAGE_CONSUMER_MODULES]
+        print(",".join(consumers))
     elif cmd == "state_bucket":
         print(cluster_cfg.get("state_bucket", f"ciforge-tfstate-{cluster_id}"))
     elif cmd == "region":

--- a/osdc/scripts/test_cluster_config.py
+++ b/osdc/scripts/test_cluster_config.py
@@ -328,6 +328,56 @@ class TestMain:
         assert "monitoring" in lines
         assert "buildkit" in lines
 
+    def test_runner_image_modules_staging(self, capsys):
+        """Staging enables arc-runners only (no -b200/-h100) — output is that single entry."""
+        code = run_main("staging", "runner-image-modules")
+        assert code == 0
+        assert capsys.readouterr().out.strip() == "arc-runners"
+
+    def test_runner_image_modules_production(self, capsys):
+        """Production enables arc-runners; the -b200/-h100 delegates are not in
+        FAKE_CONFIG, so only arc-runners appears."""
+        code = run_main("production", "runner-image-modules")
+        assert code == 0
+        assert capsys.readouterr().out.strip() == "arc-runners"
+
+    def test_runner_image_modules_preserves_yaml_order(self, capsys, monkeypatch):
+        """Output ordering matches the cluster's modules: list, not the
+        RUNNER_IMAGE_CONSUMER_MODULES constant — keeps the filter purely
+        a membership test."""
+        cfg = {
+            "defaults": {},
+            "clusters": {
+                "ordered": {
+                    "cluster_name": "ordered",
+                    "region": "r",
+                    "modules": ["arc-runners-h100", "arc-runners", "arc-runners-b200"],
+                },
+            },
+        }
+        monkeypatch.setattr(cluster_config, "load_config", lambda: cfg)
+        code = run_main("ordered", "runner-image-modules")
+        assert code == 0
+        assert capsys.readouterr().out.strip() == "arc-runners-h100,arc-runners,arc-runners-b200"
+
+    def test_runner_image_modules_none_enabled(self, capsys, monkeypatch):
+        """Cluster with no runner-image consumer modules prints an empty line —
+        the auto-deploy workflow keys on this to skip the cluster entirely."""
+        cfg = {
+            "defaults": {},
+            "clusters": {
+                "no-runners": {
+                    "cluster_name": "no-runners",
+                    "region": "r",
+                    "modules": ["karpenter", "monitoring"],
+                },
+            },
+        }
+        monkeypatch.setattr(cluster_config, "load_config", lambda: cfg)
+        code = run_main("no-runners", "runner-image-modules")
+        assert code == 0
+        assert capsys.readouterr().out.strip() == ""
+
     def test_has_module_present(self):
         code = run_main("staging", "has-module", "karpenter")
         assert code == 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* #642
* #641
* #640
* #639
* #638
* #637
* #636
* #635
* __->__ #634

**Impact:** OSDC tooling for cluster config introspection
**Risk:** low

## What
Adds a new `runner-image-modules` subcommand to `cluster-config.py` that
returns the comma-separated list of enabled modules consuming
`runner_image_tag`. Exposes `region` and `runner-image-modules` as `just`
recipes so workflows and operators can call them uniformly.

## Why
Upcoming Renovate-driven runner image auto-update needs a single source of
truth for which modules to redeploy when `runner_image_tag` bumps. CI
workflows also need a uniform way to derive the AWS region for a cluster
without hardcoding values.

## How
- New constant `RUNNER_IMAGE_CONSUMER_MODULES` lists the modules whose
  generated manifests embed `runner_image_tag` (arc-runners and its
  b200/h100 delegates).
- `runner-image-modules` filters the cluster's enabled modules through
  that list and prints comma-joined output.
- `just region` and `just runner-image-modules` thin-wrap the existing
  cluster-config commands so downstream tooling has one entrypoint.

## Changes
- `osdc/scripts/cluster-config.py`: new subcommand + consumer list.
- `osdc/scripts/test_cluster_config.py`: unit tests for the new path.
- `osdc/justfile`: two new recipes.

## Testing
- `cd osdc && just test` to run unit tests.
- `just region arc-staging` and `just runner-image-modules arc-staging`
  for manual sanity.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>