### PR TITLE
osdc-pre-merge: doc updates and path-filter for new workflows

### DIFF
--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -14,7 +14,9 @@ permissions:
 # per workflow invocation against arc-staging. cancel-in-progress: false
 # so a later run waits for the prior run's slow jobs to finish before
 # deploy/smoke/integration even start — protects test fixtures from
-# interleaving.
+# interleaving. Shared with osdc-pr-validate.yml so PR-branch validation
+# dispatched by the Renovate autoapprover queues behind any merge_group
+# run touching staging, and vice versa.
 concurrency:
   group: osdc-staging
   cancel-in-progress: false
@@ -22,8 +24,8 @@ concurrency:
 jobs:
   # ------------------------------------------------------------------
   # Path filter: skip expensive jobs when no OSDC files changed.
-  # The marker job (pre-merge-ok) still runs and reports green so the
-  # merge queue's required check resolves.
+  # The marker job (pre-merge-ok) still runs and reports green so any
+  # legacy required-check configuration on the merge queue resolves.
   # ------------------------------------------------------------------
   changes:
     runs-on: ubuntu-latest
@@ -45,14 +47,18 @@ jobs:
               - '!osdc/**/test_*.py'
               - '!osdc/**/*_test.py'
               - '!osdc/**/tests/**'
-              - '.github/workflows/osdc-deploy-prod.yml'
-              - '.github/workflows/osdc-pre-merge.yml'
               - '.github/workflows/_osdc-deploy.yml'
               - '.github/workflows/_osdc-slow-tests.yml'
+              - '.github/workflows/osdc-auto-update-deploy-prod.yml'
+              - '.github/workflows/osdc-deploy-prod.yml'
+              - '.github/workflows/osdc-pre-merge.yml'
+              - '.github/workflows/osdc-renovate-autoapprove.yml'
+              - '.github/workflows/osdc-renovate.yml'
 
   # ------------------------------------------------------------------
-  # Fast set: deploy + smoke + integration. Gates the merge queue
-  # via the pre-merge-ok marker job below.
+  # Fast set: deploy + smoke + integration. Informational signal on
+  # merge_group runs. Renovate PR merges are gated by osdc-pr-validate.yml
+  # via the osdc/pr-validate commit status, not by this workflow.
   # ------------------------------------------------------------------
   deploy-fast:
     needs: changes
@@ -87,14 +93,18 @@ jobs:
     secrets: inherit
 
   # ------------------------------------------------------------------
-  # Marker job: the SOLE required status check on the merge queue.
+  # Marker job. Historically the sole required status check on the
+  # merge queue; under script-gated Renovate merging, the actual gate
+  # is the osdc/pr-validate commit status posted by osdc-pr-validate.yml,
+  # and this marker is retained as a no-op signal for any legacy
+  # branch-protection configuration still pointing at it.
   # Reports green when either:
   #   (a) no osdc changes (path filter excluded), OR
   #   (b) deploy-fast succeeded.
   # slow-tests result is NOT considered — they're informational.
   # if: always() is required so this job still runs (and reports) when
-  # deploy-fast is skipped by the path filter; otherwise the required
-  # check never reports and the merge queue times out.
+  # deploy-fast is skipped by the path filter; otherwise nothing
+  # reports back on the merge_group event.
   # ------------------------------------------------------------------
   pre-merge-ok:
     needs: [changes, deploy-fast]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* #642
* #641
* #640
* #639
* __->__ #638
* #637
* #636
* #635
* #634

**Impact:** OSDC pre-merge workflow comments + path filter
**Risk:** low

## What
Comment/wording-only updates to the concurrency block and marker job to
document that the merge gate has moved to the `osdc/pr-validate` commit
status. Also adds the upcoming auto-update, renovate, and renovate
autoapprove workflow paths to the `paths:` filter so edits to those
files still trigger pre-merge.

## Why
The pre-merge workflow is being supplemented (not replaced) by per-PR
deploy validation; the docstrings need to reflect that. The new
workflows themselves must be covered by the same pre-merge gate.

## How
- Updated concurrency comment to mention sharing with
  `osdc-pr-validate.yml`.
- Updated marker job comments to point at the new merge gate signal.
- Extended `paths:` filter to include the three new workflow files.
- No behavioral changes to the gate itself.

## Changes
- `.github/workflows/osdc-pre-merge.yml`: comments + path-filter only.

## Testing
- Open a PR touching any of the new workflows; confirm pre-merge runs.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>