### PR TITLE
[Grafana][PyTorch DevX] Allow choosing repos

### DIFF
--- a/grafana/pytorch_devx.json
+++ b/grafana/pytorch_devx.json
@@ -55,7 +55,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "WITH viable AS (\n    SELECT\n        repository.pushed_at AS pushed_ts,\n        toUnixTimestamp(head_commit.timestamp) AS commit_ts,\n        repository.full_name AS repo\n    FROM push\n    WHERE repository.full_name = 'pytorch/pytorch'\n      AND ref = 'refs/heads/viable/strict'\n      AND head_commit.id != ''\n),\nmain AS (\n    SELECT\n        repository.pushed_at AS pushed_ts,\n        toUnixTimestamp(head_commit.timestamp) AS commit_ts,\n        repository.full_name AS repo\n    FROM push\n    WHERE repository.full_name = 'pytorch/pytorch'\n      AND ref = 'refs/heads/main'\n      AND head_commit.id != ''\n)\nSELECT fromUnixTimestamp(pushed_ts) AS pushed_time, lag_minutes, trend_7d_avg\nFROM (\n    SELECT\n        m.pushed_ts,\n        (toInt64(m.commit_ts) - toInt64(nullIf(v.commit_ts, 0))) / 60.0 AS lag_minutes,\n        avg(lag_minutes) OVER (\n            ORDER BY m.pushed_ts\n            RANGE BETWEEN 604800 PRECEDING AND CURRENT ROW\n        ) AS trend_7d_avg\n    FROM main m\n    ASOF LEFT JOIN viable v\n        ON m.repo = v.repo AND m.pushed_ts >= v.pushed_ts\n)\nWHERE $__timeFilter(pushed_time)\nORDER BY pushed_time ASC"
+                      "rawSql": "WITH viable AS (\n    SELECT\n        repository.pushed_at AS pushed_ts,\n        toUnixTimestamp(head_commit.timestamp) AS commit_ts,\n        repository.full_name AS repo\n    FROM push\n    WHERE repository.full_name = '$repository'\n      AND ref = 'refs/heads/viable/strict'\n      AND head_commit.id != ''\n),\nmain AS (\n    SELECT\n        repository.pushed_at AS pushed_ts,\n        toUnixTimestamp(head_commit.timestamp) AS commit_ts,\n        repository.full_name AS repo\n    FROM push\n    WHERE repository.full_name = '$repository'\n      AND ref = 'refs/heads/main'\n      AND head_commit.id != ''\n)\nSELECT fromUnixTimestamp(pushed_ts) AS pushed_time, lag_minutes, trend_7d_avg\nFROM (\n    SELECT\n        m.pushed_ts,\n        (toInt64(m.commit_ts) - toInt64(nullIf(v.commit_ts, 0))) / 60.0 AS lag_minutes,\n        avg(lag_minutes) OVER (\n            ORDER BY m.pushed_ts\n            RANGE BETWEEN 604800 PRECEDING AND CURRENT ROW\n        ) AS trend_7d_avg\n    FROM main m\n    ASOF LEFT JOIN viable v\n        ON m.repo = v.repo AND m.pushed_ts >= v.pushed_ts\n)\nWHERE $__timeFilter(pushed_time)\nORDER BY pushed_time ASC"
                     },
                     "version": "v0"
                   },
@@ -70,7 +70,7 @@
         "description": "How long it takes viable/strict to catch up to main.",
         "id": 4,
         "links": [],
-        "title": "viable/strict Lag",
+        "title": "viable/strict Lag [repository]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -194,7 +194,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n    revert_day,\n    prs_reverted,\n    sum(prs_reverted) OVER (\n        ORDER BY toUnixTimestamp(revert_day) ASC\n        RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW\n    ) / 7.0 AS trend_7d_avg\nFROM (\n    SELECT\n        toStartOfDay(head_commit.timestamp) AS revert_day,\n        COUNT() AS prs_reverted\n    FROM push\n    WHERE\n        repository.full_name = 'pytorch/pytorch'\n        AND ref IN ('refs/heads/master', 'refs/heads/main')\n        AND (\n            head_commit.message LIKE 'Revert %'\n            OR head_commit.message LIKE 'Back out%'\n        )\n        AND $__timeFilter(head_commit.timestamp)\n    GROUP BY revert_day\n)\nORDER BY revert_day DESC"
+                      "rawSql": "SELECT\n    revert_day,\n    prs_reverted,\n    sum(prs_reverted) OVER (\n        ORDER BY toUnixTimestamp(revert_day) ASC\n        RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW\n    ) / 7.0 AS trend_7d_avg\nFROM (\n    SELECT\n        toStartOfDay(head_commit.timestamp) AS revert_day,\n        COUNT() AS prs_reverted\n    FROM push\n    WHERE\n        repository.full_name = '$repository'\n        AND ref IN ('refs/heads/master', 'refs/heads/main')\n        AND (\n            head_commit.message LIKE 'Revert %'\n            OR head_commit.message LIKE 'Back out%'\n        )\n        AND $__timeFilter(head_commit.timestamp)\n    GROUP BY revert_day\n)\nORDER BY revert_day DESC"
                     },
                     "version": "v0"
                   },
