### PR TITLE
Simplify cluster recreation runbook

### DIFF
--- a/osdc/docs/cluster-recreation.md
+++ b/osdc/docs/cluster-recreation.md
@@ -1,141 +1,197 @@
 # Cluster Recreation Runbook
 
-## What this is and when to use it
+## 1. Introduction and pre-flight
 
-Operator-facing runbook for destroying and recreating an existing OSDC cluster. Use this whenever a planned change touches a property of `aws_eks_cluster` (or one of its directly-dependent resources) that is **immutable after cluster creation** and that AWS rejects in-place with a ForceNew plan.
+Operator-facing runbook for destroying and recreating an existing OSDC cluster. Use this whenever a planned change touches a property of `aws_eks_cluster` (or a directly-dependent resource) that AWS rejects in-place with a ForceNew plan — VPC / IP family / CIDR changes, encryption_config additions, or any other immutable field.
 
-Common triggers:
+**Per-cluster, never in parallel.** Do `arc-staging` (us-west-1) first; only promote to `arc-cbr-production` (us-east-2) after staging has soaked.
 
-- IP family change (`kubernetes_network_config.ip_family`: `ipv4` ↔ `ipv6`)
-- Service CIDR change (`kubernetes_network_config.service_ipv4_cidr` / `service_ipv6_cidr`)
-- KMS encryption added to a previously-unencrypted cluster (`encryption_config`)
-- Any other field on `aws_eks_cluster` (or the VPC it lives in) that the AWS API refuses to mutate
+**Code change must already be on `main` with green CI.** `just deploy <cluster>` after destroy is the only path that brings up the new cluster shape.
 
-Per-cluster: do `arc-staging` (us-west-1) first, then `arc-cbr-production` (us-east-2) once staging has soaked. Never pipeline both clusters.
+**Accepted data losses** (audit and design preservation steps per change if unacceptable):
 
-**The code change that enables the new cluster shape MUST already be merged to `main` and CI must be green.** `just deploy <cluster>` after destroy is what brings up the new cluster — there is no manual override path.
+- Harbor S3 bucket (`<cluster_name>-harbor-registry`) — re-caches lazily over weeks.
+- EFS pypi-cache wheelhouse — rebuilds from upstream S3 over days.
+- Any in-cluster state not preserved by terraform (runtime-created PVCs / secrets / ConfigMaps).
 
-Accepted data losses (default; audit per migration):
+### Pre-flight checklist
 
-- **Harbor S3 bucket** (`<cluster_name>-harbor-registry`) is destroyed. All cached image layers are gone. Re-cached lazily from upstream over weeks as runners pull images.
-- **EFS pypi-cache wheelhouse** is destroyed. Wheels rebuild from the upstream S3 wheel pipeline over days.
-- Any other in-cluster state that is not preserved by terraform (cluster-local PVCs, in-cluster secrets created at runtime, ConfigMaps written by controllers, etc.).
-
-**Operator action**: before scheduling the maintenance window, audit every module being destroyed for data the operator does not want to lose. Surface anything ambiguous to stakeholders. If anything unacceptable surfaces, design preservation steps and add them to this runbook (or a migration-specific addendum) BEFORE proceeding.
-
-Out of scope for this runbook:
-
-- The migration-specific code changes themselves — those must be merged before following this runbook
-- Harbor S3 / EFS data preservation (design separately if the migration cannot tolerate the default loss)
-- Dependency / tool / image version bumps
+- [ ] Change code merged to `main`; `just lint` and `just test` green.
+- [ ] Any out-of-band image / hook bumps required by the change are deployed.
+- [ ] AWS quotas verified for the target region (NAT GWs / AZ ≥ 1; plus anything the change introduces).
+- [ ] Maintenance window communicated to pytorch/pytorch on-call.
+- [ ] Two operators on the bridge.
+- [ ] Shell prepped: `export CLUSTER=<cluster>; source scripts/state-config.sh`.
 
 ---
 
-## Pre-flight checklist
-
-### Pre-flight commands
-
-Read-only sanity checks. Run these BEFORE destroying anything. If any do not match expectations, STOP.
-
-```bash
-# Verify AWS account
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws sts get-caller-identity --query 'Account' --output text
-# Expected: 308535385114
-
-# Verify kubectl context (after just kubeconfig <cluster>)
-NO_PROXY="$NO_PROXY,.eks.amazonaws.com" no_proxy="$no_proxy,.eks.amazonaws.com" \
-  mise exec -- kubectl config current-context
-# Expected: arn:aws:eks:<region>:308535385114:cluster/<cluster_name>
-
-# Verify mise tools
-mise doctor
-
-# Verify just/uv/tofu versions
-just --version
-uv --version
-tofu version
-```
-
-### Checklist
-
-Complete every item before scheduling the maintenance window.
-
-- [ ] All migration code merged to `main` and CI green (`just lint`, `just test`)
-- [ ] Any out-of-band image / hook bumps required by the migration are deployed (handled outside this runbook)
-- [ ] AWS quotas in the target region:
-  - `L-FE5A380F` (NAT GWs / AZ): ≥ 1 per AZ (current default of 5 is plenty)
-  - Any AWS quotas the migration-specific changes introduce — operator must enumerate per migration
-- [ ] Data audit complete (see "Accepted data losses" above) — preservation steps in place for anything not safe to lose
-- [ ] Maintenance window communicated to pytorch/pytorch on-call and any stakeholders consuming the cluster
-- [ ] On-call reviewer paired for the cutover (2 people on the bridge)
-- [ ] State-bucket backup directory created locally: `mkdir -p ${HOME}/.osdc-cutover/${CLUSTER}`
-
----
-
-## Per-cluster sequence
-
-Run the steps below per cluster, in order. Do NOT pipeline staging and production — staging must complete its soak before production starts.
-
-> **Shell prerequisite — set `CLUSTER` once, up front.** Every code block below references `${CLUSTER}` (e.g. `uv run scripts/cluster-config.py ${CLUSTER} cluster_name`, `just deploy ${CLUSTER}`, S3 keys under `s3://$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)/...`). If it's unset, commands either no-op confusingly or — worse — target the wrong bucket/region. Export it at the start of the session and keep working in the same shell.
->
-> Also source `scripts/state-config.sh` so `STATE_REGION` is in scope for the state-bucket and DynamoDB commands below.
->
-> ```bash
-> export CLUSTER=arc-staging          # or arc-cbr-production
-> source scripts/state-config.sh      # exports STATE_REGION
-> ```
->
-> If you open a new shell mid-cutover, re-export it before resuming.
+## 2. Cluster destroy
 
 ### 1. Disable OSDC traffic
 
