### PR TITLE
Deploy staging org-wide; rename arc-staging → meta-staging-aws-uw1

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       cluster:
-        description: "Cluster id from clusters.yaml (e.g. arc-staging, arc-cbr-production)"
+        description: "Cluster id from clusters.yaml (e.g. meta-staging-aws-uw1, arc-cbr-production)"
         required: true
         type: string
       environment:

--- a/.github/workflows/_osdc-slow-tests.yml
+++ b/.github/workflows/_osdc-slow-tests.yml
@@ -2,7 +2,7 @@ name: "~ OSDC: Slow tests (reusable)"
 
 # NOTE: AWS region is hardcoded to us-west-1 in all jobs below, matching
 # _osdc-deploy.yml. This reusable is currently called only for the
-# arc-staging cluster (which lives in us-west-1). Re-using it for a
+# meta-staging-aws-uw1 cluster (which lives in us-west-1). Re-using it for a
 # cluster in a different region requires either parameterizing the
 # region from `just region "${{ inputs.cluster }}"` or adding an
 # aws_region input. Do not call this reusable for non-us-west-1
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       cluster:
-        description: "Cluster id from clusters.yaml (e.g. arc-staging, arc-cbr-production)"
+        description: "Cluster id from clusters.yaml (e.g. meta-staging-aws-uw1, arc-cbr-production)"
         required: true
         type: string
       environment:

--- a/.github/workflows/osdc-pre-merge.yml
+++ b/.github/workflows/osdc-pre-merge.yml
@@ -11,7 +11,7 @@ permissions:
   actions: write
 
 # Workflow-level concurrency. Serializes the ENTIRE battery (fast + slow)
-# per workflow invocation against arc-staging. cancel-in-progress: false
+# per workflow invocation against meta-staging-aws-uw1. cancel-in-progress: false
 # so a later run waits for the prior run's slow jobs to finish before
 # deploy/smoke/integration even start — protects test fixtures from
 # interleaving.
@@ -44,6 +44,9 @@ jobs:
           filters: |
             code:
               - 'osdc/**'
+              # Skip staging deploy when the only osdc/ changes are tests.
+              # Unit tests already run on the PR via osdc-test.yml; spinning
+              # up meta-staging-aws-uw1 adds nothing for a test-only fix.
               - '!osdc/**/test_*.py'
               - '!osdc/**/*_test.py'
               - '!osdc/**/tests/**'
@@ -69,7 +72,7 @@ jobs:
     if: needs.changes.outputs.osdc == 'true'
     uses: ./.github/workflows/_osdc-deploy.yml
     with:
-      cluster: arc-staging
+      cluster: meta-staging-aws-uw1
       # Environment gate: the staging role trusts only tokens with
       # environment:osdc-staging in the sub, which blocks fork PRs.
       environment: osdc-staging
@@ -92,7 +95,7 @@ jobs:
     if: needs.changes.outputs.osdc == 'true' && needs.deploy-fast.result == 'success'
     uses: ./.github/workflows/_osdc-slow-tests.yml
     with:
-      cluster: arc-staging
+      cluster: meta-staging-aws-uw1
       environment: osdc-staging
     secrets: inherit
 

--- a/osdc/base/kubernetes/harbor/pdb.yaml.tpl
+++ b/osdc/base/kubernetes/harbor/pdb.yaml.tpl
@@ -6,7 +6,7 @@
 #
 # Per-cluster value: clusters.yaml -> harbor.pdb_max_unavailable
 #   default:     1       (conservative — at most 1 pod down per component)
-#   arc-staging: "100%"  (aggressive — staging has 1 replica each)
+#   meta-staging-aws-uw1: "100%"  (aggressive — staging has 1 replica each)
 #
 # Single-replica components (jobservice, portal, exporter, internal redis/db)
 # are intentionally NOT covered: a PDB on a 1-replica Deployment with

--- a/osdc/base/kubernetes/image-cache-janitor/docker/Dockerfile
+++ b/osdc/base/kubernetes/image-cache-janitor/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/docker/library/python:3.12-alpine
-RUN apk add --no-cache util-linux=2.41.4-r0
+RUN apk add --no-cache util-linux=2.42-r0
 
 # Install crictl (CRI CLI) so the janitor is self-contained and does not
 # depend on the host AMI shipping crictl.

--- a/osdc/base/kubernetes/image-cache-janitor/tests/e2e/conftest.py
+++ b/osdc/base/kubernetes/image-cache-janitor/tests/e2e/conftest.py
@@ -84,7 +84,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "--cluster-id",
             action="store",
             required=True,
-            help="Cluster ID from clusters.yaml (e.g. arc-staging)",
+            help="Cluster ID from clusters.yaml (e.g. meta-staging-aws-uw1)",
         )
 
 

--- a/osdc/base/node-compactor/tests/e2e/conftest.py
+++ b/osdc/base/node-compactor/tests/e2e/conftest.py
@@ -214,7 +214,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--cluster-id",
         action="store",
         required=True,
-        help="Cluster ID from clusters.yaml (e.g. arc-staging)",
+        help="Cluster ID from clusters.yaml (e.g. meta-staging-aws-uw1)",
     )
 
 

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -113,12 +113,12 @@ defaults:
     target_manylinux: "2_28"
 
 clusters:
-  arc-staging:
+  meta-staging-aws-uw1:
     region: us-west-1
-    cluster_name: pytorch-arc-staging
+    cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
     proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
-    state_bucket: ciforge-tfstate-arc-staging
+    state_bucket: ciforge-tfstate-meta-staging-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
       cluster_admin_role_names:
@@ -154,9 +154,13 @@ clusters:
       gpu_consolidate_after: "10s"
       cpu_consolidate_after: "10s"
     arc-runners:
-      github_config_url: "https://github.com/pytorch/pytorch-canary"
-      github_secret_name: pytorch-arc-staging
-      runner_name_prefix: "c-mt-"
+      # Org-wide (was github.com/pytorch/pytorch-canary). A repo-scoped URL forces
+      # runner_group → "default" in generate_runners.py, so the org URL is required
+      # for the runner_group below to take effect.
+      github_config_url: "https://github.com/pytorch"
+      github_secret_name: meta-staging-aws-uw1
+      runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
+      runner_group: "meta-staging-aws-uw1"
     buildkit:
       arm64_instance_type: m7gd.16xlarge
       arm64_pods_per_node: 4

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -118,7 +118,7 @@ clusters:
     cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
     proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
-    state_bucket: ciforge-tfstate-meta-staging-uw1
+    state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
       cluster_admin_role_names:

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -222,18 +222,18 @@ CPU/T4/A10G/L4/A100 runner defs currently do not set `max_runners`.
 
 ## Load Testing the Capacity Monitor
 
