### PR TITLE
Add Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,19 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude-code:
+    uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets: inherit
+    with:
+      additional_claude_args: '--allowedTools Skill'

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,6 +6,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   claude-code:
     uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code.yml` to enable the Claude Code bot on this repo, triggered by issue comments and new issues.
- Calls the reusable `pytorch/test-infra/.github/workflows/_claude-code.yml@main` workflow with `--allowedTools Skill`.
- Mirrors https://github.com/pytorch/helion/pull/2412.

## Test plan
- [ ] After merge, mention `@claude` in an issue or PR comment and confirm the workflow runs.