### PR TITLE
Enable safe removal of pypi-cache and cache-enforcer modules

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -298,8 +298,6 @@ clusters:
       # max_runners are sized assuming this count.
       capacity_reservation_ids:
         - cr-0b15c0b3163f09d26
-    pypi_cache:
-      replicas: 10
     modules:
       - karpenter
       - arc

--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -231,6 +231,7 @@ def generate_workflow(
     b200_enabled: bool,
     cache_enforcer_enabled: bool = False,
     release_enabled: bool = False,
+    pypi_cache_enabled: bool = False,
     pypi_cache_slugs: str = "cpu cu121 cu124",
     pypi_cache_cuda_version: str = "12.8",
 ) -> str:
@@ -249,6 +250,7 @@ def generate_workflow(
     content = _strip_conditional_block(content, "B200", keep=b200_enabled)
     content = _strip_conditional_block(content, "CACHE_ENFORCER", keep=cache_enforcer_enabled)
     content = _strip_conditional_block(content, "RELEASE", keep=release_enabled)
+    content = _strip_conditional_block(content, "PYPI_CACHE", keep=pypi_cache_enabled)
 
     return content
 

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -211,6 +211,7 @@ def main():
     b200_enabled = has_module(cfg, "nodepools-b200") and has_module(cfg, "arc-runners-b200")
     cache_enforcer_enabled = has_module(cfg, "cache-enforcer")
     release_enabled = has_module(cfg, "arc-runners")
+    pypi_cache_enabled = has_module(cfg, "pypi-cache")
 
     # Build pypi-cache slug list: always "cpu", plus one per configured CUDA version
     cuda_versions = resolve(cfg, "pypi_cache.cuda_versions", [])
@@ -233,6 +234,7 @@ def main():
     log.info("  B200 enabled: %s", b200_enabled)
     log.info("  Release runners: %s", release_enabled)
     log.info("  Cache enforcer: %s", cache_enforcer_enabled)
+    log.info("  PyPI cache: %s", pypi_cache_enabled)
     log.info("  PyPI cache slugs: %s", pypi_cache_slugs)
     log.info("  Smoke tests: %s", "skip" if skip_smoke else "run")
     log.info("  Compactor tests: %s", "skip" if skip_compactor else "run")
@@ -264,6 +266,7 @@ def main():
             b200_enabled,
             cache_enforcer_enabled=cache_enforcer_enabled,
             release_enabled=release_enabled,
+            pypi_cache_enabled=pypi_cache_enabled,
             pypi_cache_slugs=pypi_cache_slugs,
             pypi_cache_cuda_version=pypi_cache_cuda_version,
         )

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -105,6 +105,13 @@ def workflow_template(tmp_path):
         "    steps:\n"
         "      - run: echo enforcer\n"
         "  # END_CACHE_ENFORCER\n"
+        "  # BEGIN_PYPI_CACHE\n"
+        "  pypi-cache-job:\n"
+        "    runs-on: {{PREFIX}}pypi-runner\n"
+        "    steps:\n"
+        "      - run: echo {{PYPI_CACHE_SLUGS}}\n"
+        "      - run: echo {{PYPI_CACHE_CUDA_VERSION}}\n"
+        "  # END_PYPI_CACHE\n"
         "  pypi-job:\n"
         "    steps:\n"
         "      - run: echo {{PYPI_CACHE_SLUGS}}\n"
@@ -251,6 +258,34 @@ class TestGenerateWorkflow:
         assert "runs-on: cbrenforcer-runner" in result
         assert "BEGIN_CACHE_ENFORCER" not in result
         assert "END_CACHE_ENFORCER" not in result
