### PR TITLE
[OSDC] Refresh us-east-2 B200 capacity reservations

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -295,12 +295,11 @@ clusters:
       capacity_reservation_ids:
         - cr-0c3f05dffb85ed832
     nodepools-b200:
-      # us-east-2 B200 capacity reservations (p6-b200.48xlarge, 8× B200 each).
-      # Two reserved nodes total = 16 B200 GPUs. arc-runners-b200/defs/*.yaml
+      # us-east-2 B200 capacity reservation (p6-b200.48xlarge, 8× B200 each).
+      # One reserved node total = 8 B200 GPUs. arc-runners-b200/defs/*.yaml
       # max_runners are sized assuming this count.
       capacity_reservation_ids:
-        - cr-02cf82c9a0f7fa8c0
-        - cr-06ec9d6c14b9d9981
+        - cr-0b15c0b3163f09d26
     pypi_cache:
       replicas: 10
     modules:

--- a/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-bx86iamx-176-1800-b200-8.yaml
@@ -12,5 +12,5 @@ runner:
   vcpu: 176
   memory: 1800Gi
   gpu: 8
-  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 8 GPUs per runner = 2 concurrent runners.
-  max_runners: 2
+  # Fixed-capacity cap: 1 reserved 8-GPU node (8 GPUs) / 8 GPUs per runner = 1 concurrent runner.
+  max_runners: 1

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-22-225-b200.yaml
@@ -8,5 +8,5 @@ runner:
   vcpu: 22
   memory: 225Gi
   gpu: 1
-  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 1 GPU per runner = 16 concurrent runners.
-  max_runners: 16
+  # Fixed-capacity cap: 1 reserved 8-GPU node (8 GPUs) / 1 GPU per runner = 8 concurrent runners.
+  max_runners: 8

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-44-450-b200-2.yaml
@@ -7,5 +7,5 @@ runner:
   vcpu: 44
   memory: 450Gi
   gpu: 2
-  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 2 GPUs per runner = 8 concurrent runners.
-  max_runners: 8
+  # Fixed-capacity cap: 1 reserved 8-GPU node (8 GPUs) / 2 GPUs per runner = 4 concurrent runners.
+  max_runners: 4

--- a/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
+++ b/osdc/modules/arc-runners-b200/defs/l-x86iamx-88-900-b200-4.yaml
@@ -7,5 +7,5 @@ runner:
   vcpu: 88
   memory: 900Gi
   gpu: 4
-  # Fixed-capacity cap: 2 reserved 8-GPU nodes (16 GPUs) / 4 GPUs per runner = 4 concurrent runners.
-  max_runners: 4
+  # Fixed-capacity cap: 1 reserved 8-GPU node (8 GPUs) / 4 GPUs per runner = 2 concurrent runners.
+  max_runners: 2


### PR DESCRIPTION
## What

The two B200 capacity reservations referenced for `arc-cbr-production` (us-east-2) have **expired** and no longer exist in AWS:

- `cr-02cf82c9a0f7fa8c0` → `InvalidCapacityReservationId.NotFound`
- `cr-06ec9d6c14b9d9981` → `InvalidCapacityReservationId.NotFound`

Replace them with the new active reservation **`cr-0b15c0b3163f09d26`** (`p6-b200.48xlarge`, 1 node / 8 B200 GPUs, ends 2026-08-04).

## Capacity / max_runners

Reserved B200 capacity drops from 2 nodes (16 GPUs) to 1 node (8 GPUs), so `max_runners` is halved across all `arc-runners-b200` defs:

| Runner | GPUs/runner | Before | After |
|--------|------------|--------|-------|
| `l-bx86iamx-176-1800-b200-8` | 8 | 2 | 1 |
| `l-x86iamx-88-900-b200-4` | 4 | 4 | 2 |
| `l-x86iamx-44-450-b200-2` | 2 | 8 | 4 |
| `l-x86iamx-22-225-b200` | 1 | 16 | 8 |

## Notes

- Verified all other tracked reservations (us-west-1 H100 ×2, us-east-2 H100) are still **active** — left unchanged.
- Other active us-east-2 reservations visible in AWS belong to other teams and are intentionally left untracked here.

## Test plan

- `just lint` — all 13 linters pass
- `just test` — all unit tests pass (98.71% coverage)