### PR TITLE
add opt-in-status = opt-in-not-required for aws_availability_zones for us-east-1

### DIFF
--- a/osdc/modules/eks/terraform/main.tf
+++ b/osdc/modules/eks/terraform/main.tf
@@ -5,6 +5,13 @@
 
 data "aws_availability_zones" "available" {
   state = "available"
+
+  # Exclude Local Zones and Wavelength Zones — they belong to separate network
+  # border groups and cannot use the VPC's auto-assigned IPv6 CIDR block.
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 locals {


### PR DESCRIPTION
`meta-prod-aws-ue1` have some additional AZs that have some network limitations, so we enabled `opt-in-status` = `opt-in-not-required` to bypass those