### PR TITLE
Add secondary EIPs to NAT Gateways

### DIFF
--- a/osdc/modules/eks/terraform/modules/vpc/main.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/main.tf
@@ -9,6 +9,21 @@ terraform {
   }
 }
 
+locals {
+  secondary_eip_count = 7
+  nat_gateway_count   = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
+  nat_secondary_eips = var.enable_nat_gateway ? {
+    for pair in flatten([
+      for nat_idx in range(local.nat_gateway_count) : [
+        for sec_idx in range(local.secondary_eip_count) : {
+          key     = "${var.azs[nat_idx]}-${sec_idx}"
+          nat_idx = nat_idx
+        }
+      ]
+    ]) : pair.key => pair
+  } : {}
+}
+
 # VPC
 resource "aws_vpc" "this" {
   cidr_block                       = var.cidr
@@ -115,12 +130,29 @@ resource "aws_eip" "nat" {
   depends_on = [aws_internet_gateway.this]
 }
 
+# Secondary Elastic IPs for NAT Gateways (allows up to 8 total EIPs per NAT GW)
+resource "aws_eip" "nat_secondary" {
+  for_each = local.nat_secondary_eips
+  domain   = "vpc"
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name}-nat-${each.value.nat_idx + 1}-sec-${each.key}"
+    }
+  )
+  depends_on = [aws_internet_gateway.this]
+}
+
 # NAT Gateways
 resource "aws_nat_gateway" "this" {
   count = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
 
   allocation_id = aws_eip.nat[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
+  secondary_allocation_ids = [
+    for sec in local.nat_secondary_eips : aws_eip.nat_secondary[sec.key].id
+    if sec.nat_idx == count.index
+  ]
+  subnet_id = aws_subnet.public[count.index].id
 
   tags = merge(
     var.tags,

--- a/osdc/modules/eks/terraform/modules/vpc/outputs.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/outputs.tf
@@ -33,6 +33,19 @@ output "nat_gateway_ids" {
   value       = aws_nat_gateway.this[*].id
 }
 
+output "nat_gateway_public_ips" {
+  description = "Map of NAT Gateway index (0-based) to list of public IPv4 addresses (primary first, then secondaries)."
+  value = {
+    for nat_idx in range(local.nat_gateway_count) :
+    "nat-${nat_idx + 1}" => concat(
+      [aws_eip.nat[nat_idx].public_ip],
+      [for sec_key, sec in local.nat_secondary_eips :
+        aws_eip.nat_secondary[sec_key].public_ip
+      if sec.nat_idx == nat_idx]
+    )
+  }
+}
+
 output "internet_gateway_id" {
   description = "The ID of the Internet Gateway"
   value       = aws_internet_gateway.this.id


### PR DESCRIPTION
- Allocate 7 secondary EIPs per NAT Gateway (8 total IPv4 addresses each)
- Attach secondary EIPs via secondary_allocation_ids on aws_nat_gateway
- Add nat_gateway_public_ips output mapping each NAT GW to all its public IPs

## Per cluster

| Cluster | Region | AZs used | NAT GWs | EIPs/NAT GW (before → after) | Total EIPs (before → after) |
|---|---|---|---|---|---|
| `arc-staging` | us-west-1 | 2 (single_nat_gateway: true) | 1 | 1 → **8** | 1 → **8** |
| `arc-cbr-production-uw1` | us-west-1 | 2 | 2 | 1 → **8** | 2 → **16** |
| `meta-prod-aws-ue1` | us-east-1 | 3 | 3 | 1 → **8** | 3 → **24** |
| `arc-cbr-production` | us-east-2 | 3 | 3 | 1 → **8** | 3 → **24** |
| **Fleet total** | | | **9** | | **9 → 72** |

## Per region (account-level EIP quota impact)

| Region | Clusters in region | NAT GWs | Total EIPs (before → after) |
|---|---|---|---|
| us-west-1 | arc-staging + arc-cbr-production-uw1 | 1 + 2 = 3 | 3 → **24** |
| us-east-1 | meta-prod-aws-ue1 | 3 | 3 → **24** |
| us-east-2 | arc-cbr-production | 3 | 3 → **24** |