### PR TITLE
Tune WoW % change panels: 3h avg, wider bands

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -540,7 +540,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "app": "grafana-assistant-app",
-                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[1h:]) - avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:])) / avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:]) > 0)",
+                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0)",
                       "instant": false,
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
@@ -556,10 +556,10 @@
             "transformations": []
           }
         },
-        "description": "Week-over-week percentage change in the 1-hour rolling average of running jobs.",
+        "description": "Week-over-week percentage change in the 3-hour rolling average of running jobs.",
         "id": 4,
         "links": [],
-        "title": "Running Jobs Week-over-Week % Change, 1h Avg [cluster, scale_set]",
+        "title": "Running Jobs Week-over-Week % Change, 3h Avg [cluster, scale_set]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -617,19 +617,19 @@
                     },
                     {
                       "color": "#EAB839",
-                      "value": -20
+                      "value": -35
                     },
                     {
                       "color": "rgba(255, 255, 255, 0)",
-                      "value": -10
+                      "value": -20
                     },
                     {
                       "color": "#EAB839",
-                      "value": 10
+                      "value": 80
                     },
                     {
                       "color": "red",
-                      "value": 20
+                      "value": 100
                     }
                   ]
                 },
@@ -678,7 +678,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "app": "grafana-assistant-app",
-                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[1h:]) - avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:])) / avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[1h:]) > 0)",
+                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0)",
                       "instant": false,
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
@@ -694,10 +694,10 @@
             "transformations": []
           }
         },
-        "description": "Week-over-week percentage change in the 1-hour rolling average of assigned jobs.",
+        "description": "Week-over-week percentage change in the 3-hour rolling average of assigned jobs.",
         "id": 5,
         "links": [],
-        "title": "Assigned Jobs Week-over-Week % Change, 1h Avg [cluster, scale_set]",
+        "title": "Assigned Jobs Week-over-Week % Change, 3h Avg [cluster, scale_set]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -755,19 +755,19 @@
                     },
                     {
                       "color": "#EAB839",
-                      "value": -20
+                      "value": -35
                     },
                     {
                       "color": "rgba(255, 255, 255, 0)",
-                      "value": -10
+                      "value": -20
                     },
                     {
                       "color": "#EAB839",
-                      "value": 10
+                      "value": 80
                     },
                     {
                       "color": "red",
-                      "value": 20
+                      "value": 100
                     }
                   ]
                 },


### PR DESCRIPTION
- Increase rolling average window from 1h to 3h for both Running Jobs and Assigned Jobs WoW % change panels
- Widen color threshold bands: neutral zone now -20..+80% (was -10..+10%), warning at -35/+80, red at +100%
- Update panel titles and descriptions to reflect 3h avg

The 1h window produced noisy spikes that obscured real trends. A 3h rolling average smooths out transient bursts while still surfacing meaningful week-over-week shifts. Thresholds widened to reduce false-alarm coloring given normal operational variance.

Dashboard: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc