### PR TITLE
scripts: add wait-for-pr-validate.py dispatcher + status poller

### DIFF
--- a/osdc/scripts/test_wait_for_pr_validate.py
+++ b/osdc/scripts/test_wait_for_pr_validate.py
@@ -1,0 +1,402 @@
+"""Unit tests for wait-for-pr-validate.py."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The module is named wait-for-pr-validate.py (hyphens), so load via importlib.
+_spec = importlib.util.spec_from_file_location(
+    "wait_for_pr_validate",
+    Path(__file__).resolve().parent / "wait-for-pr-validate.py",
+)
+wait_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wait_mod)
+
+
+VALID_SHA = "a" * 40
+VALID_REF = "renovate-runner/main-actions-runner"
+
+
+@pytest.fixture(autouse=True)
+def _required_env(monkeypatch, tmp_path):
+    """Default env that satisfies _env() lookups for almost every test."""
+    out_file = tmp_path / "GITHUB_OUTPUT"
+    out_file.touch()
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setenv("HEAD_SHA", VALID_SHA)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out_file))
+    # Make the poll loop fast.
+    monkeypatch.setenv("POLL_INTERVAL_SEC", "0")
+    monkeypatch.setenv("MAX_WAIT_SEC", "1")
+    return out_file
+
+
+def _read_output(path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in Path(path).read_text().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_env_required(monkeypatch):
+    monkeypatch.delenv("REPO", raising=False)
+    with pytest.raises(SystemExit, match="REPO"):
+        wait_mod._env("REPO")
+
+
+def test_env_default(monkeypatch):
+    monkeypatch.delenv("FOO", raising=False)
+    assert wait_mod._env("FOO", "bar") == "bar"
+
+
+def test_env_returns_set_value(monkeypatch):
+    monkeypatch.setenv("FOO", "baz")
+    assert wait_mod._env("FOO", "bar") == "baz"
+
+
+def test_int_env_default(monkeypatch):
+    monkeypatch.delenv("FOO", raising=False)
+    assert wait_mod._int_env("FOO", 42) == 42
+
+
+def test_int_env_parses(monkeypatch):
+    monkeypatch.setenv("FOO", "7")
+    assert wait_mod._int_env("FOO", 42) == 7
+
+
+def test_int_env_invalid(monkeypatch):
+    monkeypatch.setenv("FOO", "not-a-number")
+    with pytest.raises(SystemExit, match="must be an integer"):
+        wait_mod._int_env("FOO", 1)
+
+
+def test_emit_output_writes_to_file(_required_env):
+    wait_mod._emit_output("approve", "all good")
+    out = _read_output(_required_env)
+    assert out == {"decision": "approve", "reason": "all good"}
+
+
+def test_emit_output_without_github_output(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    wait_mod._emit_output("approve", "no file set")
+    captured = capsys.readouterr()
+    assert "decision=approve" in captured.out
+    assert "reason=no file set" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# _gh_api retry semantics
+# ---------------------------------------------------------------------------
+
+
+def _run_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def test_gh_api_success_first_try():
+    with patch.object(wait_mod.subprocess, "run", return_value=_run_result(0, '{"ok":true}')) as m:
+        result = wait_mod._gh_api(["repos/x/y"], retries=3, backoff=0)
+    assert result == '{"ok":true}'
+    assert m.call_count == 1
+
+
+def test_gh_api_retries_on_transient_then_succeeds():
+    sequence = [_run_result(1, stderr="500 server error"), _run_result(0, "ok")]
+    with patch.object(wait_mod.subprocess, "run", side_effect=sequence), patch.object(wait_mod.time, "sleep"):
+        result = wait_mod._gh_api(["x"], retries=3, backoff=0)
+    assert result == "ok"
+
+
+def test_gh_api_hard_fails_on_401():
+    with (
+        patch.object(wait_mod.subprocess, "run", return_value=_run_result(1, stderr="401 Bad credentials")),
+        pytest.raises(RuntimeError, match="non-retryable"),
+    ):
+        wait_mod._gh_api(["x"], retries=5, backoff=0)
+
+
+def test_gh_api_hard_fails_on_403_resource_not_accessible():
+    with (
+        patch.object(
+            wait_mod.subprocess, "run", return_value=_run_result(1, stderr="Resource not accessible by integration")
+        ),
+        pytest.raises(RuntimeError, match="non-retryable"),
+    ):
+        wait_mod._gh_api(["x"], retries=5, backoff=0)
+
+
+def test_gh_api_exhausts_retries():
+    with (
+        patch.object(wait_mod.subprocess, "run", return_value=_run_result(1, stderr="500")),
+        patch.object(wait_mod.time, "sleep"),
+        pytest.raises(RuntimeError, match="exhausted retries"),
+    ):
+        wait_mod._gh_api(["x"], retries=2, backoff=0)
+
+
+# ---------------------------------------------------------------------------
+# _gh_workflow_run
+# ---------------------------------------------------------------------------
+
+
+def test_gh_workflow_run_invokes_cli_correctly():
+    with patch.object(wait_mod.subprocess, "run", return_value=_run_result(0)) as m:
+        wait_mod._gh_workflow_run("o/r", "w.yml", "main", {"a": "1", "b": "2"})
+    args = m.call_args[0][0]
+    assert args[:2] == ["gh", "workflow"]
+    assert "--ref" in args
+    assert args[args.index("--ref") + 1] == "main"
+    assert args.count("-f") == 2
+
+
+def test_gh_workflow_run_raises_on_failure():
+    with (
+        patch.object(wait_mod.subprocess, "run", return_value=_run_result(1, stderr="nope")),
+        pytest.raises(RuntimeError, match="gh workflow run failed"),
+    ):
+        wait_mod._gh_workflow_run("o/r", "w.yml", "main", {})
+
+
+# ---------------------------------------------------------------------------
+# _read_status
+# ---------------------------------------------------------------------------
+
+
+def test_read_status_missing_returns_empty():
+    payload = '{"statuses": []}'
+    with patch.object(wait_mod, "_gh_api", return_value=payload):
+        state = wait_mod._read_status("o/r", VALID_SHA)
+    assert state == ""
+
+
+def test_read_status_returns_state():
+    payload = (
+        '{"statuses": [{"context": "osdc/pr-validate", "state": "pending", "updated_at": "2026-05-26T20:00:00Z"}]}'
+    )
+    with patch.object(wait_mod, "_gh_api", return_value=payload):
+        state = wait_mod._read_status("o/r", VALID_SHA)
+    assert state == "pending"
+
+
+def test_read_status_picks_latest_when_multiple():
+    payload = (
+        '{"statuses": ['
+        '{"context": "osdc/pr-validate", "state": "pending", "updated_at": "2026-01-01T00:00:00Z"},'
+        '{"context": "osdc/pr-validate", "state": "success", "updated_at": "2026-05-26T00:00:00Z"},'
+        '{"context": "other", "state": "failure", "updated_at": "2026-05-27T00:00:00Z"}'
+        "]}"
+    )
+    with patch.object(wait_mod, "_gh_api", return_value=payload):
+        state = wait_mod._read_status("o/r", VALID_SHA)
+    assert state == "success"
+
+
+# ---------------------------------------------------------------------------
+# main() integration paths
+# ---------------------------------------------------------------------------
+
+
+def _pr_json(sha=VALID_SHA, ref=VALID_REF) -> str:
+    return f'{{"head": {{"sha": "{sha}", "ref": "{ref}"}}}}'
+
+
+def test_main_rejects_invalid_head_sha(_required_env, monkeypatch):
+    monkeypatch.setenv("HEAD_SHA", "deadbeef")  # too short
+    rc = wait_mod.main()
+    assert rc == 0
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-validation-failed"
+    assert "40-char hex" in out["reason"]
+
+
+def test_main_rejects_invalid_head_ref(_required_env):
+    with patch.object(wait_mod, "_read_pr", return_value={"head": {"sha": VALID_SHA, "ref": "main"}}):
+        rc = wait_mod.main()
+    assert rc == 0
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-branch-name-invalid"
+
+
+def test_main_rejects_head_ref_with_dash_prefix(_required_env):
+    with patch.object(wait_mod, "_read_pr", return_value={"head": {"sha": VALID_SHA, "ref": "-fno-good"}}):
+        rc = wait_mod.main()
+    assert rc == 0
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-branch-name-invalid"
+
+
+def test_main_happy_path_status_already_green(_required_env):
+    with (
+        patch.object(wait_mod, "_read_pr", return_value={"head": {"sha": VALID_SHA, "ref": VALID_REF}}),
+        patch.object(wait_mod, "_read_status", return_value="success"),
+    ):
+        rc = wait_mod.main()
+    out = _read_output(_required_env)
+    assert rc == 0
+    assert out["decision"] == "approve"
+
+
+def test_main_dispatches_when_no_status_then_succeeds(_required_env):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    states = ["", "success"]
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", side_effect=states),
+        patch.object(wait_mod, "_dispatch_validate") as dispatch,
+    ):
+        rc = wait_mod.main()
+    assert rc == 0
+    out = _read_output(_required_env)
+    assert out["decision"] == "approve"
+    dispatch.assert_called_once_with("owner/repo", "42", VALID_SHA)
+
+
+def test_main_closes_on_failure(_required_env):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", return_value="failure"),
+    ):
+        rc = wait_mod.main()
+    out = _read_output(_required_env)
+    assert rc == 0
+    assert out["decision"] == "close-validation-failed"
+
+
+def test_main_closes_on_error(_required_env):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", return_value="error"),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-validation-failed"
+
+
+def test_main_closes_on_head_moved(_required_env):
+    pr_initial = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    new_sha = "b" * 40
+    pr_moved = {"head": {"sha": new_sha, "ref": VALID_REF}}
+    with patch.object(wait_mod, "_read_pr", side_effect=[pr_initial, pr_moved]):
+        rc = wait_mod.main()
+    out = _read_output(_required_env)
+    assert rc == 0
+    assert out["decision"] == "close-head-moved"
+    assert new_sha in out["reason"]
+
+
+def test_main_closes_on_dispatch_failure(_required_env):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", return_value=""),
+        patch.object(wait_mod, "_dispatch_validate", side_effect=RuntimeError("boom")),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-dispatch-failed"
+
+
+def test_main_timeout(_required_env, monkeypatch):
+    monkeypatch.setenv("MAX_WAIT_SEC", "0")
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", return_value="pending"),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "close-validation-timeout"
+
+
+def test_main_polls_pending_until_success(_required_env):
+    """No status initially → dispatch once; then pending pending success → approve, no re-dispatch."""
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    states = ["", "pending", "pending", "success"]
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", side_effect=states),
+        patch.object(wait_mod, "_dispatch_validate") as dispatch,
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "approve"
+    assert dispatch.call_count == 1
+
+
+def test_main_unexpected_state_continues_polling(_required_env, capsys):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    states = ["weird", "success"]
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", side_effect=states),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "approve"
+    assert "unexpected" in capsys.readouterr().out
+
+
+def test_main_recovers_from_transient_pr_read_failure(_required_env):
+    """Single failure to re-read PR mid-poll should not abort the wait."""
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    pr_calls = [pr, RuntimeError("transient"), pr]
+    states = ["pending", "success"]
+
+    def pr_side(*_a, **_kw):
+        r = pr_calls.pop(0)
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+    with (
+        patch.object(wait_mod, "_read_pr", side_effect=pr_side),
+        patch.object(wait_mod, "_read_status", side_effect=states),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "approve"
+
+
+def test_main_recovers_from_transient_status_read_failure(_required_env):
+    pr = {"head": {"sha": VALID_SHA, "ref": VALID_REF}}
+    status_results = [RuntimeError("transient"), "success"]
+
+    def status_side(*_a, **_kw):
+        r = status_results.pop(0)
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+    with (
+        patch.object(wait_mod, "_read_pr", return_value=pr),
+        patch.object(wait_mod, "_read_status", side_effect=status_side),
+        patch.object(wait_mod, "_dispatch_validate"),
+    ):
+        wait_mod.main()
+    out = _read_output(_required_env)
+    assert out["decision"] == "approve"
+
+
+def test_dispatch_validate_uses_main_ref():
+    with patch.object(wait_mod, "_gh_workflow_run") as m:
+        wait_mod._dispatch_validate("o/r", "42", VALID_SHA)
+    _, kwargs = m.call_args
+    assert kwargs["ref"] == "main"
+    assert kwargs["inputs"]["head_sha"] == VALID_SHA
+    assert kwargs["inputs"]["pr_number"] == "42"

--- a/osdc/scripts/wait-for-pr-validate.py
+++ b/osdc/scripts/wait-for-pr-validate.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Wait for the osdc/pr-validate commit status to flip to success or failure.
+
+Used by osdc-renovate-autoapprove.yml to gate Renovate PR merges on a
+staging validation that runs in osdc-pr-validate.yml. This script is the
+"client side" of the gate: it dispatches the validation workflow (if no
+status exists yet), polls the commit status, and emits a final decision
+into $GITHUB_OUTPUT for the surrounding workflow.
+
+Inputs (env vars, all required):
+    GH_TOKEN     GitHub token with actions:write + statuses:read scope
+    REPO         owner/repo (e.g. pytorch/ci-infra)
+    PR_NUMBER    PR number (integer as string)
+    HEAD_SHA     full 40-char SHA the autoapprover validated and will merge
+
+Optional env vars:
+    POLL_INTERVAL_SEC  default 90
+    MAX_WAIT_SEC       default 21600 (6h)
+    GITHUB_OUTPUT      path to the per-step output file (set automatically
+                       by GH Actions runner; required when run by a step)
+
+Outputs (appended to $GITHUB_OUTPUT):
+    decision=approve | close-head-moved | close-validation-failed |
+             close-validation-timeout | close-dispatch-failed |
+             close-branch-name-invalid
+    reason=<human-readable explanation>
+
+Hardening notes (each is load-bearing — see PR review):
+    - Dispatch uses --ref main so the workflow FILE comes from a trusted
+      branch. The PR's head_sha is passed as input so the validated CODE
+      is still the PR head. A compromised PR-opening bot cannot swap the
+      workflow file underneath us.
+    - Re-reads head.sha on every poll. If the PR is force-pushed/rebased
+      mid-wait, the old SHA's status is meaningless — bail with
+      close-head-moved so Renovate reopens cleanly next cycle.
+    - Defensive branch-name regex on head.ref before any gh calls that
+      touch ref-shaped strings.
+    - All gh api calls have bounded retry with backoff to absorb the
+      occasional transient 5xx during a 6h wait.
+    - A persistent `pending` state is treated as "validation in progress
+      or queued behind the osdc-staging concurrency group" — the script
+      just keeps polling until the status flips or MAX_WAIT_SEC elapses.
+      If the post job dies (rare: runner eviction at the wrong moment),
+      the script will time out and Renovate reopens on the next cycle.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from typing import Any
+
+# Strict shape we accept: only the canonical renovate-runner branch
+# prefix with no leading-dash flag-injection risk.
+HEAD_REF_PATTERN = re.compile(r"^renovate-runner/[A-Za-z0-9._/-]+$")
+
+VALIDATE_WORKFLOW = "osdc-pr-validate.yml"
+STATUS_CONTEXT = "osdc/pr-validate"
+
+# Always dispatch the workflow at main so the workflow definition cannot
+# be swapped by a malicious PR head.
+DISPATCH_REF = "main"
+
+
+def _env(name: str, default: str | None = None) -> str:
+    v = os.environ.get(name, default)
+    if v is None or v == "":
+        sys.exit(f"missing required env var: {name}")
+    return v
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        sys.exit(f"env var {name} must be an integer, got {raw!r}")
+
+
+def _emit_output(decision: str, reason: str) -> None:
+    """Append decision/reason to $GITHUB_OUTPUT for the surrounding step."""
+    print(f"decision={decision}")
+    print(f"reason={reason}")
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if out_path:
+        with open(out_path, "a") as f:
+            f.write(f"decision={decision}\n")
+            f.write(f"reason={reason}\n")
+
+
+def _gh_api(args: list[str], retries: int = 3, backoff: float = 5.0) -> str:
+    """Run `gh api ARGS` with bounded retry. Returns stdout on success.
+
+    Transient failures (network, GitHub 5xx) are swallowed up to `retries`
+    attempts. Unrecoverable failures (auth, 4xx that isn't 404) raise.
+    """
+    last_err = ""
+    for attempt in range(1, retries + 1):
+        proc = subprocess.run(
+            ["gh", "api", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            return proc.stdout
+        last_err = proc.stderr.strip() or proc.stdout.strip()
+        # Hard-fail on 4xx auth/permission errors — retry won't help.
+        if any(m in last_err for m in ("401", "403", "Bad credentials", "Resource not accessible")):
+            raise RuntimeError(f"gh api {args} failed (non-retryable): {last_err}")
+        if attempt < retries:
+            print(f"::warning::gh api transient failure (attempt {attempt}/{retries}): {last_err}")
+            time.sleep(backoff * attempt)
+    raise RuntimeError(f"gh api {args} exhausted retries: {last_err}")
+
+
+def _gh_workflow_run(repo: str, workflow: str, ref: str, inputs: dict[str, str]) -> None:
+    """Dispatch a workflow via gh CLI. Raises on failure."""
+    args = [
+        "workflow",
+        "run",
+        workflow,
+        "--repo",
+        repo,
+        "--ref",
+        ref,
+    ]
+    for k, v in inputs.items():
+        args += ["-f", f"{k}={v}"]
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh workflow run failed: {proc.stderr.strip() or proc.stdout.strip()}")
+
+
+def _read_pr(repo: str, pr_number: str) -> dict[str, Any]:
+    raw = _gh_api([f"repos/{repo}/pulls/{pr_number}"])
+    return json.loads(raw)
+
+
+def _read_status(repo: str, sha: str) -> str:
+    """Return the most recent osdc/pr-validate status state for `sha`.
+
+    Returns one of "", "pending", "success", "failure", "error" — empty
+    string when no status with that context exists on the SHA.
+    """
+    raw = _gh_api([f"repos/{repo}/commits/{sha}/status"])
+    payload = json.loads(raw)
+    matching = [s for s in payload.get("statuses", []) if s.get("context") == STATUS_CONTEXT]
+    if not matching:
+        return ""
+    # GitHub returns statuses ordered most-recent first within the combined
+    # endpoint, but be explicit: pick the one with the latest updated_at.
+    latest = max(matching, key=lambda s: s.get("updated_at", ""))
+    return latest.get("state", "")
+
+
+def _dispatch_validate(repo: str, pr_number: str, head_sha: str) -> None:
+    _gh_workflow_run(
+        repo=repo,
+        workflow=VALIDATE_WORKFLOW,
+        ref=DISPATCH_REF,
+        inputs={"pr_number": pr_number, "head_sha": head_sha},
+    )
+    print(f"Dispatched {VALIDATE_WORKFLOW} on {DISPATCH_REF} for PR #{pr_number} (sha {head_sha[:12]}).")
+
+
+def main() -> int:
+    repo = _env("REPO")
+    pr_number = _env("PR_NUMBER")
+    head_sha = _env("HEAD_SHA")
+
+    poll_interval = _int_env("POLL_INTERVAL_SEC", 90)
+    max_wait = _int_env("MAX_WAIT_SEC", 6 * 60 * 60)
+
+    if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+        _emit_output("close-validation-failed", f"HEAD_SHA is not a 40-char hex SHA: {head_sha!r}")
+        return 0
+
+    pr = _read_pr(repo, pr_number)
+    head_ref = pr.get("head", {}).get("ref", "")
+    if not HEAD_REF_PATTERN.fullmatch(head_ref):
+        _emit_output(
+            "close-branch-name-invalid",
+            f"head.ref {head_ref!r} does not match renovate-runner/<safe-chars> pattern",
+        )
+        return 0
+
+    deadline = time.monotonic() + max_wait
+    dispatched = False
+
+    while True:
+        # Bail if the PR head moved while we were waiting. A force-push
+        # invalidates the SHA we validated; only the new head's status
+        # would be meaningful, and Renovate will reopen on the next run.
+        try:
+            current_pr = _read_pr(repo, pr_number)
+        except RuntimeError as e:
+            print(f"::warning::failed to re-read PR: {e}")
+            current_pr = None
+        if current_pr is not None:
+            current_sha = current_pr.get("head", {}).get("sha", "")
+            if current_sha and current_sha != head_sha:
+                _emit_output(
+                    "close-head-moved",
+                    f"PR head moved from {head_sha} to {current_sha} during validation",
+                )
+                return 0
+
+        try:
+            state = _read_status(repo, head_sha)
+        except RuntimeError as e:
+            print(f"::warning::failed to read status: {e}")
+            state = ""
+
+        if state == "success":
+            print(f"{STATUS_CONTEXT} is green for {head_sha} — proceeding.")
+            _emit_output("approve", f"{STATUS_CONTEXT} success on {head_sha}")
+            return 0
+
+        if state in ("failure", "error"):
+            print(f"::warning::{STATUS_CONTEXT} is {state} for {head_sha} — PR will be auto-closed.")
+            _emit_output(
+                "close-validation-failed",
+                f"{STATUS_CONTEXT} status was {state} on {head_sha}",
+            )
+            return 0
+
+        if state == "":
+            # No status posted yet. On the first iteration, dispatch the
+            # validate workflow. On later iterations, just keep polling —
+            # dispatches are idempotent (osdc-staging concurrency group
+            # serializes them) and there is no reliable cheap signal to
+            # tell whether the prior dispatch is genuinely lost or just
+            # queued. If validation is truly dead, we time out at MAX_WAIT
+            # and Renovate retries next cycle.
+            if not dispatched:
+                print(f"No {STATUS_CONTEXT} status on {head_sha} yet — dispatching.")
+                try:
+                    _dispatch_validate(repo, pr_number, head_sha)
+                except RuntimeError as e:
+                    _emit_output("close-dispatch-failed", f"initial dispatch failed: {e}")
+                    return 0
+                dispatched = True
+        elif state != "pending":
+            print(f"::warning::unexpected {STATUS_CONTEXT} state {state!r} on {head_sha} — continuing to poll.")
+        # state == "pending" → validation is running (or queued behind
+        # the osdc-staging concurrency group). Just keep polling.
+
+        if time.monotonic() >= deadline:
+            _emit_output(
+                "close-validation-timeout",
+                f"timed out after {max_wait // 3600}h waiting for {STATUS_CONTEXT} on {head_sha}",
+            )
+            return 0
+
+        time.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* #642
* #641
* __->__ #640
* #639
* #638
* #637
* #636
* #635
* #634

**Impact:** OSDC scripts — new standalone CLI tool
**Risk:** low

## What
New Python CLI that dispatches `osdc-pr-validate.yml` for a given PR
number and polls the resulting `osdc/pr-validate` commit status until
it reaches a terminal state (success/failure/error/timeout). Ships
with comprehensive unit tests.

## Why
Both the Renovate auto-approve workflow and human operators need a
reliable way to fire-and-wait on the PR validate workflow without
hand-rolling polling + status parsing in shell.

## How
- Pure-Python CLI using only stdlib + `gh` via subprocess; no extra deps.
- Dispatches the workflow with the PR's head SHA, then polls the
  GitHub commit-status API at a configurable interval until the
  `osdc/pr-validate` context flips out of `pending`.
- Distinguishes timeout from failure so callers can act differently.
- Test file mocks subprocess + HTTP boundary so the suite is hermetic.

## Changes
- `osdc/scripts/wait-for-pr-validate.py`: new CLI.
- `osdc/scripts/test_wait_for_pr_validate.py`: unit tests.

## Notes
Used standalone today; wired into the autoapprove workflow later in
this stack.

## Testing
- `cd osdc && just test` runs the new test suite.
- Manual: invoke against any open OSDC PR after `osdc-pr-validate.yml`
  is deployed.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>