@@ -209,7 +209,7 @@
         "description": "",
         "id": 5,
         "links": [],
-        "title": "Daily PR Reverts",
+        "title": "Daily PR Reverts [repository]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -368,7 +368,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "  WITH commits AS (\n      SELECT\n          commit.id AS commit_sha,\n          commit.timestamp AS commit_time\n      FROM default.push\n      ARRAY JOIN commits AS commit\n      WHERE\n          repository.full_name = 'pytorch/pytorch'\n          AND ref = 'refs/heads/main'\n  ),\n  blocking_runs AS (\n      SELECT id\n      FROM default.workflow_run\n      WHERE\n          head_branch = 'main'\n          AND event = 'push'\n          AND path IN (\n              -- Core\n              '.github/workflows/lint.yml',\n              '.github/workflows/pull.yml',\n              '.github/workflows/trunk.yml',\n              '.github/workflows/inductor.yml',\n              '.github/workflows/inductor-periodic.yml',\n              '.github/workflows/inductor-unittest.yml',\n              '.github/workflows/periodic.yml',\n              '.github/workflows/slow.yml',\n              '.github/workflows/dynamo-unittest.yml',\n              -- Modern hardware\n              '.github/workflows/rocm-mi300.yml',\n              '.github/workflows/rocm-mi355.yml',\n              '.github/workflows/xpu.yml',\n              '.github/workflows/mac-mps.yml',\n              '.github/workflows/tsan.yml',\n              '.github/workflows/inductor-rocm-mi300.yml',\n              '.github/workflows/inductor-rocm-mi355.yml',\n              -- Distributed\n              '.github/workflows/b200-distributed.yml',\n              '.github/workflows/h100-distributed.yml',\n              -- Adjacent / integrations\n              '.github/workflows/dtensor.yml',\n              '.github/workflows/inductor-pallas.yml',\n              '.github/workflows/vllm.yml',\n              '.github/workflows/torchtitan.yml'\n          )\n  )\n  \nSELECT\n    commits.commit_time AS commit_time,\n    round((countIf(default.workflow_job.conclusion = 'failure') / count()) * 100.0, 2) AS failure_percent,\n    avg(failure_percent) OVER (ORDER BY toUnixTimestamp(commits.commit_time) ASC RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW) AS trend_7d_avg\nFROM default.workflow_job\nINNER JOIN commits ON commits.commit_sha = default.workflow_job.head_sha\nINNER JOIN blocking_runs ON blocking_runs.id = default.workflow_job.run_id\nWHERE\n    default.workflow_job.run_attempt = 1\n    AND $__timeFilter(commits.commit_time)\nGROUP BY commits.commit_sha, commits.commit_time\nORDER BY commit_time ASC"
+                      "rawSql": "  WITH commits AS (\n      SELECT\n          commit.id AS commit_sha,\n          commit.timestamp AS commit_time\n      FROM default.push\n      ARRAY JOIN commits AS commit\n      WHERE\n          repository.full_name = '$repository'\n          AND ref = 'refs/heads/main'\n  ),\n  blocking_runs AS (\n      SELECT id\n      FROM default.workflow_run\n      WHERE\n          head_branch = 'main'\n          AND event = 'push'\n          AND path IN (\n              -- Core\n              '.github/workflows/lint.yml',\n              '.github/workflows/pull.yml',\n              '.github/workflows/trunk.yml',\n              '.github/workflows/inductor.yml',\n              '.github/workflows/inductor-periodic.yml',\n              '.github/workflows/inductor-unittest.yml',\n              '.github/workflows/periodic.yml',\n              '.github/workflows/slow.yml',\n              '.github/workflows/dynamo-unittest.yml',\n              -- Modern hardware\n              '.github/workflows/rocm-mi300.yml',\n              '.github/workflows/rocm-mi355.yml',\n              '.github/workflows/xpu.yml',\n              '.github/workflows/mac-mps.yml',\n              '.github/workflows/tsan.yml',\n              '.github/workflows/inductor-rocm-mi300.yml',\n              '.github/workflows/inductor-rocm-mi355.yml',\n              -- Distributed\n              '.github/workflows/b200-distributed.yml',\n              '.github/workflows/h100-distributed.yml',\n              -- Adjacent / integrations\n              '.github/workflows/dtensor.yml',\n              '.github/workflows/inductor-pallas.yml',\n              '.github/workflows/vllm.yml',\n              '.github/workflows/torchtitan.yml'\n          )\n  )\n  \nSELECT\n    commits.commit_time AS commit_time,\n    round((countIf(default.workflow_job.conclusion = 'failure') / count()) * 100.0, 2) AS failure_percent,\n    avg(failure_percent) OVER (ORDER BY toUnixTimestamp(commits.commit_time) ASC RANGE BETWEEN 6 * 24 * 60 * 60 PRECEDING AND CURRENT ROW) AS trend_7d_avg\nFROM default.workflow_job\nINNER JOIN commits ON commits.commit_sha = default.workflow_job.head_sha\nINNER JOIN blocking_runs ON blocking_runs.id = default.workflow_job.run_id\nWHERE\n    default.workflow_job.run_attempt = 1\n    AND $__timeFilter(commits.commit_time)\nGROUP BY commits.commit_sha, commits.commit_time\nORDER BY commit_time ASC"
                     },
                     "version": "v0"
                   },
