### PR TITLE
[Grafana][OSDC] Add queue time heatmaps

### DIFF
--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -28,6 +28,14 @@ mise run push --folder "..."
   * NEVER make edits to any folders other than the folder UID provided with `--folder`
   * NEVER use curl directly to interact with the API
 * Panel titles must end with the list of dashboard variables referenced in the panel's query, formatted as `[var1, var2]` without the `$` prefix (e.g. `Running Jobs [cluster, scale_set]`). The `$` is omitted so Grafana doesn't interpolate the variable value into the title. Include every `$var`/`${var}` the query uses; omit the suffix entirely if the query uses no variables.
+* Every time a series apear in more than one graph, all graphs that use it should use `palette-classic-by-name`, unless there is an explicit reason for this that is well documented and valid.
+* ClickHouse queries that filter OSDC runners by `${cluster}` must map `runner_group_name` (GitHub) to the Prometheus `cluster` value using the table below. Keep all panels using this mapping in sync — when a cluster is added, update every panel that uses it.
+
+  | `runner_group_name` | `${cluster}` value |
+  |---|---|
+  | `default`, `release-runners` | `pytorch-arc-cbr-production` |
+  | `arc-cbr-prod-uw1` | `pytorch-arc-cbr-production-uw1` |
+  | `meta-prod-aws-ue1` | `meta-prod-aws-ue1` |
 
 ## Datasources
 
@@ -35,4 +43,15 @@ mise run push --folder "..."
   * Contains GitHub data
 * grafanacloud-pytorchci-prom, grafanacloud-prom
   * Contains GitHub Actions Runner Controller data
-  * Clone https://github.com/actions/actions-runner-controller to a temporary directory to understand the ARC provided data
+* pytorch-hud (MCP) 
+  * If available it is a powerful tool that helps you get more in-depth context on clickhouse data, plus it exports HUD APIs that can be used to query and get information while developing (not useful for dashboard queries, but powerful for planning)
+
+## Reference repositories
+
+This repo, on <repo-root>/osdc the OSDC project lives, scan it to understand how metrics are exported and what metrics are available to be used, read the docs on <repo-root>/osdc/docs to understand the scope and project setup.
+
+### Clone those repositories in a temp source if you don't have them already in other known places
+
+* https://github.com/jeanschmidt/actions-runner-controller - to understand how actions-runner-controller exposes data
+* https://github.com/seemethere/actions-knowledge-base - to understand how all other components expose data (kubernetes, harbor, etc)
+

--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -28,6 +28,7 @@ mise run push --folder "..."
   * NEVER make edits to any folders other than the folder UID provided with `--folder`
   * NEVER use curl directly to interact with the API
 * Panel titles must end with the list of dashboard variables referenced in the panel's query, formatted as `[var1, var2]` without the `$` prefix (e.g. `Running Jobs [cluster, scale_set]`). The `$` is omitted so Grafana doesn't interpolate the variable value into the title. Include every `$var`/`${var}` the query uses; omit the suffix entirely if the query uses no variables.
+* Every time a series apear in more than one graph, all graphs that use it should use `palette-classic-by-name`, unless there is an explicit reason for this that is well documented and valid.
 
 ## Datasources
 
@@ -35,4 +36,15 @@ mise run push --folder "..."
   * Contains GitHub data
 * grafanacloud-pytorchci-prom, grafanacloud-prom
   * Contains GitHub Actions Runner Controller data
-  * Clone https://github.com/actions/actions-runner-controller to a temporary directory to understand the ARC provided data
+* pytorch-hud (MCP) 
+  * If available it is a powerful tool that helps you get more in-depth context on clickhouse data, plus it exports HUD APIs that can be used to query and get information while developing (not useful for dashboard queries, but powerful for planning)
+
+## Reference repositories
+
+This repo, on <repo-root>/osdc the OSDC project lives, scan it to understand how metrics are exported and what metrics are available to be used, read the docs on <repo-root>/osdc/docs to understand the scope and project setup.
+
+### Clone those repositories in a temp source if you don't have them already in other known places
+
+* https://github.com/jeanschmidt/actions-runner-controller - to understand how actions-runner-controller exposes data
+* https://github.com/seemethere/actions-knowledge-base - to understand how all other components expose data (kubernetes, harbor, etc)
+

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1182,6 +1182,260 @@
           "version": "13.1.0-25668120414"
         }
       }
