### PR TITLE
[OSDC] Pin full helm patch version in mise.toml

### DIFF
--- a/osdc/mise.toml
+++ b/osdc/mise.toml
@@ -8,7 +8,7 @@
 python = "3.12"
 opentofu = "1.7"
 kubectl = "1.34"
-helm = "3.14"
+helm = "3.14.4"
 awscli = "2"
 packer = "1.10"
 crane = "latest"


### PR DESCRIPTION
## Problem

`just list` (and any recipe that triggers a tool install) fails with:

```
mise ERROR Failed to install aqua:helm/helm@3.14: HTTP status client error (404 Not Found) for url (https://get.helm.sh/helm-3.14-darwin-arm64.tar.gz)
```

mise (2026.5.x) resolves `helm` through the **aqua** backend, which no longer expands a bare minor version to a concrete release tag. The `"3.14"` string is templated literally into the asset name — `helm-3.14-darwin-arm64.tar.gz`, missing both the `v` prefix and the patch number — which does not exist on `get.helm.sh`, hence the 404.

## Fix

Pin the full patch version `3.14.4` so the asset resolves correctly to `helm-v3.14.4-darwin-arm64.tar.gz`. This stays on the intended 3.14 minor — not a version bump.

## Verification

```
$ mise install helm
mise helm@3.14.4  [1/3] download helm-v3.14.4-darwin-arm64.tar.gz
mise helm@3.14.4  ✓ installed
$ mise exec -- helm version
version.BuildInfo{Version:"v3.14.4", ...}
```

## Note

`kubectl = "1.34"` and `opentofu = "1.7"` are pinned the same bare-minor way and may hit the same 404 the next time they (re)install. Left unchanged here to keep this fix focused; happy to follow up if desired.