### PR TITLE
ue1: remove pypi-cache and cache-enforcer; runners use public PyPI

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -241,15 +241,16 @@ clusters:
       github_secret_name: meta-prod-aws-ue1
       runner_name_prefix: "mt-"
       runner_group: "meta-prod-aws-ue1"
-    pypi_cache:
-      replicas: 10
+    # ue1 runs without pypi-cache and cache-enforcer: runners install from
+    # public PyPI directly (no wheel cache, no SNI egress firewall). The
+    # arc-runners generator gates the pypi-cache pip env on pypi-cache module
+    # membership, so omitting the module also drops the PIP_INDEX_URL/UV_*
+    # injection -- otherwise pip would target a removed service.
     modules:
       - karpenter
       - arc
       - nodepools
       - arc-runners
-      - pypi-cache
-      - cache-enforcer
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -172,6 +172,35 @@ def resolve_max_runners(value, def_file, cluster_id):
     return value
 
 
+PYPI_CACHE_HOST = "pypi-cache-cpu.pypi-cache.svc.cluster.local"
+
+
+def render_pypi_cache_env(enabled):
+    """Render the pip/uv env entries that point installs at the pypi-cache.
+
+    Returns a string to substitute after `env:` (leading newline, 12-space
+    indent, no trailing newline), or "" when the cluster has no pypi-cache
+    module so runners fall back to public PyPI defaults.
+    """
+    if not enabled:
+        return ""
+    simple = f"http://{PYPI_CACHE_HOST}:8080/simple/"
+    whl = f"http://{PYPI_CACHE_HOST}:8080/whl/cpu/"
+    pairs = [
+        ("PIP_INDEX_URL", simple),
+        ("PIP_TRUSTED_HOST", PYPI_CACHE_HOST),
+        ("PIP_EXTRA_INDEX_URL", whl),
+        ("UV_DEFAULT_INDEX", simple),
+        ("UV_INSECURE_HOST", f"{PYPI_CACHE_HOST}:8080"),
+        ("UV_INDEX", whl),
+        ("UV_INDEX_STRATEGY", "unsafe-best-match"),
+        ("PYPI_CACHE_SIMPLE_URL", simple),
+        ("PYPI_CACHE_WHL_URL", whl),
+    ]
+    lines = [f'\n            - name: {name}\n              value: "{value}"' for name, value in pairs]
+    return "".join(lines)
+
+
 def generate_runner(def_file, template_content, cluster_config, output_dir, module_name):
     """Generate a single runner config from its definition."""
     with open(def_file) as f:
@@ -328,6 +357,11 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     # Optional maxRunners line — only emitted when max_runners is set in the def
     max_runners_line = f"maxRunners: {max_runners}" if max_runners is not None else ""
 
+    # pypi-cache pip/uv env. Injected only when the cluster deploys the
+    # pypi-cache module; otherwise runners resolve against public PyPI and
+    # pointing these at the (absent) cache service would break installs.
+    pypi_cache_env = render_pypi_cache_env(cluster_config.get("pypi_cache_enabled", True))
+
     # Replace all template placeholders
     output_content = template_content
     replacements = {
@@ -356,6 +390,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
         "{{PROACTIVE_CAPACITY}}": str(proactive_capacity),
         "{{MAX_BURST_CAPACITY}}": str(max_burst_capacity),
         "{{HUD_FAILURE_BASE_CAPACITY}}": str(hud_failure_base_capacity),
+        "{{PYPI_CACHE_ENV}}": pypi_cache_env,
     }
 
     for placeholder, value in replacements.items():
@@ -432,6 +467,11 @@ def main():
             f"proactive_capacity_max={proactive_cap} for cluster '{cluster_id}' — "
             f"proactive_capacity capped at {proactive_cap} for all scale sets"
         )
+
+    # Gate the pypi-cache pip env on whether this cluster deploys pypi-cache.
+    # Without the module the cache service does not exist, so runners must use
+    # public PyPI rather than a dead index URL.
+    cluster_config["pypi_cache_enabled"] = "pypi-cache" in (cluster_cfg.get("modules") or [])
 
     cluster_config["pause_runners"] = bool(cluster_cfg.get("pause_runners"))
     if cluster_config["pause_runners"]:

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -714,6 +714,54 @@ class TestGenerateRunner:
         assert "{{" not in content
         assert "}}" not in content
 
+    def test_pypi_cache_env_present_by_default(self, tmp_path, real_template):
+        """With pypi_cache_enabled unset (default) the cache pip env is injected."""
+        def_file = make_def_file(tmp_path, "test-runner", "c7i.24xlarge", 2, 4)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "https://github.com/org",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "pre-",
+        }
+
+        generate_runner(def_file, real_template, cluster_config, output_dir, "arc-runners")
+        content = (output_dir / "test-runner.yaml").read_text()
+        assert "PIP_INDEX_URL" in content
+        assert "pypi-cache-cpu.pypi-cache.svc.cluster.local" in content
+        # env block must still be valid and carry the non-cache var
+        assert "TORCH_CI_MAX_MEMORY" in content
+        list(yaml.safe_load_all(content))
+
+    def test_pypi_cache_env_omitted_when_disabled(self, tmp_path, real_template):
+        """With pypi_cache_enabled False (cluster lacks pypi-cache) the cache env is dropped."""
+        def_file = make_def_file(tmp_path, "test-runner", "c7i.24xlarge", 2, 4)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "https://github.com/org",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "pre-",
+            "pypi_cache_enabled": False,
+        }
+
+        generate_runner(def_file, real_template, cluster_config, output_dir, "arc-runners")
+        content = (output_dir / "test-runner.yaml").read_text()
+        for var in (
+            "PIP_INDEX_URL",
+            "PIP_TRUSTED_HOST",
+            "PIP_EXTRA_INDEX_URL",
+            "UV_DEFAULT_INDEX",
+            "UV_INDEX",
+            "PYPI_CACHE_SIMPLE_URL",
+            "PYPI_CACHE_WHL_URL",
+        ):
+            assert var not in content, f"{var} should be absent when pypi-cache is disabled"
+        assert "pypi-cache-cpu.pypi-cache.svc.cluster.local" not in content
+        # env block still renders the non-cache var and stays valid YAML
+        assert "TORCH_CI_MAX_MEMORY" in content
+        list(yaml.safe_load_all(content))
+
     def test_normalized_name_in_output(self, tmp_path):
         def_file = make_def_file(tmp_path, "runner.with_dots", "m6i.32xlarge", 4, 16)
         output_dir = tmp_path / "out"

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -416,25 +416,7 @@ data:
 
       containers:
         - name: "$job"
-          env:
-            - name: PIP_INDEX_URL
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/simple/"
-            - name: PIP_TRUSTED_HOST
-              value: "pypi-cache-cpu.pypi-cache.svc.cluster.local"
-            - name: PIP_EXTRA_INDEX_URL
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/whl/cpu/"
-            - name: UV_DEFAULT_INDEX
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/simple/"
-            - name: UV_INSECURE_HOST
-              value: "pypi-cache-cpu.pypi-cache.svc.cluster.local:8080"
-            - name: UV_INDEX
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/whl/cpu/"
-            - name: UV_INDEX_STRATEGY
-              value: "unsafe-best-match"
-            - name: PYPI_CACHE_SIMPLE_URL
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/simple/"
-            - name: PYPI_CACHE_WHL_URL
-              value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/whl/cpu/"
+          env:{{PYPI_CACHE_ENV}}
             - name: TORCH_CI_MAX_MEMORY
               value: "{{MEMORY_BYTES}}"
           # Workflow container gets the actual compute resources


### PR DESCRIPTION
Drop `pypi-cache` and `cache-enforcer` from `meta-prod-aws-ue1`; its runners install from public PyPI directly. `arc-runners` gates the pypi-cache pip/uv env on module membership (default on), so every other cluster is unchanged.

**Why:** the cache-enforcer SNI egress rule is non-deterministically defeated by kube-proxy resync, causing flaky `spmd-types` failures installing nightly torch (ci-infra#745). ue1 moves off the cache+enforcer stack.

**Rollout** (`just deploy` doesn't prune; delete the live resources by hand while the region is drained, so nothing breaks and new nodes come back clean). Merge first, then:
1. `just drain-runners meta-prod-aws-ue1` — `maxRunners=0`, taint, wait for in-flight. Jobs route to siblings. Drain bridges the window where the cache is gone but the runner env isn't flipped yet.
2. Delete the live k8s resources while drained (`remove-module` doesn't cover these — no `osdc.io/module` label):
   - `kubectl delete -k osdc/modules/cache-enforcer/kubernetes` (DaemonSet so it can't reschedule onto fresh nodes)
   - `kubectl delete namespace pypi-cache` + its karpenter `nodepool`/`ec2nodeclass`
3. Deploy ue1 via CI — runners re-render gated off; the two modules aren't redeployed (already gone → new nodes come up clean).
4. `just resume-runners meta-prod-aws-ue1` + `just untaint-nodes meta-prod-aws-ue1`. Verify a canary job installs from public PyPI.

**Follow-up (not cutover-critical):** `tofu destroy` the `modules/pypi-cache/terraform` root (IRSA + EFS wheelhouse) once the region is healthy — orphaned infra, only costs money, and keeping it out of the cutover keeps rollback cheap.

**Rollback:** re-add both modules to ue1 in `clusters.yaml` and redeploy (pypi-cache infra rebuilds from its tofu root).

**Test:** `just lint` + `just test` pass; ue1 renders no pypi-cache env, arc-cbr-production unchanged.
