### PR TITLE
_osdc-deploy: add modules/ref inputs and dynamic-region aws-login action

### DIFF
--- a/.github/actions/osdc-aws-login/action.yml
+++ b/.github/actions/osdc-aws-login/action.yml
@@ -1,0 +1,42 @@
+name: "OSDC: Resolve cluster region and configure AWS credentials"
+description: "Looks up the cluster's AWS region from clusters.yaml and assumes the OSDC deploy role."
+inputs:
+  cluster:
+    description: "Cluster id from clusters.yaml"
+    required: true
+  account-id:
+    description: "AWS account ID (typically secrets.META_AWS_ACC_ID)"
+    required: true
+  role:
+    description: "AWS IAM role to assume (typically secrets.META_AWS_DEPLOY_ROLE)"
+    required: true
+  role-duration-seconds:
+    description: "STS session duration"
+    required: false
+    default: "7200"
+outputs:
+  region:
+    description: "Resolved AWS region"
+    value: ${{ steps.region.outputs.region }}
+runs:
+  using: composite
+  steps:
+    - name: Determine AWS region
+      id: region
+      shell: bash
+      working-directory: osdc
+      run: |
+        set -euo pipefail
+        REGION="$(just region "${{ inputs.cluster }}")"
+        if [ -z "$REGION" ]; then
+          echo "::error::just region returned empty for cluster '${{ inputs.cluster }}'"
+          exit 1
+        fi
+        echo "region=$REGION" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.account-id }}:role/${{ inputs.role }}
+        aws-region: ${{ steps.region.outputs.region }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -37,6 +37,16 @@ on:
         required: false
         type: boolean
         default: false
+      modules:
+        description: "Comma-separated list of modules to deploy with `just deploy-module` (empty = full `just deploy`)"
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Git ref (branch, tag, or SHA) to check out. Empty = the ref that triggered the caller workflow."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -59,6 +69,8 @@ jobs:
         working-directory: osdc
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
@@ -81,12 +93,13 @@ jobs:
         if: ${{ !inputs.skip_lint_test }}
         run: just test
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      - name: Configure AWS for cluster
+        id: aws
+        uses: ./.github/actions/osdc-aws-login
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
-          aws-region: us-west-1
-          role-duration-seconds: 7200
+          cluster: ${{ inputs.cluster }}
+          account-id: ${{ secrets.META_AWS_ACC_ID }}
+          role: ${{ secrets.META_AWS_DEPLOY_ROLE }}
 
       # Register QEMU binfmt handlers so `docker build --platform linux/arm64`
       # works on an amd64 runner. The base deploy builds image-cache-janitor
@@ -97,8 +110,21 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Deploy ${{ inputs.cluster }}
-        run: just deploy "${{ inputs.cluster }}"
+        run: |
+          set -euo pipefail
+          if [ -z "${MODULES}" ]; then
+            just deploy "${CLUSTER}"
+          else
+            IFS=',' read -ra MODULE_LIST <<< "${MODULES}"
+            for module in "${MODULE_LIST[@]}"; do
+              module="$(echo "$module" | tr -d '[:space:]')"
+              [ -z "${module}" ] && continue
+              just deploy-module "${CLUSTER}" "${module}"
+            done
+          fi
         env:
+          CLUSTER: ${{ inputs.cluster }}
+          MODULES: ${{ inputs.modules }}
           OSDC_CONFIRM: "yes"
           # smoke runs as a dedicated job below, skip the in-deploy step
           OSDC_SMOKE: "no"
@@ -117,6 +143,8 @@ jobs:
         working-directory: osdc
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
@@ -131,12 +159,13 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      - name: Configure AWS for cluster
+        id: aws
+        uses: ./.github/actions/osdc-aws-login
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
-          aws-region: us-west-1
-          role-duration-seconds: 7200
+          cluster: ${{ inputs.cluster }}
+          account-id: ${{ secrets.META_AWS_ACC_ID }}
+          role: ${{ secrets.META_AWS_DEPLOY_ROLE }}
 
       - name: Run smoke tests
         run: just smoke "${{ inputs.cluster }}"
@@ -153,6 +182,8 @@ jobs:
         working-directory: osdc
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install just
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
@@ -172,12 +203,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CANARY_GITHUB_TOKEN }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      - name: Configure AWS for cluster
+        id: aws
+        uses: ./.github/actions/osdc-aws-login
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.META_AWS_ACC_ID }}:role/${{ secrets.META_AWS_DEPLOY_ROLE }}
-          aws-region: us-west-1
-          role-duration-seconds: 7200
+          cluster: ${{ inputs.cluster }}
+          account-id: ${{ secrets.META_AWS_ACC_ID }}
+          role: ${{ secrets.META_AWS_DEPLOY_ROLE }}
 
       - name: Run integration tests
         run: just integration-test "${{ inputs.cluster }}" --skip-drain --skip-smoke --skip-compactor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* #642
* #641
* #640
* #639
* #638
* #637
* #636
* __->__ #635
* #634

**Impact:** OSDC reusable deploy workflow + GitHub composite action
**Risk:** medium

## What
Introduces a new `./.github/actions/osdc-aws-login` composite action that
derives the AWS region from `just region <cluster>` and configures AWS
credentials, then refactors `_osdc-deploy.yml` to use it. Adds two new
inputs to `_osdc-deploy.yml`: `modules` (comma-separated list for partial
deploys) and `ref` (git ref to check out for the deploy).

## Why
- Region was hard-coded in three places across `_osdc-deploy.yml`; future
  multi-region clusters and PR-validation flows need region resolved
  dynamically per cluster.
- The auto-update + PR-validate pipelines need a way to deploy only the
  affected modules from a specific commit SHA (e.g. a Renovate PR head).

## How
- New composite action `osdc-aws-login` runs `just region <cluster>` and
  passes the result to `aws-actions/configure-aws-credentials`. Outputs
  the resolved region for downstream steps that need it.
- `_osdc-deploy.yml` replaces three inline configure-aws-credentials
  blocks with the composite action.
- `modules` input is plumbed through to `just deploy-module`/`deploy-base`
  so callers can scope a deploy to a subset of modules.
- `ref` input is plumbed through to `actions/checkout` so deploys can
  target any commit, defaulting to the workflow's own ref.

## Changes
- `.github/actions/osdc-aws-login/action.yml`: new composite action.
- `.github/workflows/_osdc-deploy.yml`: new inputs + 3 login-call sites
  refactored to the composite.

## Testing
- Dispatch `_osdc-deploy.yml` against a staging cluster after merge to
  confirm region resolution and module scoping work end-to-end.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>