### PR TITLE
renovate: bootstrap runner_image_tag auto-bump pipeline

### DIFF
--- a/.github/workflows/osdc-renovate.yml
+++ b/.github/workflows/osdc-renovate.yml
@@ -1,0 +1,80 @@
+name: "OSDC: Renovate (runner image)"
+
+# Scheduled bi-weekly check for new actions/runner releases. Opens a PR when
+# a release is at least 5 days old (see osdc/renovate.json minimumReleaseAge).
+# The PR is auto-approved by osdc-renovate-autoapprove.yml and routed through
+# the merge queue, which triggers osdc-pre-merge.yml for full staging
+# validation. After merge, osdc-auto-update-deploy-prod.yml deploys to both
+# prod clusters sequentially.
+#
+# UPDATEBOT_TOKEN is the shared `pytorchupdatebot` PAT maintained by the
+# pytorch/test-infra team (also used by
+# pytorch/test-infra/.github/actions/update-commit-hash). Reusing it avoids
+# minting a new bot account that would have to sign the Meta CLA before its
+# commits could land. The token likely has broader org-wide scope than this
+# workflow strictly requires — that scope is outside our control.
+#
+# The token is read from the dedicated `osdc-renovate` GitHub Environment so
+# only opted-in jobs in this repo can read it. The Environment must NOT have
+# required reviewers or a wait timer (the auto-update pipeline runs
+# unattended on the happy path); deployment-branch policy should restrict
+# to `main`.
+#
+# If UPDATEBOT_TOKEN is ever revoked or replaced with a dedicated PAT for
+# this workflow, the minimum required scopes are:
+#   - Contents: Read and write       (push renovate-runner/* branches)
+#   - Pull requests: Read and write  (open PRs)
+#   - Metadata: Read                 (always required)
+#   - And emphatically NOT: Workflows (would allow self-modification of
+#     these workflows), Administration, Actions, Secrets, or any
+#     organization permissions. A token with Workflows scope can bypass
+#     every defense-in-depth check below.
+on:
+  schedule:
+    # Mon + Thu, 14:00 UTC. 3-4 day cadence absorbs GitHub cron drift.
+    - cron: "0 14 * * 1,4"
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Dry run (log only, no PR)"
+        required: false
+        type: boolean
+        default: false
+      logLevel:
+        description: "Log level"
+        required: false
+        type: choice
+        default: info
+        options:
+          - info
+          - debug
+
+permissions:
+  contents: read
+
+concurrency:
+  group: osdc-renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    environment: osdc-renovate
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          configurationFile: osdc/renovate.json
+          token: ${{ secrets.UPDATEBOT_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_DRY_RUN: ${{ (inputs.dryRun && 'full') || '' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_PLATFORM: github
+          # NOTE: The downstream auto-approve and auto-deploy workflows compare
+          # pull_request.user.login against vars.OSDC_RENOVATE_BOT_LOGIN, which
+          # must be set to "pytorchupdatebot" (the GitHub login that owns
+          # UPDATEBOT_TOKEN). The email's local part is unrelated to that check.
+          RENOVATE_GIT_AUTHOR: "PyTorch UpdateBot <pytorchupdatebot@users.noreply.github.com>"

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -62,7 +62,8 @@ defaults:
     pdb_min_available: 1
   arc:
     chart_version: "0.14.1-jeanschmidt.11"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
-    runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
+    # renovate: keep marker — Renovate auto-bumps only lines tagged with this comment; per-cluster overrides are not matched. ghcr.io/actions/actions-runner tag — pinned to avoid :latest.
+    runner_image_tag: "2.334.0"
     replica_count: 4
     log_level: info
     controller_cpu_request: "1"

--- a/osdc/renovate.json
+++ b/osdc/renovate.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "onboarding": false,
+  "requireConfig": "optional",
+  "branchPrefix": "renovate-runner/",
+  "labels": ["auto-runner-update", "renovate"],
+  "rangeStrategy": "pin",
+  "enabledManagers": ["custom.regex"],
+  "platformAutomerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^osdc/clusters\\.yaml$/"],
+      "matchStrings": [
+        "# renovate: keep marker[^\\n]*\\n\\s*runner_image_tag:\\s*[\"'](?<currentValue>[^\"']+)[\"']"
+      ],
+      "depNameTemplate": "ghcr.io/actions/actions-runner",
+      "packageNameTemplate": "ghcr.io/actions/actions-runner",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["ghcr.io/actions/actions-runner"],
+      "allowedVersions": "<3.0.0",
+      "ignoreUnstable": true,
+      "minimumReleaseAge": "5 days",
+      "prCreation": "immediate",
+      "commitMessageTopic": "GHA runner image",
+      "commitMessageAction": "bump",
+      "prBodyNotes": [
+        "Auto-update for `ghcr.io/actions/actions-runner`. After approval and merge, prod deploy fires via `osdc-auto-update-deploy-prod.yml`."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* #642
* #641
* #640
* #639
* #638
* __->__ #637
* #636
* #635
* #634

**Impact:** OSDC clusters.yaml + new Renovate workflow
**Risk:** low

## What
Bootstraps Renovate for OSDC. Adds a `renovate.json` config that detects
the runner image tag pinned in `osdc/clusters.yaml`, a scheduled GitHub
Actions workflow that runs Renovate, and a `renovate: keep marker`
comment on the defaults' `runner_image_tag` line so the regex matches
only the defaults (not per-cluster overrides).

## Why
We pin `ghcr.io/actions/actions-runner` and want patch/minor bumps to
flow through automatically with a normal PR review path — instead of
relying on manual sweeps.

## How
- `osdc/renovate.json`: docker datasource targeting the marker line,
  with strict regex extraction so per-cluster overrides stay untouched.
- `.github/workflows/osdc-renovate.yml`: scheduled (and manually
  dispatchable) workflow that runs Renovate. Opens PRs only; auto-merge
  / auto-deploy are wired up in subsequent commits.
- `osdc/clusters.yaml`: adds the marker comment on the defaults line.

## Changes
- `osdc/renovate.json`: new.
- `.github/workflows/osdc-renovate.yml`: new.
- `osdc/clusters.yaml`: 1 comment + 1 line reflow on the defaults entry.

## Notes
This commit only opens Renovate PRs. The auto-approve and auto-deploy
workflows land in later commits in this stack.

## Testing
- Manually dispatch `osdc-renovate.yml` once landed; confirm a PR is
  opened if a newer `actions/actions-runner` tag exists upstream.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>