### PR TITLE
uw1: re-add nodepools module to unfreeze c7i-runner startup-taint scheme

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -203,6 +203,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - nodepools
       - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
       - arc-runners-h100
       - pypi-cache


### PR DESCRIPTION
## Problem

All 3 H100 scale sets on `arc-cbr-production-uw1` are at 100% "Assigned Jobs Not Running" — 28 runner-orchestrator pods stuck `Pending` for hours on the one c7i-runner node, which carries a `git-cache-not-ready:NoSchedule` taint nothing removes.

## Cause

A cross-PR landmine:
- **#688** dropped `nodepools` from uw1's module list. This **didn't delete** the live NodePools (removing a module from `clusters.yaml` only stops future deploys from touching it — deletion needs an explicit `just remove-module`, which wasn't run). The orphaned NodePools stayed live and kept provisioning c7i-runner nodes, but **frozen** on the old `git-cache-not-ready` taint.
- **#703** deleted the git-cache module, including `git-cache-warmer` — the only remover of that taint.
- **#706** migrated the fleet to the new `node-init.osdc.io/*` taint scheme.

Every cluster still deploying `nodepools` (e.g. us-east-2) regenerated onto the new scheme. uw1 was skipped, so its nodes keep the stale taint with no remover.

Live proof — `c7i-runner-48xlarge` NodePool `startupTaints`:
- us-east-2: `node-init.osdc.io/*` (removers running) ✅
- uw1: `git-cache-not-ready` (remover deleted in #703) ❌

## Fix

Re-add `- nodepools`. A deploy regenerates uw1's NodePools onto the `node-init.osdc.io/*` scheme, whose removers (`cache-enforcer`, `registry-mirror-config`, `node-performance-tuning`, `algif-mitigation`, `dirtyfrag-mitigation`) already run on uw1. NodePools are `min=0` templates, so this is cost-neutral; general `arc-runners` (CPU) is intentionally left out.

## After deploy

The already-stuck node won't be re-tainted automatically — drain it or:
`kubectl taint node ip-10-8-41-32.us-west-1.compute.internal git-cache-not-ready=true:NoSchedule-`

## Testing

`just lint` / `just test` (config-only). Post-deploy: new c7i-runner NodePool shows `node-init.osdc.io/*`, new nodes come up untainted, uw1 panel drops to ~0%.