-To verify the capacity monitor and HUD integration on arc-staging:
+To verify the capacity monitor and HUD integration on meta-staging-aws-uw1:
 
 ```bash
-just load-test arc-staging --label l-x86iamx-8-16:400
+just load-test meta-staging-aws-uw1 --label l-x86iamx-8-16:400
 ```
 
-**Why `--label l-x86iamx-8-16:400`**: arc-staging runs in us-west-1 where `c7a` instances are not available. The default distribution assigns most jobs to `l-x86iavx512-8-16` (node-fleet `c7a`), which will never schedule. `l-x86iamx-8-16` uses node-fleet `c7i`, which is available in us-west-1.
+**Why `--label l-x86iamx-8-16:400`**: meta-staging-aws-uw1 runs in us-west-1 where `c7a` instances are not available. The default distribution assigns most jobs to `l-x86iavx512-8-16` (node-fleet `c7a`), which will never schedule. `l-x86iamx-8-16` uses node-fleet `c7i`, which is available in us-west-1.
 
 To exercise multiple runner types in parallel (e.g., CPU + GPU), repeat `--label`:
 
 ```bash
-just load-test arc-staging --label l-x86iamx-8-16:400 --label l-x86iavx512-29-115-t4:200
+just load-test meta-staging-aws-uw1 --label l-x86iamx-8-16:400 --label l-x86iavx512-29-115-t4:200
 ```
 
 **GPU labels in us-west-1**: g5 (A10G) and g6 (L4) fleets have `exclude_regions: [us-west-1]`. Only g4dn (T4) is available — pick from `l-x86iavx512-29-115-t4` (1×T4), `l-x86iavx512-45-172-t4-4` (4×T4), or `l-bx86iavx512-94-344-t4-8` (8×T4, bare-metal). Scale sets for excluded instance types still deploy but render with `maxRunners: 0`, so picking one of them in `--label` is a no-op.

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -56,10 +56,10 @@ The single source of truth for what gets deployed where:
 
 ```yaml
 clusters:
-  arc-staging:
+  meta-staging-aws-uw1:
     region: us-west-1
-    cluster_name: pytorch-arc-staging
-    state_bucket: ciforge-tfstate-arc-staging
+    cluster_name: meta-staging-aws-uw1
+    state_bucket: ciforge-tfstate-meta-staging-uw1
     base:
       vpc_cidr: "10.0.0.0/16"
       single_nat_gateway: true

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -59,7 +59,7 @@ clusters:
   meta-staging-aws-uw1:
     region: us-west-1
     cluster_name: meta-staging-aws-uw1
-    state_bucket: ciforge-tfstate-meta-staging-uw1
+    state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     base:
       vpc_cidr: "10.0.0.0/16"
       single_nat_gateway: true

--- a/osdc/docs/ci-pre-merge.md
+++ b/osdc/docs/ci-pre-merge.md
@@ -2,14 +2,14 @@
 
 ## What this is
 
-The pre-merge CI runs the OSDC validation battery against the `arc-staging` cluster when PRs enter the merge queue. It is the gate that determines whether a PR is allowed to merge into `main`.
+The pre-merge CI runs the OSDC validation battery against the `meta-staging-aws-uw1` cluster when PRs enter the merge queue. It is the gate that determines whether a PR is allowed to merge into `main`.
 
 ## Workflow shape
 
 The workflow is defined in `.github/workflows/osdc-pre-merge.yml` and triggers on `merge_group` and `workflow_dispatch`. It is composed of four jobs:
 
 1. `changes` — uses `dorny/paths-filter` to detect whether the PR touches osdc-related files. Outputs `osdc: true|false`.
-2. `deploy-fast` — calls reusable `_osdc-deploy.yml` (lint+test → deploy `arc-staging` → smoke + integration tests). Runs only when osdc files changed.
+2. `deploy-fast` — calls reusable `_osdc-deploy.yml` (lint+test → deploy `meta-staging-aws-uw1` → smoke + integration tests). Runs only when osdc files changed.
 3. `slow-tests` — calls reusable `_osdc-slow-tests.yml` (load-test → compactor + janitor). Runs after `deploy-fast` succeeds. Informational only.
 4. `pre-merge-ok` — marker job that always runs and reports SUCCESS when the gate is satisfied.
 
@@ -32,7 +32,7 @@ Dependency chain:
 
 | Aspect            | Fast (`deploy-fast`)                       | Slow (`slow-tests`)                  |
 |-------------------|--------------------------------------------|--------------------------------------|
-| What it runs      | lint + test, deploy arc-staging, smoke, integration | load-test, compactor e2e, janitor e2e |
+| What it runs      | lint + test, deploy meta-staging-aws-uw1, smoke, integration | load-test, compactor e2e, janitor e2e |
 | Gates merge?      | Yes (via `pre-merge-ok`)                   | No (informational only)              |
 | Typical duration  | ~30-60 min                                 | ~2-3 h                               |
 | Failure effect    | Blocks merge                               | Surfaces red check, merge still allowed |
@@ -72,7 +72,7 @@ Repo Settings → Rules → "main" ruleset → Merge queue → Required status c
 
 - `pre-merge-ok`
 
-It MUST NOT contain individual job names like `Deploy arc-staging`, `Smoke tests`, `Integration tests`, `Load tests`, `Compactor e2e tests`, `Janitor e2e tests`.
+It MUST NOT contain individual job names like `Deploy meta-staging-aws-uw1`, `Smoke tests`, `Integration tests`, `Load tests`, `Compactor e2e tests`, `Janitor e2e tests`.
 
 Why: those individual jobs may be SKIPPED (path filter excluded the PR) and never report. The merge queue would wait forever for a check that never arrives. The `pre-merge-ok` marker always runs and always reports.
 
@@ -90,9 +90,9 @@ Repo Settings → Rules → "main" ruleset → Merge queue → Build concurrency
 
 Slow-test failures DO NOT block merges (by design). They surface as a red check in the PR's Actions tab but the PR can still merge. Treat slow-test failures as a regression report for someone to investigate post-merge.
 
-- If load-test fails: check that the canary GitHub token still works and that the runner controller is healthy in `arc-staging`.
-- If compactor fails: investigate node-compactor pod logs in `arc-staging`.
-- If janitor fails: investigate image-cache-janitor in `arc-staging`.
+- If load-test fails: check that the canary GitHub token still works and that the runner controller is healthy in `meta-staging-aws-uw1`.
+- If compactor fails: investigate node-compactor pod logs in `meta-staging-aws-uw1`.
+- If janitor fails: investigate image-cache-janitor in `meta-staging-aws-uw1`.
 
 No notification automation today — see follow-up section.
 

--- a/osdc/docs/cluster-recreation.md
+++ b/osdc/docs/cluster-recreation.md
@@ -4,12 +4,12 @@
 
 Operator-facing runbook for destroying and recreating an existing OSDC cluster. Use this whenever a planned change touches a property of `aws_eks_cluster` (or a directly-dependent resource) that AWS rejects in-place with a ForceNew plan — VPC / IP family / CIDR changes, encryption_config additions, or any other immutable field.
 
-**Per-cluster, never in parallel.** Do `arc-staging` (us-west-1) first; only promote to the new/changed production cluster after staging has soaked. 
+**Per-cluster, never in parallel.** Do `meta-staging-aws-uw1` (us-west-1) first; only promote to the new/changed production cluster after staging has soaked. 
 
 - This can change if you are deploying a new cluster with a tested configuration or migrating a cluster from one state to another:
  - Creating a new cluster: green signals on [osdc-pre-merge.yml](https://github.com/pytorch/ci-infra/blob/main/.github/workflows/osdc-pre-merge.yml) for the latest main version should be sufficient;
  - Fully destroying / recreating: same as for creating a new cluster;
- - Migrating / terraform network eks changes: please deploy `arc-staging` to your current version, then execute this procedure to it and follow the testing guidelines first;
+ - Migrating / terraform network eks changes: please deploy `meta-staging-aws-uw1` to your current version, then execute this procedure to it and follow the testing guidelines first;
 
 **Code change must already be on `main` with green CI.** `just deploy <cluster>` after destroy is the only path that brings up the new cluster shape.
 
@@ -136,9 +136,9 @@ Read `scripts/destroy-cluster.sh` if you need to bypass it (debugging partial st
 Add `pause_runners: true` at the top level of the cluster's entry in `clusters.yaml`:
 
 ```diff
