### PR TITLE
Add proactive_capacity_max clusters.yaml option

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -121,6 +121,7 @@ clusters:
     region: us-west-1
     cluster_name: pytorch-arc-staging
     recycle_karpenter_nodes: true
+    proactive_capacity_max: 0
     state_bucket: ciforge-tfstate-arc-staging
     access_config:
       authentication_mode: API_AND_CONFIG_MAP

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -181,7 +181,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
 
-Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` forces `proactive_capacity` to `0` for staging clusters (`force_proactive_capacity_zero` is set when the cluster id contains `staging`), so placeholders are not pre-provisioned in staging — only on-demand pairs created for in-flight jobs.
+Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. The staging cluster sets `proactive_capacity_max: 0`, so no placeholders are pre-provisioned there — only on-demand pairs created for in-flight jobs.
 
 ## Creating the HUD API Secret
 

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1963,7 +1963,7 @@ analyze-utilization *args:
 
 # Generate ARC runner scale set YAMLs for a cluster (no validation, no apply).
 # Mirrors Step 1 of modules/arc-runners/deploy.sh — generation only. Used by
-# smoke tests to obtain post-override YAMLs (e.g. force_proactive_capacity_zero
+# smoke tests to obtain post-override YAMLs (e.g. proactive_capacity_max
 # on staging) without touching the cluster.
 generate-arc-runners cluster:
     #!/usr/bin/env bash

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -159,8 +159,9 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     proactive_capacity = runner.get("proactive_capacity", 0)
     max_burst_capacity = runner.get("max_burst_capacity", 0)
     node_fleet_override = runner.get("node_fleet")
-    if cluster_config.get("force_proactive_capacity_zero"):
-        proactive_capacity = 0
+    proactive_cap = cluster_config.get("proactive_capacity_max")
+    if proactive_cap is not None:
+        proactive_capacity = min(proactive_capacity, proactive_cap)
 
     if not runner_name or not instance_type:
         log_error(f"Invalid definition file: {def_file}")
@@ -390,8 +391,20 @@ def main():
     runner_image_tag = resolve_value(cluster_cfg, defaults, "arc.runner_image_tag") or "2.333.1"
     cluster_config["runner_image"] = f"ghcr.io/actions/actions-runner:{runner_image_tag}"
 
-    # Staging clusters: force proactive_capacity to 0 regardless of runner def value
-    cluster_config["force_proactive_capacity_zero"] = "staging" in cluster_id
+    proactive_cap = cluster_cfg.get("proactive_capacity_max")
+    if proactive_cap is not None and (
+        isinstance(proactive_cap, bool) or not isinstance(proactive_cap, int) or proactive_cap < 0
+    ):
+        log_error(
+            f"proactive_capacity_max for cluster '{cluster_id}' must be a non-negative integer, got {proactive_cap!r}"
+        )
+        return 1
+    cluster_config["proactive_capacity_max"] = proactive_cap
+    if proactive_cap is not None:
+        log_warning(
+            f"proactive_capacity_max={proactive_cap} for cluster '{cluster_id}' — "
+            f"proactive_capacity capped at {proactive_cap} for all scale sets"
+        )
 
     cluster_config["pause_runners"] = bool(cluster_cfg.get("pause_runners"))
     if cluster_config["pause_runners"]:

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -1066,8 +1066,8 @@ class TestGenerateRunner:
         listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
         assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "30"
 
-    def test_proactive_capacity_forced_zero(self, tmp_path):
-        """force_proactive_capacity_zero overrides any def value to 0."""
+    def test_proactive_capacity_capped_to_zero(self, tmp_path):
+        """proactive_capacity_max=0 clamps any def value down to 0."""
         def_file = make_def_file(tmp_path, "forced-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
@@ -1075,7 +1075,7 @@ class TestGenerateRunner:
             "github_config_url": "url",
             "github_secret_name": "secret",
             "runner_name_prefix": "",
-            "force_proactive_capacity_zero": True,
+            "proactive_capacity_max": 0,
         }
 
         assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
@@ -1084,8 +1084,8 @@ class TestGenerateRunner:
         listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
         assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "0"
 
-    def test_proactive_capacity_not_forced_when_false(self, tmp_path):
-        """force_proactive_capacity_zero=False preserves the def value."""
+    def test_proactive_capacity_uncapped(self, tmp_path):
+        """No proactive_capacity_max preserves the def value."""
         def_file = make_def_file(tmp_path, "kept-runner", "c7i.24xlarge", 4, 16, proactive_capacity=10)
         output_dir = tmp_path / "out"
         output_dir.mkdir()
@@ -1093,12 +1093,47 @@ class TestGenerateRunner:
             "github_config_url": "url",
             "github_secret_name": "secret",
             "runner_name_prefix": "",
-            "force_proactive_capacity_zero": False,
         }
 
         assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
 
         docs = list(yaml.safe_load_all((output_dir / "kept-runner.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "10"
+
+    def test_proactive_capacity_capped_below_def(self, tmp_path):
+        """proactive_capacity_max clamps a def value down to the cap."""
+        def_file = make_def_file(tmp_path, "capped-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "proactive_capacity_max": 5,
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "capped-runner.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "5"
+
+    def test_proactive_capacity_cap_above_def_noop(self, tmp_path):
+        """proactive_capacity_max higher than the def value is a no-op."""
+        def_file = make_def_file(tmp_path, "noop-runner", "c7i.24xlarge", 4, 16, proactive_capacity=10)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+            "proactive_capacity_max": 50,
+        }
+
+        assert generate_runner(def_file, MINIMAL_TEMPLATE, cluster_config, output_dir, "arc-runners") is True
+
+        docs = list(yaml.safe_load_all((output_dir / "noop-runner.yaml").read_text()))
         listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
         assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "10"
 
@@ -2028,32 +2063,6 @@ class TestMain:
         with patch.object(sys, "argv", ["generate_runners.py", "staging"]):
             assert main() == 1
 
-    def test_staging_forces_proactive_capacity_zero(self, tmp_path, monkeypatch):
-        """main() sets force_proactive_capacity_zero for staging clusters."""
-        p = tmp_path / "clusters.yaml"
-        p.write_text(yaml.dump(FAKE_CLUSTERS_YAML, default_flow_style=False))
-
-        defs_dir = tmp_path / "defs"
-        defs_dir.mkdir()
-        make_def_file(defs_dir, "warm-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30)
-        make_nodepool_defs(tmp_path, ["c7i.24xlarge"])
-
-        output_dir = tmp_path / "out"
-
-        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
-        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
-        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tmp_path / "tpl.yaml"))
-        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
-
-        (tmp_path / "tpl.yaml").write_text(MINIMAL_TEMPLATE)
-
-        with patch.object(sys, "argv", ["generate_runners.py", "staging"]):
-            assert main() == 0
-
-        docs = list(yaml.safe_load_all((output_dir / "warm-runner.yaml").read_text()))
-        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
-        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "0"
-
     def test_production_preserves_proactive_capacity(self, tmp_path, monkeypatch):
         """main() does NOT force proactive_capacity to zero for production clusters."""
         prod_config = {
@@ -2101,6 +2110,98 @@ class TestMain:
         docs = list(yaml.safe_load_all((output_dir / "warm-runner.yaml").read_text()))
         listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
         assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "30"
+
+    def test_proactive_capacity_max_clusters_yaml(self, tmp_path, monkeypatch):
+        """main() honors proactive_capacity_max: 0 in clusters.yaml."""
+        prod_config = {
+            "defaults": {
+                "arc": {"runner_image_tag": "2.333.1"},
+                "arc-runners": {
+                    "github_config_url": "https://github.com/prod-org",
+                    "github_secret_name": "prod-secret",
+                    "runner_name_prefix": "prod-",
+                },
+            },
+            "clusters": {
+                "arc-prod": {
+                    "cluster_name": "production",
+                    "region": "us-east-1",
+                    "modules": ["nodepools", "arc-runners"],
+                    "proactive_capacity_max": 0,
+                    "arc-runners": {
+                        "github_config_url": "https://github.com/prod-org",
+                        "github_secret_name": "prod-secret",
+                        "runner_name_prefix": "prod-",
+                    },
+                },
+            },
+        }
+        p = tmp_path / "clusters.yaml"
+        p.write_text(yaml.dump(prod_config, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "warm-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30)
+        make_nodepool_defs(tmp_path, ["c7i.24xlarge"])
+
+        output_dir = tmp_path / "out"
+
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tmp_path / "tpl.yaml"))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
+
+        (tmp_path / "tpl.yaml").write_text(MINIMAL_TEMPLATE)
+
+        with patch.object(sys, "argv", ["generate_runners.py", "arc-prod"]):
+            assert main() == 0
+
+        docs = list(yaml.safe_load_all((output_dir / "warm-runner.yaml").read_text()))
+        listener_env = {e["name"]: e["value"] for e in docs[0]["listenerTemplate"]["spec"]["containers"][0]["env"]}
+        assert listener_env["CAPACITY_AWARE_PROACTIVE_CAPACITY"] == "0"
+
+    def test_proactive_capacity_max_invalid_clusters_yaml(self, tmp_path, monkeypatch):
+        """main() exits 1 when proactive_capacity_max is not a non-negative integer."""
+        invalid_config = {
+            "defaults": {
+                "arc": {"runner_image_tag": "2.333.1"},
+                "arc-runners": {
+                    "github_config_url": "https://github.com/prod-org",
+                    "github_secret_name": "prod-secret",
+                    "runner_name_prefix": "prod-",
+                },
+            },
+            "clusters": {
+                "arc-prod": {
+                    "cluster_name": "production",
+                    "region": "us-east-1",
+                    "modules": ["nodepools", "arc-runners"],
+                    "proactive_capacity_max": -1,
+                    "arc-runners": {
+                        "github_config_url": "https://github.com/prod-org",
+                        "github_secret_name": "prod-secret",
+                        "runner_name_prefix": "prod-",
+                    },
+                },
+            },
+        }
+        p = tmp_path / "clusters.yaml"
+        p.write_text(yaml.dump(invalid_config, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "warm-runner", "c7i.24xlarge", 4, 16, proactive_capacity=30)
+        make_nodepool_defs(tmp_path, ["c7i.24xlarge"])
+
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tmp_path / "tpl.yaml"))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(tmp_path / "out"))
+
+        (tmp_path / "tpl.yaml").write_text(MINIMAL_TEMPLATE)
+
+        with patch.object(sys, "argv", ["generate_runners.py", "arc-prod"]):
+            assert main() == 1
 
     def test_pause_runners_forces_max_runners_zero(self, tmp_path, monkeypatch):
         """main() honors cluster-level pause_runners=true by forcing maxRunners: 0."""

--- a/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
@@ -290,7 +290,7 @@ class TestPlaceholderSchedulingParity:
         # placeholders running. Use the GENERATED YAML's
         # CAPACITY_AWARE_PROACTIVE_CAPACITY env value (post-override) — not
         # the raw def — so cluster-specific overrides like
-        # `force_proactive_capacity_zero` on staging correctly skip all defs.
+        # `proactive_capacity_max` on staging correctly skip all defs.
         proactive_defs = {
             name: d
             for name, d in defs_by_name.items()

--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -295,7 +295,7 @@ class TestListenerCapacityAwareEnvVars:
 
     The generated YAML is the single source of truth for what should be
     deployed: it already accounts for cluster-specific overrides such as
-    ``force_proactive_capacity_zero`` (staging) and any future generator
+    ``proactive_capacity_max`` (staging) and any future generator
     transformations. Comparing the deployed listener directly against the
     runner def would re-introduce knowledge of those overrides into the test.
     """


### PR DESCRIPTION
Adds a per-cluster ceiling for ARC runner proactive capacity.
Setting proactive_capacity_max: N in clusters.yaml causes each scale
set to render min(def_proactive_capacity, N). Setting it to 0 disables
warm-pool pre-provisioning entirely. Leaving it unset (default) leaves
every runner def value intact. The cap never raises capacity.

This allows gradual dial-down (e.g. 10 → 5 → 0) rather than a cliff
edge, which is needed to safely reduce warm-pool cost over multiple
deploys.

The staging cluster sets proactive_capacity_max: 0 so no placeholders
are pre-provisioned there — only on-demand pairs created for in-flight
jobs.