### PR TITLE
[Grafana][OSDC] Include meta-prod-aws-ue1 in Jobs Submitted panel

### DIFF
--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -37,6 +37,8 @@ mise run push --folder "..."
   | `arc-cbr-prod-uw1` | `pytorch-arc-cbr-production-uw1` |
   | `meta-prod-aws-ue1` | `meta-prod-aws-ue1` |
 
+  `workflow_job` data doesn't carry the Prometheus cluster name — only `runner_group_name`. Something has to translate the two, and since the mapping rarely changes and lives entirely in our control, hardcoding it in the panel queries (with this table as the source of truth) is simpler than a ClickHouse dictionary or an ARC label-injection change, which just relocate the same mapping while adding moving parts.
+
 ## Datasources
 
 * grafana-clickhouse-datasource

--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -37,7 +37,9 @@ mise run push --folder "..."
   | `arc-cbr-prod-uw1` | `pytorch-arc-cbr-production-uw1` |
   | `meta-prod-aws-ue1` | `meta-prod-aws-ue1` |
 
-  `workflow_job` data doesn't carry the Prometheus cluster name — only `runner_group_name`. Something has to translate the two, and since the mapping rarely changes and lives entirely in our control, hardcoding it in the panel queries (with this table as the source of truth) is simpler than a ClickHouse dictionary or an ARC label-injection change, which just relocate the same mapping while adding moving parts.
+  `workflow_job` data doesn't carry the Prometheus cluster name — only `runner_group_name` — so each panel hardcodes the mapping above.
+
+  **Agents: before editing any panel that uses this mapping (or adding a new one), verify the table above is still current.** Query ClickHouse for `SELECT DISTINCT runner_group_name FROM default.workflow_job WHERE arrayExists(label -> match(label, '^mt-(rel-)?l-'), labels) AND started_at > now() - INTERVAL 7 DAY` and cross-check against the Prometheus cluster list (`label_values(gha_assigned_jobs{cluster=~".*arc.*production.*|meta-prod-aws-.*"},cluster)`). If either side has values not represented in the table, update this table AND every panel query that hardcodes the mapping (find them by grepping all dashboard JSONs for `runner_group_name IN` and `runner_group_name =`). Do not assume the table is complete just because it covers the most recent cluster you added.
 
 ## Datasources
 

--- a/grafana/AGENTS.md
+++ b/grafana/AGENTS.md
@@ -28,6 +28,14 @@ mise run push --folder "..."
   * NEVER make edits to any folders other than the folder UID provided with `--folder`
   * NEVER use curl directly to interact with the API
 * Panel titles must end with the list of dashboard variables referenced in the panel's query, formatted as `[var1, var2]` without the `$` prefix (e.g. `Running Jobs [cluster, scale_set]`). The `$` is omitted so Grafana doesn't interpolate the variable value into the title. Include every `$var`/`${var}` the query uses; omit the suffix entirely if the query uses no variables.
+* Every time a series apear in more than one graph, all graphs that use it should use `palette-classic-by-name`, unless there is an explicit reason for this that is well documented and valid.
+* ClickHouse queries that filter OSDC runners by `${cluster}` must map `runner_group_name` (GitHub) to the Prometheus `cluster` value using the table below. Keep all panels using this mapping in sync — when a cluster is added, update every panel that uses it.
+
+  | `runner_group_name` | `${cluster}` value |
+  |---|---|
+  | `default`, `release-runners` | `pytorch-arc-cbr-production` |
+  | `arc-cbr-prod-uw1` | `pytorch-arc-cbr-production-uw1` |
+  | `meta-prod-aws-ue1` | `meta-prod-aws-ue1` |
 
 ## Datasources
 

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -964,7 +964,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n  toStartOfInterval(created_at, INTERVAL 5 MINUTE) AS time,\n  uniqExact(id) AS jobs\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n  AND arrayExists(label -> match(label, '^mt-(rel-)?l-'), labels)\n  AND (\n    (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n    OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n  )\n  AND $__timeFilter(created_at)\nGROUP BY time\nORDER BY time ASC"
+                      "rawSql": "SELECT\n  toStartOfInterval(created_at, INTERVAL 5 MINUTE) AS time,\n  uniqExact(id) AS jobs\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n  AND arrayExists(label -> match(label, '^mt-(rel-)?l-'), labels)\n  AND (\n    (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n    OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n    OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n  )\n  AND $__timeFilter(created_at)\nGROUP BY time\nORDER BY time ASC"
                     },
                     "version": "v0"
                   },

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -69,7 +69,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -189,7 +189,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -318,7 +318,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -447,7 +447,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -567,7 +567,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -705,7 +705,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -1108,7 +1108,7 @@
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic",
+                  "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
@@ -1180,6 +1180,260 @@
             }
           },
           "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND NOT arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND match(extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$'), '^(${runner_name_prefix:regex})$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > created_at\nORDER BY started_at"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-job queue time distribution over time for OSDC production runners, excluding capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
+        "id": 10,
+        "links": [],
+        "title": "Queue Time Distribution (excl. capacity-constrained instances) [cluster, repository, scale_set, runner_name_prefix]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "calculate": true,
+              "calculation": {
+                "xBuckets": {
+                  "mode": "size",
+                  "value": ""
+                },
+                "yBuckets": {
+                  "mode": "count",
+                  "scale": {
+                    "log": 10,
+                    "type": "log"
+                  },
+                  "value": "30"
+                }
+              },
+              "cellGap": 0,
+              "cellValues": {
+                "unit": "short"
+              },
+              "color": {
+                "exponent": 0.5,
+                "fill": "#96D98D",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-9
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "showValue": "never",
+              "tooltip": {
+                "mode": "single",
+                "show": true,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisLabel": "Queue (min)",
+                "axisPlacement": "left",
+                "decimals": 1,
+                "min": 0.01,
+                "reverse": false,
+                "unit": "m"
+              }
+            },
+            "version": ""
+          }
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n    started_at AS time,\n    dateDiff('second', created_at, started_at) / 60.0 AS queue_minutes\nFROM default.workflow_job\nWHERE match(repository_full_name, '^(${repository:regex})$')\n    AND arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels)\n    AND arrayExists(x -> position(x, 'h100') > 0 OR position(x, 'b200') > 0 OR position(x, 'gb200') > 0 OR position(x, 'a100') > 0, labels)\n    AND match(runner_name, '^(${scale_set:regex})-runner-[^-]+$')\n    AND match(extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$'), '^(${runner_name_prefix:regex})$')\n    AND (\n      (runner_group_name IN ('default', 'release-runners') AND match('pytorch-arc-cbr-production', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'arc-cbr-prod-uw1' AND match('pytorch-arc-cbr-production-uw1', '^(${cluster:regex})$'))\n      OR (runner_group_name = 'meta-prod-aws-ue1' AND match('meta-prod-aws-ue1', '^(${cluster:regex})$'))\n    )\n    AND $__timeFilter(started_at)\n    AND started_at > created_at\nORDER BY started_at"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-job queue time distribution over time for OSDC production runners, ONLY capacity-constrained GPU runners (h100, b200, gb200, a100). Y-axis log scale, minutes.",
+        "id": 11,
+        "links": [],
+        "title": "Queue Time Distribution (capacity-constrained instances only) [cluster, repository, scale_set, runner_name_prefix]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "calculate": true,
+              "calculation": {
+                "xBuckets": {
+                  "mode": "size",
+                  "value": ""
+                },
+                "yBuckets": {
+                  "mode": "count",
+                  "scale": {
+                    "log": 10,
+                    "type": "log"
+                  },
+                  "value": "30"
+                }
+              },
+              "cellGap": 0,
+              "cellValues": {
+                "unit": "short"
+              },
+              "color": {
+                "exponent": 0.5,
+                "fill": "#5794F2",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-9
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "showValue": "never",
+              "tooltip": {
+                "mode": "single",
+                "show": true,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisLabel": "Queue (min)",
+                "axisPlacement": "left",
+                "decimals": 1,
+                "min": 0.01,
+                "reverse": false,
+                "unit": "m"
+              }
+            },
+            "version": ""
+          }
         }
       }
     }
@@ -1304,6 +1558,32 @@
             "x": 0,
             "y": 30
           }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-10"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 40
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-11"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 12,
+            "y": 40
+          }
         }
       ]
     }
@@ -1392,7 +1672,46 @@
             "$__all"
           ]
         },
-        "definition": "label_values(gha_assigned_jobs{cluster=~\"${cluster:regex}\"},name)",
+        "definition": "SELECT DISTINCT extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$') AS prefix FROM default.workflow_job WHERE arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels) AND started_at > now() - INTERVAL 7 DAY AND runner_group_name IN ('default', 'release-runners', 'arc-cbr-prod-uw1', 'meta-prod-aws-ue1') AND extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$') != '' ORDER BY prefix",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Runner name",
+        "multi": true,
+        "name": "runner_name_prefix",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "ceczcsck1b20wb"
+          },
+          "group": "grafana-clickhouse-datasource",
+          "kind": "DataQuery",
+          "spec": {
+            "editorType": "sql",
+            "format": 1,
+            "queryType": "table",
+            "rawSql": "SELECT DISTINCT extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$') AS prefix FROM default.workflow_job WHERE arrayExists(x -> startsWith(x, 'mt-l-') OR startsWith(x, 'mt-rel-l-'), labels) AND started_at > now() - INTERVAL 7 DAY AND runner_group_name IN ('default', 'release-runners', 'arc-cbr-prod-uw1', 'meta-prod-aws-ue1') AND extract(runner_name, '^(.+)-[^-]+-runner-[^-]+$') != '' ORDER BY prefix"
+          },
+          "version": "v0"
+        },
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allValue": ".*",
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(gha_assigned_jobs{cluster=~\"${cluster:regex}\", name=~\"(${runner_name_prefix:regex})-.*\"},name)",
         "hide": "dontHide",
         "includeAll": true,
         "label": "Scale set",
@@ -1407,7 +1726,7 @@
           "kind": "DataQuery",
           "spec": {
             "qryType": 1,
-            "query": "label_values(gha_assigned_jobs{cluster=~\"${cluster:regex}\"},name)",
+            "query": "label_values(gha_assigned_jobs{cluster=~\"${cluster:regex}\", name=~\"(${runner_name_prefix:regex})-.*\"},name)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "version": "v0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #659
* #657
* #656
* #655

Panel-7 ("Jobs Submitted to OSDC Runners, per 5min") was only
matching two of the three runner_group_name -> cluster pairs,
so jobs submitted to meta-prod-aws-ue1 runners did not show
up in the panel even when its cluster was selected.

Add the third OR clause to match the mapping documented in
grafana/AGENTS.md and already used by the queue time heatmap
panels (panel-10, panel-11).

Signed-off-by: Jean Schmidt <contato@jschmidt.me>