@@ -383,7 +383,7 @@
         "description": "",
         "id": 6,
         "links": [],
-        "title": "Workflow Failure Percent / Main Commit",
+        "title": "Workflow Failure Percent / Main Commit [repository]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -534,7 +534,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "WITH\n  commits AS (\n    SELECT\n      toStartOfDay(head_commit.timestamp) AS day,\n      head_commit.id AS sha\n    FROM push\n    WHERE repository.full_name = 'pytorch/pytorch'\n      AND ref IN ('refs/heads/master', 'refs/heads/main')\n      AND $__timeFilter(head_commit.timestamp)\n  ),\n  all_runs AS (\n    SELECT workflow_run.id AS id, commits.day AS day, commits.sha AS sha\n    FROM workflow_run FINAL\n    JOIN commits ON workflow_run.head_sha = commits.sha\n    WHERE lower(workflow_run.name) IN ('lint', 'pull', 'trunk', 'linux-aarch64')\n      AND workflow_run.event != 'workflow_run'\n      AND workflow_run.id IN (\n        SELECT id FROM materialized_views.workflow_run_by_head_sha\n        WHERE head_sha IN (SELECT sha FROM commits)\n      )\n  ),\n  all_jobs AS (\n    SELECT all_runs.day AS day, all_runs.sha AS sha, workflow_job.conclusion AS conclusion,\n      ROW_NUMBER() OVER (PARTITION BY workflow_job.name, workflow_job.head_sha\n                         ORDER BY workflow_job.run_attempt DESC) AS row_num\n    FROM workflow_job FINAL\n    JOIN all_runs ON all_runs.id = workflow_job.run_id\n    WHERE workflow_job.name NOT IN ('ciflow_should_run', 'generate-test-matrix')\n      AND workflow_job.name NOT LIKE '%rerun_disabled_tests%'\n      AND workflow_job.name NOT LIKE '%mem_leak_check%'\n      AND workflow_job.name NOT LIKE '%unstable%'\n      AND workflow_job.id IN (\n        SELECT id FROM materialized_views.workflow_job_by_head_sha\n        WHERE head_sha IN (SELECT sha FROM commits)\n      )\n  ),\n  per_commit AS (\n    SELECT day, sha,\n      max(row_num = 1 AND conclusion IN ('failure', 'timed_out', 'cancelled')) AS broken_trunk_red\n    FROM all_jobs\n    GROUP BY day, sha\n    HAVING COUNT(*) > 10 AND countIf(conclusion = '') = 0\n  ),\n  daily AS (\n    SELECT day,\n      countIf(broken_trunk_red) AS red_count,\n      COUNT(*) AS commit_count\n    FROM per_commit\n    GROUP BY day\n  )\nSELECT\n  day AS time,\n  red_count * 100.0 / commit_count AS red_percent,\n  sum(red_count) OVER w * 100.0 / sum(commit_count) OVER w AS trend_7d_avg\nFROM daily\nWINDOW w AS (\n  ORDER BY toUnixTimestamp(day) ASC\n  RANGE BETWEEN 6 * 86400 PRECEDING AND CURRENT ROW\n)\nORDER BY day ASC"
+                      "rawSql": "WITH\n  commits AS (\n    SELECT\n      toStartOfDay(head_commit.timestamp) AS day,\n      head_commit.id AS sha\n    FROM push\n    WHERE repository.full_name = '$repository'\n      AND ref IN ('refs/heads/master', 'refs/heads/main')\n      AND $__timeFilter(head_commit.timestamp)\n  ),\n  all_runs AS (\n    SELECT workflow_run.id AS id, commits.day AS day, commits.sha AS sha\n    FROM workflow_run FINAL\n    JOIN commits ON workflow_run.head_sha = commits.sha\n    WHERE lower(workflow_run.name) IN ('lint', 'pull', 'trunk', 'linux-aarch64')\n      AND workflow_run.event != 'workflow_run'\n      AND workflow_run.id IN (\n        SELECT id FROM materialized_views.workflow_run_by_head_sha\n        WHERE head_sha IN (SELECT sha FROM commits)\n      )\n  ),\n  all_jobs AS (\n    SELECT all_runs.day AS day, all_runs.sha AS sha, workflow_job.conclusion AS conclusion,\n      ROW_NUMBER() OVER (PARTITION BY workflow_job.name, workflow_job.head_sha\n                         ORDER BY workflow_job.run_attempt DESC) AS row_num\n    FROM workflow_job FINAL\n    JOIN all_runs ON all_runs.id = workflow_job.run_id\n    WHERE workflow_job.name NOT IN ('ciflow_should_run', 'generate-test-matrix')\n      AND workflow_job.name NOT LIKE '%rerun_disabled_tests%'\n      AND workflow_job.name NOT LIKE '%mem_leak_check%'\n      AND workflow_job.name NOT LIKE '%unstable%'\n      AND workflow_job.id IN (\n        SELECT id FROM materialized_views.workflow_job_by_head_sha\n        WHERE head_sha IN (SELECT sha FROM commits)\n      )\n  ),\n  per_commit AS (\n    SELECT day, sha,\n      max(row_num = 1 AND conclusion IN ('failure', 'timed_out', 'cancelled')) AS broken_trunk_red\n    FROM all_jobs\n    GROUP BY day, sha\n    HAVING COUNT(*) > 10 AND countIf(conclusion = '') = 0\n  ),\n  daily AS (\n    SELECT day,\n      countIf(broken_trunk_red) AS red_count,\n      COUNT(*) AS commit_count\n    FROM per_commit\n    GROUP BY day\n  )\nSELECT\n  day AS time,\n  red_count * 100.0 / commit_count AS red_percent,\n  sum(red_count) OVER w * 100.0 / sum(commit_count) OVER w AS trend_7d_avg\nFROM daily\nWINDOW w AS (\n  ORDER BY toUnixTimestamp(day) ASC\n  RANGE BETWEEN 6 * 86400 PRECEDING AND CURRENT ROW\n)\nORDER BY day ASC"
                     },
                     "version": "v0"
                   },