- arc-staging:
+ meta-staging-aws-uw1:
    region: us-west-1
-   cluster_name: arc-staging
+   cluster_name: meta-staging-aws-uw1
 +  pause_runners: true
    modules:
      - karpenter

--- a/osdc/docs/modules.md
+++ b/osdc/docs/modules.md
@@ -16,8 +16,8 @@ The justfile auto-detects and runs these in order:
 
 `deploy.sh` receives three positional arguments:
 ```bash
-$1 = cluster-id      # e.g. "arc-staging"
-$2 = cluster-name    # e.g. "pytorch-arc-staging"
+$1 = cluster-id      # e.g. "meta-staging-aws-uw1"
+$2 = cluster-name    # e.g. "meta-staging-aws-uw1"
 $3 = region           # e.g. "us-west-1"
 ```
 

--- a/osdc/docs/operations.md
+++ b/osdc/docs/operations.md
@@ -5,6 +5,7 @@
 - AWS CLI configured with credentials for an IAM principal mapped to one of the roles in the target cluster's `access_config.cluster_admin_role_names` (e.g. `osdc_gha_staging` for `meta-staging-aws-uw1`, `osdc_gha_prod` for `arc-cbr-production`). How those credentials are acquired (SSO, role assumption, static keys) is left to the operator's organization — the project does not prescribe a profile or login flow.
 - `mise` installed ([mise.jdx.dev](https://mise.jdx.dev))
 - `just` installed (not managed by `mise` — install separately)
+- Docker with **BuildKit** enabled — local deploys build container images (e.g. `image-cache-janitor`) and require BuildKit; see [Docker / BuildKit (local builds)](#docker--buildkit-local-builds) below
 - Working directory: `osdc/`
 
 `mise` auto-installs all other tools (tofu, kubectl, helm, crane, awscli, packer, `uv`, plus linters) on first run. Run `just setup` once to create the Python virtualenv (`uv sync`) used by `cluster-config.py` and other helpers.
@@ -21,6 +22,35 @@ export no_proxy="${no_proxy:-},.eks.amazonaws.com"
 ```
 
 Every `just` recipe that touches the EKS API inlines this bypass for you. The export above is only needed when invoking `aws`, `kubectl`, or `helm` directly — for example during the read-only debugging session below.
+
+### Docker / BuildKit (local builds)
+
+`just deploy` / `just deploy-base` build container images locally (e.g. `image-cache-janitor`) for both `amd64` and `arm64`. These builds **require BuildKit**: the Dockerfiles rely on the `TARGETARCH` build arg, which only BuildKit auto-populates. Under the legacy builder `TARGETARCH` is empty, so arch-specific downloads (crictl, etc.) resolve to a malformed URL and fail with HTTP 404.
+
+CI has BuildKit; a fresh local Docker (especially Colima on Apple Silicon) often does not. To wire it up:
+
+```bash
+# 1. Install the buildx CLI plugin (Homebrew example)
+brew install docker-buildx
+
+# 2. Register it where the Docker CLI looks for plugins
+mkdir -p ~/.docker/cli-plugins
+ln -sfn "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+docker buildx version   # verify
+
+# 3. Make BuildKit the default for plain `docker build` (deploy.sh uses it directly)
+export DOCKER_BUILDKIT=1   # add to your shell profile, or run `docker buildx install` once
+```
+
+On Apple Silicon, the `amd64` half of each build runs under emulation. With Colima this is handled by **Rosetta** — no manual binfmt registration is needed — as long as the VM uses `vmType: vz` with `rosetta: true` (e.g. `colima start --vm-type vz --vz-rosetta`) and Rosetta is installed on the host:
+
+```bash
+softwareupdate --install-rosetta --agree-to-license
+```
+
+Colima then registers the Rosetta handler in the VM automatically; you do **not** need `docker run --privileged tonistiigi/binfmt --install all` (that would install slower QEMU handlers instead).
+
+A BuildKit build shows `#5` / `#6 DONE`-style step output; the legacy builder shows `Step N/M` / `Running in <hash>` plus a `The requested image's platform ... does not match the detected host platform` warning. That platform warning is harmless on its own — the real failure is the empty `TARGETARCH`.
 
 ## First-time setup
 

--- a/osdc/docs/operations.md
+++ b/osdc/docs/operations.md
@@ -272,7 +272,7 @@ To inspect state:
 ```bash
 cd modules/eks/terraform
 tofu init -reconfigure \
-    -backend-config="bucket=ciforge-tfstate-meta-staging-uw1" \
+    -backend-config="bucket=ciforge-tfstate-meta-staging-aws-uw1" \
     -backend-config="key=meta-staging-aws-uw1/base/terraform.tfstate" \
     -backend-config="region=us-west-2" \
     -backend-config="dynamodb_table=ciforge-terraform-locks"

--- a/osdc/docs/operations.md
+++ b/osdc/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- AWS CLI configured with credentials for an IAM principal mapped to one of the roles in the target cluster's `access_config.cluster_admin_role_names` (e.g. `osdc_gha_staging` for `arc-staging`, `osdc_gha_prod` for `arc-cbr-production`). How those credentials are acquired (SSO, role assumption, static keys) is left to the operator's organization — the project does not prescribe a profile or login flow.
+- AWS CLI configured with credentials for an IAM principal mapped to one of the roles in the target cluster's `access_config.cluster_admin_role_names` (e.g. `osdc_gha_staging` for `meta-staging-aws-uw1`, `osdc_gha_prod` for `arc-cbr-production`). How those credentials are acquired (SSO, role assumption, static keys) is left to the operator's organization — the project does not prescribe a profile or login flow.
 - `mise` installed ([mise.jdx.dev](https://mise.jdx.dev))
 - `just` installed (not managed by `mise` — install separately)
 - Working directory: `osdc/`
@@ -30,7 +30,7 @@ Each cluster needs an S3 bucket for tofu state and a shared DynamoDB lock table.
 
 ```bash
 # Single cluster
-just bootstrap arc-staging
+just bootstrap meta-staging-aws-uw1
 
 # All clusters defined in clusters.yaml
 just bootstrap-all
@@ -42,21 +42,21 @@ Idempotent — safe to run multiple times.
 
 ```bash
 # Full deploy (base + all modules)
-just deploy arc-staging
+just deploy meta-staging-aws-uw1
 
 # Or step by step
-just deploy-base arc-staging
-just deploy-module arc-staging karpenter
-just deploy-module arc-staging arc
-just deploy-module arc-staging nodepools
-just deploy-module arc-staging arc-runners
-just deploy-module arc-staging buildkit
-just deploy-module arc-staging pypi-cache
-just deploy-module arc-staging cache-enforcer
-just deploy-module arc-staging zombie-cleanup
-just deploy-module arc-staging harbor-cache-recovery
-just deploy-module arc-staging monitoring
-just deploy-module arc-staging logging
+just deploy-base meta-staging-aws-uw1
+just deploy-module meta-staging-aws-uw1 karpenter
+just deploy-module meta-staging-aws-uw1 arc
+just deploy-module meta-staging-aws-uw1 nodepools
+just deploy-module meta-staging-aws-uw1 arc-runners
+just deploy-module meta-staging-aws-uw1 buildkit
+just deploy-module meta-staging-aws-uw1 pypi-cache
+just deploy-module meta-staging-aws-uw1 cache-enforcer
+just deploy-module meta-staging-aws-uw1 zombie-cleanup
+just deploy-module meta-staging-aws-uw1 harbor-cache-recovery
+just deploy-module meta-staging-aws-uw1 monitoring
+just deploy-module meta-staging-aws-uw1 logging
 ```
 
 The full per-cluster module list lives in `clusters.yaml` under `clusters.<id>.modules`. Production clusters add GPU pools (`nodepools-h100`, `nodepools-b200`) and matching runners (`arc-runners-h100`, `arc-runners-b200`).
@@ -68,11 +68,11 @@ For the module contract (directory layout, deploy phases, adding a new module) s
 ### Deploy a specific module
 
 ```bash
-just deploy-module arc-staging nodepools
-just deploy-module arc-staging arc-runners
+just deploy-module meta-staging-aws-uw1 nodepools
+just deploy-module meta-staging-aws-uw1 arc-runners
 
 # Force a Helm upgrade even when the release looks unchanged
-just deploy-module arc-staging arc force
+just deploy-module meta-staging-aws-uw1 arc force
 ```
 
 ### Preview changes without applying
@@ -80,13 +80,13 @@ just deploy-module arc-staging arc force
 `just plan <cluster>` runs `tofu plan` for the base and every terraform-backed module. Read-only: no apply, no Kubernetes side effects, safe to run from CI on PRs.
 
 ```bash
-just plan arc-staging
+just plan meta-staging-aws-uw1
 ```
 
 ### Inspect cluster state
 
 ```bash
-just show arc-staging        # config, modules, tofu vars
+just show meta-staging-aws-uw1        # config, modules, tofu vars
 just list                    # all clusters and their modules
 ```
 
@@ -95,18 +95,18 @@ just list                    # all clusters and their modules
 The deploy commands write an audit log into ConfigMaps in the `osdc-system` namespace.
 
 ```bash
-just deploy-history arc-staging              # list of deploy entries (oldest → newest)
-just deploy-status arc-staging               # current versions + recent history (all)
-just deploy-status arc-staging arc-runners   # narrow to a single module/command
+just deploy-history meta-staging-aws-uw1              # list of deploy entries (oldest → newest)
+just deploy-status meta-staging-aws-uw1               # current versions + recent history (all)
+just deploy-status meta-staging-aws-uw1 arc-runners   # narrow to a single module/command
 ```
 
 ### Post-deploy validation
 
 ```bash
-just smoke arc-staging              # pytest-based smoke suite (per-module)
-just integration-test arc-staging   # full integration suite
-just load-test arc-staging          # synthetic load
-just workload-test arc-staging      # production workload replay
+just smoke meta-staging-aws-uw1              # pytest-based smoke suite (per-module)
+just integration-test meta-staging-aws-uw1   # full integration suite
+just load-test meta-staging-aws-uw1          # synthetic load
+just workload-test meta-staging-aws-uw1      # production workload replay
 ```
 
 `just deploy` itself prompts to run smoke at the end (skipped when `OSDC_SMOKE=no`).
@@ -116,8 +116,8 @@ just workload-test arc-staging      # production workload replay
 To roll new runner configurations or AMIs without aborting in-flight CI jobs:
 
 ```bash
-just drain-runners arc-staging      # patch maxRunners=0, taint nodes, wait for in-flight pods
-just resume-runners arc-staging     # restore maxRunners from def files, remove the taint
+just drain-runners meta-staging-aws-uw1      # patch maxRunners=0, taint nodes, wait for in-flight pods
+just resume-runners meta-staging-aws-uw1     # restore maxRunners from def files, remove the taint
 ```
 
 `drain-runners` waits up to `OSDC_DRAIN_TIMEOUT_SECS` (default `3600`) for runner pods to finish before declaring stragglers. The default 1h matches typical PyTorch suite duration — raise it for longer test windows.
@@ -149,7 +149,7 @@ Set these to suppress the interactive prompts in `just deploy` — required for 
 
 ## Adding a new cluster
 
-1. Pick a cluster ID, region, VPC CIDR, and decide which modules. The VPC CIDR sizes only the IPv4 footprint (nodes, NAT, ENI primary IPs) — pod IPs come from an AWS-allocated /56 IPv6 block, so a `/16` is more than enough even for very large fleets. Module names must match a directory under `modules/` — see the existing `arc-staging` and `arc-cbr-production` entries in `clusters.yaml` for full, working examples. Minimal skeleton:
+1. Pick a cluster ID, region, VPC CIDR, and decide which modules. The VPC CIDR sizes only the IPv4 footprint (nodes, NAT, ENI primary IPs) — pod IPs come from an AWS-allocated /56 IPv6 block, so a `/16` is more than enough even for very large fleets. Module names must match a directory under `modules/` — see the existing `meta-staging-aws-uw1` and `arc-cbr-production` entries in `clusters.yaml` for full, working examples. Minimal skeleton:
 
    ```yaml
    # clusters.yaml
@@ -236,9 +236,26 @@ Two modules need definitions: `nodepools` (compute) and `arc-runners` (ARC scale
 
 3. Deploy:
    ```bash
-   just deploy-module arc-staging nodepools
-   just deploy-module arc-staging arc-runners
+   just deploy-module meta-staging-aws-uw1 nodepools
+   just deploy-module meta-staging-aws-uw1 arc-runners
    ```
+
+## Adding a cached git repository
+
+The git cache uses a two-tier architecture: a central StatefulSet clones repos from GitHub and serves them via rsync, while a DaemonSet on each node syncs locally.
+
+1. Edit the appropriate list in the `central.py` script inside `base/kubernetes/git-cache/central-configmap.yaml`. There are **two** lists — pick the right one:
+   - `REPOS_FULL` — repos with submodules. Cloned non-bare with `--recurse-submodules` so `.git/modules/<name>/objects/` is available for `actions/checkout` submodule alternates. Currently: `pytorch/pytorch`.
+   - `REPOS_BARE` — repos without submodules. Cloned bare (lightweight). Currently: `pytorch/test-infra`.
+
+   Adding a submodule-bearing repo to `REPOS_BARE` will break checkout — when in doubt, use `REPOS_FULL`.
+
+2. Redeploy:
+   ```bash
+   just deploy-base meta-staging-aws-uw1
+   ```
+
+Note: Runner pods use `CHECKOUT_GIT_CACHE_DIR` (not `GIT_ALTERNATE_OBJECT_DIRECTORIES`) to find the cache. The `actions/checkout` action uses `reference-repository` to leverage the cache. No runner template changes are needed when adding a new repository.
 
 ## Terraform state management
 
@@ -255,8 +272,8 @@ To inspect state:
 ```bash
 cd modules/eks/terraform
 tofu init -reconfigure \
-    -backend-config="bucket=ciforge-tfstate-arc-staging" \
-    -backend-config="key=arc-staging/base/terraform.tfstate" \
+    -backend-config="bucket=ciforge-tfstate-meta-staging-uw1" \
+    -backend-config="key=meta-staging-aws-uw1/base/terraform.tfstate" \
     -backend-config="region=us-west-2" \
     -backend-config="dynamodb_table=ciforge-terraform-locks"
 tofu state list

--- a/osdc/docs/pypi-package-cache.md
+++ b/osdc/docs/pypi-package-cache.md
@@ -59,11 +59,11 @@ Each pod runs three containers:
   `8080` and `[::]:8080` so this works under IPv6-only EKS. Reverting to a
   single-stack IPv4 deployment would require changing the scrape URL.
 
-Replicas: default 2, override per-cluster (`arc-staging: 1`,
+Replicas: default 2, override per-cluster (`meta-staging-aws-uw1: 1`,
 `arc-cbr-production: 10`). Pods spread across nodes via `podAntiAffinity` on
 `kubernetes.io/hostname`. A per-slug `PodDisruptionBudget` with `minAvailable: 1`
 guards each Deployment, so voluntary disruptions (node drain, rolling update)
-block until a replacement pod is ready — on `arc-staging` with `replicas: 1`
+block until a replacement pod is ready — on `meta-staging-aws-uw1` with `replicas: 1`
 this means drains stall until the new pod schedules.
 
 Pods are scheduled on dedicated Karpenter nodes (`workload=pypi-cache:NoSchedule`

--- a/osdc/integration-tests/load-test/scripts/python/test_load_test_run.py
+++ b/osdc/integration-tests/load-test/scripts/python/test_load_test_run.py
@@ -28,7 +28,7 @@ from load_test_run import (
 
 class TestBranchName:
     def test_basic(self):
-        assert branch_name("arc-staging") == "osdc-load-test-arc-staging"
+        assert branch_name("meta-staging-aws-uw1") == "osdc-load-test-meta-staging-aws-uw1"
 
     def test_production(self):
         assert branch_name("arc-prod") == "osdc-load-test-arc-prod"

--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -142,15 +142,15 @@ def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX):
             run_cmd(["gh", "run", "cancel", str(r["databaseId"]), "--repo", CANARY_REPO], check=False)
 
 
-# ── Phase 1: Staging pool clear (arc-staging only) ─────────────────────
+# ── Phase 1: Staging pool clear (meta-staging-aws-uw1 only) ─────────────────────
 
 
 def clear_staging_pools(cluster_id: str, force: bool = False):
-    """Clear karpenter nodepools and runner pods for staging. Only for arc-staging."""
-    if cluster_id != "arc-staging":
+    """Clear karpenter nodepools and runner pods for staging. Only for meta-staging-aws-uw1."""
+    if cluster_id != "meta-staging-aws-uw1":
         return
 
-    log.info("Phase 1: Checking for active runner pods (arc-staging only)...")
+    log.info("Phase 1: Checking for active runner pods (meta-staging-aws-uw1 only)...")
     result = run_cmd(
         ["kubectl", "get", "pods", "-n", "arc-runners", "--no-headers"],
         check=False,
@@ -188,7 +188,7 @@ def clear_staging_pools(cluster_id: str, force: bool = False):
         time.sleep(10)
 
     log.info("  Re-deploying nodepools...")
-    run_cmd(["just", "deploy-module", "arc-staging", "nodepools"], check=False)
+    run_cmd(["just", "deploy-module", "meta-staging-aws-uw1", "nodepools"], check=False)
 
 
 # ── Phase 2: Prepare PR ────────────────────────────────────────────────

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -3,7 +3,7 @@
 
 Runs a full integration test against an OSDC cluster by:
 1. Cleaning up stale PRs on pytorch/pytorch-canary
-2. Optionally clearing staging pools (arc-staging only)
+2. Optionally clearing staging pools (meta-staging-aws-uw1 only)
 3. Opening a PR with test workflows that exercise every cluster capability
 4. Optionally running smoke tests and node-compactor tests in parallel
 5. Collecting workflow results and reporting

--- a/osdc/integration-tests/scripts/python/test_phases_validation.py
+++ b/osdc/integration-tests/scripts/python/test_phases_validation.py
@@ -61,7 +61,7 @@ class TestPrintReport:
             "compactor": {"status": "passed"},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is True
         out = capsys.readouterr().out
@@ -83,7 +83,7 @@ class TestPrintReport:
             "compactor": {"status": "passed"},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is False
 
@@ -94,7 +94,7 @@ class TestPrintReport:
             "compactor": {"status": "skipped"},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is False
 
@@ -105,7 +105,7 @@ class TestPrintReport:
             "compactor": {"status": "skipped"},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is True
 
@@ -119,7 +119,7 @@ class TestPrintReport:
         ]
         validation = {"smoke": {"status": "passed"}, "compactor": {"status": "passed"}}
 
-        self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         out = capsys.readouterr().out
         assert "something broke" in out
@@ -132,7 +132,7 @@ class TestPrintReport:
             "compactor": {"status": "passed"},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is False
         out = capsys.readouterr().out
@@ -146,14 +146,14 @@ class TestPrintReport:
             "compactor": {"status": "failed", "output": ""},
         }
 
-        result = self.print_report("arc-staging", "pytorch-arc-staging", workflow_results, validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", workflow_results, validation)
 
         assert result is False
 
     def test_interrupted_header(self, capsys):
         self.print_report(
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             [],
             {},
             interrupted=True,
@@ -167,8 +167,8 @@ class TestPrintReport:
             "compactor": {"status": "interrupted"},
         }
         result = self.print_report(
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             [],
             validation,
             interrupted=True,
@@ -189,8 +189,8 @@ class TestPrintReport:
         ]
         validation = {"smoke": {"status": "passed"}, "compactor": {"status": "passed"}}
         result = self.print_report(
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             workflow_results,
             validation,
             interrupted=True,
@@ -212,8 +212,8 @@ class TestPrintReport:
         ]
         validation = {"smoke": {"status": "passed"}, "compactor": {"status": "passed"}}
         result = self.print_report(
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             workflow_results,
             validation,
             interrupted=True,
@@ -228,7 +228,7 @@ class TestPrintReport:
             "smoke": {"status": "passed", "duration_s": 125.3},
             "compactor": {"status": "passed", "duration_s": 7.0},
         }
-        result = self.print_report("arc-staging", "pytorch-arc-staging", [], validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", [], validation)
         assert result is True
         out = capsys.readouterr().out
         assert "2m05s" in out  # 125s -> 2m05s
@@ -240,7 +240,7 @@ class TestPrintReport:
             "smoke": {"status": "passed"},
             "compactor": {"status": "skipped"},
         }
-        result = self.print_report("arc-staging", "pytorch-arc-staging", [], validation)
+        result = self.print_report("meta-staging-aws-uw1", "meta-staging-aws-uw1", [], validation)
         assert result is True
         out = capsys.readouterr().out
         # No duration suffix expected
@@ -263,8 +263,8 @@ class TestPrintReport:
             "compactor": {"status": "interrupted"},
         }
         result = self.print_report(
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             workflow_results,
             validation,
             interrupted=True,

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -37,8 +37,8 @@ def clusters_yaml(tmp_path):
             "logging": {"namespace": "logging"},
         },
         "clusters": {
-            "arc-staging": {
-                "cluster_name": "pytorch-arc-staging",
+            "meta-staging-aws-uw1": {
+                "cluster_name": "meta-staging-aws-uw1",
                 "aws_region": "us-west-2",
                 "modules": ["eks", "karpenter", "nodepools", "arc", "arc-runners"],
                 "harbor": {"core_replicas": 1},
@@ -68,8 +68,8 @@ def clusters_yaml(tmp_path):
 
 @pytest.fixture
 def cfg_staging(clusters_yaml):
-    """Return loaded config for arc-staging."""
-    return load_cluster_config(clusters_yaml, "arc-staging")
+    """Return loaded config for meta-staging-aws-uw1."""
+    return load_cluster_config(clusters_yaml, "meta-staging-aws-uw1")
 
 
 @pytest.fixture
@@ -126,8 +126,8 @@ def workflow_template(tmp_path):
 
 class TestLoadClusterConfig:
     def test_valid_cluster(self, clusters_yaml):
-        cfg = load_cluster_config(clusters_yaml, "arc-staging")
-        assert cfg["cluster"]["cluster_name"] == "pytorch-arc-staging"
+        cfg = load_cluster_config(clusters_yaml, "meta-staging-aws-uw1")
+        assert cfg["cluster"]["cluster_name"] == "meta-staging-aws-uw1"
         assert cfg["cluster"]["aws_region"] == "us-west-2"
         assert "defaults" in cfg
 
@@ -158,7 +158,7 @@ class TestResolve:
         assert resolve(cfg_staging, "nonexistent.path") is None
 
     def test_top_level_key(self, cfg_staging):
-        assert resolve(cfg_staging, "cluster_name") == "pytorch-arc-staging"
+        assert resolve(cfg_staging, "cluster_name") == "meta-staging-aws-uw1"
 
 
 # ── has_module ────────────────────────────────────────────────────────────
@@ -196,8 +196,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
         )
         assert "b200-job" not in result
@@ -227,8 +227,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
             cache_enforcer_enabled=False,
         )
@@ -241,8 +241,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
             cache_enforcer_enabled=True,
         )
@@ -256,8 +256,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
             pypi_cache_slugs="cpu cu121 cu124",
         )
@@ -268,8 +268,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
         )
         # Default value should be substituted
@@ -279,8 +279,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
             pypi_cache_cuda_version="13.0",
         )
@@ -291,8 +291,8 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "arc-staging",
-            "pytorch-arc-staging",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             b200_enabled=False,
         )
         # Default value should be substituted
