### PR TITLE
workflows: add osdc-renovate-autoapprove auto-merge gate

### DIFF
--- a/.github/workflows/osdc-renovate-autoapprove.yml
+++ b/.github/workflows/osdc-renovate-autoapprove.yml
@@ -1,0 +1,360 @@
+name: "OSDC: Auto-approve Renovate runner-image PRs"
+
+# Triggered by `workflow_run` after `osdc-renovate` completes. Runs in the
+# base-repo context (same secret access pull_request_target would give), so
+# GH_PYTORCHBOT_TOKEN from the `osdc-renovate` Environment is accessible.
+#
+# We do NOT touch PR-author-controlled content:
+#   - `discover` queries the API for open PRs matching the Renovate label
+#     and branch prefix and splits them by age.
+#   - `approve` operates only on the diff (a single line in
+#     osdc/clusters.yaml) — never on the PR body, title, or workflow file.
+#   - `close_stale` operates on metadata only.
+#
+# Branch ruleset on main requires 1 approving review and forbids
+# self-approval, so a SEPARATE identity approves the PR and adds it to the
+# merge queue: `osdc-renovate.yml` opens PRs as `pytorchupdatebot` (via
+# UPDATEBOT_TOKEN), this workflow approves them as `pytorchbot` (via
+# GH_PYTORCHBOT_TOKEN). Before approving, this workflow dispatches
+# osdc-pr-validate.yml against the PR head SHA and waits for the
+# `osdc/pr-validate` commit status to flip to success — that is the gate.
+# Merging happens immediately (gh pr merge --squash, no --auto) once the
+# status is green. The merge_group entrypoint in osdc-pre-merge.yml still
+# fires on the eventual merge but is informational only; GitHub does not
+# reliably enforce required checks at merge-queue time, which is why the
+# gating moved here.
+#
+# Auto-close behaviors operators should know about:
+#   - Diff-validation failure (wrong file, wrong line count, bad regex,
+#     downgrade, no-version-change): PR is closed with an explanatory
+#     comment. Renovate will reopen on the next run when a new eligible
+#     version is available.
+#   - Open >7 days: PR is closed with a comment. Renovate will reopen on
+#     the next run if the version is still relevant. To pause without
+#     auto-closure, remove the `auto-runner-update` label.
+#   - Author check failure (PR author != configured Renovate bot): job
+#     fails loudly, PR left open for human investigation (could be a
+#     mislabeling).
+#
+# GH_PYTORCHBOT_TOKEN is the shared `pytorchbot` PAT maintained by the
+# pytorch/test-infra team (also used by pytorch/pytorch's nightly approval
+# flow). Reusing it avoids minting a new bot account that would have to
+# sign the Meta CLA before its commits could land. The token likely has
+# broader org-wide scope than this workflow strictly requires — that scope
+# is outside our control.
+#
+# The token is read from the dedicated `osdc-renovate` GitHub Environment
+# (the same one used by `osdc-renovate.yml`) so only opted-in jobs in this
+# repo can read it. The Environment must NOT have required reviewers or a
+# wait timer (the auto-approve job runs unattended); deployment-branch
+# policy should restrict to `main`. `pytorchbot` MUST remain a different
+# identity than `pytorchupdatebot` — GitHub forbids self-approval, so the
+# approver cannot be the PR author.
+#
+# If GH_PYTORCHBOT_TOKEN is ever revoked or replaced with a dedicated PAT
+# for this workflow, the minimum required scopes are:
+#   - Contents: Read                 (read PR diff)
+#   - Pull requests: Read and write  (review, enqueue, close, comment)
+#   - Metadata: Read                 (always required)
+#   - And emphatically NOT: Workflows, Administration, Actions, Secrets,
+#     or any organization permissions.
+on:
+  workflow_run:
+    workflows: ["OSDC: Renovate (runner image)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+  statuses: read
+
+concurrency:
+  # Constant group serializes re-runs of osdc-renovate so the second autoapprove
+  # waits for the first to finish — prevents two runs racing on the same PR set
+  # with overlapping dispatches and immediate squash merges.
+  group: osdc-renovate-approve
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    # Gate: only act on legit scheduled / dispatch renovate runs from main
+    # in the base repo. Blocks fork-spoofing and PR-triggered renovate runs.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      approve_matrix: ${{ steps.split.outputs.approve_matrix }}
+      close_matrix: ${{ steps.split.outputs.close_matrix }}
+      approve_count: ${{ steps.split.outputs.approve_count }}
+      close_count: ${{ steps.split.outputs.close_count }}
+    steps:
+      - name: Verify OSDC_RENOVATE_BOT_LOGIN is configured
+        env:
+          EXPECTED_BOT: ${{ vars.OSDC_RENOVATE_BOT_LOGIN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$EXPECTED_BOT" ]; then
+            echo "::error::Repo variable OSDC_RENOVATE_BOT_LOGIN must be set to the GitHub login of the PR-opening bot (e.g. 'pytorchupdatebot' — the identity that owns UPDATEBOT_TOKEN)."
+            exit 1
+          fi
+          echo "Bot login configured: $EXPECTED_BOT"
+
+      - name: List open Renovate runner-image PRs and split by age
+        id: split
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          STALE_DAYS: "7"
+        run: |
+          set -euo pipefail
+
+          # GitHub's `head:` search qualifier is exact-branch-only, so we
+          # request the branch name and filter in jq instead.
+          RAW=$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --label auto-runner-update \
+            --json number,updatedAt,headRefName \
+            --limit 100)
+          PRS=$(echo "$RAW" | jq -c '[.[] | select(.headRefName | startswith("renovate-runner/"))]')
+
+          NOW=$(date -u +%s)
+          STALE_CUTOFF=$((NOW - STALE_DAYS * 86400))
+
+          # Use updatedAt (not createdAt) so PRs Renovate keeps rebasing don't
+          # get closed under us just because the original open is old.
+          # fromdate handles RFC3339 with optional fractional seconds.
+          APPROVE=$(echo "$PRS" | jq -c --argjson cutoff "$STALE_CUTOFF" '
+            [.[] | select((.updatedAt | fromdate) >= $cutoff) | {pr: .number}]
+          ')
+          CLOSE=$(echo "$PRS" | jq -c --argjson cutoff "$STALE_CUTOFF" '
+            [.[] | select((.updatedAt | fromdate) <  $cutoff) | {pr: .number}]
+          ')
+          APPROVE_COUNT=$(echo "$APPROVE" | jq 'length')
+          CLOSE_COUNT=$(echo "$CLOSE" | jq 'length')
+
+          echo "Found $APPROVE_COUNT PR(s) to validate/approve and $CLOSE_COUNT stale PR(s) to close."
+          {
+            echo "approve_matrix={\"include\":$APPROVE}"
+            echo "close_matrix={\"include\":$CLOSE}"
+            echo "approve_count=$APPROVE_COUNT"
+            echo "close_count=$CLOSE_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+  approve:
+    needs: discover
+    if: needs.discover.outputs.approve_count != '0'
+    runs-on: ubuntu-latest
+    environment: osdc-renovate
+    # 360 = 6h. The validate step waits for osdc/pr-validate on the PR
+    # head SHA, which serializes behind any other staging consumer in the
+    # osdc-staging concurrency group; a queued PR can wait hours.
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.approve_matrix) }}
+    steps:
+      - name: Verify PR author matches expected Renovate bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_BOT: ${{ vars.OSDC_RENOVATE_BOT_LOGIN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          if [ "$PR_AUTHOR" != "$EXPECTED_BOT" ]; then
+            echo "::error::PR #$PR_NUMBER author '$PR_AUTHOR' does not match expected Renovate bot '$EXPECTED_BOT' — refusing to auto-approve. PR left open for investigation."
+            exit 1
+          fi
+          echo "Author check passed for PR #$PR_NUMBER: $PR_AUTHOR"
+
+      # Defense-in-depth: even if UPDATEBOT_TOKEN is compromised, refuse to
+      # auto-approve unless the PR diff matches the expected single-line
+      # runner_image_tag bump. Intentionally redundant with the same guard
+      # in osdc-auto-update-deploy-prod.yml (post-merge) — if the metadata
+      # gates leak (compromised token producing a PR with the right author,
+      # branch, label), this stops auto-approval from rubber-stamping
+      # arbitrary content. Uses the read-only GITHUB_TOKEN so we don't
+      # widen the approver token's blast radius for diff inspection.
+      #
+      # Both enforcement points (this step and the post-merge gate in
+      # osdc-auto-update-deploy-prod.yml) call osdc/scripts/validate-runner-bump.py
+      # so the regex, line-count, and monotonicity rules cannot drift apart.
+      - name: Checkout repo (for validate-runner-bump.py)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: false
+
+      - name: Validate PR diff and decide
+        id: validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+            echo "::error::Failed to read PR #$PR_NUMBER head.sha for SHA pinning."
+            exit 1
+          fi
+
+          PATCH_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate)
+          export PATCH_JSON
+
+          uv run osdc/scripts/validate-runner-bump.py > /tmp/validate.out
+          DECISION=$(grep '^decision=' /tmp/validate.out | head -1 | cut -d= -f2-)
+          REASON=$(grep '^reason='   /tmp/validate.out | head -1 | cut -d= -f2-)
+          OLD_VER=$(grep '^old_ver=' /tmp/validate.out | head -1 | cut -d= -f2- || true)
+          NEW_VER=$(grep '^new_ver=' /tmp/validate.out | head -1 | cut -d= -f2- || true)
+
+          if [ "$DECISION" = "approve" ]; then
+            echo "Diff validation passed for PR #$PR_NUMBER: $OLD_VER -> $NEW_VER"
+          else
+            echo "Diff validation rejected PR #$PR_NUMBER: $DECISION — $REASON"
+          fi
+
+          {
+            echo "decision=$DECISION"
+            echo "reason=$REASON"
+            echo "head_sha=$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      # Client-side merge gate: dispatch osdc-pr-validate against the PR
+      # head SHA (using the trusted workflow definition on `main`, NOT
+      # the PR branch — a compromised PR cannot swap the workflow file
+      # underneath us) and poll the `osdc/pr-validate` commit status
+      # until it flips to success or failure. The validation workflow
+      # shares the `osdc-staging` concurrency group with osdc-pre-merge.yml,
+      # so this serializes behind any other consumer touching arc-staging.
+      # A backlog of 2-3 PRs can keep this step waiting for several hours;
+      # the job timeout is 360 min to match.
+      #
+      # The wait script also re-checks PR head.sha on each iteration and
+      # bails as `close-head-moved` if the PR is rebased mid-wait, and
+      # retries transient gh api failures so a single GitHub 5xx during
+      # the 6h window doesn't abort the wait. A persistent `pending`
+      # state is treated as in-flight / queued — the script keeps polling
+      # until the status flips or the 6h timeout expires.
+      - name: Wait for osdc/pr-validate status
+        id: wait
+        if: steps.validate.outputs.decision == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+        run: uv run osdc/scripts/wait-for-pr-validate.py
+
+      - name: Approve PR
+        if: steps.wait.outputs.decision == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          # gh pr review has no SHA-pin flag, so we hit the REST API
+          # directly and pass commit_id. If the PR head moves between
+          # validate and review (force-push race), GitHub rejects the
+          # review with 422 — preventing approval of unvalidated content.
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event=APPROVE \
+            -f commit_id="$HEAD_SHA" \
+            -f body="Auto-approved by OSDC auto-approver: runner-image bump PR from Renovate (validated at $HEAD_SHA)."
+
+      - name: Merge PR
+        if: steps.wait.outputs.decision == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.validate.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          # Immediate squash merge (no --auto). Gating happened in the
+          # wait step above: osdc/pr-validate is green for this SHA.
+          # --match-head-commit pins the merge to the validated SHA;
+          # if a force-push lands between the wait check and this call,
+          # GitHub rejects the merge rather than landing unvalidated code.
+          gh pr merge --squash \
+            --match-head-commit "$HEAD_SHA" \
+            "$PR_NUMBER" \
+            --repo "$REPO"
+
+      - name: Close PR on validation failure
+        if: |
+          startsWith(steps.validate.outputs.decision, 'close-') ||
+          startsWith(steps.wait.outputs.decision, 'close-')
+        env:
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+          DIFF_DECISION: ${{ steps.validate.outputs.decision }}
+          DIFF_REASON: ${{ steps.validate.outputs.reason }}
+          WAIT_DECISION: ${{ steps.wait.outputs.decision }}
+          WAIT_REASON: ${{ steps.wait.outputs.reason }}
+        run: |
+          set -euo pipefail
+          if [[ "$WAIT_DECISION" == close-* ]]; then
+            DECISION="$WAIT_DECISION"
+            REASON="$WAIT_REASON"
+          else
+            DECISION="$DIFF_DECISION"
+            REASON="$DIFF_REASON"
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "Auto-closed: \`$DECISION\` — $REASON. If a fix is needed, a new PR will be opened by Renovate on the next run when an eligible version is available."
+          gh pr close "$PR_NUMBER" --repo "$REPO"
+
+  close_stale:
+    needs: discover
+    if: needs.discover.outputs.close_count != '0'
+    runs-on: ubuntu-latest
+    environment: osdc-renovate
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.close_matrix) }}
+    steps:
+      - name: Verify PR author matches expected Renovate bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_BOT: ${{ vars.OSDC_RENOVATE_BOT_LOGIN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          if [ "$PR_AUTHOR" != "$EXPECTED_BOT" ]; then
+            echo "::error::PR #$PR_NUMBER author '$PR_AUTHOR' does not match expected Renovate bot '$EXPECTED_BOT' — refusing to auto-close. PR left open for investigation."
+            exit 1
+          fi
+          echo "Author check passed for PR #$PR_NUMBER: $PR_AUTHOR"
+
+      - name: Close stale Renovate PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          PR_NUMBER: ${{ matrix.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "Auto-closed: PR has been open for >7 days without merging. Renovate will reopen on the next run if the version is still relevant. To pause without auto-closure, remove the \`auto-runner-update\` label."
+          gh pr close "$PR_NUMBER" --repo "$REPO"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #644
* #643
* __->__ #642
* #641
* #640
* #639
* #638
* #637
* #636
* #635
* #634

**Impact:** new PR-triggered GitHub Actions workflow
**Risk:** medium

## What
Adds `osdc-renovate-autoapprove.yml`. On Renovate-authored PRs that
touch only `osdc/clusters.yaml`, this workflow validates the diff,
approves the PR under the bot identity, dispatches
`osdc-pr-validate.yml`, waits for the resulting commit status, and
on success squash-merges the PR.

## Why
A Renovate runner-image bump is a high-frequency, low-risk change
that we want shipped quickly without burning human review cycles —
but only if the diff is shaped exactly the way we expect AND the
staging deploy is green.

## How
- Trigger: `pull_request_target` on Renovate-authored PRs.
- Eligibility gate: bot author, branch prefix, single-file diff
  scoped to `osdc/clusters.yaml`.
- Validation: `validate-runner-bump.py` for single-line strict-semver
  monotonic bump.
- Approve via the bot identity, then dispatch + wait on
  `osdc-pr-validate.yml` using `wait-for-pr-validate.py`.
- Squash-merge only if the commit status returns success.

## Changes
- `.github/workflows/osdc-renovate-autoapprove.yml`: new workflow.

## Notes
Depends on:
- `validate-runner-bump.py` (earlier in stack).
- `osdc-pr-validate.yml` (earlier in stack).
- `wait-for-pr-validate.py` (earlier in stack).
- Renovate must be opening PRs (earlier) and merged PRs must be
  deploying (earlier).

## Testing
- Wait for the next Renovate bump PR after this lands; observe the
  full auto-approve -> validate -> merge -> deploy chain.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>