### PR TITLE
Fix smoke test for catch-all toleration matching

### DIFF
--- a/osdc/modules/cache-enforcer/tests/smoke/test_cache_enforcer.py
+++ b/osdc/modules/cache-enforcer/tests/smoke/test_cache_enforcer.py
@@ -244,12 +244,26 @@ class TestCacheEnforcerPodSpec:
     def test_tolerates_runner_node_taints(self, ds_spec: dict) -> None:
         """Must tolerate all taints used by Karpenter runner nodepools.
 
-        At minimum: instance-type, nvidia.com/gpu.
+        At minimum: instance-type, nvidia.com/gpu, cpu-type, CriticalAddonsOnly.
         These taints are present on runner nodes and would prevent scheduling
         without matching tolerations.
+
+        A toleration matches a taint if either:
+          - its `key` matches the taint key and operator is Exists or Equal, OR
+          - it has no `key` set (`""` or absent) and operator is Exists, which
+            is the K8s catch-all that matches every taint.
         """
         tolerations = ds_spec.get("tolerations", [])
-        toleration_keys = {t.get("key") for t in tolerations}
+
+        def tolerates(taint_key: str) -> bool:
+            for t in tolerations:
+                op = t.get("operator", "Equal")
+                t_key = t.get("key") or ""
+                if not t_key and op == "Exists":
+                    return True
+                if t_key == taint_key and op in ("Exists", "Equal"):
+                    return True
+            return False
 
         required_keys = {
             "instance-type",
@@ -257,7 +271,7 @@ class TestCacheEnforcerPodSpec:
             "cpu-type",
             "CriticalAddonsOnly",
         }
-        missing = required_keys - toleration_keys
+        missing = {k for k in required_keys if not tolerates(k)}
         assert not missing, (
             f"Missing tolerations for runner node taints: {missing}. "
             f"DaemonSet will not schedule on nodes with these taints."


### PR DESCRIPTION
Fix regression: https://github.com/pytorch/ci-infra/actions/runs/27315703174/job/80698504415#step:7:177

introduced by stack: https://github.com/pytorch/ci-infra/pull/706

- Replace simple key-set lookup with proper K8s toleration matching logic
- Handle catch-all tolerations (operator=Exists with no key) that match every taint
- Add cpu-type and CriticalAddonsOnly to required taint keys

The previous test extracted toleration keys into a flat set and checked membership. This broke when the DaemonSet uses a catch-all toleration (no key + operator: Exists), which K8s treats as matching all taints but never appeared in the key set. The new `tolerates()` helper mirrors actual K8s scheduling semantics.