### PR TITLE
buildkit: raise HAProxy server-template counts above autoscaling max

### DIFF
--- a/osdc/modules/buildkit/kubernetes/base/haproxy.yaml
+++ b/osdc/modules/buildkit/kubernetes/base/haproxy.yaml
@@ -69,17 +69,22 @@ data:
     # server-line keyword (not valid inside the `resolvers` section) so it goes
     # on each server-template — keeps HAProxy from logging benign A-family
     # resolution warnings.
+    #
+    # The server-template count is the max pods HAProxy can route to for that
+    # backend, so it must stay >= the autoscaling *_max — otherwise pods scaled
+    # past the count are unreachable and builds beyond it stall on "waiting for
+    # connection". Sized above prod (amd64_max=360 / arm64_max=30).
     backend bk_arm64
       balance leastconn
-      server-template arm 10 buildkitd-arm64-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
+      server-template arm 40 buildkitd-arm64-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
 
     backend bk_amd64
       balance leastconn
-      server-template amd 10 buildkitd-amd64-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
+      server-template amd 400 buildkitd-amd64-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
 
     backend bk_all
       balance leastconn
-      server-template all 20 buildkitd-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
+      server-template all 440 buildkitd-pods.buildkit.svc.cluster.local:1234 check resolvers k8s init-addr none resolve-prefer ipv6 maxconn 1
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## Problem

The BuildKit LB's `bk_amd64` / `bk_arm64` / `bk_all` backends each had only `server-template ... 10` (and 20 for `all`) server slots, so HAProxy could route to **at most 10 builder pods per arch** no matter how far KEDA scaled the Deployment.

Observed live on `arc-cbr-production` under a ~27-build burst:

| metric | value |
|---|---|
| `server-template amd` slots | 10 |
| amd64 servers with an active session | 10 (all full, `maxconn 1`) |
| `bk_amd64` backend `scur` / `qcur` / `qmax` | 14 / 4 / 26 |
| amd64 pods actually Running | **31** |

So 31 pods existed, HAProxy used 10, the other 21 sat idle, and builds beyond the 10th queued and stalled on `[internal] waiting for connection` (each `docker buildx build` dial timed out at the gRPC ~20s connect gate and the client connect-retry looped). KEDA kept scaling pods — they read `current_sessions`, which is inflated by the queue — but the new pods were unreachable dead weight.

Staging never hit this: its `*_max` is 8, which is `<= 10`.

## Fix

Raise the counts above prod's autoscaling max (`amd64_max=360`, `arm64_max=30`):

- `amd 10 → 400`
- `arm 10 → 40`
- `all 20 → 440`

Unresolved slots are cheap (`init-addr none` → no address and no health check until the headless-service DNS supplies one), so over-provisioning is safe. Added a comment documenting the invariant: the `server-template` count must stay `>=` the autoscaling `*_max`, else scaled-up pods are unreachable.

## Test

- `just lint` — 13/13 pass
- `just test` — pass (98.76% coverage)
- `kubectl kustomize` renders the new counts cleanly