@@ -549,7 +549,7 @@
         "description": "Share of main commits classified as red on the trunk-blocking workflows (Lint, pull, trunk, linux-aarch64). A commit is red if any job's latest run_attempt is failure/timed_out/cancelled. Commits with pending jobs or fewer than 10 jobs are excluded. Mirrors the test-infra HUD '% commits red on main (broken trunk)' definition.",
         "id": 7,
         "links": [],
-        "title": "% Commits Red on Main (broken trunk)",
+        "title": "% Commits Red on Main (broken trunk) [repository]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -763,5 +763,35 @@
     "to": "now"
   },
   "title": "PyTorch DevX",
-  "variables": []
+  "variables": [
+    {
+      "kind": "CustomVariable",
+      "spec": {
+        "name": "repository",
+        "label": "Repository",
+        "query": "pytorch/pytorch,pytorch/executorch",
+        "current": {
+          "text": "pytorch/pytorch",
+          "value": "pytorch/pytorch"
+        },
+        "options": [
+          {
+            "selected": true,
+            "text": "pytorch/pytorch",
+            "value": "pytorch/pytorch"
+          },
+          {
+            "selected": false,
+            "text": "pytorch/executorch",
+            "value": "pytorch/executorch"
+          }
+        ],
+        "multi": false,
+        "includeAll": false,
+        "allowCustomValue": false,
+        "hide": "dontHide",
+        "skipUrlSync": false
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Instead of hardcoding `pytorch/pytorch`, let's support selecting a specific repo. For now let's include PT and ET.

## Test Plan

Pushed to my test folder: https://pytorchci.grafana.net/dashboards/f/flrhzs.

```
$ mise run generate --folder flrhzs
```