### PR TITLE
[Grafana][OSDC] Use palette-classic-by-name colors

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -69,7 +69,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -189,7 +189,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -318,7 +318,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -447,7 +447,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -567,7 +567,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -705,7 +705,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -1108,7 +1108,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #659
* #657
* #656
* __->__ #655

----

- Switch all 7 panels from palette-classic to
  palette-classic-by-name color mode

Notes:
palette-modern-by-name does not work as expected.
fieldConfig.overrides would require deployment-time
tooling to query clusters and assign colors dynamically,
which adds unwanted complexity. palette-classic-by-name
is a best-effort approach but consistent per-series
colors across time ranges remain an open problem.

Final version with all changes in this stack: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc

Signed-off-by: Jean Schmidt <contato@jschmidt.me>