@@ -347,7 +347,7 @@ class TestCleanupStalePrs:
             MagicMock(returncode=0),
         ]
 
-        cleanup_stale_prs("osdc-integration-test-arc-staging")
+        cleanup_stale_prs("osdc-integration-test-meta-staging-aws-uw1")
 
         assert mock_run.call_count == 6
 
@@ -367,7 +367,7 @@ class TestCleanupStalePrs:
     @patch("phases.run_cmd")
     def test_handles_pr_list_failure(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="auth required", stdout="")
-        cleanup_stale_prs("osdc-integration-test-arc-staging")
+        cleanup_stale_prs("osdc-integration-test-meta-staging-aws-uw1")
         # Should not raise, just log and return
         assert mock_run.call_count == 1
 
@@ -382,7 +382,7 @@ class TestCleanupStalePrs:
             MagicMock(returncode=0, stdout=empty_runs),  # in_progress runs
         ]
 
-        cleanup_stale_prs("osdc-integration-test-arc-staging")
+        cleanup_stale_prs("osdc-integration-test-meta-staging-aws-uw1")
         # pr list + 2 run list calls, no close/cancel calls
         assert mock_run.call_count == 3
 
@@ -409,7 +409,7 @@ class TestPreparePr:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: test\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=True,
         )
 