-Flip the OSDC experiment / GK that gates user traffic into the cluster. New jobs stop being routed; in-flight jobs continue until drained in step 2.
+Flip the OSDC experiment / GK. New jobs stop being routed; in-flight jobs continue.
 
-### 2. Drain runners
+### 2. Drain runners and tear down compute
 
 ```bash
 just drain-runners ${CLUSTER}
 ```
 
-This patches every `AutoScalingRunnerSet` to `maxRunners=0`, taints runner nodes, and polls until pod count is zero or the timeout (default 1h) hits.
+Patches every `AutoScalingRunnerSet` to `maxRunners=0`, taints runner nodes, polls until pod count is zero. For stragglers: `OSDC_DRAIN_TIMEOUT_SECS=<larger>` or `kubectl delete pod -n arc-runners --grace-period=0 --force <pod>` (the latter leaks GitHub-side job state — coordinate with on-call).
 
-For stragglers: operator decides whether to wait (re-run with `OSDC_DRAIN_TIMEOUT_SECS=<larger>`) or force-terminate via `kubectl delete pod -n arc-runners --grace-period=0 --force <pod>`. Force-termination leaks job state at the GitHub side — coordinate with pytorch/pytorch on-call.
-
-Verify:
+Then delete NodePools so Karpenter cascade-terminates owned EC2:
 
 ```bash
+just kubeconfig ${CLUSTER}
 kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner --no-headers | wc -l   # must be 0
-```
-
-Once runner pods are gone, tear down Karpenter-managed compute so the destroy doesn't stall on lingering EC2.
-
-**Order matters.** Delete NodePools FIRST — Karpenter cascade-deletes the owned NodeClaims and gracefully terminates the EC2 instances via its `karpenter.sh/termination` finalizer. Deleting NodeClaims first leaves orphans Karpenter cannot reconcile (see Recovery below).
-
-```bash
 kubectl delete nodepools --all
-```
-
-This also stops re-provisioning: `drain-runners` only zeroes out ARC `AutoScalingRunnerSet` capacity, but non-ARC workloads (buildkit, pypi-cache, monitoring DaemonSets) keep requesting nodes. With no NodePool spec left, Karpenter has nothing to provision from. Buildkit / pypi-cache pods sit Pending until `tofu destroy` removes their controllers — that's fine.
-
-Wait for NodeClaims to drain:
-
-```bash
 kubectl get nodeclaims    # expect: No resources found
 ```
 
-If they hang in `Terminating` (status: `Ready=False`, non-empty `metadata.deletionTimestamp`), see Recovery below.
+**Delete NodePools first, not NodeClaims** — Karpenter cascade-deletes the owned NodeClaims via its `karpenter.sh/termination` finalizer. Deleting NodeClaims first leaves orphans (see "Stuck NodeClaim finalizers" in the annex).
 
-#### Recovery: stuck NodeClaim finalizers
+### 3. Suspend CronJobs
 
-Symptom: `kubectl get nodeclaims` keeps showing the same NodeClaims with the same names, and `kubectl delete --wait=false` "deletes" them but they reappear. Karpenter controller logs spam `NodePool.karpenter.sh "<name>" not found (nodeclaim=<x>, nodepool=<name>)`. The `karpenter.sh/termination` finalizer never clears because the controller's reconciler errors out before it gets to the finalizer-removal step.
-
-Fix: terminate the orphan EC2 instances directly, then force-clear the finalizers.
+Snapshot suspend-state first so step 11 only re-enables what was originally active:
 
 ```bash
-# 1) Find Karpenter-managed instances for this cluster.
-#    Tag for cluster scoping is `eks:eks-cluster-name` (NOT `karpenter.sh/cluster`,
-#    which doesn't exist).
+just kubeconfig ${CLUSTER}
+mkdir -p ${HOME}/.osdc-cutover/${CLUSTER}
+kubectl get cronjobs -A -o json \
+  | jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name) \(.spec.suspend // false)"' \
+  > ${HOME}/.osdc-cutover/${CLUSTER}/cronjob-state-pre-cutover.txt
+
+kubectl get cronjobs -A -o json \
+  | jq -r '.items[] | select(.spec.suspend != true) |
+           "kubectl -n \(.metadata.namespace) patch cronjob \(.metadata.name) -p '\''{\"spec\":{\"suspend\":true}}'\''"' \
+  | bash
+```
+
+Prevents scheduled work (zombie-cleanup, harbor-cache-recovery, image-cache-janitor) from racing the destroy.
+
+### 4. Empty Harbor S3 bucket
+
+`aws_s3_bucket.harbor_registry` lacks `force_destroy = true`; `tofu destroy` refuses on a non-empty bucket.
+
+```bash
+CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
+REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3 rm "s3://${CNAME}-harbor-registry" --recursive --region ${REGION}
+
+# Versioned bucket: also delete versions and delete-markers
+NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
+  aws s3api list-object-versions --bucket ${CNAME}-harbor-registry --region ${REGION} --output json \
+  | jq -r '[.Versions // [], .DeleteMarkers // []] | flatten | .[] | "\(.Key)\t\(.VersionId)"' \
+  | while IFS=$'\t' read -r k v; do
+      aws s3api delete-object --bucket ${CNAME}-harbor-registry --key "$k" --version-id "$v" --region ${REGION}
+    done
+```
+
+EFS pypi-cache destroys cleanly even when populated; no equivalent step needed.
+
+### 5. Tofu destroy
+
+```bash
+./scripts/destroy-cluster.sh ${CLUSTER}
+```
+
+Encodes the dependency order (leaf modules → workloads → compute → pypi-cache → base), picks per-module vs base var sets, gates the base destroy behind a confirmation prompt. Idempotent — re-run if it fails partway. Override prompts with `OSDC_CONFIRM=yes` and `OSDC_CONFIRM_BASE=destroy`.
+
+Expected hangs: EKS control plane delete (~10 min), NAT GW drain (~5 min). If `aws_eks_addon.vpc_cni` stalls because the API server is half-gone, re-run.
+
+Read `scripts/destroy-cluster.sh` if you need to bypass it (debugging partial state, etc.); the per-module command pattern lives there.
+
+---
+
+## 3. Cluster create
+
+### 7. Set `pause_runners` (local edit, do NOT commit)
+
+Add `pause_runners: true` at the top level of the cluster's entry in `clusters.yaml`:
+
+```diff
+ arc-staging:
+   region: us-west-1
+   cluster_name: arc-staging
++  pause_runners: true
+   modules:
+     - karpenter
+```
+
+`generate_runners.py` reads this and forces every rendered `AutoScalingRunnerSet` to `maxRunners: 0`, so the GitHub listener cannot request a runner even if traffic gets flipped on early.
+
+**Keep this edit local through the entire window.** If it gets committed and merged, the next CI deploy rolls `pause_runners: true` to every cluster that change touches — blast radius is every prod cluster picking up the merged config. Stash it or work from a dirty tree; revert (`git checkout clusters.yaml`) before any unrelated commit.
+
+### 8. Bootstrap state (only if state bucket was also destroyed)
+
+```bash
+just bootstrap ${CLUSTER}
+```
+
+Skip unless you nuked the state bucket on purpose — it persists across recreation.
+
+### 9. Deploy from local
+
+```bash
+just deploy ${CLUSTER}
+```
+
+Run from local, NOT CI — CI deploys only what's on `main`, and the pause_runners edit is local-only. Applies base + every module in `clusters.yaml` order; arc-runners modules render with `maxRunners: 0` due to the pause flag.
+
+### 10. Smoke gate (MANDATORY)
+
+```bash
+just smoke ${CLUSTER}
+```
+
+Must exit 0 before proceeding. Aggregates pytest from `modules/eks/tests/smoke/` and every enabled module's `tests/smoke/`; fetches kubeconfig itself.
+
+**If smoke fails: do NOT re-enable traffic, do NOT revert pause_runners.** Fix in place (re-run `just deploy ${CLUSTER}`) or roll back per the rollback section.
+
+Changes that introduce new invariants should add assertions to the relevant smoke test before merging.
+
+### 11. Restore CronJobs
+
+```bash
+just kubeconfig ${CLUSTER}
+awk '$2=="false"{print $1}' ${HOME}/.osdc-cutover/${CLUSTER}/cronjob-state-pre-cutover.txt \
+  | while IFS=/ read -r ns name; do
+      kubectl -n "$ns" patch cronjob "$name" -p '{"spec":{"suspend":false}}'
+    done
+```
+
+### 12. Un-pause runners
+
+**Staging** — local:
+
+1. `git checkout clusters.yaml` to revert the pause edit.
+2. `just deploy ${CLUSTER}` again.
+
+**Production** — via CI:
+
+1. Revert the local pause edit (it must never be merged).
+2. Trigger `osdc-deploy-prod.yml` (`workflow_dispatch`) with `target` set to the specific cluster — NOT `all`.
+
+The prod path is gated by the `osdc-production` GitHub environment and an OIDC trust-policy `sub` claim; CI is the only audit-clean way in.
+
+### 13. Re-enable OSDC traffic
+
+The un-pause deploy in step 12 already re-synced every `AutoScalingRunnerSet`. Flip the OSDC experiment / GK and watch the queue drain.
+
+`just resume-runners` is out-of-band recovery, NOT the standard cutover path.
+
+---
+
+## 4. Annex and additional details
+
+### Stuck NodeClaim finalizers
+
+Symptom: NodeClaims reappear after delete; Karpenter logs spam `NodePool.karpenter.sh "<name>" not found`. The `karpenter.sh/termination` finalizer never clears because the reconciler errors before reaching the removal step.
+
+Fix: terminate the EC2 instances directly, then strip the finalizers.
+
+```bash
 CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
 REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
 INSTANCES=$(NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
@@ -144,332 +200,67 @@ INSTANCES=$(NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.c
               "Name=tag:eks:eks-cluster-name,Values=${CNAME}" \
               "Name=instance-state-name,Values=running,pending,stopping,stopped" \
     --query 'Reservations[].Instances[].InstanceId' --output text)
-echo "$INSTANCES"
 
-# 2) Terminate them. Without this the VPC destroy in step 6 will fail
-#    because the instances still hold ENIs in the soon-to-be-destroyed subnets.
 [[ -n "$INSTANCES" ]] && NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
   aws ec2 terminate-instances --region "${REGION}" --instance-ids $INSTANCES
 
-# 3) Force-strip the finalizers so the k8s objects clean up.
+just kubeconfig ${CLUSTER}
 kubectl get nodeclaims -o name | xargs -r -I{} \
   kubectl patch {} --type=merge -p '{"metadata":{"finalizers":null}}'
 ```
 
-Steps 1+2 are the load-bearing ones — they kill the actual AWS resources. Step 3 just unblocks the k8s objects so `kubectl get nodeclaims` returns empty.
+The terminate-instances call is the load-bearing part; the finalizer strip just unblocks the k8s side. The cluster-scoping tag is `eks:eks-cluster-name`, not `karpenter.sh/cluster` (which doesn't exist).
 
-### 3. Capture pre-cutover state
+### Validation gates
 
-```bash
-export STATE_DIR=${HOME}/.osdc-cutover/${CLUSTER}
-mkdir -p ${STATE_DIR}
+All must pass before declaring cutover complete and starting the soak.
 
-BUCKET=$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)
-
-# Tofu state for every module (in case of partial-recovery debugging)
-for mod in $(uv run scripts/cluster-config.py ${CLUSTER} modules) base; do
-  KEY="${CLUSTER}/${mod}/terraform.tfstate"
-  NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-    aws s3 cp "s3://${BUCKET}/${KEY}" \
-      "${STATE_DIR}/${mod}.tfstate" --region ${STATE_REGION} || true
-done
-
-# ConfigMap snapshot (deploy history, harbor secrets, etc.)
-kubectl get cm -A -o yaml > ${STATE_DIR}/configmaps-pre-cutover.yaml
-
-# CronJob suspend state (so step 9 only un-suspends entries originally false)
-kubectl get cronjobs -A -o json \
-  | jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name) \(.spec.suspend // false)"' \
-  > ${STATE_DIR}/cronjob-state-pre-cutover.txt
-
-```
-
-Treat `${STATE_DIR}` as sensitive — do not commit, keep on operator workstation.
-
-### 4. Suspend CronJobs
-
-```bash
-kubectl get cronjobs -A -o json \
-  | jq -r '.items[] | select(.spec.suspend != true) |
-           "kubectl -n \(.metadata.namespace) patch cronjob \(.metadata.name) -p '\''{\"spec\":{\"suspend\":true}}'\''"' \
-  | bash
-```
-
-This prevents scheduled work (zombie-cleanup, harbor-cache-recovery, image-cache-janitor) from racing the destroy.
-
-### 5. Empty Harbor S3 bucket
-
-`aws_s3_bucket.harbor_registry` is declared **without `force_destroy = true`** — `tofu destroy` will refuse on a non-empty bucket. Drain the bucket first:
-
-```bash
-CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
-REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws s3 rm "s3://${CNAME}-harbor-registry" --recursive --region ${REGION}
-
-# If versioning is on, also delete versions + delete-markers (paginated)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws s3api list-object-versions --bucket ${CNAME}-harbor-registry --region ${REGION} \
-    --output json | jq -r '
-      [.Versions // [], .DeleteMarkers // []] | flatten |
-      .[] | "\(.Key)\t\(.VersionId)"' \
-  | while IFS=$'\t' read -r k v; do
-      aws s3api delete-object --bucket ${CNAME}-harbor-registry --key "$k" --version-id "$v" --region ${REGION}
-    done
-```
-
-The pypi-cache module uses EFS (not S3), so no equivalent step is needed there — `aws_efs_file_system` destroys cleanly even when populated.
-
-### 6. Tofu destroy modules in dependency order
-
-#### Recommended: run the helper script
-
-```bash
-./scripts/destroy-cluster.sh ${CLUSTER}
-```
-
-The script encodes the dependency order, picks the right `-var` set per module (modules need `cluster_name` / `aws_region` / `state_bucket` / `cluster_id`; the base needs the full `tfvars` string from `scripts/cluster-config.py ${CLUSTER} tfvars`), uses the cluster's actual `state_bucket` (production is `ciforge-tfstate-arc-cbr-prod`, not `…-arc-cbr-production`), and gates the base destroy behind a second confirmation prompt. It does NOT empty the Harbor S3 bucket — step 5 must be run first.
-
-Env-var overrides:
-
-- `OSDC_CONFIRM=yes` — skip the up-front "type the cluster name" prompt
-- `OSDC_CONFIRM_BASE=destroy` — skip the final "type 'destroy <cluster>'" prompt before the base destroy
-
-Only modules that have a `terraform/main.tf` (`karpenter`, `pypi-cache`, and the base `modules/eks`) are tofu-destroyed. Every other module is k8s-only and dies with the EKS cluster — the script lists them under "k8s-only modules" but does not act on them.
-
-If the script fails partway through, fix the underlying issue and re-run — `tofu destroy` is idempotent against already-destroyed state.
-
-#### Manual procedure (use only when bypassing the script)
-
-Destroy in **reverse-deploy order**: leaf modules first, base last. `tofu init -reconfigure` in each module directory before `destroy`; pass the same `-var` flags the deploy uses.
-
-Compute the base tfvars string once:
-
-```bash
-TFVARS=$(uv run scripts/cluster-config.py ${CLUSTER} tfvars)
-BUCKET=$(uv run scripts/cluster-config.py ${CLUSTER} state_bucket)
-CNAME=$(uv run scripts/cluster-config.py ${CLUSTER} cluster_name)
-REGION=$(uv run scripts/cluster-config.py ${CLUSTER} region)
-```
-
-`TFVARS` matches the **base** schema only — module destroys reject the extra vars; pass just `-var="cluster_name=${CNAME}" -var="aws_region=${REGION}" -var="state_bucket=${BUCKET}" -var="cluster_id=${CLUSTER}"` for those.
-
-Destroy order (reverse of the cluster's `modules` list in `clusters.yaml`, ending at the base):
-
-1. **Leaf cron / enforcement modules** (no dependents):
-   - `modules/harbor-cache-recovery`
-   - `modules/zombie-cleanup`
-   - `modules/cache-enforcer`
-2. **Observability**:
-   - `modules/logging`
-   - `modules/monitoring`
-3. **Workload modules** (depend on arc / nodepools):
-   - `modules/buildkit`
-   - `modules/arc-runners-h100` (production only)
-   - `modules/arc-runners-b200` (production only)
-   - `modules/arc-runners`
-   - `modules/arc`
-4. **Compute provisioning**:
-   - `modules/nodepools-h100` (production only)
-   - `modules/nodepools-b200` (production only)
-   - `modules/nodepools`
-   - `modules/karpenter`
-5. **PyPI cache** — **WARNING**: EFS file system + wheelhouse data is destroyed.
-   - `modules/pypi-cache`
-6. **Base / EKS** — **WARNING**: Harbor S3 bucket (already emptied in step 5), VPC, EKS control plane, base node group, IAM roles, KMS keys all destroyed.
-   - `modules/eks` (state key `${CLUSTER}/base/terraform.tfstate`)
-
-Per-module command pattern:
-
-```bash
-cd modules/<mod>/terraform
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  tofu init -reconfigure \
-    -backend-config="bucket=${BUCKET}" \
-    -backend-config="key=${CLUSTER}/<mod>/terraform.tfstate" \
-    -backend-config="region=${STATE_REGION}" \
-    -backend-config="dynamodb_table=ciforge-terraform-locks"
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  tofu destroy -auto-approve \
-    -var="cluster_name=${CNAME}" \
-    -var="aws_region=${REGION}" \
-    -var="state_bucket=${BUCKET}" \
-    -var="cluster_id=${CLUSTER}"
-cd -
-```
-
-For the base, the key is `${CLUSTER}/base/terraform.tfstate` (not `${CLUSTER}/eks/...`), and the destroy must use the full base var set:
-
-```bash
-cd modules/eks/terraform
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  tofu init -reconfigure \
-    -backend-config="bucket=${BUCKET}" \
-    -backend-config="key=${CLUSTER}/base/terraform.tfstate" \
-    -backend-config="region=${STATE_REGION}" \
-    -backend-config="dynamodb_table=ciforge-terraform-locks"
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  eval tofu destroy ${TFVARS} -auto-approve
-cd -
-```
-
-Hangs to expect:
-
-- `aws_eks_cluster` destroy can stall ~10 min while EKS deletes the control plane
-- `aws_nat_gateway` destroy waits ~5 min for the NAT to drain
-- `aws_efs_file_system` destroy fails if mount targets aren't gone — `tofu destroy` deletes them in the same plan, but a half-applied destroy may need a retry
-- `aws_eks_addon.vpc_cni` may stall if it can't reach the API server because the cluster is half-gone — re-run destroy
-
-### 7. Verify survivors
-
-After base destroy completes, spot-check that NON-cluster resources are untouched:
-
-```bash
-# ECR mirrors (separate from Harbor S3 — these survive)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws ecr describe-repositories --region ${REGION} | jq '.repositories | length'
-
-# Tofu state bucket (lives in us-west-2 regardless of cluster region)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws s3 ls "s3://${BUCKET}/" --region ${STATE_REGION}
-
-# DynamoDB lock table (shared across all clusters)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws dynamodb describe-table --table-name ciforge-terraform-locks --region ${STATE_REGION} \
-    --query 'Table.TableStatus'
-
-# S3 wheel pipeline bucket (external to OSDC, feeds pypi-cache)
-NO_PROXY="$NO_PROXY,.amazonaws.com" no_proxy="$no_proxy,.amazonaws.com" \
-  aws s3 ls "s3://pytorch-pypi-wheel-cache/" --region us-east-2 | head -5
-```
-
-If anything cluster-related is left over (orphaned ENIs, NAT GW, EIP, security groups stuck on `cluster_security_group`), clean up by hand before redeploying — leftovers can collide with the recreated cluster.
-
-### 8. Bootstrap state (only if state bucket was destroyed) and redeploy
-
-The state bucket persists across recreation because it is bootstrapped via `scripts/bootstrap-state.sh` (not part of `modules/eks`). Skip the bootstrap step unless you also nuked the state bucket on purpose. If you did:
-
-```bash
-just bootstrap ${CLUSTER}
-```
-
-Then full deploy:
-
-```bash
-just deploy ${CLUSTER}
-```
-
-This applies base (VPC, EKS, Harbor S3/IAM, base k8s resources), then every module in the order defined in `clusters.yaml`.
-
-### 9. Smoke tests
-
-```bash
-just smoke ${CLUSTER}
-```
-
-Runs the per-base and per-module smoke suite under `modules/eks/tests/smoke/` and each module's `tests/smoke/`. All must pass before resuming traffic. Migrations that introduce new invariants should add assertions to the relevant smoke test before merging — those assertions then become a deploy-time gate here.
-
-### 10. Restore CronJobs
-
-Only un-suspend CronJobs that were `false` originally (preserves any CronJob suspended for unrelated reasons):
-
-```bash
-awk '$2=="false"{print $1}' ${STATE_DIR}/cronjob-state-pre-cutover.txt \
-  | while IFS=/ read -r ns name; do
-      kubectl -n "$ns" patch cronjob "$name" -p '{"spec":{"suspend":false}}'
-    done
-```
-
-### 11. Re-enable runner traffic
-
-`just deploy` already re-synced every `AutoScalingRunnerSet` from `modules/arc-runners/defs/`, so `maxRunners` is back at the def value. Re-enable the OSDC experiment / GK and watch the queue drain.
-
-`just resume-runners` is NOT used in standard cutover — it's out-of-band recovery only.
-
----
-
-## Validation gates
-
-Per cluster, all gates must pass within the maintenance window before declaring cutover complete and starting the soak.
-
-| Gate | Check | Pass criterion |
+| Gate | Check | Pass |
 |---|---|---|
-| Cluster up | `kubectl get nodes -o wide` | All `Ready`; node count matches `base_node_count` for the cluster |
-| Pod-to-internet egress | `kubectl run -it --rm --image=curlimages/curl curl-test -- curl -sI https://github.com/` | HTTP 200 |
-| Harbor proxy | `kubectl run -it --rm --image=<harbor>/dockerhub-proxy/library/alpine:latest pull-test -- echo ok` | Image pulls — proxy fetches from upstream (cold cache) |
-| pypi-cache | `kubectl exec <runner-class pod> -- pip install --index-url http://pypi-cache.pypi-cache.svc/simple/cuda-12.6.3/ requests` | Wheel fetched via pypi-cache (proxy-fetches from upstream on miss) |
-| Distributed test (production only) | NCCL / `torch.distributed` 2-node smoke test on H100 or B200 fleet | Job completes; no socket errors |
-| Smoke suite | `just smoke ${CLUSTER}` | Exit 0 |
-| Migration-specific gates | Operator adds checks specific to the migration (e.g., new IP family addressing, new addon behavior, changed network policy semantics, KMS-backed secret round-trip) | Per-migration |
+| Cluster up | `kubectl get nodes -o wide` | All `Ready`; count matches `base_node_count` |
+| Pod egress | `kubectl run -it --rm --image=curlimages/curl curl-test -- curl -sI https://github.com/` | HTTP 200 |
+| Harbor proxy | Pull `<harbor>/dockerhub-proxy/library/alpine:latest` | Image pulls (cold cache) |
+| pypi-cache | `pip install --index-url http://pypi-cache.pypi-cache.svc/simple/cuda-12.6.3/ requests` | Wheel fetched |
+| Distributed (prod only) | NCCL / `torch.distributed` 2-node on H100 or B200 | Job completes; no socket errors |
+| Smoke | `just smoke ${CLUSTER}` | Exit 0 |
+| Change-specific | Operator adds checks specific to the change | Per-change |
 
-If any gate fails: stop, do not advance to soak. Investigate; either fix in place or roll back per the rollback section.
+### IRSA refresh sanity check
 
-### IRSA refresh check
-
-Cluster recreation produces a new OIDC issuer URL. All IRSA-using ServiceAccounts get re-bound automatically by terraform on `just deploy` (modules read OIDC ARN from `terraform_remote_state.base.outputs.oidc_provider_arn`). Verify post-deploy:
+Recreation produces a new OIDC issuer URL; modules pick it up automatically from `terraform_remote_state.base.outputs.oidc_provider_arn`. Spot-check that ServiceAccount role ARNs reference roles bound to the new OIDC provider:
 
 ```bash
-NO_PROXY="$NO_PROXY,.eks.amazonaws.com" no_proxy="$no_proxy,.eks.amazonaws.com" \
-  mise exec -- kubectl get sa -A -o json | \
-  jq -r '.items[] | select(.metadata.annotations."eks.amazonaws.com/role-arn") | "\(.metadata.namespace)/\(.metadata.name) \(.metadata.annotations."eks.amazonaws.com/role-arn")"'
-# Spot-check that role ARNs reference roles bound to the NEW OIDC provider URL
+just kubeconfig ${CLUSTER}
+kubectl get sa -A -o json | \
+  jq -r '.items[] | select(.metadata.annotations."eks.amazonaws.com/role-arn") |
+         "\(.metadata.namespace)/\(.metadata.name) \(.metadata.annotations."eks.amazonaws.com/role-arn")"'
 ```
 
----
+### Soak window
 
-## Soak window
+Run ≥ 3 days, preferably 7 days at production load, before promoting `arc-staging` → `arc-cbr-production`.
 
-Run for **≥ 3 days, preferably 7 days at production load** before declaring success and moving to the next cluster.
+Watch:
 
-Watch list (Grafana panels, alerts, and ad-hoc kubectl):
+- kube-apiserver p99 latency — drift > 2x baseline = etcd / control-plane sizing issue.
+- CoreDNS QPS — flat vs baseline.
+- Pod startup P50 / P99 — drift > 2x P99 = scheduler pressure or CNI tuning.
+- GitHub Actions runner success rate — within ± 1pp of pre-cutover.
+- Harbor 5xx / cache miss — elevated for ~ 2 weeks as cold S3 re-fills; watch for 5xx that are NOT misses.
+- pypi-cache cold-start errors — re-population from wheel-pipeline S3 takes days.
+- Change-specific watch items — operator enumerates per change.
 
-- **NAT GW data egress trend** — compare bytes-out vs the pre-cutover baseline. Spike > 2x baseline indicates an unexpected destination set; investigate via VPC flow logs.
-- **conntrack table fill** — `node_nf_conntrack_entries / node_nf_conntrack_entries_limit` per node. > 80% fill is concerning; > 95% will start dropping connections (`nf_conntrack: table full, dropping packet`).
-- **kube-apiserver p99 latency** — should match pre-cutover baseline. Drift > 2x is a red flag (etcd / control plane sizing issue).
-- **CoreDNS QPS** — should be flat vs baseline. Spike means node-local DNS is missing.
-- **Node-local DNS health** — `coredns_nodecache_setup_errors_total` must remain 0. Any non-zero value means NLD failed to set up its iptables intercept on a node; the dummy interface bind will still work but liveness can flap.
-- **Pod startup time P50 / P99** — vs pre-cutover baseline. Drift > 2x P99 needs investigation (likely VPC CNI prefix warm-pool tuning or scheduler pressure).
-- **GitHub Actions runner success rate** — pull from ClickHouse / pytorch HUD. Should match pre-cutover within ± 1 percentage point.
-- **Harbor 5xx rate / cache miss rate** — expected to be elevated for the first ~ 2 weeks as the cold S3 backend re-fills. Watch for 5xx spikes that are NOT cache misses.
-- **pypi-cache cold-start errors** — wheel fetches from upstream may temporarily exceed the network policy budget; tune as needed. Re-population from the wheel-pipeline S3 takes days.
-- **Migration-specific watch items** — operator enumerates per migration (new metrics introduced, behaviors the migration changes, regressions specific to the property being mutated).
+Daily check-in. Promote only after a clean full soak window.
 
-Daily check-in: read the watch list, decide go/no-go for the next 24h. Promote `arc-staging` → `arc-cbr-production` only when staging has been clean for the full soak window.
+### Rollback
 
----
+Cluster recreation is one-way. Rollback = revert the change on a hotfix branch, merge it, destroy + recreate again. Costs: one extra maintenance window per cluster, another round of Harbor/EFS loss, another IRSA refresh.
 
-## Rollback
+If the validation gates fail and the hotfix is small (parameter tweak, addon version), fix forward (`just deploy ${CLUSTER}` after merge) instead of destroying.
 
-Cluster recreation is one-way. Once destroyed, you commit to recreate — there is no per-step rollback within a single cutover.
+### References
 
-"Rollback" means: revert the migration code change on a hotfix branch, get it merged to `main`, then destroy + recreate the cluster a second time (same procedure as this runbook). Costs:
-
-- One additional maintenance window per cluster
-- Harbor S3 / EFS / any other accepted-loss data is lost a second time (rebuilds again over weeks)
-- IRSA refresh again
-- Any state you captured in step 3 is now two cutovers stale
-
-Some migrations may design an explicit safety net (e.g., keeping inert fallback infrastructure in the codebase that can be activated post-recreation without another destroy). If the migration provides one, document the activation procedure in a migration-specific addendum to this runbook. For migrations without a safety net, plan one maintenance window per cluster for the rollback.
-
-If the validation gates fail and a hotfix is small (parameter tweak, addon version), prefer fixing forward over rolling back — a forward fix is `just deploy ${CLUSTER}` after the hotfix is merged, no destroy needed.
-
----
-
-## Post-cutover follow-ups
-
-After both clusters are stable for several weeks:
-
-- **Per-cluster tuning** — update `clusters.yaml` if the migration introduces any per-cluster overrides (e.g. component memory, replica counts).
-- **Monitoring / alerting additions** — consider whether the migration introduces new failure modes worth alerting on. Add the rules with the migration's PR if possible, or as a follow-up PR.
-- **Codebase cleanup** — if the migration left behind transitional code (feature flags, dual-path conditionals, fallback infrastructure), schedule its removal once the new path has been stable long enough that rollback is no longer plausible. Treat as a separate PR.
-
----
-
-## References
-
-- `docs/architecture.md` — cluster architecture, base vs modules, deploy flow
-- `docs/operations.md` — day-to-day ops; bootstrap and deploy recipes
-- `scripts/destroy-cluster.sh` — the destroy helper invoked in step 6
+- `docs/architecture.md`, `docs/operations.md`
+- `scripts/destroy-cluster.sh` — destroy helper (step 5)
 - `scripts/cluster-config.py` — resolves cluster-name / region / state-bucket / tfvars / module list from `clusters.yaml`
-- `clusters.yaml` — per-cluster module list and overrides (source of truth for destroy order)
-- `modules/eks/tests/smoke/` — base smoke assertions; add migration-specific assertions here
+- `modules/eks/tests/smoke/` — base smoke assertions; add change-specific ones here

--- a/osdc/docs/cluster-recreation.md
+++ b/osdc/docs/cluster-recreation.md
@@ -236,31 +236,8 @@ kubectl get sa -A -o json | \
          "\(.metadata.namespace)/\(.metadata.name) \(.metadata.annotations."eks.amazonaws.com/role-arn")"'
 ```
 
-### Soak window
-
-Run ≥ 3 days, preferably 7 days at production load, before promoting `arc-staging` → `arc-cbr-production`.
-
-Watch:
-
-- kube-apiserver p99 latency — drift > 2x baseline = etcd / control-plane sizing issue.
-- CoreDNS QPS — flat vs baseline.
-- Pod startup P50 / P99 — drift > 2x P99 = scheduler pressure or CNI tuning.
-- GitHub Actions runner success rate — within ± 1pp of pre-cutover.
-- Harbor 5xx / cache miss — elevated for ~ 2 weeks as cold S3 re-fills; watch for 5xx that are NOT misses.
-- pypi-cache cold-start errors — re-population from wheel-pipeline S3 takes days.
-- Change-specific watch items — operator enumerates per change.
-
-Daily check-in. Promote only after a clean full soak window.
-
 ### Rollback
 
 Cluster recreation is one-way. Rollback = revert the change on a hotfix branch, merge it, destroy + recreate again. Costs: one extra maintenance window per cluster, another round of Harbor/EFS loss, another IRSA refresh.
 
 If the validation gates fail and the hotfix is small (parameter tweak, addon version), fix forward (`just deploy ${CLUSTER}` after merge) instead of destroying.
-
-### References
-
-- `docs/architecture.md`, `docs/operations.md`
-- `scripts/destroy-cluster.sh` — destroy helper (step 5)
-- `scripts/cluster-config.py` — resolves cluster-name / region / state-bucket / tfvars / module list from `clusters.yaml`
-- `modules/eks/tests/smoke/` — base smoke assertions; add change-specific ones here

--- a/osdc/docs/cluster-recreation.md
+++ b/osdc/docs/cluster-recreation.md
@@ -4,7 +4,12 @@
 
 Operator-facing runbook for destroying and recreating an existing OSDC cluster. Use this whenever a planned change touches a property of `aws_eks_cluster` (or a directly-dependent resource) that AWS rejects in-place with a ForceNew plan — VPC / IP family / CIDR changes, encryption_config additions, or any other immutable field.
 
-**Per-cluster, never in parallel.** Do `arc-staging` (us-west-1) first; only promote to `arc-cbr-production` (us-east-2) after staging has soaked.
+**Per-cluster, never in parallel.** Do `arc-staging` (us-west-1) first; only promote to the new/changed production cluster after staging has soaked. 
+
+- This can change if you are deploying a new cluster with a tested configuration or migrating a cluster from one state to another:
+ - Creating a new cluster: green signals on [osdc-pre-merge.yml](https://github.com/pytorch/ci-infra/blob/main/.github/workflows/osdc-pre-merge.yml) for the latest main version should be sufficient;
+ - Fully destroying / recreating: same as for creating a new cluster;
+ - Migrating / terraform network eks changes: please deploy `arc-staging` to your current version, then execute this procedure to it and follow the testing guidelines first;
 
 **Code change must already be on `main` with green CI.** `just deploy <cluster>` after destroy is the only path that brings up the new cluster shape.
 
@@ -27,9 +32,26 @@ Operator-facing runbook for destroying and recreating an existing OSDC cluster. 
 
 ## 2. Cluster destroy
 
-### 1. Disable OSDC traffic
+### 1. Rebalance traffic away from the cluster's provider
 
-Flip the OSDC experiment / GK. New jobs stop being routed; in-flight jobs continue.
+**When this step applies:** OSDC LF traffic is live (provider migration complete) AND the cluster being recreated serves real production traffic on either provider (Meta or Linux Foundation). Skip for staging, dev, or any cluster outside the live traffic pool.
+
+Steady state is roughly 50/50 between Meta and LF, with two clusters per provider sharing each half (Meta 25/25, LF 25/25). Taking a cluster down leaves the surviving cluster on that provider carrying the full provider share. Shift the `lf:` experiment percentage so per-cluster load stays roughly flat.
+
+Example — destroying one Meta cluster:
+
+| Phase | Meta total | Meta per-cluster | LF total | LF per-cluster |
+|---|---|---|---|---|
+| Pre-cutover  | 50% (2 clusters) | 25% / 25% | 50% (2 clusters) | 25% / 25% |
+| During cutover | 34% (1 cluster) | 34% | 66% (2 clusters) | 33% / 33% |
+| Post-cutover | 50% (2 clusters) | 25% / 25% | 50% (2 clusters) | 25% / 25% |
+
+Toggle by editing the body of the [pytorch/test-infra#5132 routing comment](https://github.com/pytorch/test-infra/issues/5132#issuecomment-2076772891) and updating the `lf:` experiment value. New jobs route per the new split immediately; in-flight jobs continue on whichever cluster picked them up.
+
+Record the pre-cutover percentage so step 13 can restore it.
+
+> [!IMPORTANT]
+> Step **1** & **2** can be done right after each other if a cluster affected have full replication for the same runners in other regions/clusters (or just another cluster is being added, so step 1 is a no-op). BUT, if there is no replication, it is advisable to wait multiple hours (4-6+) in between to make sure no newer jobs will be assigned on step **2**.
 
 ### 2. Drain runners and tear down compute
 
@@ -47,6 +69,9 @@ kubectl get pods -n arc-runners -l app.kubernetes.io/component=runner --no-heade
 kubectl delete nodepools --all
 kubectl get nodeclaims    # expect: No resources found
 ```
+
+> [!IMPORTANT]
+> After step 2, it is important to wait for ALL JOBS CURRETLY RUNNING  TO FINISH, this can, potentially, take 6h+ depending on the assigned jobs. Proceeding will cause canceled jobs. And this also helps ensure no newer jobs are being picked up.
 
 **Delete NodePools first, not NodeClaims** — Karpenter cascade-deletes the owned NodeClaims via its `karpenter.sh/termination` finalizer. Deleting NodeClaims first leaves orphans (see "Stuck NodeClaim finalizers" in the annex).
 
@@ -175,9 +200,12 @@ awk '$2=="false"{print $1}' ${HOME}/.osdc-cutover/${CLUSTER}/cronjob-state-pre-c
 
 The prod path is gated by the `osdc-production` GitHub environment and an OIDC trust-policy `sub` claim; CI is the only audit-clean way in.
 
-### 13. Re-enable OSDC traffic
+### 13. Rebalance traffic back
 
-The un-pause deploy in step 12 already re-synced every `AutoScalingRunnerSet`. Flip the OSDC experiment / GK and watch the queue drain.
+If you shifted the `lf:` experiment percentage in step 1, restore it to the pre-cutover value via the same [pytorch/test-infra#5132 routing comment](https://github.com/pytorch/test-infra/issues/5132#issuecomment-2076772891). The un-pause deploy in step 12 already re-synced every `AutoScalingRunnerSet`, so the recreated cluster is ready to accept its share.
+
+> [!NOTE]
+> Re-balancing depends on the final desired state.
 
 `just resume-runners` is out-of-band recovery, NOT the standard cutover path.
 


### PR DESCRIPTION
- Flatten structure from verbose multi-section layout to a compact destroy/create/annex flow with numbered steps
- Remove redundant manual tofu destroy procedure and inline pre-flight commands; defer to destroy-cluster.sh
- Drop survivor verification, state backup, and post-cutover sections that added noise without operational value
- Move NodeClaim recovery, validation gates, IRSA check, soak window, and rollback into a concise annex
- Merge drain-runners and NodePool teardown into a single step

The previous version was written for a specific IPv6 migration and carried migration-specific framing throughout. This rewrite generalizes the runbook for any immutable-field cluster recreation while cutting ~60% of the content.