### PR TITLE
Add NFD topology-updater and numa-scheduler modules (#696)

### DIFF
--- a/osdc/modules/nfd/deploy.sh
+++ b/osdc/modules/nfd/deploy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Deploy NFD topology-updater for NUMA-aware scheduling.
+# Called by: just deploy-module <cluster> nfd
+#
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+#
+# Installs the Node Feature Discovery Helm chart with only the
+# topology-updater enabled. This publishes NodeResourceTopology CRDs
+# that the numa-scheduler reads to make NUMA-aware placement decisions.
+
+CLUSTER="$1"
+_CNAME="$2"  # unused but required by deploy-module interface
+_REGION="$3" # unused but required by deploy-module interface
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
+
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/helm-upgrade.sh"
+
+CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
+
+# --- Check if enabled ---
+ENABLED=$(uv run "$CFG" "$CLUSTER" nfd.enabled "false")
+if [[ "$ENABLED" != "true" ]]; then
+  echo "NFD disabled for cluster $CLUSTER, skipping."
+  exit 0
+fi
+
+NFD_VERSION=$(uv run "$CFG" "$CLUSTER" nfd.version "0.17.1")
+NFD_UPDATE_INTERVAL=$(uv run "$CFG" "$CLUSTER" nfd.update_interval "15s")
+
+echo "Installing NFD topology-updater v${NFD_VERSION}..."
+helm_upgrade_if_changed nfd nfd \
+  --create-namespace \
+  --history-max 3 \
+  -f "$MODULE_DIR/helm/values.yaml" \
+  --set topologyUpdater.updateInterval="${NFD_UPDATE_INTERVAL}" \
+  --timeout 5m \
+  --wait \
+  oci://ghcr.io/kubernetes-sigs/charts/node-feature-discovery \
+  --version "${NFD_VERSION}"
+
+echo "NFD topology-updater deployed."

--- a/osdc/modules/nfd/helm/values.yaml
+++ b/osdc/modules/nfd/helm/values.yaml
@@ -1,0 +1,57 @@
+# Node Feature Discovery — topology-updater only
+# Chart: https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery
+#
+# We only need the topology-updater component, which publishes
+# NodeResourceTopology CRDs per node. The NFD worker (feature detection)
+# and master (label reconciliation) are disabled — we don't need node
+# feature labels, just per-NUMA-zone resource visibility for the
+# numa-scheduler.
+
+master:
+  enable: false
+
+worker:
+  enable: false
+
+topologyUpdater:
+  enable: true
+
+  # Poll kubelet PodResources API every 15s (default 60s). Needs to be
+  # faster than the ARC capacity provisioner interval (30s) so NRT
+  # objects reflect current GPU allocations before placeholder pods are
+  # evaluated by the NUMA-aware scheduler.
+  updateInterval: 15s
+
+  # Only run on GPU nodes — non-GPU nodes don't have NUMA topology
+  # concerns and don't need NRT objects.
+  nodeSelector:
+    nvidia.com/gpu: "true"
+
+  # Tolerate all GPU node taints so the topology-updater schedules
+  # at provisioning time, same as other GPU-node DaemonSets.
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: node-fleet
+      operator: Exists
+      effect: NoSchedule
+    - key: instance-type
+      operator: Exists
+      effect: NoSchedule
+    - key: git-cache-not-ready
+      operator: Exists
+      effect: NoSchedule
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+# The topology-updater needs the NRT CRD. The NFD chart installs it
+# when topologyUpdater is enabled.
+topologyGC:
+  enable: true

--- a/osdc/modules/scheduler-plugins/deploy.sh
+++ b/osdc/modules/scheduler-plugins/deploy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Deploy NUMA-aware secondary scheduler (scheduler-plugins).
+# Called by: just deploy-module <cluster> scheduler-plugins
+#
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+#
+# Installs the scheduler-plugins Helm chart as a secondary scheduler
+# named "numa-scheduler" with NodeResourceTopologyMatch enabled. Pods
+# that set schedulerName: numa-scheduler get NUMA-aware placement.
+
+CLUSTER="$1"
+_CNAME="$2"  # unused but required by deploy-module interface
+_REGION="$3" # unused but required by deploy-module interface
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
+
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/helm-upgrade.sh"
+
+CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
+
+# --- Check if enabled ---
+ENABLED=$(uv run "$CFG" "$CLUSTER" scheduler_plugins.enabled "false")
+if [[ "$ENABLED" != "true" ]]; then
+  echo "Scheduler-plugins disabled for cluster $CLUSTER, skipping."
+  exit 0
+fi
+
+SCHEDULER_PLUGINS_VERSION=$(uv run "$CFG" "$CLUSTER" scheduler_plugins.version "0.30.6")
+SCHEDULER_REPLICAS=$(uv run "$CFG" "$CLUSTER" scheduler_plugins.replicas "2")
+
+echo "Installing numa-scheduler (scheduler-plugins v${SCHEDULER_PLUGINS_VERSION})..."
+helm_upgrade_if_changed numa-scheduler scheduler-plugins \
+  --create-namespace \
+  --history-max 3 \
+  -f "$MODULE_DIR/helm/values.yaml" \
+  --set scheduler.replicaCount="${SCHEDULER_REPLICAS}" \
+  --timeout 5m \
+  --wait \
+  oci://ghcr.io/kubernetes-sigs/charts/scheduler-plugins \
+  --version "${SCHEDULER_PLUGINS_VERSION}"
+
+echo "numa-scheduler deployed."

--- a/osdc/modules/scheduler-plugins/helm/values.yaml
+++ b/osdc/modules/scheduler-plugins/helm/values.yaml
@@ -1,0 +1,49 @@
+# Scheduler-plugins — NUMA-aware secondary scheduler
+# Chart: https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/charts/as-a-second-scheduler
+#
+# Deploys a second kube-scheduler named "numa-scheduler" with the
+# NodeResourceTopologyMatch plugin enabled. Pods that set
+# schedulerName: numa-scheduler will be filtered/scored by per-NUMA-zone
+# resource availability (read from NodeResourceTopology CRDs published
+# by the NFD topology-updater).
+#
+# Nothing uses this scheduler until runner definitions set
+# scheduler_name: numa-scheduler — deploying it is a no-op.
+
+scheduler:
+  name: numa-scheduler
+  replicaCount: 2
+
+  # Run on base-infrastructure nodes alongside other control plane components.
+  nodeSelector:
+    role: base-infrastructure
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Enable the NodeResourceTopologyMatch plugin for NUMA-aware filtering
+# and scoring. The plugin reads NodeResourceTopology CRDs (published by
+# NFD topology-updater) and ensures pods only land on nodes where a
+# single NUMA zone can satisfy the full resource request.
+plugins:
+  enabled:
+    - NodeResourceTopologyMatch
+
+pluginConfig:
+  - name: NodeResourceTopologyMatch
+    args:
+      scoringStrategy:
+        # Prefer NUMA zones with the most free resources to reduce
+        # future fragmentation.
+        type: LeastAllocated


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #715

Adds two new OSDC modules for NUMA-aware GPU scheduling:

1. nfd — deploys NFD topology-updater as a DaemonSet on GPU nodes.
   Publishes NodeResourceTopology CRDs showing per-NUMA-zone resource
   availability (GPU/CPU/memory per socket). Polls every 15s to stay
   ahead of the ARC capacity provisioner's 30s interval.

2. scheduler-plugins — deploys a secondary kube-scheduler named
   "numa-scheduler" with the NodeResourceTopologyMatch plugin. Reads
   NRT objects and only places pods on nodes where a single NUMA zone
   can satisfy the full resource request.

Both modules default to enabled=false in clusters.yaml and are inert
until runner definitions set scheduler_name: numa-scheduler on
workflow pods. Deploying them has no effect on existing scheduling.

Part of https://github.com/pytorch/ci-infra/issues/696

**Dry-Run** both targets for `helm upgrade`:
```
# pointed at arc-staging
helm upgrade --install nfd nfd/node-feature-discovery --version 0.17.1 --namespace nfd --create-namespace -f modules/nfd/helm/values.yaml --dry-run=server
...
STATUS: pending-install
...
```
```
gh release download v0.34.7 --repo kubernetes-sigs/scheduler-plugins --pattern "scheduler-plugins-0.34.7.tgz" --dir /tmp --clobber

helm upgrade --install numa-scheduler /tmp/scheduler-plugins-0.34.7.tgz --namespace numa-scheduler --create-namespace -f modules/numa-scheduler/helm/values.yaml --set scheduler.replicaCount=2 --dry-run=server
...
STATUS: pending-install
...
```
**Follow-Ups**
1. Update ARC fork to allow H100 targets to refer to the numa-scheduler, accounting for a SchedulerName override.
2. Deploy these changes via: `arc: chart_version` in *clusters.yaml* // `just deploy-module <cluster> arc`
3. Deploy `schedulerName: numa-scheduler` with `just deploy-module <cluster>` arc-runners-h100.