@@ -437,7 +437,7 @@ class TestPreparePr:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: test workflow\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=True,
         )
 
@@ -472,7 +472,7 @@ class TestPreparePr:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: test\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=False,
         )
 
@@ -609,7 +609,7 @@ class TestEnsureCanaryRepo:
 
 
 def test_branch_name():
-    assert branch_name("arc-staging") == "osdc-integration-test-arc-staging"
+    assert branch_name("meta-staging-aws-uw1") == "osdc-integration-test-meta-staging-aws-uw1"
     assert branch_name("arc-cbr-production") == "osdc-integration-test-arc-cbr-production"
 
 
@@ -737,7 +737,7 @@ class TestParseArgs:
             [
                 "run.py",
                 "--cluster-id",
-                "arc-staging",
+                "meta-staging-aws-uw1",
                 "--clusters-yaml",
                 "/tmp/c.yaml",
                 "--upstream-dir",
@@ -747,7 +747,7 @@ class TestParseArgs:
             ],
         ):
             args = parse_args()
-        assert args.cluster_id == "arc-staging"
+        assert args.cluster_id == "meta-staging-aws-uw1"
         assert str(args.clusters_yaml) == "/tmp/c.yaml"
         assert str(args.upstream_dir) == "/tmp/upstream"
         assert str(args.root_dir) == "/tmp/root"
