### PR TITLE
Test: point hooks-warmer at malfet/runner-container-hooks v0.8.15

### DIFF
--- a/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc-runners/kubernetes/hooks-warmer.yaml
@@ -2,7 +2,7 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.14
+# See: https://github.com/malfet/runner-container-hooks/releases/tag/v0.8.14
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -61,8 +61,8 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.14"
-              HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
+              HOOKS_VERSION="0.8.15"
+              HOOKS_URL="https://github.com/malfet/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"
 


### PR DESCRIPTION
  Test release of https://github.com/jeanschmidt/runner-container-hooks/pull/8
  (auto-install python3 via apt when missing from job container).

  Not for merge — staging test only.