+
+    def test_pypi_cache_removed_when_disabled(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
+            b200_enabled=False,
+            pypi_cache_enabled=False,
+        )
+        assert "pypi-cache-job" not in result
+        assert "BEGIN_PYPI_CACHE" not in result
+        assert "END_PYPI_CACHE" not in result
+        assert "basic:" in result
+
+    def test_pypi_cache_preserved_when_enabled(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
+            b200_enabled=False,
+            pypi_cache_enabled=True,
+        )
+        assert "pypi-cache-job:" in result
+        assert "runs-on: cbrpypi-runner" in result
+        assert "BEGIN_PYPI_CACHE" not in result
+        assert "END_PYPI_CACHE" not in result
 
     def test_pypi_cache_slugs_substituted(self, workflow_template):
         result = generate_workflow(

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -210,6 +210,7 @@ jobs:
           fi
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
 
+  # BEGIN_PYPI_CACHE
   # ── PyPI Cache: Default Pod Environment ─────────────────────────────
   # Validates runner pod-level defaults: pip install, uv install,
   # download.pytorch.org proxy, URL rewriting, torch install, and
@@ -1316,6 +1317,7 @@ jobs:
           print(f'numpy location: {np.__file__}')
           print(f'PASS: numpy functional validation')
           "
+  # END_PYPI_CACHE
 
   # ── GPU Runner Tests ──────────────────────────────────────────────────
   test-gpu-t4:

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -531,34 +531,254 @@ deploy-module cluster module force="":
     deploy_log_finish module "$CLUSTER" "$MODULE" "$DEPLOY_LOG_MOD_START"
     deploy_log_finish cmd "$CLUSTER" "deploy-module-$MODULE" "$DEPLOY_LOG_CMD_START"
 
-# Remove a module's resources from a cluster. Operator is expected to have
-# run `just drain-runners` first for runner modules. Deletes everything
-# labelled osdc.io/module=<module> (today: nodepools*, arc-runners*) and
-# helm-uninstalls matching arc-runners releases.
+# Operator is expected to have run `just drain-runners` first for runner modules.
+# Sweeps every namespaced and cluster-scoped kind labelled osdc.io/module=<module>,
+# helm-uninstalls matching arc-runners releases, drops the module namespace (if
+# labelled), and runs `tofu destroy` on the module's per-cluster terraform root
+# (if any). Honors OSDC_CONFIRM=yes|no|ask (default ask).
+# Remove a module's resources (kubernetes + per-cluster terraform) from a cluster.
 remove-module cluster module:
     #!/usr/bin/env bash
     set -euo pipefail
     source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    source "{{UPSTREAM}}/scripts/state-config.sh"
+    : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
+    export OSDC_ROOT="{{ROOT}}"
+    export OSDC_UPSTREAM="{{UPSTREAM}}"
     export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
     CLUSTER="{{cluster}}"
     MODULE="{{module}}"
+
+    if [[ -z "$CLUSTER" ]] || [[ -z "$MODULE" ]]; then
+        echo "Usage: just remove-module <cluster> <module>" >&2
+        exit 2
+    fi
+
     just kubeconfig "$CLUSTER"
 
-    echo "Removing all resources labelled osdc.io/module=$MODULE from $CLUSTER..."
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+    REGION=$(uv run {{CFG}} "$CLUSTER" region)
+    BUCKET=$(uv run {{CFG}} "$CLUSTER" state_bucket)
 
-    # arc-runners convention: arc-runner-hook-<n> ConfigMap → arc-<n> Helm release
-    while IFS=/ read -r ns name; do
-        [ -z "$name" ] && continue
-        [[ "$name" == arc-runner-hook-* ]] || continue
-        release="arc-${name#arc-runner-hook-}"
-        echo "  helm uninstall $release -n $ns"
-        helm uninstall "$release" -n "$ns" --ignore-not-found || true
-        kubectl delete secret -n "$ns" -l "owner=helm,name=$release" --ignore-not-found || true
-    done < <(kubectl get cm -A -l "osdc.io/module=$MODULE" \
-        -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+    # Module resolution mirrors deploy-module: consumer first, then upstream.
+    MODULE_DIR=""
+    if [[ -d "$OSDC_ROOT/modules/$MODULE" ]]; then
+        MODULE_DIR="$OSDC_ROOT/modules/$MODULE"
+    elif [[ -d "$OSDC_UPSTREAM/modules/$MODULE" ]]; then
+        MODULE_DIR="$OSDC_UPSTREAM/modules/$MODULE"
+    fi
+    HAS_TF="no"
+    if [[ -n "$MODULE_DIR" ]] && [[ -f "$MODULE_DIR/terraform/main.tf" ]]; then
+        HAS_TF="yes"
+    fi
 
-    kubectl delete configmap,nodepool.karpenter.sh,ec2nodeclass.karpenter.k8s.aws \
-        -A -l "osdc.io/module=$MODULE" --ignore-not-found
+    NS_KINDS="deployment,daemonset,statefulset,service,configmap,secret,serviceaccount,role,rolebinding,networkpolicy,pdb,pvc"
+    CLUSTER_KINDS=(
+        clusterrole
+        clusterrolebinding
+        storageclass
+        nodepool.karpenter.sh
+        ec2nodeclass.karpenter.k8s.aws
+    )
+
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "REMOVE MODULE: $MODULE from $CLUSTER ($CNAME)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "Selector: osdc.io/module=$MODULE"
+    echo ""
+
+    echo "── Planned actions ──"
+    echo "  1. helm uninstall arc-runner-hook-* matching releases (arc-runners convention)"
+    echo "  2. kubectl delete -A on namespaced kinds: $NS_KINDS"
+    echo "  3. kubectl delete on cluster-scoped kinds: ${CLUSTER_KINDS[*]}"
+    echo "  4. kubectl delete namespace (only if labelled osdc.io/module=$MODULE)"
+    if [[ "$HAS_TF" == "yes" ]]; then
+        echo "  5. tofu destroy: $MODULE_DIR/terraform (state key: $CLUSTER/$MODULE/terraform.tfstate)"
+    else
+        echo "  5. tofu destroy: (skipped — no $MODULE/terraform/main.tf)"
+    fi
+    echo ""
+
+    echo "── Resources currently matching osdc.io/module=$MODULE ──"
+    echo "  Namespaced ($NS_KINDS):"
+    kubectl get "$NS_KINDS" -A -l "osdc.io/module=$MODULE" --ignore-not-found 2>/dev/null \
+        | sed 's/^/    /' || echo "    (query failed or none found)"
+    echo ""
+    echo "  Cluster-scoped:"
+    for k in "${CLUSTER_KINDS[@]}"; do
+        OUT=$(kubectl get "$k" -l "osdc.io/module=$MODULE" --ignore-not-found 2>/dev/null || true)
+        if [[ -n "$OUT" ]]; then
+            echo "    [$k]"
+            echo "$OUT" | sed 's/^/      /'
+        fi
+    done
+    echo ""
+    echo "  Namespaces:"
+    kubectl get namespace -l "osdc.io/module=$MODULE" --ignore-not-found 2>/dev/null \
+        | sed 's/^/    /' || echo "    (none)"
+    echo ""
+
+    CONFIRM="${OSDC_CONFIRM:-ask}"
+    if [[ "$CONFIRM" == "yes" ]]; then
+        echo "Auto-confirmed (OSDC_CONFIRM=yes)"
+    elif [[ "$CONFIRM" == "no" ]]; then
+        echo "Cancelled (OSDC_CONFIRM=no)."
+        exit 1
+    else
+        read -p "Proceed with removal? [y/N] " -n 1 -r
+        echo
+        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 1; }
+    fi
+    echo ""
+
+    PARTIAL=0
+
+    # ── Phase 1: arc-runner-hook helm uninstall ────────────────────────────
+    # arc-runners convention: arc-runner-hook-<n> ConfigMap → arc-<n> Helm release.
+    # Must run BEFORE the namespaced-kind sweep deletes those ConfigMaps,
+    # otherwise we lose the mapping to discover release names.
+    echo "── Phase 1: helm uninstall arc-runner-hook releases ──"
+    HOOK_CMS=$(kubectl get cm -A -l "osdc.io/module=$MODULE" \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' \
+        2>/dev/null || true)
+    if [[ -z "$HOOK_CMS" ]]; then
+        echo "  No arc-runner-hook ConfigMaps found for module $MODULE."
+    else
+        FOUND=0
+        while IFS=/ read -r ns name; do
+            [ -z "$name" ] && continue
+            [[ "$name" == arc-runner-hook-* ]] || continue
+            release="arc-${name#arc-runner-hook-}"
+            FOUND=$((FOUND + 1))
+            echo "  helm uninstall $release -n $ns"
+            helm uninstall "$release" -n "$ns" --ignore-not-found || PARTIAL=1
+            kubectl delete secret -n "$ns" -l "owner=helm,name=$release" --ignore-not-found || PARTIAL=1
+        done <<< "$HOOK_CMS"
+        [[ $FOUND -eq 0 ]] && echo "  No arc-runner-hook-* ConfigMaps among labelled CMs."
+    fi
+    echo ""
+
+    # ── Phase 2: namespaced kinds ──────────────────────────────────────────
+    echo "── Phase 2: delete namespaced kinds labelled osdc.io/module=$MODULE ──"
+    if ! kubectl delete "$NS_KINDS" -A -l "osdc.io/module=$MODULE" --ignore-not-found; then
+        PARTIAL=1
+    fi
+    echo ""
+
+    # ── Phase 3: cluster-scoped kinds ──────────────────────────────────────
+    echo "── Phase 3: delete cluster-scoped kinds labelled osdc.io/module=$MODULE ──"
+    for k in "${CLUSTER_KINDS[@]}"; do
+        if ! kubectl delete "$k" -l "osdc.io/module=$MODULE" --ignore-not-found; then
+            PARTIAL=1
+        fi
+    done
+    echo ""
+
+    # ── Phase 4: namespace (cascade defense in depth) ──────────────────────
+    # Only delete namespaces that carry the module label — never fabricate or
+    # guess names. Anything left in the namespace that lacked the per-resource
+    # label dies with the namespace.
+    echo "── Phase 4: delete namespace(s) labelled osdc.io/module=$MODULE ──"
+    if ! kubectl delete namespace -l "osdc.io/module=$MODULE" --ignore-not-found; then
+        PARTIAL=1
+    fi
+    echo ""
+
+    # ── Phase 5: tofu destroy (per-cluster terraform root, if any) ─────────
+    echo "── Phase 5: tofu destroy per-cluster terraform state ──"
+    if [[ "$HAS_TF" == "yes" ]]; then
+        echo "  Destroying $MODULE_DIR/terraform (state key: $CLUSTER/$MODULE/terraform.tfstate)"
+        cd "$MODULE_DIR/terraform"
+        if ! tofu init -reconfigure \
+            -backend-config="bucket=${BUCKET}" \
+            -backend-config="key=${CLUSTER}/${MODULE}/terraform.tfstate" \
+            -backend-config="region=${STATE_REGION}" \
+            -backend-config="dynamodb_table=ciforge-terraform-locks"; then
+            echo "  ERROR: tofu init failed for $MODULE." >&2
+            PARTIAL=1
+        else
+            # OSDC_CONFIRM=yes → -auto-approve; otherwise let tofu prompt.
+            DESTROY_ARGS=(
+                -lock-timeout=15m
+                -var="cluster_name=${CNAME}"
+                -var="aws_region=${REGION}"
+                -var="state_bucket=${BUCKET}"
+                -var="cluster_id=${CLUSTER}"
+            )
+            [[ "$CONFIRM" == "yes" ]] && DESTROY_ARGS+=(-auto-approve)
+            if ! tofu destroy "${DESTROY_ARGS[@]}"; then
+                echo "  ERROR: tofu destroy failed for $MODULE." >&2
+                PARTIAL=1
+            fi
+        fi
+        cd - >/dev/null
+    else
+        echo "  Skipped — module has no per-cluster terraform root."
+        echo "  (Sub-roots like $MODULE/terraform/<subdir>/main.tf are NOT touched by remove-module.)"
+    fi
+    echo ""
+
+    # ── Operator reminders (module-specific) ───────────────────────────────
+    if [[ "$MODULE" == "cache-enforcer" ]]; then
+        echo "━━━ OPERATOR WARNING: cache-enforcer requires nodepools redeploy ━━━"
+        echo "modules/nodepools/scripts/python/generate_nodepools.py gates the"
+        echo "node-init.osdc.io/cache-enforcer=true startup taint on the presence"
+        echo "of 'cache-enforcer' in the cluster's modules list. After dropping"
+        echo "cache-enforcer from clusters.yaml, the rendered NodePool spec on"
+        echo "the cluster still emits that taint until nodepools is redeployed."
+        echo "Fresh Karpenter nodes will be tainted with nothing to clear them"
+        echo "(the DaemonSet that removed the taint is now gone) and will never"
+        echo "schedule pods. Redeploy nodepools BEFORE recycling nodes:"
+        echo "  just deploy-module $CLUSTER nodepools"
+        echo ""
+        echo "━━━ OPERATOR WARNING: cache-enforcer iptables persistence ━━━"
+        echo "Removing the DaemonSet does NOT undo iptables rules already installed"
+        echo "on runner nodes. Every node that ever ran cache-enforcer still has the"
+        echo "CACHE_ENFORCER chain wired into OUTPUT (both iptables and ip6tables)."
+        echo ""
+        echo "Recommended: recycle the affected nodes so fresh nodes come up clean"
+        echo "(after the nodepools redeploy above):"
+        echo "  just recycle-nodes $CLUSTER"
+        echo ""
+        echo "Verify a node is still affected (any non-empty output = chain present):"
+        echo "  kubectl debug node/<node> -it --image=alpine -- chroot /host sh -c \\"
+        echo "    'iptables -S CACHE_ENFORCER 2>/dev/null; ip6tables -S CACHE_ENFORCER 2>/dev/null'"
+        echo ""
+    fi
+    if [[ "$MODULE" == "pypi-cache" ]]; then
+        echo "━━━ OPERATOR WARNING: stale env vars on existing runner pods ━━━"
+        echo "Workflow pods scheduled before this removal still carry PIP_INDEX_URL,"
+        echo "UV_DEFAULT_INDEX, and the rest of the pypi-cache env block pointing at"
+        echo "pypi-cache-cpu.pypi-cache.svc.cluster.local. The Service is gone, so"
+        echo "DNS will NXDOMAIN and pip/uv installs in those pods will fail."
+        echo "Drain in-flight runners and recycle nodes to roll fresh pods that get"
+        echo "the regenerated (pypi-cache-less) ConfigMap:"
+        echo "  just drain-runners $CLUSTER && just recycle-nodes $CLUSTER"
+        echo ""
+        echo "━━━ OPERATOR WARNING: EFS wheelhouse data dropped ━━━"
+        echo "tofu destroy wiped the per-cluster aws_efs_file_system.pypi_cache,"
+        echo "which held the cached .whl files. Recoverable: the shared S3 bucket"
+        echo "s3://pytorch-pypi-wheel-cache/{slug}/ (account-wide, NOT destroyed)"
+        echo "is the source of truth. On the next pypi-cache deploy, wheel-syncer"
+        echo "re-pulls everything from S3 — expect slow first-cache-warm and"
+        echo "elevated pip install latency on the first jobs after redeploy."
+        echo ""
+        echo "━━━ OPERATOR WARNING: pypi-cache leftovers in monitoring module ━━━"
+        echo "The 'monitoring' module owns modules/monitoring/.../pypi-cache.yaml"
+        echo "ServiceMonitor independently of the pypi-cache module. After this"
+        echo "removal it will go stale (no matching endpoints) — harmless, but"
+        echo "consider redeploying monitoring to drop the orphan once pypi-cache"
+        echo "is permanently gone from this cluster."
+        echo ""
+    fi
+
+    if [[ $PARTIAL -eq 0 ]]; then
+        echo "Module $MODULE removed from $CLUSTER."
+    else
+        echo "Module $MODULE partially removed from $CLUSTER — see errors above."
+        exit 1
+    fi
 
 # Run `tofu plan` for base + every terraform-backed module of a cluster.
 # Read-only: no apply, no k8s/helm side effects. Safe to run from CI on PRs.

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -94,6 +94,33 @@ def parse_memory_bytes(memory_str):
     return int(s)
 
 
+def _strip_conditional_block(content: str, tag: str, keep: bool) -> str:
+    """Remove or keep a `# BEGIN_<tag>` / `# END_<tag>` conditional block.
+
+    When *keep* is False the block (markers + content between them) is stripped
+    entirely. When *keep* is True the marker comment lines are removed but the
+    content between them is preserved. Marker lines are matched on their stripped
+    form, so indentation doesn't matter.
+    """
+    begin = f"# BEGIN_{tag}"
+    end = f"# END_{tag}"
+    lines = content.split("\n")
+    filtered = []
+    inside = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == begin:
+            inside = True
+            continue
+        if stripped == end:
+            inside = False
+            continue
+        if not keep and inside:
+            continue
+        filtered.append(line)
+    return "\n".join(filtered)
+
+
 def load_clusters_yaml(repo_root):
     """Load clusters.yaml from the repository root."""
     config_path = repo_root / "clusters.yaml"
@@ -172,8 +199,14 @@ def resolve_max_runners(value, def_file, cluster_id):
     return value
 
 
-def generate_runner(def_file, template_content, cluster_config, output_dir, module_name):
-    """Generate a single runner config from its definition."""
+def generate_runner(def_file, template_content, cluster_config, output_dir, module_name, pypi_cache_enabled=True):
+    """Generate a single runner config from its definition.
+
+    pypi_cache_enabled controls whether the `# BEGIN_PYPI_CACHE` / `# END_PYPI_CACHE`
+    block in the template is preserved (True) or stripped (False). Strip when the
+    cluster does not deploy the pypi-cache module — the env vars would otherwise
+    point at a Service that doesn't exist on this cluster.
+    """
     with open(def_file) as f:
         data = yaml.safe_load(f)
 
@@ -330,6 +363,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
 
     # Replace all template placeholders
     output_content = template_content
+    output_content = _strip_conditional_block(output_content, "PYPI_CACHE", keep=pypi_cache_enabled)
     replacements = {
         "{{GITHUB_CONFIG_URL}}": github_url,
         "{{GITHUB_SECRET_NAME}}": k8s_secret_ref,
@@ -488,9 +522,14 @@ def main():
         log_error(f"No definition files found in {defs_dir}")
         return 1
 
+    # pypi-cache module is cluster-scoped: when absent, strip the pypi-cache env
+    # vars from the workflow pod template so jobs don't try to reach a Service
+    # that doesn't exist on this cluster.
+    pypi_cache_enabled = "pypi-cache" in (cluster_cfg.get("modules") or [])
+
     count = 0
     for def_file in def_files:
-        if generate_runner(def_file, template_content, cluster_config, output_dir, module_name):
+        if generate_runner(def_file, template_content, cluster_config, output_dir, module_name, pypi_cache_enabled):
             count += 1
 
     print()

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 from fleet_naming import derive_fleet_name
 from generate_runners import (
+    _strip_conditional_block,
     generate_runner,
     get_cluster_config,
     load_clusters_yaml,
@@ -2333,3 +2334,248 @@ class TestMain:
 
         with patch.object(sys, "argv", ["generate_runners.py", "staging"]):
             assert main() == 1
+
+
+# ============================================================================
+# Conditional block stripping (pypi-cache cluster-scope gate)
+# ============================================================================
+
+
+# Names of the pypi-cache env vars injected on the workflow pod when the
+# pypi-cache module is enabled. When the module is disabled, NONE of these may
+# appear in the rendered runner config — otherwise jobs reach for a Service
+# that doesn't exist on this cluster and pip/uv install fails.
+PYPI_CACHE_ENV_VAR_NAMES = [
+    "PIP_INDEX_URL",
+    "PIP_TRUSTED_HOST",
+    "PIP_EXTRA_INDEX_URL",
+    "UV_DEFAULT_INDEX",
+    "UV_INSECURE_HOST",
+    "UV_INDEX",
+    "UV_INDEX_STRATEGY",
+    "PYPI_CACHE_SIMPLE_URL",
+    "PYPI_CACHE_WHL_URL",
+]
+
+
+class TestStripConditionalBlock:
+    def test_keep_true_removes_markers_preserves_content(self):
+        content = textwrap.dedent("""\
+            before
+                # BEGIN_FOO
+                inside
+                # END_FOO
+            after
+        """)
+        result = _strip_conditional_block(content, "FOO", keep=True)
+        assert "# BEGIN_FOO" not in result
+        assert "# END_FOO" not in result
+        assert "inside" in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_keep_false_removes_markers_and_content(self):
+        content = textwrap.dedent("""\
+            before
+                # BEGIN_FOO
+                inside
+                # END_FOO
+            after
+        """)
+        result = _strip_conditional_block(content, "FOO", keep=False)
+        assert "# BEGIN_FOO" not in result
+        assert "# END_FOO" not in result
+        assert "inside" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_no_markers_in_content_is_noop(self):
+        content = "just\nplain\ntext\n"
+        assert _strip_conditional_block(content, "FOO", keep=True) == content
+        assert _strip_conditional_block(content, "FOO", keep=False) == content
+
+    def test_indentation_does_not_matter(self):
+        """Markers are matched on stripped form so any indentation works."""
+        content = "x\n            # BEGIN_BAR\nkeepme\n            # END_BAR\ny\n"
+        out_keep = _strip_conditional_block(content, "BAR", keep=True)
+        assert "# BEGIN_BAR" not in out_keep
+        assert "keepme" in out_keep
+        out_strip = _strip_conditional_block(content, "BAR", keep=False)
+        assert "keepme" not in out_strip
+
+
+class TestPypiCacheConditional:
+    """Cluster-scoped gating of the PYPI_CACHE env-var block in the workflow pod."""
+
+    def test_pypi_cache_block_kept_when_module_enabled(self, tmp_path, real_template):
+        """With pypi-cache in the modules list, all 9 env vars render and the
+        marker comments are cleanly stripped from the output."""
+        def_file = make_def_file(tmp_path, "kept-runner", "c7i.24xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert (
+            generate_runner(
+                def_file,
+                real_template,
+                cluster_config,
+                output_dir,
+                "arc-runners",
+                pypi_cache_enabled=True,
+            )
+            is True
+        )
+
+        content = (output_dir / "kept-runner.yaml").read_text()
+        # Marker comments must NOT leak into the rendered output.
+        assert "# BEGIN_PYPI_CACHE" not in content
+        assert "# END_PYPI_CACHE" not in content
+
+        docs = list(yaml.safe_load_all(content))
+        cm_data = yaml.safe_load(docs[1]["data"]["job-pod.yaml"])
+        container = cm_data["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container["env"]}
+        for name in PYPI_CACHE_ENV_VAR_NAMES:
+            assert name in env_vars, f"{name} missing from rendered env when pypi-cache enabled"
+
+    def test_pypi_cache_block_stripped_when_module_disabled(self, tmp_path, real_template):
+        """With pypi-cache absent from the modules list, NONE of the 9 env vars
+        render and the marker comments are stripped."""
+        def_file = make_def_file(tmp_path, "stripped-runner", "c7i.24xlarge", 4, 16)
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        cluster_config = {
+            "github_config_url": "url",
+            "github_secret_name": "secret",
+            "runner_name_prefix": "",
+        }
+
+        assert (
+            generate_runner(
+                def_file,
+                real_template,
+                cluster_config,
+                output_dir,
+                "arc-runners",
+                pypi_cache_enabled=False,
+            )
+            is True
+        )
+
+        content = (output_dir / "stripped-runner.yaml").read_text()
+        # Marker comments must NOT leak into the rendered output.
+        assert "# BEGIN_PYPI_CACHE" not in content
+        assert "# END_PYPI_CACHE" not in content
+
+        docs = list(yaml.safe_load_all(content))
+        cm_data = yaml.safe_load(docs[1]["data"]["job-pod.yaml"])
+        container = cm_data["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container["env"]}
+        for name in PYPI_CACHE_ENV_VAR_NAMES:
+            assert name not in env_vars, f"{name} must NOT be present when pypi-cache disabled"
+        # Other env vars (e.g. TORCH_CI_MAX_MEMORY) must still be intact.
+        assert "TORCH_CI_MAX_MEMORY" in env_vars
+        # Belt-and-braces: the rendered config must not mention the Service host either.
+        assert "pypi-cache-cpu.pypi-cache.svc.cluster.local" not in content
+
+    def test_main_strips_when_cluster_lacks_pypi_cache_module(self, tmp_path, monkeypatch, real_template):
+        """End-to-end: main() reads modules from clusters.yaml and strips when pypi-cache is absent."""
+        config = {
+            "defaults": {
+                "arc": {"runner_image_tag": "2.333.1"},
+                "arc-runners": {
+                    "github_config_url": "https://github.com/org",
+                    "github_secret_name": "secret",
+                    "runner_name_prefix": "p-",
+                },
+            },
+            "clusters": {
+                "no-cache-cluster": {
+                    "cluster_name": "no-cache",
+                    "region": "us-east-1",
+                    "modules": ["nodepools", "arc-runners"],  # no pypi-cache
+                    "arc-runners": {
+                        "github_config_url": "https://github.com/org",
+                        "github_secret_name": "secret",
+                        "runner_name_prefix": "p-",
+                    },
+                },
+            },
+        }
+        (tmp_path / "clusters.yaml").write_text(yaml.dump(config, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "runner-x", "c7i.24xlarge", 4, 16)
+        make_nodepool_defs(tmp_path, ["c7i.24xlarge"])
+
+        output_dir = tmp_path / "out"
+        tpl_file = tmp_path / "tpl.yaml"
+        tpl_file.write_text(real_template)
+
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tpl_file))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
+
+        with patch.object(sys, "argv", ["generate_runners.py", "no-cache-cluster"]):
+            assert main() == 0
+
+        content = (output_dir / "runner-x.yaml").read_text()
+        for name in PYPI_CACHE_ENV_VAR_NAMES:
+            assert name not in content
+        assert "# BEGIN_PYPI_CACHE" not in content
+
+    def test_main_keeps_when_cluster_has_pypi_cache_module(self, tmp_path, monkeypatch, real_template):
+        """End-to-end: main() preserves the env vars when pypi-cache is in modules."""
+        config = {
+            "defaults": {
+                "arc": {"runner_image_tag": "2.333.1"},
+                "arc-runners": {
+                    "github_config_url": "https://github.com/org",
+                    "github_secret_name": "secret",
+                    "runner_name_prefix": "p-",
+                },
+            },
+            "clusters": {
+                "with-cache-cluster": {
+                    "cluster_name": "with-cache",
+                    "region": "us-east-1",
+                    "modules": ["nodepools", "arc-runners", "pypi-cache"],
+                    "arc-runners": {
+                        "github_config_url": "https://github.com/org",
+                        "github_secret_name": "secret",
+                        "runner_name_prefix": "p-",
+                    },
+                },
+            },
+        }
+        (tmp_path / "clusters.yaml").write_text(yaml.dump(config, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "runner-y", "c7i.24xlarge", 4, 16)
+        make_nodepool_defs(tmp_path, ["c7i.24xlarge"])
+
+        output_dir = tmp_path / "out"
+        tpl_file = tmp_path / "tpl.yaml"
+        tpl_file.write_text(real_template)
+
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tpl_file))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
+
+        with patch.object(sys, "argv", ["generate_runners.py", "with-cache-cluster"]):
+            assert main() == 0
+
+        content = (output_dir / "runner-y.yaml").read_text()
+        for name in PYPI_CACHE_ENV_VAR_NAMES:
+            assert name in content
+        assert "# BEGIN_PYPI_CACHE" not in content
+        assert "# END_PYPI_CACHE" not in content

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -417,6 +417,7 @@ data:
       containers:
         - name: "$job"
           env:
+            # BEGIN_PYPI_CACHE
             - name: PIP_INDEX_URL
               value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/simple/"
             - name: PIP_TRUSTED_HOST
@@ -435,6 +436,7 @@ data:
               value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/simple/"
             - name: PYPI_CACHE_WHL_URL
               value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/whl/cpu/"
+            # END_PYPI_CACHE
             - name: TORCH_CI_MAX_MEMORY
               value: "{{MEMORY_BYTES}}"
           # Workflow container gets the actual compute resources

--- a/osdc/modules/cache-enforcer/kubernetes/configmap.yaml
+++ b/osdc/modules/cache-enforcer/kubernetes/configmap.yaml
@@ -12,6 +12,8 @@ kind: ConfigMap
 metadata:
   name: cache-enforcer-script
   namespace: kube-system
+  labels:
+    osdc.io/module: cache-enforcer
 data:
   enforce-cache.sh: |
     #!/bin/bash

--- a/osdc/modules/cache-enforcer/kubernetes/daemonset.yaml
+++ b/osdc/modules/cache-enforcer/kubernetes/daemonset.yaml
@@ -11,6 +11,7 @@ metadata:
   name: cache-enforcer
   namespace: kube-system
   labels:
+    osdc.io/module: cache-enforcer
     app: cache-enforcer
     app.kubernetes.io/name: cache-enforcer
     app.kubernetes.io/component: node-configuration
@@ -132,4 +133,5 @@ metadata:
   name: cache-enforcer
   namespace: kube-system
   labels:
+    osdc.io/module: cache-enforcer
     app: cache-enforcer

--- a/osdc/modules/cache-enforcer/kubernetes/rbac.yaml
+++ b/osdc/modules/cache-enforcer/kubernetes/rbac.yaml
@@ -8,6 +8,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cache-enforcer-taint-remover
+  labels:
+    osdc.io/module: cache-enforcer
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -17,6 +19,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cache-enforcer-taint-remover
+  labels:
+    osdc.io/module: cache-enforcer
 subjects:
   - kind: ServiceAccount
     name: cache-enforcer

--- a/osdc/modules/pypi-cache/deploy.sh
+++ b/osdc/modules/pypi-cache/deploy.sh
@@ -103,18 +103,24 @@ kubectl create configmap pypi-cache-nginx-config \
   --from-file=merge_indexes.js="$MODULE_DIR/kubernetes/merge_indexes.js" \
   -n "$NAMESPACE" \
   --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap pypi-cache-nginx-config -n "$NAMESPACE" \
+  osdc.io/module=pypi-cache --overwrite
 
 echo "[pypi-cache] Creating pypi-wants-collector-scripts ConfigMap..."
 kubectl create configmap pypi-wants-collector-scripts \
   --from-file=wants_collector.py="$MODULE_DIR/scripts/python/wants_collector.py" \
   -n "$NAMESPACE" \
   --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap pypi-wants-collector-scripts -n "$NAMESPACE" \
+  osdc.io/module=pypi-cache --overwrite
 
 echo "[pypi-cache] Creating pypi-wheel-syncer-scripts ConfigMap..."
 kubectl create configmap pypi-wheel-syncer-scripts \
   --from-file=wheel_syncer.py="$MODULE_DIR/scripts/python/wheel_syncer.py" \
   -n "$NAMESPACE" \
   --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap pypi-wheel-syncer-scripts -n "$NAMESPACE" \
+  osdc.io/module=pypi-cache --overwrite
 
 # --- Generate manifests from clusters.yaml config ---
 GENERATED_DIR="$MODULE_DIR/generated"

--- a/osdc/modules/pypi-cache/kubernetes/deployment.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/deployment.yaml.tpl
@@ -11,6 +11,7 @@ metadata:
   name: pypi-cache-__CUDA_SLUG__
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-cache
     cuda-version: __CUDA_SLUG__
     app.kubernetes.io/name: pypi-cache

--- a/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/ec2nodeclass.yaml.tpl
@@ -7,6 +7,8 @@ apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: pypi-cache
+  labels:
+    osdc.io/module: pypi-cache
 spec:
   # TODO(CVE-2026-31431): al2023@latest tracks the newest AL2023 AMI; once node
   # rotation picks up a kernel 6.12.85+ AMI, remove

--- a/osdc/modules/pypi-cache/kubernetes/namespace.yaml
+++ b/osdc/modules/pypi-cache/kubernetes/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: pypi-cache
   labels:
+    osdc.io/module: pypi-cache
     app.kubernetes.io/name: pypi-cache
     app.kubernetes.io/component: package-cache

--- a/osdc/modules/pypi-cache/kubernetes/networkpolicy.yaml
+++ b/osdc/modules/pypi-cache/kubernetes/networkpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
   name: pypi-cache-ingress
   namespace: pypi-cache
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-cache
     app.kubernetes.io/name: pypi-cache
     app.kubernetes.io/component: package-cache

--- a/osdc/modules/pypi-cache/kubernetes/nodepool.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/nodepool.yaml.tpl
@@ -6,6 +6,8 @@ apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: pypi-cache
+  labels:
+    osdc.io/module: pypi-cache
 spec:
   limits:
     cpu: "__CPU_LIMIT__"

--- a/osdc/modules/pypi-cache/kubernetes/pdb.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/pdb.yaml.tpl
@@ -9,6 +9,7 @@ metadata:
   name: pypi-cache-__CUDA_SLUG__
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-cache
     cuda-version: __CUDA_SLUG__
     app.kubernetes.io/name: pypi-cache

--- a/osdc/modules/pypi-cache/kubernetes/pvc.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/pvc.yaml.tpl
@@ -8,6 +8,7 @@ metadata:
   name: pypi-cache-data
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-cache
     app.kubernetes.io/name: pypi-cache
     app.kubernetes.io/component: package-cache

--- a/osdc/modules/pypi-cache/kubernetes/service.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/service.yaml.tpl
@@ -8,6 +8,7 @@ metadata:
   name: pypi-cache-__CUDA_SLUG__
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-cache
     cuda-version: __CUDA_SLUG__
     app.kubernetes.io/name: pypi-cache

--- a/osdc/modules/pypi-cache/kubernetes/serviceaccount.yaml
+++ b/osdc/modules/pypi-cache/kubernetes/serviceaccount.yaml
@@ -4,5 +4,6 @@ metadata:
   name: pypi-cache
   namespace: pypi-cache
   labels:
+    osdc.io/module: pypi-cache
     app.kubernetes.io/name: pypi-cache
     app.kubernetes.io/component: package-cache

--- a/osdc/modules/pypi-cache/kubernetes/storageclass.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/storageclass.yaml.tpl
@@ -6,6 +6,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-pypi-cache
+  labels:
+    osdc.io/module: pypi-cache
 provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap

--- a/osdc/modules/pypi-cache/kubernetes/wants-collector-deployment.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/wants-collector-deployment.yaml.tpl
@@ -8,6 +8,7 @@ metadata:
   name: pypi-wants-collector
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-wants-collector
     app.kubernetes.io/name: pypi-wants-collector
     app.kubernetes.io/component: wants-collector

--- a/osdc/modules/pypi-cache/kubernetes/wants-collector-sa.yaml
+++ b/osdc/modules/pypi-cache/kubernetes/wants-collector-sa.yaml
@@ -4,5 +4,6 @@ metadata:
   name: pypi-wants-collector
   namespace: pypi-cache
   labels:
+    osdc.io/module: pypi-cache
     app.kubernetes.io/name: pypi-wants-collector
     app.kubernetes.io/component: wants-collector

--- a/osdc/modules/pypi-cache/kubernetes/wheel-syncer-deployment.yaml.tpl
+++ b/osdc/modules/pypi-cache/kubernetes/wheel-syncer-deployment.yaml.tpl
@@ -7,6 +7,7 @@ metadata:
   name: pypi-wheel-syncer
   namespace: __NAMESPACE__
   labels:
+    osdc.io/module: pypi-cache
     app: pypi-wheel-syncer
     app.kubernetes.io/name: pypi-wheel-syncer
     app.kubernetes.io/component: wheel-syncer

--- a/osdc/modules/pypi-cache/kubernetes/wheel-syncer-sa.yaml
+++ b/osdc/modules/pypi-cache/kubernetes/wheel-syncer-sa.yaml
@@ -4,5 +4,6 @@ metadata:
   name: pypi-wheel-syncer
   namespace: pypi-cache
   labels:
+    osdc.io/module: pypi-cache
     app.kubernetes.io/name: pypi-wheel-syncer
     app.kubernetes.io/component: wheel-syncer


### PR DESCRIPTION
**Impact:** Operators removing pypi-cache or cache-enforcer from a cluster; arc-runners on clusters without pypi-cache 

**Risk:** medium

## What
Makes pypi-cache and cache-enforcer fully removable via `just remove-module` by adding `osdc.io/module` labels to all their k8s resources, rewrites the `remove-module` justfile recipe into a comprehensive 5-phase teardown, and gates pypi-cache env vars in runner pod templates so clusters without pypi-cache don't inject broken Service references.

## Why
Removing a module previously required manual kubectl cleanup because resources lacked the `osdc.io/module` label that `remove-module` selects on. The old recipe only handled a narrow set of resource kinds and had no terraform teardown, namespace deletion, or operator guidance. Clusters that drop pypi-cache from their modules list still rendered runner pods with PIP_INDEX_URL/UV_DEFAULT_INDEX pointing at a now-nonexistent Service, causing pip/uv install failures.

## Notes
- The `remove-module` operator warnings for cache-enforcer are critical: removing the DaemonSet does NOT undo iptables rules on existing nodes, and the startup taint (`node-init.osdc.io/cache-enforcer=true`) persists in NodePool specs until nodepools is redeployed. Failing to redeploy nodepools + recycle nodes will leave new nodes permanently untainted-but-tainted (nothing to clear the taint).
- EFS wheelhouse data is destroyed by tofu destroy but recoverable from the shared S3 bucket on next deploy (slow first warm).