@@ -812,7 +812,7 @@ class TestClearStagingPools:
     def test_no_active_pods_skips(self, mock_run):
         """When no runner pods are found, skip pool clear."""
         mock_run.return_value = MagicMock(returncode=0, stdout="\n", stderr="")
-        clear_staging_pools("arc-staging")
+        clear_staging_pools("meta-staging-aws-uw1")
         # Only the initial kubectl get pods call
         assert mock_run.call_count == 1
 
@@ -824,7 +824,7 @@ class TestClearStagingPools:
             stdout="",
             stderr="connection refused",
         )
-        clear_staging_pools("arc-staging")
+        clear_staging_pools("meta-staging-aws-uw1")
         assert mock_run.call_count == 1
 
     @patch("phases.time.sleep")
@@ -846,7 +846,7 @@ class TestClearStagingPools:
             MagicMock(returncode=0, stdout="", stderr=""),
         ]
 
-        clear_staging_pools("arc-staging", force=True)
+        clear_staging_pools("meta-staging-aws-uw1", force=True)
 
         assert mock_run.call_count == 6
         # Verify delete pods call
@@ -873,7 +873,7 @@ class TestClearStagingPools:
             stdout="pod1 Running\n",
             stderr="",
         )
-        clear_staging_pools("arc-staging", force=False)
+        clear_staging_pools("meta-staging-aws-uw1", force=False)
         # Only the get-pods call, no delete/drain/redeploy
         assert mock_run.call_count == 1
 
