### PR TITLE
arc-runners: smoke test + operator docs for runner version lock

### DIFF
--- a/osdc/docs/runner-image-autoresolve.md
+++ b/osdc/docs/runner-image-autoresolve.md
@@ -1,0 +1,147 @@
+# Runner Image Auto-Resolve
+
+## What
+
+Each `arc-runners` deploy pins the runner image
+(`ghcr.io/actions/actions-runner:<tag>@sha256:<...>`) **per OSDC commit**.
+The lookup key is the SHA of the most recent commit touching anything in
+the OSDC project (the whole `osdc/` directory) — `modules/arc-runners/`,
+the `arc-runners-h100`/`arc-runners-b200` shim modules, `clusters.yaml`,
+`deploy.sh`, and everything else under `osdc/`. The first time a given
+SHA deploys, the resolver calls GitHub `/releases/latest`, resolves the
+digest with `crane`, and writes the entry to the `arc-runner-version-lock`
+ConfigMap in `osdc-system`. Every subsequent deploy of the same SHA
+returns the exact same `tag@digest` from the ConfigMap — no GitHub API
+call, no `crane` call, no write.
+
+## Why per-commit
+
+Reproducibility for rollbacks **within the 20-SHA rolling window**.
+`git checkout <old-sha> && just deploy-module <cluster> arc-runners`
+reproduces the exact image that ran when that commit was originally
+deployed, *as long as the SHA is still inside the window*. Pair with the
+cluster's other module versions and you have a bit-for-bit rollback for
+recent history.
+
+The window is the last 20 OSDC SHAs (newest first). Rolling back to a
+SHA that has aged out of the window will create a new entry with the
+same SHA but potentially a different `tag@digest` — the original digest
+is not recoverable from the lock once it ages out. The replay is still
+safe (digest-pinned, recorded in the ConfigMap), but it is no longer
+bit-for-bit identical to the original deploy.
+
+Because the key is "any commit under `osdc/`", shim module changes
+(`arc-runners-h100`, `arc-runners-b200`), `clusters.yaml` edits, and
+unrelated module commits all bump the SHA and produce a new lock entry.
+Reproducibility is per-OSDC-commit, not per-`arc-runners`-commit.
+
+## ConfigMap shape
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arc-runner-version-lock
+  namespace: osdc-system
+  labels:
+    app.kubernetes.io/managed-by: osdc-deploy-log
+    osdc.io/lock-kind: arc-runner-version
+data:
+  history.json: |
+    [
+      {"osdc_sha": "3c22361...", "tag": "2.335.0", "digest": "sha256:abc...", "resolved_at": "2026-06-15T17:42:11Z"},
+      {"osdc_sha": "1a0f2e4...", "tag": "2.335.0", "digest": "sha256:abc...", "resolved_at": "2026-06-08T09:03:55Z"}
+    ]
+```
+
+Two different SHAs sharing the same `tag@digest` is the common case
+(most OSDC commits don't bump the upstream runner). The dedupe key is
+`osdc_sha`, not `tag` — multiple entries with the same tag are
+expected and correct.
+
+Fields: `osdc_sha` (40-char hex, the cache key), `tag` (release tag with
+leading `v` stripped), `digest` (`sha256:<64-hex>`, the OCI manifest-list
+digest — kubelet picks the per-arch manifest at pull time), `resolved_at`
+(ISO8601 UTC).
+
+History is capped at 20, newest first. Re-resolving the same SHA drops
+its older entry before prepending the new one.
+
+## Concurrent deploys
+
+The three `arc-runners*` modules (`arc-runners`, `arc-runners-h100`,
+`arc-runners-b200`) deploy concurrently and all read/write the same
+ConfigMap. Writes use Kubernetes optimistic concurrency: the resolver
+reads `metadata.resourceVersion`, includes it in the `replace` call, and
+the API server rejects the write with 409 if another deploy beat it.
+
+On 409 the loser re-reads the ConfigMap. If the winner already pinned
+this SHA, the loser returns the winner's `tag@digest` instead of writing
+— so all three modules end up with the same image. If the winner pinned
+a different SHA (none of the runners pinned ours), the loser retries the
+write with the fresh `resourceVersion`. Up to 5 attempts before giving
+up.
+
+## Rollback paths
+
+1. **Revert to an earlier OSDC commit.** `git checkout <old-sha> &&
+   just deploy-module <cluster> arc-runners`. If `<old-sha>` is still
+   inside the 20-entry window, the same `tag@digest` is replayed
+   exactly. Outside the window, the resolver re-resolves to today's
+   latest and writes a new entry (same `osdc_sha`, potentially
+   different `tag@digest` than the original).
+
+2. **Pin to a known-good tag.** Add `arc.runner_image_tag: "<tag>"`
+   under the cluster's `arc:` block in `clusters.yaml`, then redeploy.
+   The resolver is bypassed entirely: deployed image becomes
+   `ghcr.io/actions/actions-runner:<tag>` (tag-only, no digest), no
+   GitHub API call, no `crane` call, ConfigMap untouched. Removing
+   the key on a later deploy returns the cluster to auto-resolution.
+
+## Failure modes
+
+Each of these aborts the deploy with a non-zero exit and a single-line
+stderr message. Operator response is the same in every case: pin
+`arc.runner_image_tag` in `clusters.yaml` and re-run the deploy, then
+investigate before unpinning.
+
+- `git log` returns no commit history under the OSDC root (shallow
+  clone) — refetch full history or pin manually.
+- GitHub `/releases/latest` HTTP error, timeout, or response missing
+  `tag_name`.
+- `crane digest` exits non-zero (ghcr unreachable, tag missing, or auth
+  failure on the runner image).
+- ConfigMap read returns malformed JSON or entries missing
+  `osdc_sha`/`tag`/`digest`.
+- ConfigMap write fails after 5 conflict-retry attempts, or fails with a
+  non-409 error (RBAC, API outage).
+
+## Why digest pinning
+
+Tags on ghcr are mutable in principle — a re-push of the same tag would
+silently shift what kubelet pulls on the next pod restart. Digests are
+content-addressed and cannot be changed. The ConfigMap records exactly
+what was deployed, and the pod manifest pulls exactly that.
+
+## Why no Renovate bot
+
+Deploy-time resolution avoids running and maintaining bot infrastructure
+in this repo and avoids the PR-churn cycle for a value that is read
+fresh on every deploy anyway. Trade-off: deploys depend on GitHub
+releases and ghcr being reachable at deploy time (see Failure modes for
+the operator response when they are not).
+
+## Where to look
+
+- `modules/arc-runners/scripts/python/resolve_runner_version.py` — the
+  resolver implementation.
+- `modules/arc-runners/deploy.sh` — invokes the resolver and exports
+  `RUNNER_IMAGE` for the generator. The `arc-runners-h100` and
+  `arc-runners-b200` variants `exec` into this `deploy.sh` and inherit
+  the resolved image unchanged.
+- `arc-runner-version-lock` ConfigMap in the `osdc-system` namespace —
+  the lock file itself.
+- `modules/arc-runners/tests/smoke/test_runner_version_lock.py` — smoke
+  test that validates the ConfigMap shape and cross-checks the entry
+  whose `osdc_sha` matches the current commit against the deployed
+  `AutoscalingRunnerSet` pod templates.

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1844,6 +1844,9 @@ smoke cluster:
     # each variant's own deploy.sh, e.g. modules/arc-runners-b200/deploy.sh).
     # Generation must happen ONCE before any pytest worker starts —
     # previously the test fixture shelled out, which raced under pytest-xdist.
+    # OSDC_RESOLVER_READONLY: smoke must not mutate the lock ConfigMap or hit
+    # GitHub; it reads the newest cached entry the live deploy already wrote.
+    export OSDC_RESOLVER_READONLY=1
     for mod in $MODULES; do
         case "$mod" in
             arc-runners | arc-runners-*)
@@ -1856,6 +1859,7 @@ smoke cluster:
                 ;;
         esac
     done
+    unset OSDC_RESOLVER_READONLY
 
     export OSDC_ROOT="${ROOT}"
     export OSDC_UPSTREAM="${UPSTREAM}"
@@ -1991,6 +1995,15 @@ generate-arc-runners cluster:
     OUTPUT_DIR="${ARC_RUNNERS_OUTPUT_DIR:-$MODULE_DIR/generated}"
     TEMPLATE="${ARC_RUNNERS_TEMPLATE:-$MODULE_DIR/templates/runner.yaml.tpl}"
     MODULE_NAME="${ARC_RUNNERS_MODULE_NAME:-arc-runners}"
+
+    CFG="{{UPSTREAM}}/scripts/cluster-config.py"
+    EXPLICIT_TAG=$(uv run "$CFG" "$CLUSTER" arc.runner_image_tag "")
+    if [[ -n "$EXPLICIT_TAG" ]]; then
+      RUNNER_IMAGE="ghcr.io/actions/actions-runner:$EXPLICIT_TAG"
+    else
+      RUNNER_IMAGE=$(uv run "$MODULE_DIR/scripts/python/resolve_runner_version.py" "$CLUSTER")
+    fi
+    export RUNNER_IMAGE
 
     ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
         ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \

--- a/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
@@ -1,0 +1,220 @@
+"""Smoke tests for the deploy-time runner-image resolver.
+
+Verifies the `arc-runner-version-lock` ConfigMap (written by
+`resolve_runner_version.py` during `just deploy-module <cluster> arc-runners`)
+matches the runner image actually deployed in the cluster's
+AutoscalingRunnerSets.
+
+Skipped on clusters that pin `arc.runner_image_tag` in clusters.yaml
+(rollback path — the resolver is bypassed and no ConfigMap is written).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from helpers import retry_with_backoff, run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+LOCK_CM_NAME = "arc-runner-version-lock"
+LOCK_CM_NAMESPACE = "osdc-system"
+LOCK_CM_KEY = "history.json"
+HISTORY_MAX = 20
+
+EXPECTED_LABELS = {
+    "app.kubernetes.io/managed-by": "osdc-deploy-log",
+    "osdc.io/lock-kind": "arc-runner-version",
+}
+
+IMAGE_REPO = "ghcr.io/actions/actions-runner"
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+ARS_RESOURCE = "autoscalingrunnersets.actions.github.com"
+ARS_NAMESPACE = "arc-runners"
+RUNNER_CONTAINER_NAME = "runner"
+
+OSDC_PATH = "."
+
+
+def _parse_iso8601_utc(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _osdc_root() -> Path:
+    env_root = os.environ.get("OSDC_UPSTREAM")
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[4]
+
+
+def _current_osdc_sha() -> str:
+    root = _osdc_root()
+    result = subprocess.run(
+        ["git", "-C", str(root), "log", "-1", "--format=%H", "--", OSDC_PATH],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip()
+    if not sha:
+        pytest.fail(
+            f"git log returned no commit history under {root} — "
+            "shallow clone? Refetch with full history before running this smoke test."
+        )
+    return sha
+
+
+def _fetch_lock_configmap() -> dict:
+    return run_kubectl(["get", "configmap", LOCK_CM_NAME], namespace=LOCK_CM_NAMESPACE)
+
+
+def _fetch_arc_runner_sets() -> list[dict]:
+    result = run_kubectl(["get", ARS_RESOURCE], namespace=ARS_NAMESPACE)
+    return result.get("items", []) or []
+
+
+def _runner_image_from_ars(ars: dict) -> str | None:
+    containers = ars.get("spec", {}).get("template", {}).get("spec", {}).get("containers", []) or []
+    for c in containers:
+        if c.get("name") == RUNNER_CONTAINER_NAME:
+            return c.get("image")
+    return None
+
+
+@pytest.fixture(scope="module")
+def explicit_runner_tag(resolve_config) -> str | None:
+    val = resolve_config("arc.runner_image_tag")
+    if val is None or val == "":
+        return None
+    return str(val)
+
+
+@pytest.fixture(scope="module")
+def lock_history(explicit_runner_tag: str | None) -> list[dict]:
+    if explicit_runner_tag is not None:
+        pytest.skip(
+            f"arc.runner_image_tag={explicit_runner_tag!r} pinned in clusters.yaml — "
+            f"resolver bypassed, no {LOCK_CM_NAME} ConfigMap expected"
+        )
+
+    def _load() -> tuple[dict, list]:
+        cm = _fetch_lock_configmap()
+        raw = (cm.get("data") or {}).get(LOCK_CM_KEY)
+        assert raw, f"{LOCK_CM_NAME}.data[{LOCK_CM_KEY!r}] is empty or missing"
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list), f"{LOCK_CM_KEY} must be a JSON list, got {type(parsed).__name__}"
+        assert len(parsed) >= 1, f"{LOCK_CM_KEY} has zero entries — at least one expected after a deploy"
+        return cm, parsed
+
+    try:
+        cm, history = retry_with_backoff(_load)
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Failed to read ConfigMap {LOCK_CM_NAMESPACE}/{LOCK_CM_NAME}: {e.stderr or e}. "
+            f"If this cluster has never deployed arc-runners after the resolver landed, "
+            f"run `just deploy-module {{cluster}} arc-runners` first."
+        )
+
+    labels = cm.get("metadata", {}).get("labels", {}) or {}
+    for k, v in EXPECTED_LABELS.items():
+        assert labels.get(k) == v, f"{LOCK_CM_NAME} label {k!r}={labels.get(k)!r}, expected {v!r}"
+
+    return history
+
+
+class TestLockConfigMapShape:
+    def test_history_length_within_cap(self, lock_history: list[dict]) -> None:
+        assert len(lock_history) <= HISTORY_MAX, f"history.json has {len(lock_history)} entries, cap is {HISTORY_MAX}"
+
+    def test_history_entries_well_formed(self, lock_history: list[dict]) -> None:
+        problems: list[str] = []
+        for i, entry in enumerate(lock_history):
+            if not isinstance(entry, dict):
+                problems.append(f"[{i}] not an object: {entry!r}")
+                continue
+
+            osdc_sha = entry.get("osdc_sha")
+            if not isinstance(osdc_sha, str) or not SHA_RE.match(osdc_sha):
+                problems.append(f"[{i}] osdc_sha must match 40-char hex, got {osdc_sha!r}")
+
+            tag = entry.get("tag")
+            if not isinstance(tag, str) or not tag:
+                problems.append(f"[{i}] tag must be a non-empty string, got {tag!r}")
+
+            digest = entry.get("digest")
+            if not isinstance(digest, str) or not DIGEST_RE.match(digest):
+                problems.append(f"[{i}] digest must match sha256:<64-hex>, got {digest!r}")
+
+            resolved_at = entry.get("resolved_at")
+            if not isinstance(resolved_at, str):
+                problems.append(f"[{i}] resolved_at must be a string, got {resolved_at!r}")
+            else:
+                try:
+                    parsed = _parse_iso8601_utc(resolved_at)
+                except ValueError as e:
+                    problems.append(f"[{i}] resolved_at not ISO8601: {resolved_at!r} ({e})")
+                else:
+                    if parsed.tzinfo is None:
+                        problems.append(f"[{i}] resolved_at missing tz info: {resolved_at!r}")
+
+        assert not problems, "Malformed history entries:\n" + "\n".join(problems)
+
+    def test_osdc_shas_are_unique(self, lock_history: list[dict]) -> None:
+        shas = [e["osdc_sha"] for e in lock_history if isinstance(e, dict) and isinstance(e.get("osdc_sha"), str)]
+        dupes = sorted({s for s in shas if shas.count(s) > 1})
+        assert not dupes, f"Duplicate osdc_sha in history (resolver should dedupe on SHA): {dupes}"
+
+
+class TestLockMatchesDeployedRunners:
+    def test_current_sha_entry_matches_ars_runner_image(
+        self,
+        lock_history: list[dict],
+        enabled_modules: list[str],
+    ) -> None:
+        if "arc-runners" not in enabled_modules:
+            pytest.skip("arc-runners module not enabled")
+
+        current_sha = _current_osdc_sha()
+        matching = [e for e in lock_history if e.get("osdc_sha") == current_sha]
+        assert matching, (
+            f"No entry in {LOCK_CM_NAME}.{LOCK_CM_KEY} matches the current osdc_sha={current_sha} "
+            f"(most recent commit touching anything under {OSDC_PATH}). The cluster is running a stale "
+            f"image, or the most recent `just deploy-module <cluster> arc-runners` did not complete. "
+            f"Re-run the deploy to populate the entry."
+        )
+        entry = matching[0]
+        expected_image = f"{IMAGE_REPO}:{entry['tag']}@{entry['digest']}"
+
+        try:
+            ars_list = retry_with_backoff(_fetch_arc_runner_sets)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(f"Failed to list {ARS_RESOURCE} in {ARS_NAMESPACE}: {e.stderr or e}")
+
+        assert len(ars_list) >= 1, (
+            f"No {ARS_RESOURCE} found in '{ARS_NAMESPACE}' — arc-runners module enabled but no scale-sets deployed?"
+        )
+
+        mismatches: list[str] = []
+        for ars in ars_list:
+            name = ars.get("metadata", {}).get("name", "?")
+            image = _runner_image_from_ars(ars)
+            if image is None:
+                mismatches.append(f"{name}: no '{RUNNER_CONTAINER_NAME}' container in pod template")
+                continue
+            if image != expected_image:
+                mismatches.append(f"{name}: image={image!r}, expected {expected_image!r}")
+
+        assert not mismatches, (
+            f"AutoscalingRunnerSet runner image does not match the entry for current osdc_sha={current_sha} "
+            f"({expected_image!r}):\n" + "\n".join(mismatches)
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #763
* #756
* #762

**Impact:** adds `just smoke` validation for the runner-version lock ConfigMap and an operator doc. No runtime behavior change.
**Risk:** low

## What
Adds the live-cluster smoke test that validates the `arc-runner-version-lock` ConfigMap (written by `resolve_runner_version.py`) has an entry matching the current OSDC SHA and that the recorded `tag@digest` matches the runner image actually deployed in every `AutoscalingRunnerSet`. Adds a short operator doc covering the per-commit pinning model, the 20-SHA window, rollback flow, and failure modes.

## Why
PR 1 added the resolver script (keyed by OSDC commit SHA). PR 2 wired it into `deploy.sh` and switched `generate_runners.py` to read `$RUNNER_IMAGE`. This PR closes the loop:
- Smoke validates that the entry the resolver wrote for THIS commit's SHA is the same `tag@digest` actually running in pod manifests (drift detection between the lock and deployed state for this commit).
- The operator doc gives one page to look at when something fails.

## Changes
- `modules/arc-runners/tests/smoke/test_runner_version_lock.py` — new smoke test. Skipped on clusters with `arc.runner_image_tag` pinned in `clusters.yaml` (rollback path — no ConfigMap expected). Otherwise checks: ConfigMap labels (`app.kubernetes.io/managed-by=osdc-deploy-log`, `osdc.io/lock-kind=arc-runner-version`); `history.json` parses as a list of 1..20 entries; each entry has a 40-hex `osdc_sha`, non-empty `tag`, `sha256:<64-hex>` `digest`, tz-aware ISO8601 `resolved_at`; `osdc_sha` values are unique (dedupe invariant); the entry whose `osdc_sha` matches `git log -1 --format=%H -- modules/arc-runners/` is present in history and its `<repo>:<tag>@<digest>` equals the `runner` container image on every `AutoscalingRunnerSet` in `arc-runners`. Uses `retry_with_backoff` and `run_kubectl` from the shared helpers.
- `docs/runner-image-autoresolve.md` — short operator doc. Covers what the resolver does, the per-commit pin model, the 20-SHA reproducibility window, the ConfigMap YAML shape (with two entries demonstrating "two SHAs, same tag"), rollback flow (`git checkout <old-sha>` + redeploy = identical image when in window), operator-override path (`arc.runner_image_tag` in `clusters.yaml`), failure modes including shallow-clone `git log` empty, and a "where to look" file map.

## Notes
- The smoke test lives under `modules/arc-runners/tests/smoke/` so `just test` skips it (per the existing `find ... -path '*/modules/*/tests/smoke' -prune` rule). It runs only under `just smoke <cluster>`.
- AutoscalingRunnerSet is the CRD the chart produces; the runner container is named `runner` in `spec.template.spec.containers`. The test reuses `run_kubectl` rather than rolling its own k8s client to keep the surface identical to every other smoke test.

## Testing
- `just lint` — passes (all 13 linters).
- `just test` — passes (95% per-file coverage gate); the new smoke test is correctly excluded from the unit-test sweep.
- `OSDC_RESOLVER_READONLY=1 uv run resolve_runner_version.py meta-staging-aws-uw1` against the live staging cluster exits 1 with the expected SHA-keyed error when the current SHA isn't in history; populates the entry on a normal (non-readonly) deploy and the readonly call then returns the cached `tag@digest` in ~2s.