### PR TITLE
arc-runners: smoke test + operator docs for runner version lock

### DIFF
--- a/osdc/docs/runner-image-autoresolve.md
+++ b/osdc/docs/runner-image-autoresolve.md
@@ -1,0 +1,95 @@
+# Runner Image Auto-Resolve
+
+## What
+
+Each `arc-runners` deploy resolves the latest `actions/runner` GitHub release
+to a digest-pinned image (`ghcr.io/actions/actions-runner:<tag>@sha256:<...>`)
+and writes the result to the `arc-runner-version-lock` ConfigMap in
+`osdc-system`. The deployed `AutoscalingRunnerSet` pod templates then pull
+exactly that digest. Rollback is a single key in `clusters.yaml`.
+
+## ConfigMap shape
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arc-runner-version-lock
+  namespace: osdc-system
+  labels:
+    app.kubernetes.io/managed-by: osdc-deploy-log
+    osdc.io/lock-kind: arc-runner-version
+data:
+  history.json: |
+    [
+      {"tag": "2.335.0", "digest": "sha256:abc...", "resolved_at": "2026-06-15T17:42:11Z"},
+      {"tag": "2.334.0", "digest": "sha256:def...", "resolved_at": "2026-06-08T09:03:55Z"}
+    ]
+```
+
+Each entry: `tag` (release tag with leading `v` stripped), `digest`
+(`sha256:<64-hex>`, the OCI manifest-list digest — kubelet picks the per-arch
+manifest at pull time), `resolved_at` (ISO8601 UTC).
+
+History is capped at 20 entries, newest first. When a tag is resolved again,
+any older entry with the same tag is dropped before the new entry is
+prepended (no duplicate tags in the list).
+
+## Rollback paths
+
+1. **Pin to a known-good tag.** Add `arc.runner_image_tag: "<tag>"` under
+   the cluster's `arc:` block in `clusters.yaml`, then
+   `just deploy-module <cluster> arc-runners`. The resolver is bypassed
+   entirely: deployed image becomes `ghcr.io/actions/actions-runner:<tag>`
+   (tag-only, no digest), no GitHub API call, no `crane` call, ConfigMap
+   untouched. Removing the key on a later deploy returns the cluster to
+   auto-resolution.
+
+2. **Revert the OSDC commit.** Use when a particular OSDC change drove the
+   regression rather than the runner image itself. Note: reverting OSDC does
+   not change which runner version gets picked — if the same upstream tag is
+   still `latest`, the resolver re-resolves to it. Pair with option 1 if you
+   also need to roll the runner version back.
+
+## Failure modes
+
+Each of these aborts the deploy with a non-zero exit and a single-line
+stderr message. Operator response is the same in every case: pin
+`arc.runner_image_tag` in `clusters.yaml` and re-run the deploy, then
+investigate before unpinning.
+
+- GitHub `/releases/latest` HTTP error, timeout, or response missing
+  `tag_name`.
+- `crane digest` exits non-zero (ghcr unreachable, tag missing, or auth
+  failure on the runner image).
+- ConfigMap read returns malformed JSON in `history.json`.
+- ConfigMap write fails (RBAC, API outage, conflict).
+
+## Why digest pinning
+
+Tags on ghcr are mutable in principle — a re-push of the same tag would
+silently shift what kubelet pulls on the next pod restart. Digests are
+content-addressed and cannot be changed. The ConfigMap records exactly what
+was deployed, and the pod manifest pulls exactly that.
+
+## Why no Renovate bot
+
+Deploy-time resolution avoids running and maintaining bot infrastructure
+in this repo and avoids the PR-churn cycle for a value that is read fresh
+on every deploy anyway. Trade-off: deploys depend on GitHub releases and
+ghcr being reachable at deploy time (see Failure modes for the
+operator response when they are not).
+
+## Where to look
+
+- `modules/arc-runners/scripts/python/resolve_runner_version.py` — the
+  resolver implementation.
+- `modules/arc-runners/deploy.sh` — invokes the resolver and exports
+  `RUNNER_IMAGE` for the generator. The `arc-runners-h100` and
+  `arc-runners-b200` variants `exec` into this `deploy.sh` and inherit
+  the resolved image unchanged.
+- `arc-runner-version-lock` ConfigMap in the `osdc-system` namespace —
+  the lock file itself.
+- `modules/arc-runners/tests/smoke/test_runner_version_lock.py` — smoke
+  test that validates the ConfigMap shape and cross-checks the newest
+  entry against the deployed `AutoscalingRunnerSet` pod templates.

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1844,6 +1844,9 @@ smoke cluster:
     # each variant's own deploy.sh, e.g. modules/arc-runners-b200/deploy.sh).
     # Generation must happen ONCE before any pytest worker starts —
     # previously the test fixture shelled out, which raced under pytest-xdist.
+    # OSDC_RESOLVER_READONLY: smoke must not mutate the lock ConfigMap or hit
+    # GitHub; it reads the newest cached entry the live deploy already wrote.
+    export OSDC_RESOLVER_READONLY=1
     for mod in $MODULES; do
         case "$mod" in
             arc-runners | arc-runners-*)
@@ -1856,6 +1859,7 @@ smoke cluster:
                 ;;
         esac
     done
+    unset OSDC_RESOLVER_READONLY
 
     export OSDC_ROOT="${ROOT}"
     export OSDC_UPSTREAM="${UPSTREAM}"
@@ -1991,6 +1995,15 @@ generate-arc-runners cluster:
     OUTPUT_DIR="${ARC_RUNNERS_OUTPUT_DIR:-$MODULE_DIR/generated}"
     TEMPLATE="${ARC_RUNNERS_TEMPLATE:-$MODULE_DIR/templates/runner.yaml.tpl}"
     MODULE_NAME="${ARC_RUNNERS_MODULE_NAME:-arc-runners}"
+
+    CFG="{{UPSTREAM}}/scripts/cluster-config.py"
+    EXPLICIT_TAG=$(uv run "$CFG" "$CLUSTER" arc.runner_image_tag "")
+    if [[ -n "$EXPLICIT_TAG" ]]; then
+      RUNNER_IMAGE="ghcr.io/actions/actions-runner:$EXPLICIT_TAG"
+    else
+      RUNNER_IMAGE=$(uv run "$MODULE_DIR/scripts/python/resolve_runner_version.py" "$CLUSTER")
+    fi
+    export RUNNER_IMAGE
 
     ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
         ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \

--- a/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -120,7 +121,24 @@ def write_history(client: Client, history: list[dict[str, str]], cm_exists: bool
 
 
 def build_client() -> Client:
+    _force_ipv4()
     return Client()
+
+
+def _force_ipv4() -> None:
+    # AWS EKS endpoints advertise AAAA records but reject IPv6 connects from
+    # many corporate/home networks. Python's default getaddrinfo returns IPv6
+    # first and socket.create_connection then blocks for the full OS timeout
+    # (~100s) before falling back. kubectl (Go) handles this with happy-eyeballs;
+    # stdlib socket does not. Pin to IPv4 to avoid the dead-end.
+    original = socket.getaddrinfo
+
+    def ipv4_only(host, port, family=0, *args, **kwargs):
+        if family in (0, socket.AF_UNSPEC):
+            family = socket.AF_INET
+        return original(host, port, family, *args, **kwargs)
+
+    socket.getaddrinfo = ipv4_only
 
 
 def now_utc() -> datetime:
@@ -129,6 +147,18 @@ def now_utc() -> datetime:
 
 def _run(cluster_id: str, client: Client) -> str:
     print(f"resolve_runner_version: cluster={cluster_id}", file=sys.stderr)
+
+    if os.environ.get("OSDC_RESOLVER_READONLY"):
+        history, _ = read_history(client)
+        if not history:
+            raise ValueError(
+                f"OSDC_RESOLVER_READONLY set but {CM_NAME} in {CM_NAMESPACE} has no entries — "
+                "deploy arc-runners first to populate the lock"
+            )
+        newest = history[0]
+        tag, digest = newest["tag"], newest["digest"]
+        print(f"resolve_runner_version: readonly, returning newest cached {tag}@{digest}", file=sys.stderr)
+        return f"{IMAGE_REPO}:{tag}@{digest}"
 
     token = os.environ.get("GITHUB_TOKEN") or None
     tag = fetch_latest_tag(token)

--- a/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
@@ -285,6 +285,35 @@ class TestMain:
         assert rc == 2
         assert "usage" in capsys.readouterr().err
 
+    def test_readonly_returns_newest_cached(self, monkeypatch, capsys):
+        monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
+        env = _Env(
+            monkeypatch,
+            history=[
+                {"tag": "2.336.0", "digest": "sha256:new", "resolved_at": "2026-06-10T00:00:00Z"},
+                {"tag": "2.335.0", "digest": "sha256:old", "resolved_at": "2026-05-01T00:00:00Z"},
+            ],
+        )
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.336.0@sha256:new"
+        assert env.fetched_token == []
+        assert env.crane_calls == []
+        env.client.create.assert_not_called()
+        env.client.replace.assert_not_called()
+
+    def test_readonly_empty_history_fails(self, monkeypatch, capsys):
+        monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
+        env = _Env(monkeypatch, history=[], history_exists=False)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "OSDC_RESOLVER_READONLY" in captured.err
+        assert env.fetched_token == []
+        assert env.crane_calls == []
+        env.client.create.assert_not_called()
+
     def test_configmap_missing_first_deploy(self, monkeypatch, capsys):
         env = _Env(monkeypatch, history=[], history_exists=False)
         rc = rrv.main(["resolve_runner_version.py", "test-cluster"])
@@ -475,6 +504,7 @@ class TestModuleBoundaries:
         assert result.tzinfo is not None
 
     def test_build_client_constructs_client(self):
-        with patch.object(rrv, "Client") as mock_client_cls:
+        with patch.object(rrv, "Client") as mock_client_cls, patch.object(rrv, "_force_ipv4") as mock_force:
             rrv.build_client()
+            mock_force.assert_called_once_with()
             mock_client_cls.assert_called_once_with()

--- a/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
@@ -1,0 +1,179 @@
+"""Smoke tests for the deploy-time runner-image resolver.
+
+Verifies the `arc-runner-version-lock` ConfigMap (written by
+`resolve_runner_version.py` during `just deploy-module <cluster> arc-runners`)
+matches the runner image actually deployed in the cluster's
+AutoscalingRunnerSets.
+
+Skipped on clusters that pin `arc.runner_image_tag` in clusters.yaml
+(rollback path — the resolver is bypassed and no ConfigMap is written).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import datetime
+
+import pytest
+from helpers import retry_with_backoff, run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+LOCK_CM_NAME = "arc-runner-version-lock"
+LOCK_CM_NAMESPACE = "osdc-system"
+LOCK_CM_KEY = "history.json"
+HISTORY_MAX = 20
+
+EXPECTED_LABELS = {
+    "app.kubernetes.io/managed-by": "osdc-deploy-log",
+    "osdc.io/lock-kind": "arc-runner-version",
+}
+
+IMAGE_REPO = "ghcr.io/actions/actions-runner"
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+ARS_RESOURCE = "autoscalingrunnersets.actions.github.com"
+ARS_NAMESPACE = "arc-runners"
+RUNNER_CONTAINER_NAME = "runner"
+
+
+def _parse_iso8601_utc(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _fetch_lock_configmap() -> dict:
+    return run_kubectl(["get", "configmap", LOCK_CM_NAME], namespace=LOCK_CM_NAMESPACE)
+
+
+def _fetch_arc_runner_sets() -> list[dict]:
+    result = run_kubectl(["get", ARS_RESOURCE], namespace=ARS_NAMESPACE)
+    return result.get("items", []) or []
+
+
+def _runner_image_from_ars(ars: dict) -> str | None:
+    containers = ars.get("spec", {}).get("template", {}).get("spec", {}).get("containers", []) or []
+    for c in containers:
+        if c.get("name") == RUNNER_CONTAINER_NAME:
+            return c.get("image")
+    return None
+
+
+@pytest.fixture(scope="module")
+def explicit_runner_tag(resolve_config) -> str | None:
+    val = resolve_config("arc.runner_image_tag")
+    if val is None or val == "":
+        return None
+    return str(val)
+
+
+@pytest.fixture(scope="module")
+def lock_history(explicit_runner_tag: str | None) -> list[dict]:
+    if explicit_runner_tag is not None:
+        pytest.skip(
+            f"arc.runner_image_tag={explicit_runner_tag!r} pinned in clusters.yaml — "
+            f"resolver bypassed, no {LOCK_CM_NAME} ConfigMap expected"
+        )
+
+    def _load() -> tuple[dict, list]:
+        cm = _fetch_lock_configmap()
+        raw = (cm.get("data") or {}).get(LOCK_CM_KEY)
+        assert raw, f"{LOCK_CM_NAME}.data[{LOCK_CM_KEY!r}] is empty or missing"
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list), f"{LOCK_CM_KEY} must be a JSON list, got {type(parsed).__name__}"
+        assert len(parsed) >= 1, f"{LOCK_CM_KEY} has zero entries — at least one expected after a deploy"
+        return cm, parsed
+
+    try:
+        cm, history = retry_with_backoff(_load)
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Failed to read ConfigMap {LOCK_CM_NAMESPACE}/{LOCK_CM_NAME}: {e.stderr or e}. "
+            f"If this cluster has never deployed arc-runners after the resolver landed, "
+            f"run `just deploy-module {{cluster}} arc-runners` first."
+        )
+
+    labels = cm.get("metadata", {}).get("labels", {}) or {}
+    for k, v in EXPECTED_LABELS.items():
+        assert labels.get(k) == v, f"{LOCK_CM_NAME} label {k!r}={labels.get(k)!r}, expected {v!r}"
+
+    return history
+
+
+class TestLockConfigMapShape:
+    def test_history_length_within_cap(self, lock_history: list[dict]) -> None:
+        assert len(lock_history) <= HISTORY_MAX, f"history.json has {len(lock_history)} entries, cap is {HISTORY_MAX}"
+
+    def test_history_entries_well_formed(self, lock_history: list[dict]) -> None:
+        problems: list[str] = []
+        for i, entry in enumerate(lock_history):
+            if not isinstance(entry, dict):
+                problems.append(f"[{i}] not an object: {entry!r}")
+                continue
+
+            tag = entry.get("tag")
+            if not isinstance(tag, str) or not tag:
+                problems.append(f"[{i}] tag must be a non-empty string, got {tag!r}")
+
+            digest = entry.get("digest")
+            if not isinstance(digest, str) or not DIGEST_RE.match(digest):
+                problems.append(f"[{i}] digest must match sha256:<64-hex>, got {digest!r}")
+
+            resolved_at = entry.get("resolved_at")
+            if not isinstance(resolved_at, str):
+                problems.append(f"[{i}] resolved_at must be a string, got {resolved_at!r}")
+            else:
+                try:
+                    parsed = _parse_iso8601_utc(resolved_at)
+                except ValueError as e:
+                    problems.append(f"[{i}] resolved_at not ISO8601: {resolved_at!r} ({e})")
+                else:
+                    if parsed.tzinfo is None:
+                        problems.append(f"[{i}] resolved_at missing tz info: {resolved_at!r}")
+
+        assert not problems, "Malformed history entries:\n" + "\n".join(problems)
+
+    def test_tags_are_unique(self, lock_history: list[dict]) -> None:
+        tags = [e["tag"] for e in lock_history if isinstance(e, dict) and isinstance(e.get("tag"), str)]
+        dupes = sorted({t for t in tags if tags.count(t) > 1})
+        assert not dupes, f"Duplicate tags in history (resolver should dedupe): {dupes}"
+
+
+class TestLockMatchesDeployedRunners:
+    def test_newest_entry_matches_ars_runner_image(
+        self,
+        lock_history: list[dict],
+        enabled_modules: list[str],
+    ) -> None:
+        if "arc-runners" not in enabled_modules:
+            pytest.skip("arc-runners module not enabled")
+
+        newest = lock_history[0]
+        expected_image = f"{IMAGE_REPO}:{newest['tag']}@{newest['digest']}"
+
+        try:
+            ars_list = retry_with_backoff(_fetch_arc_runner_sets)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(f"Failed to list {ARS_RESOURCE} in {ARS_NAMESPACE}: {e.stderr or e}")
+
+        assert len(ars_list) >= 1, (
+            f"No {ARS_RESOURCE} found in '{ARS_NAMESPACE}' — arc-runners module enabled but no scale-sets deployed?"
+        )
+
+        mismatches: list[str] = []
+        for ars in ars_list:
+            name = ars.get("metadata", {}).get("name", "?")
+            image = _runner_image_from_ars(ars)
+            if image is None:
+                mismatches.append(f"{name}: no '{RUNNER_CONTAINER_NAME}' container in pod template")
+                continue
+            if image != expected_image:
+                mismatches.append(f"{name}: image={image!r}, expected {expected_image!r}")
+
+        assert not mismatches, (
+            f"AutoscalingRunnerSet runner image does not match newest lock entry "
+            f"({expected_image!r}):\n" + "\n".join(mismatches)
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #760
* #756
* #755

**Impact:** adds `just smoke` validation for the runner-version lock ConfigMap and an operator doc. Also fixes `just generate-arc-runners` and adds a read-only resolver mode so smoke can pre-generate ARC YAMLs without hitting GitHub or mutating cluster state.
**Risk:** low

## What
Adds the live-cluster smoke test that validates the `arc-runner-version-lock` ConfigMap (written by `resolve_runner_version.py`) matches the runner image actually deployed in the cluster's AutoscalingRunnerSets, plus a short operator doc covering the ConfigMap shape, rollback paths, and failure modes. Adds an `OSDC_RESOLVER_READONLY` env-var mode to the resolver so smoke can pre-generate runner YAMLs by reading the newest cached entry instead of resolving anew, and fixes the `generate-arc-runners` recipe so it sets `$RUNNER_IMAGE` for both the live and smoke paths.

## Why
The two preceding commits in this stack added the resolver script and wired it into `deploy.sh`. This commit closes the loop:
- Smoke validates that the lock ConfigMap matches what's actually deployed (drift detection).
- The operator doc gives one page to look at when something fails.
- `generate-arc-runners` is invoked by `just smoke` to pre-generate ARC YAMLs without touching the cluster — but it was missed in the env-driven generator switch, so the smoke flow failed with `KeyError: 'RUNNER_IMAGE'`.
- Smoke must not call GitHub or rewrite the lock ConfigMap (verification, not deploy) — hence the readonly mode that reads the newest cached entry already populated by the live deploy.