### PR TITLE
arc-runners: pin runner image to digest via deploy-time resolver

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -54,7 +54,6 @@ defaults:
     pdb_min_available: 1
   arc:
     chart_version: "0.14.1-jeanschmidt.12"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
-    runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 4
     log_level: info
     controller_cpu_request: "1"

--- a/osdc/modules/arc-runners/deploy.sh
+++ b/osdc/modules/arc-runners/deploy.sh
@@ -47,6 +47,14 @@ if ! uv run "$CFG" "$CLUSTER" has-module arc; then
 fi
 
 # --- Step 1: Generate ARC runner configs ---
+EXPLICIT_TAG=$(uv run "$CFG" "$CLUSTER" arc.runner_image_tag "")
+if [[ -n "$EXPLICIT_TAG" ]]; then
+  RUNNER_IMAGE="ghcr.io/actions/actions-runner:$EXPLICIT_TAG"
+else
+  RUNNER_IMAGE=$(uv run "$MODULE_DIR/scripts/python/resolve_runner_version.py" "$CLUSTER")
+fi
+export RUNNER_IMAGE
+
 echo "Generating ARC runner configs from definitions..."
 ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
   ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -414,9 +414,7 @@ def main():
         log_error(f"No 'arc-runners.github_config_url' configured for cluster '{cluster_id}' in clusters.yaml")
         return 1
 
-    # Resolve runner image tag from arc.runner_image_tag (shared with arc module)
-    runner_image_tag = resolve_value(cluster_cfg, defaults, "arc.runner_image_tag") or "2.333.1"
-    cluster_config["runner_image"] = f"ghcr.io/actions/actions-runner:{runner_image_tag}"
+    cluster_config["runner_image"] = os.environ["RUNNER_IMAGE"]
 
     proactive_cap = cluster_cfg.get("proactive_capacity_max")
     if proactive_cap is not None and (

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -152,9 +152,6 @@ def real_template():
 
 FAKE_CLUSTERS_YAML = {
     "defaults": {
-        "arc": {
-            "runner_image_tag": "2.333.1",
-        },
         "arc-runners": {
             "github_config_url": "https://github.com/default-org",
             "github_secret_name": "default-secret",
@@ -2004,6 +2001,13 @@ class TestRealTemplate:
 
 
 class TestMain:
+    @pytest.fixture(autouse=True)
+    def _runner_image_env(self, monkeypatch):
+        monkeypatch.setenv(
+            "RUNNER_IMAGE",
+            "ghcr.io/actions/actions-runner:2.333.1@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        )
+
     def test_no_args_exits_1(self):
         with patch.object(sys, "argv", ["generate_runners.py"]):
             assert main() == 1
@@ -2080,6 +2084,33 @@ class TestMain:
         assert generated[0].name == "runner-a.yaml"
         assert generated[1].name == "runner-b.yaml"
 
+    def test_runner_image_from_env(self, tmp_path, monkeypatch):
+        """main() renders RUNNER_IMAGE env var into the runner template; no clusters.yaml key needed."""
+        p = tmp_path / "clusters.yaml"
+        p.write_text(yaml.dump(FAKE_CLUSTERS_YAML, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "runner-a", "m6i.32xlarge", 2, 4)
+        make_nodepool_defs(tmp_path, ["m6i.32xlarge"])
+
+        output_dir = tmp_path / "out"
+
+        explicit_ref = "ghcr.io/actions/actions-runner:2.999.0@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        monkeypatch.setenv("RUNNER_IMAGE", explicit_ref)
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tmp_path / "tpl.yaml"))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
+
+        (tmp_path / "tpl.yaml").write_text(MINIMAL_TEMPLATE)
+
+        with patch.object(sys, "argv", ["generate_runners.py", "staging"]):
+            assert main() == 0
+
+        rendered = (output_dir / "runner-a.yaml").read_text()
+        assert explicit_ref in rendered
+
     def test_output_dir_cleaned(self, tmp_path, monkeypatch):
         """Output dir is cleaned before generation so stale files are removed."""
         p = tmp_path / "clusters.yaml"
@@ -2135,7 +2166,6 @@ class TestMain:
         """main() does NOT force proactive_capacity to zero for production clusters."""
         prod_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2183,7 +2213,6 @@ class TestMain:
         """main() honors proactive_capacity_max: 0 in clusters.yaml."""
         prod_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2232,7 +2261,6 @@ class TestMain:
         """main() exits 1 when proactive_capacity_max is not a non-negative integer."""
         invalid_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2275,7 +2303,6 @@ class TestMain:
         """main() honors cluster-level pause_runners=true by forcing maxRunners: 0."""
         paused_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #763
* __->__ #756
* #762

**Impact:** all arc-runners deploys (including arc-runners-h100 and arc-runners-b200, which exec into this deploy.sh) — runner pods are now pinned to `ghcr.io/actions/actions-runner:<tag>@sha256:<digest>` resolved at deploy time.
**Risk:** medium

## What
Wires the resolver script from 5ed854c into `modules/arc-runners/deploy.sh` and switches `generate_runners.py` to consume the resolved image via `$RUNNER_IMAGE`. Removes the hardcoded `defaults.arc.runner_image_tag: "2.334.0"` pin from `clusters.yaml`.

## Why
We want each deploy to pick up the latest `actions/runner` release without depending on a mutable tag like `:latest`, while preserving an explicit rollback knob. Pinning to a digest means the pod manifest is immutable regardless of any future tag re-push at ghcr.

## Notes
- The resolver fails the deploy loudly on GitHub API outage, malformed releases response, `crane digest` failure, or ConfigMap I/O error. Operator unblocks by setting `arc.runner_image_tag` in `clusters.yaml` and re-running deploy.
- arc-runners-h100 and arc-runners-b200 require no change: they `exec` into this `deploy.sh` and inherit the exported `RUNNER_IMAGE`.
- First deploy after this commit creates the `arc-runner-version-lock` ConfigMap organically — no backfill needed.