### PR TITLE
[Grafana][OSDC] Add meta-prod-aws clusters

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1354,7 +1354,7 @@
             "$__all"
           ]
         },
-        "definition": "label_values(gha_assigned_jobs{cluster=~\".*arc.*production.*\"},cluster)",
+        "definition": "label_values(gha_assigned_jobs{cluster=~\".*arc.*production.*|meta-prod-aws-.*\"},cluster)",
         "hide": "dontHide",
         "includeAll": true,
         "label": "Cluster",
@@ -1369,7 +1369,7 @@
           "kind": "DataQuery",
           "spec": {
             "qryType": 1,
-            "query": "label_values(gha_assigned_jobs{cluster=~\".*arc.*production.*\"},cluster)",
+            "query": "label_values(gha_assigned_jobs{cluster=~\".*arc.*production.*|meta-prod-aws-.*\"},cluster)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "version": "v0"


### PR DESCRIPTION
- Extend cluster variable regex to include meta-prod-aws-* clusters
- Update both definition and query fields for consistency

Notes:
The cluster dropdown previously only matched ARC production clusters (.*arc.*production.*). This adds the meta-prod-aws-.* pattern so Meta-managed AWS runner clusters also appear in the dashboard filter.

https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc?orgId=1&from=now-6h&to=now&timezone=browser&var-cluster=$__all&var-scale_set=$__all&var-repository=$__all