### PR TITLE
Use uv to provide pyyaml in deploy script

### DIFF
--- a/osdc/base/kubernetes/node-taint-remover/deploy.sh
+++ b/osdc/base/kubernetes/node-taint-remover/deploy.sh
@@ -62,8 +62,9 @@ kubectl create configmap "$CM_NAME" \
 
 # Inject labels so the ConfigMap is identifiable like other base components.
 # kubectl create configmap doesn't accept --labels in older versions, so we
-# patch them in after rendering.
-python3 - "$MANIFEST" <<'PY'
+# patch them in after rendering. `uv run --with pyyaml` brings pyyaml into
+# scope on every host without depending on the project's mise/venv state.
+uv run --with pyyaml python3 - "$MANIFEST" <<'PY'
 import sys
 import yaml
 


### PR DESCRIPTION
> [!warning]
> **A CLASSIC CASE OF "WORK IN MY MACHINE"**

- Replace bare `python3` with `uv run --with pyyaml python3` for the YAML label-patching step in node-taint-remover deploy

The inline Python script imports pyyaml, which was only available when the project's mise/venv happened to be active. Using `uv run --with pyyaml` makes the dependency explicit and portable so the script works on any host regardless of local virtualenv state.