### PR TITLE
CODEOWNERS: add @zxiiro to /osdc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,5 +12,5 @@
 /crcr @fffrog @can-gaa-hou
 /helpers/ @zxiiro @jeanschmidt
 /modules/backend-state/ @jeanschmidt
-/osdc @jeanschmidt @huydhn
+/osdc @jeanschmidt @huydhn @zxiiro
 /scripts/ @jeanschmidt @zxiiro


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #644
* #643
* #642
* #641
* #640
* #639
* #638
* #637
* #636
* #635
* #634

**Impact:** CODEOWNERS / OSDC reviewers
**Risk:** low

## What
Adds `@zxiiro` as a co-owner of the `/osdc` path in CODEOWNERS, alongside
the existing `@jeanschmidt` and `@huydhn`.

## Why
Acknowledges the shared on-call for OSDC and lets `@zxiiro` be auto-requested
on reviews for PRs touching `/osdc`, matching the existing ownership of
`/helpers/` and `/scripts/`.

## How
- Append `@zxiiro` to the `/osdc` line in CODEOWNERS.

## Changes
- `CODEOWNERS`: one line modified.

## Testing
- N/A — CODEOWNERS is enforced by GitHub on subsequent PRs.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>