+    },
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND NOT arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > toDateTime('2020-01-01')\n    AND started_at > created_at\nORDER BY started_at"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-job queue time distribution over time for OSDC production runners, excluding capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
+        "id": 10,
+        "links": [],
+        "title": "Queue Time Distribution (excl. capacity-constrained instances) [cluster, repository]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "calculate": true,
+              "calculation": {
+                "xBuckets": {
+                  "mode": "size",
+                  "value": ""
+                },
+                "yBuckets": {
+                  "mode": "count",
+                  "scale": {
+                    "log": 10,
+                    "type": "log"
+                  },
+                  "value": "30"
+                }
+              },
+              "cellGap": 0,
+              "cellValues": {
+                "unit": "short"
+              },
+              "color": {
+                "exponent": 0.5,
+                "fill": "#96D98D",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-9
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "showValue": "never",
+              "tooltip": {
+                "mode": "single",
+                "show": true,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisLabel": "Queue (min)",
+                "axisPlacement": "left",
+                "decimals": 1,
+                "min": 0.01,
+                "reverse": false,
+                "unit": "m"
+              }
+            },
+            "version": ""
+          }
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > toDateTime('2020-01-01')\n    AND started_at > created_at\nORDER BY started_at"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-job queue time distribution over time for OSDC production runners, ONLY capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
+        "id": 11,
+        "links": [],
+        "title": "Queue Time Distribution (capacity-constrained instances only) [cluster, repository]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "calculate": true,
+              "calculation": {
+                "xBuckets": {
+                  "mode": "size",
+                  "value": ""
+                },
+                "yBuckets": {
+                  "mode": "count",
+                  "scale": {
+                    "log": 10,
+                    "type": "log"
+                  },
+                  "value": "30"
+                }
+              },
+              "cellGap": 0,
+              "cellValues": {
+                "unit": "short"
+              },
+              "color": {
+                "exponent": 0.5,
+                "fill": "#5794F2",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-9
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "showValue": "never",
+              "tooltip": {
+                "mode": "single",
+                "show": true,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisLabel": "Queue (min)",
+                "axisPlacement": "left",
+                "decimals": 1,
+                "min": 0.01,
+                "reverse": false,
+                "unit": "m"
+              }
+            },
+            "version": ""
+          }
+        }
+      }
     }
   },
   "layout": {
@@ -1303,6 +1557,32 @@
             "width": 24,
             "x": 0,
             "y": 30
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-10"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 40
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-11"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 12,
+            "y": 40
           }
         }
       ]

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1215,7 +1215,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND NOT arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > toDateTime('2020-01-01')\n    AND started_at > created_at\nORDER BY started_at"
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND NOT arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > created_at\nORDER BY started_at"
                     },
                     "version": "v0"
                   },
@@ -1230,7 +1230,7 @@
         "description": "Per-job queue time distribution over time for OSDC production runners, excluding capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
         "id": 10,
         "links": [],
-        "title": "Queue Time Distribution (excl. capacity-constrained instances) [cluster, repository]",
+        "title": "Queue Time Distribution (excl. capacity-constrained instances) [cluster, repository, scale_set]",
         "vizConfig": {
           "group": "heatmap",
           "kind": "VizConfig",
@@ -1342,7 +1342,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > toDateTime('2020-01-01')\n    AND started_at > created_at\nORDER BY started_at"
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > created_at\nORDER BY started_at"
                     },
                     "version": "v0"
                   },
@@ -1357,7 +1357,7 @@
         "description": "Per-job queue time distribution over time for OSDC production runners, ONLY capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
         "id": 11,
         "links": [],
-        "title": "Queue Time Distribution (capacity-constrained instances only) [cluster, repository]",
+        "title": "Queue Time Distribution (capacity-constrained instances only) [cluster, repository, scale_set]",
         "vizConfig": {
           "group": "heatmap",
           "kind": "VizConfig",

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -69,7 +69,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -189,7 +189,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -318,7 +318,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -447,7 +447,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -567,7 +567,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -705,7 +705,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -1108,7 +1108,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #659
* #657
* __->__ #656
* #655

----

- Add panel-10: queue time heatmap excluding capacity-constrained GPU instances (h100, b200, gb200, a100)
- Add panel-11: queue time heatmap for capacity-constrained GPU instances only
- Both panels use ClickHouse workflow_job data with log-scale Y-axis in minutes
- Layout places the two heatmaps side-by-side (12 cols each) in a new row at y=40

Notes:
The two panels split queue time visibility by GPU scarcity.
Non-constrained runners (panel-10, green) show general queue health,
while constrained runners (panel-11, blue) isolate wait times caused
by limited GPU capacity. Both use exponential opacity color scaling
with 30 log-10 Y-buckets for resolution across sub-minute to
multi-hour queue times.

Final version with all changes in this stack: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc

Signed-off-by: Jean Schmidt <contato@jschmidt.me>