@@ -895,7 +895,7 @@ class TestClearStagingPools:
             MagicMock(returncode=0, stdout="", stderr=""),
         ]
 
-        clear_staging_pools("arc-staging", force=False)
+        clear_staging_pools("meta-staging-aws-uw1", force=False)
 
         assert mock_run.call_count == 5
         # Verify the drain and redeploy happened
@@ -925,7 +925,7 @@ class TestPreparePrAdditional:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: test\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=True,
         )
 
@@ -954,7 +954,7 @@ class TestPreparePrAdditional:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: new test\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=True,
         )
 
@@ -983,7 +983,7 @@ class TestPreparePrAdditional:
             canary_path=canary,
             upstream_dir=workflow_template,
             workflow_content="name: test\n",
-            branch="osdc-integration-test-arc-staging",
+            branch="osdc-integration-test-meta-staging-aws-uw1",
             dry_run=False,
         )
 
@@ -1010,7 +1010,7 @@ class TestMain:
         from run import main
 
         mock_parse_args.return_value = MagicMock(
-            cluster_id="arc-staging",
+            cluster_id="meta-staging-aws-uw1",
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1049,7 +1049,7 @@ class TestMain:
         from run import main
 
         mock_parse_args.return_value = MagicMock(
-            cluster_id="arc-staging",
+            cluster_id="meta-staging-aws-uw1",
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1089,7 +1089,7 @@ class TestMain:
         from run import main
 
         mock_parse_args.return_value = MagicMock(
-            cluster_id="arc-staging",
+            cluster_id="meta-staging-aws-uw1",
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1125,7 +1125,7 @@ class TestMain:
         from run import main
 
         mock_parse_args.return_value = MagicMock(
-            cluster_id="arc-staging",
+            cluster_id="meta-staging-aws-uw1",
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,

--- a/osdc/integration-tests/workload-test/scripts/python/test_workload_run.py
+++ b/osdc/integration-tests/workload-test/scripts/python/test_workload_run.py
@@ -20,7 +20,7 @@ from workload_run import (
 
 class TestBranchName:
     def test_basic(self):
-        assert branch_name("arc-staging") == "osdc-workload-test-arc-staging"
+        assert branch_name("meta-staging-aws-uw1") == "osdc-workload-test-meta-staging-aws-uw1"
 
     def test_production(self):
         assert branch_name("arc-cbr-production") == "osdc-workload-test-arc-cbr-production"

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -14,9 +14,9 @@
 #
 # Usage:
 #   just list                          # show clusters and their modules
-#   just deploy arc-staging            # full deploy (base + all modules)
-#   just deploy-base arc-staging       # base infra only
-#   just deploy-module arc-staging arc # single module
+#   just deploy meta-staging-aws-uw1            # full deploy (base + all modules)
+#   just deploy-base meta-staging-aws-uw1       # base infra only
+#   just deploy-module meta-staging-aws-uw1 arc # single module
 #   just test                            # run all tests
 #   just lint                            # lint all code
 
@@ -1153,7 +1153,7 @@ _arc-drift-report name='':
     NAME="{{name}}"
 
     # Stage kubectl outputs in tempfiles — combined JSON exceeds ARG_MAX on
-    # large clusters (~1.25MB ARS blob alone on arc-staging), so --argjson is
+    # large clusters (~1.25MB ARS blob alone on meta-staging-aws-uw1), so --argjson is
     # not viable. --slurpfile takes a file path instead.
     WORK=$(mktemp -d)
     trap 'rm -rf "$WORK"' EXIT

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-16-32
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-16-32
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-2-4
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-2-4
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-37-68
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-37-68
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-46-85
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-46-85
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-8-16
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-8-16
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
@@ -1,6 +1,6 @@
 # ARC runner definition: l-x86iavx512-94-192
 # Instance type: c7a.48xlarge (pool: x86-cpu)
-# NOTE: c7a.48xlarge is NOT available in us-west-1 (arc-staging). Will not schedule there.
+# NOTE: c7a.48xlarge is NOT available in us-west-1 (meta-staging-aws-uw1). Will not schedule there.
 runner:
   name: l-x86iavx512-94-192
   instance_type: c7a.48xlarge

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -375,7 +375,7 @@ def main():
     if len(sys.argv) < 2:
         print("Usage: generate_runners.py <cluster-id>")
         print()
-        print("Example: generate_runners.py arc-staging")
+        print("Example: generate_runners.py meta-staging-aws-uw1")
         return 1
 
     cluster_id = sys.argv[1]

--- a/osdc/modules/eks/scripts/mirror-images.sh
+++ b/osdc/modules/eks/scripts/mirror-images.sh
@@ -37,7 +37,7 @@ log_error() { echo -e "${RED}x${NC} $*"; }
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <cluster-id>"
-  echo "  e.g. $0 arc-staging"
+  echo "  e.g. $0 meta-staging-aws-uw1"
   exit 1
 fi
 

--- a/osdc/modules/eks/terraform/variables.tf
+++ b/osdc/modules/eks/terraform/variables.tf
@@ -2,7 +2,7 @@
 # which reads values from clusters.yaml.
 
 variable "cluster_name" {
-  description = "EKS cluster name (e.g. pytorch-arc-staging)"
+  description = "EKS cluster name (e.g. meta-staging-aws-uw1)"
   type        = string
 }
 

--- a/osdc/modules/karpenter/terraform/variables.tf
+++ b/osdc/modules/karpenter/terraform/variables.tf
@@ -14,6 +14,6 @@ variable "state_bucket" {
 }
 
 variable "cluster_id" {
-  description = "Cluster identifier in clusters.yaml (e.g. arc-staging)"
+  description = "Cluster identifier in clusters.yaml (e.g. meta-staging-aws-uw1)"
   type        = string
 }

--- a/osdc/modules/logging/scripts/python/assemble_config.py
+++ b/osdc/modules/logging/scripts/python/assemble_config.py
@@ -14,7 +14,7 @@ Usage:
         --base-pipeline base.alloy \
         --modules-dir /path/to/consumer/modules \
         --upstream-modules-dir /path/to/upstream/modules \
-        --cluster arc-staging \
+        --cluster meta-staging-aws-uw1 \
         --clusters-yaml /path/to/clusters.yaml \
         --namespace logging \
         --output generated/alloy-config.yaml

--- a/osdc/modules/pypi-cache/terraform/variables.tf
+++ b/osdc/modules/pypi-cache/terraform/variables.tf
@@ -14,6 +14,6 @@ variable "state_bucket" {
 }
 
 variable "cluster_id" {
-  description = "Cluster identifier in clusters.yaml (e.g. arc-staging)"
+  description = "Cluster identifier in clusters.yaml (e.g. meta-staging-aws-uw1)"
   type        = string
 }

--- a/osdc/scripts/bootstrap-state.sh
+++ b/osdc/scripts/bootstrap-state.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #
 # Usage:
 #   ./scripts/bootstrap-state.sh <cluster-id>
-#   ./scripts/bootstrap-state.sh arc-staging
+#   ./scripts/bootstrap-state.sh meta-staging-aws-uw1
 #   ./scripts/bootstrap-state.sh --all              # bootstrap all clusters
 #
 # Idempotent: safe to run multiple times.

--- a/osdc/scripts/cluster-config.py
+++ b/osdc/scripts/cluster-config.py
@@ -7,16 +7,16 @@
 
 Usage:
     # Get a single field
-    cluster-config.py arc-staging region              -> us-west-1
-    cluster-config.py arc-staging cluster_name        -> pytorch-arc-staging
-    cluster-config.py arc-staging base.vpc_cidr       -> 10.0.0.0/16
+    cluster-config.py meta-staging-aws-uw1 region              -> us-west-1
+    cluster-config.py meta-staging-aws-uw1 cluster_name        -> meta-staging-aws-uw1
+    cluster-config.py meta-staging-aws-uw1 base.vpc_cidr       -> 10.0.0.0/16
 
     # Get all base terraform vars as -var flags
-    cluster-config.py arc-staging tfvars
-        -> -var="cluster_name=pytorch-arc-staging" -var="aws_region=us-west-1" ...
+    cluster-config.py meta-staging-aws-uw1 tfvars
+        -> -var="cluster_name=meta-staging-aws-uw1" -var="aws_region=us-west-1" ...
 
     # Check if a module is enabled
-    cluster-config.py arc-staging has-module arc      -> exits 0 (true) or 1 (false)
+    cluster-config.py meta-staging-aws-uw1 has-module arc      -> exits 0 (true) or 1 (false)
 
     # List all cluster IDs
     cluster-config.py --list

--- a/osdc/scripts/deploy-log.sh
+++ b/osdc/scripts/deploy-log.sh
@@ -35,7 +35,7 @@ readonly _DEPLOY_LOG_HISTORY_MAX=50
 # Record the start of a deploy. Prints epoch timestamp to stdout.
 # Args: <scope> <cluster> <name>
 #   scope:   "module" or "cmd"
-#   cluster: cluster ID (e.g., arc-staging)
+#   cluster: cluster ID (e.g., meta-staging-aws-uw1)
 #   name:    module name or command name
 deploy_log_start() {
   local scope="$1" cluster="$2" name="$3"

--- a/osdc/tests/smoke/smoke_conftest.py
+++ b/osdc/tests/smoke/smoke_conftest.py
@@ -69,7 +69,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "--cluster-id",
             action="store",
             required=True,
-            help="Cluster ID from clusters.yaml (e.g. arc-staging)",
+            help="Cluster ID from clusters.yaml (e.g. meta-staging-aws-uw1)",
         )
 
 


### PR DESCRIPTION
Move staging from the `pytorch-canary` repo to the `pytorch` org and into the `meta-staging-aws-uw1` runner group, and rename the cluster `arc-staging` → `meta-staging-aws-uw1`.

`clusters.yaml`:
- `github_config_url`: `pytorch/pytorch-canary` → `pytorch` (org-wide — required, since a repo-scoped URL forces `runner_group` to `default`)
- add `runner_group: meta-staging-aws-uw1`; keep `c-mt-` prefix so labels stay distinct from prod
- cluster name, `state_bucket`, `github_secret_name` renamed to `meta-staging-aws-uw1`

Everything else is the same rename applied across CI workflows, integration tests, docs, and comments.

Needs teardown + recreate (see `osdc/docs/cluster-recreation.md`): create the org runner group, install the GitHub App org-wide, provision the `meta-staging-aws-uw1` secret, `just bootstrap`, then redeploy.

`just lint` + `just test` pass.