### PR TITLE
arc-runners: smoke test + operator docs for runner version lock

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -54,7 +54,6 @@ defaults:
     pdb_min_available: 1
   arc:
     chart_version: "0.14.1-jeanschmidt.12"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
-    runner_image_tag: "2.334.0"  # ghcr.io/actions/actions-runner tag — pin to avoid :latest
     replica_count: 4
     log_level: info
     controller_cpu_request: "1"

--- a/osdc/docs/runner-image-autoresolve.md
+++ b/osdc/docs/runner-image-autoresolve.md
@@ -1,0 +1,147 @@
+# Runner Image Auto-Resolve
+
+## What
+
+Each `arc-runners` deploy pins the runner image
+(`ghcr.io/actions/actions-runner:<tag>@sha256:<...>`) **per OSDC commit**.
+The lookup key is the SHA of the most recent commit touching anything in
+the OSDC project (the whole `osdc/` directory) — `modules/arc-runners/`,
+the `arc-runners-h100`/`arc-runners-b200` shim modules, `clusters.yaml`,
+`deploy.sh`, and everything else under `osdc/`. The first time a given
+SHA deploys, the resolver calls GitHub `/releases/latest`, resolves the
+digest with `crane`, and writes the entry to the `arc-runner-version-lock`
+ConfigMap in `osdc-system`. Every subsequent deploy of the same SHA
+returns the exact same `tag@digest` from the ConfigMap — no GitHub API
+call, no `crane` call, no write.
+
+## Why per-commit
+
+Reproducibility for rollbacks **within the 20-SHA rolling window**.
+`git checkout <old-sha> && just deploy-module <cluster> arc-runners`
+reproduces the exact image that ran when that commit was originally
+deployed, *as long as the SHA is still inside the window*. Pair with the
+cluster's other module versions and you have a bit-for-bit rollback for
+recent history.
+
+The window is the last 20 OSDC SHAs (newest first). Rolling back to a
+SHA that has aged out of the window will create a new entry with the
+same SHA but potentially a different `tag@digest` — the original digest
+is not recoverable from the lock once it ages out. The replay is still
+safe (digest-pinned, recorded in the ConfigMap), but it is no longer
+bit-for-bit identical to the original deploy.
+
+Because the key is "any commit under `osdc/`", shim module changes
+(`arc-runners-h100`, `arc-runners-b200`), `clusters.yaml` edits, and
+unrelated module commits all bump the SHA and produce a new lock entry.
+Reproducibility is per-OSDC-commit, not per-`arc-runners`-commit.
+
+## ConfigMap shape
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arc-runner-version-lock
+  namespace: osdc-system
+  labels:
+    app.kubernetes.io/managed-by: osdc-deploy-log
+    osdc.io/lock-kind: arc-runner-version
+data:
+  history.json: |
+    [
+      {"osdc_sha": "3c22361...", "tag": "2.335.0", "digest": "sha256:abc...", "resolved_at": "2026-06-15T17:42:11Z"},
+      {"osdc_sha": "1a0f2e4...", "tag": "2.335.0", "digest": "sha256:abc...", "resolved_at": "2026-06-08T09:03:55Z"}
+    ]
+```
+
+Two different SHAs sharing the same `tag@digest` is the common case
+(most OSDC commits don't bump the upstream runner). The dedupe key is
+`osdc_sha`, not `tag` — multiple entries with the same tag are
+expected and correct.
+
+Fields: `osdc_sha` (40-char hex, the cache key), `tag` (release tag with
+leading `v` stripped), `digest` (`sha256:<64-hex>`, the OCI manifest-list
+digest — kubelet picks the per-arch manifest at pull time), `resolved_at`
+(ISO8601 UTC).
+
+History is capped at 20, newest first. Re-resolving the same SHA drops
+its older entry before prepending the new one.
+
+## Concurrent deploys
+
+The three `arc-runners*` modules (`arc-runners`, `arc-runners-h100`,
+`arc-runners-b200`) deploy concurrently and all read/write the same
+ConfigMap. Writes use Kubernetes optimistic concurrency: the resolver
+reads `metadata.resourceVersion`, includes it in the `replace` call, and
+the API server rejects the write with 409 if another deploy beat it.
+
+On 409 the loser re-reads the ConfigMap. If the winner already pinned
+this SHA, the loser returns the winner's `tag@digest` instead of writing
+— so all three modules end up with the same image. If the winner pinned
+a different SHA (none of the runners pinned ours), the loser retries the
+write with the fresh `resourceVersion`. Up to 5 attempts before giving
+up.
+
+## Rollback paths
+
+1. **Revert to an earlier OSDC commit.** `git checkout <old-sha> &&
+   just deploy-module <cluster> arc-runners`. If `<old-sha>` is still
+   inside the 20-entry window, the same `tag@digest` is replayed
+   exactly. Outside the window, the resolver re-resolves to today's
+   latest and writes a new entry (same `osdc_sha`, potentially
+   different `tag@digest` than the original).
+
+2. **Pin to a known-good tag.** Add `arc.runner_image_tag: "<tag>"`
+   under the cluster's `arc:` block in `clusters.yaml`, then redeploy.
+   The resolver is bypassed entirely: deployed image becomes
+   `ghcr.io/actions/actions-runner:<tag>` (tag-only, no digest), no
+   GitHub API call, no `crane` call, ConfigMap untouched. Removing
+   the key on a later deploy returns the cluster to auto-resolution.
+
+## Failure modes
+
+Each of these aborts the deploy with a non-zero exit and a single-line
+stderr message. Operator response is the same in every case: pin
+`arc.runner_image_tag` in `clusters.yaml` and re-run the deploy, then
+investigate before unpinning.
+
+- `git log` returns no commit history under the OSDC root (shallow
+  clone) — refetch full history or pin manually.
+- GitHub `/releases/latest` HTTP error, timeout, or response missing
+  `tag_name`.
+- `crane digest` exits non-zero (ghcr unreachable, tag missing, or auth
+  failure on the runner image).
+- ConfigMap read returns malformed JSON or entries missing
+  `osdc_sha`/`tag`/`digest`.
+- ConfigMap write fails after 5 conflict-retry attempts, or fails with a
+  non-409 error (RBAC, API outage).
+
+## Why digest pinning
+
+Tags on ghcr are mutable in principle — a re-push of the same tag would
+silently shift what kubelet pulls on the next pod restart. Digests are
+content-addressed and cannot be changed. The ConfigMap records exactly
+what was deployed, and the pod manifest pulls exactly that.
+
+## Why no Renovate bot
+
+Deploy-time resolution avoids running and maintaining bot infrastructure
+in this repo and avoids the PR-churn cycle for a value that is read
+fresh on every deploy anyway. Trade-off: deploys depend on GitHub
+releases and ghcr being reachable at deploy time (see Failure modes for
+the operator response when they are not).
+
+## Where to look
+
+- `modules/arc-runners/scripts/python/resolve_runner_version.py` — the
+  resolver implementation.
+- `modules/arc-runners/deploy.sh` — invokes the resolver and exports
+  `RUNNER_IMAGE` for the generator. The `arc-runners-h100` and
+  `arc-runners-b200` variants `exec` into this `deploy.sh` and inherit
+  the resolved image unchanged.
+- `arc-runner-version-lock` ConfigMap in the `osdc-system` namespace —
+  the lock file itself.
+- `modules/arc-runners/tests/smoke/test_runner_version_lock.py` — smoke
+  test that validates the ConfigMap shape and cross-checks the entry
+  whose `osdc_sha` matches the current commit against the deployed
+  `AutoscalingRunnerSet` pod templates.

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1844,6 +1844,9 @@ smoke cluster:
     # each variant's own deploy.sh, e.g. modules/arc-runners-b200/deploy.sh).
     # Generation must happen ONCE before any pytest worker starts —
     # previously the test fixture shelled out, which raced under pytest-xdist.
+    # OSDC_RESOLVER_READONLY: smoke must not mutate the lock ConfigMap or hit
+    # GitHub; it reads the newest cached entry the live deploy already wrote.
+    export OSDC_RESOLVER_READONLY=1
     for mod in $MODULES; do
         case "$mod" in
             arc-runners | arc-runners-*)
@@ -1856,6 +1859,7 @@ smoke cluster:
                 ;;
         esac
     done
+    unset OSDC_RESOLVER_READONLY
 
     export OSDC_ROOT="${ROOT}"
     export OSDC_UPSTREAM="${UPSTREAM}"
@@ -1991,6 +1995,15 @@ generate-arc-runners cluster:
     OUTPUT_DIR="${ARC_RUNNERS_OUTPUT_DIR:-$MODULE_DIR/generated}"
     TEMPLATE="${ARC_RUNNERS_TEMPLATE:-$MODULE_DIR/templates/runner.yaml.tpl}"
     MODULE_NAME="${ARC_RUNNERS_MODULE_NAME:-arc-runners}"
+
+    CFG="{{UPSTREAM}}/scripts/cluster-config.py"
+    EXPLICIT_TAG=$(uv run "$CFG" "$CLUSTER" arc.runner_image_tag "")
+    if [[ -n "$EXPLICIT_TAG" ]]; then
+      RUNNER_IMAGE="ghcr.io/actions/actions-runner:$EXPLICIT_TAG"
+    else
+      RUNNER_IMAGE=$(uv run "$MODULE_DIR/scripts/python/resolve_runner_version.py" "$CLUSTER")
+    fi
+    export RUNNER_IMAGE
 
     ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
         ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \

--- a/osdc/modules/arc-runners/deploy.sh
+++ b/osdc/modules/arc-runners/deploy.sh
@@ -47,6 +47,14 @@ if ! uv run "$CFG" "$CLUSTER" has-module arc; then
 fi
 
 # --- Step 1: Generate ARC runner configs ---
+EXPLICIT_TAG=$(uv run "$CFG" "$CLUSTER" arc.runner_image_tag "")
+if [[ -n "$EXPLICIT_TAG" ]]; then
+  RUNNER_IMAGE="ghcr.io/actions/actions-runner:$EXPLICIT_TAG"
+else
+  RUNNER_IMAGE=$(uv run "$MODULE_DIR/scripts/python/resolve_runner_version.py" "$CLUSTER")
+fi
+export RUNNER_IMAGE
+
 echo "Generating ARC runner configs from definitions..."
 ARC_RUNNERS_DEFS_DIR="$DEFS_DIR" \
   ARC_RUNNERS_OUTPUT_DIR="$OUTPUT_DIR" \

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -414,9 +414,7 @@ def main():
         log_error(f"No 'arc-runners.github_config_url' configured for cluster '{cluster_id}' in clusters.yaml")
         return 1
 
-    # Resolve runner image tag from arc.runner_image_tag (shared with arc module)
-    runner_image_tag = resolve_value(cluster_cfg, defaults, "arc.runner_image_tag") or "2.333.1"
-    cluster_config["runner_image"] = f"ghcr.io/actions/actions-runner:{runner_image_tag}"
+    cluster_config["runner_image"] = os.environ["RUNNER_IMAGE"]
 
     proactive_cap = cluster_cfg.get("proactive_capacity_max")
     if proactive_cap is not None and (

--- a/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Pin the actions/runner image per OSDC commit SHA.
+
+Lookup key is the SHA of the most recent commit touching anything under
+``osdc/`` (the project directory). Same SHA -> same ``tag@digest``
+within the 20-entry rolling window: re-deploying a recent commit
+reproduces the exact image that was deployed the first time it ran.
+Entries that age out of the window will re-resolve to whatever is
+``latest`` at the next deploy of that SHA.
+
+A miss (new SHA) calls GitHub /releases/latest, resolves the digest via
+crane, and prepends an entry to the `arc-runner-version-lock` ConfigMap
+in `osdc-system`. Writes use optimistic concurrency (resourceVersion);
+on 409 the loser re-reads — if the winner pinned this SHA, the loser
+returns the winner's image instead of writing.
+
+Operator override: set `arc.runner_image_tag` in `clusters.yaml`; the
+caller bypasses this script entirely in that case.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import requests
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import ConfigMap
+
+GITHUB_RELEASES_URL = "https://api.github.com/repos/actions/runner/releases/latest"
+IMAGE_REPO = "ghcr.io/actions/actions-runner"
+
+CM_NAME = "arc-runner-version-lock"
+CM_NAMESPACE = "osdc-system"
+CM_KEY = "history.json"
+HISTORY_MAX = 20
+
+CM_LABELS = {
+    "app.kubernetes.io/managed-by": "osdc-deploy-log",
+    "osdc.io/lock-kind": "arc-runner-version",
+}
+
+OSDC_PATH = "."
+
+REQUEST_TIMEOUT_SECONDS = 10
+MAX_WRITE_ATTEMPTS = 5
+
+
+def osdc_root() -> str:
+    env_root = os.environ.get("OSDC_UPSTREAM")
+    if env_root:
+        return env_root
+    return str(Path(__file__).resolve().parents[3])
+
+
+def osdc_sha() -> str:
+    root = osdc_root()
+    result = subprocess.run(
+        ["git", "-C", root, "log", "-1", "--format=%H", "--", OSDC_PATH],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip()
+    if not sha:
+        raise ValueError(
+            f"git log returned no commit history under {root}. "
+            "Likely a shallow clone — refetch with full history, or pin "
+            "arc.runner_image_tag in clusters.yaml to bypass the resolver."
+        )
+    return sha
+
+
+def fetch_latest_tag(token: str | None) -> str:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.get(GITHUB_RELEASES_URL, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+    resp.raise_for_status()
+    data = resp.json()
+    tag = data.get("tag_name")
+    if not isinstance(tag, str) or not tag:
+        raise ValueError("GitHub releases response missing 'tag_name'")
+    return tag.lstrip("v")
+
+
+def read_history(client: Client) -> tuple[list[dict[str, str]], bool, str | None]:
+    try:
+        cm = client.get(ConfigMap, name=CM_NAME, namespace=CM_NAMESPACE)
+    except ApiError as e:
+        if getattr(e.status, "code", None) == 404:
+            return [], False, None
+        raise
+    rv = cm.metadata.resourceVersion if cm.metadata else None
+    raw = (cm.data or {}).get(CM_KEY)
+    if raw is None:
+        return [], True, rv
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError(f"{CM_KEY} must contain a JSON list")
+    for entry in parsed:
+        if not isinstance(entry, dict) or not {"osdc_sha", "tag", "digest"} <= entry.keys():
+            raise ValueError(f"{CM_KEY} entries must be objects with 'osdc_sha', 'tag', 'digest'")
+    return parsed, True, rv
+
+
+def find_cached_entry(history: list[dict[str, str]], sha: str) -> dict[str, str] | None:
+    for entry in history:
+        if entry.get("osdc_sha") == sha:
+            return entry
+    return None
+
+
+def resolve_digest(tag: str) -> str:
+    ref = f"{IMAGE_REPO}:{tag}"
+    result = subprocess.run(
+        ["crane", "digest", ref],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    if not digest.startswith("sha256:"):
+        raise ValueError(f"crane digest returned unexpected value: {digest!r}")
+    return digest
+
+
+def update_history(
+    history: list[dict[str, str]],
+    sha: str,
+    tag: str,
+    digest: str,
+    now: datetime,
+) -> list[dict[str, str]]:
+    new_entry = {
+        "osdc_sha": sha,
+        "tag": tag,
+        "digest": digest,
+        "resolved_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    kept = [e for e in history if e.get("osdc_sha") != sha]
+    return [new_entry, *kept][:HISTORY_MAX]
+
+
+def write_history(
+    client: Client,
+    history: list[dict[str, str]],
+    cm_exists: bool,
+    resource_version: str | None,
+) -> None:
+    payload = json.dumps(history, indent=2)
+    metadata = ObjectMeta(name=CM_NAME, namespace=CM_NAMESPACE, labels=CM_LABELS)
+    if cm_exists and resource_version is not None:
+        metadata.resourceVersion = resource_version
+    cm = ConfigMap(metadata=metadata, data={CM_KEY: payload})
+    if cm_exists:
+        client.replace(cm)
+    else:
+        client.create(cm)
+
+
+def build_client() -> Client:
+    _force_ipv4()
+    return Client()
+
+
+def _force_ipv4() -> None:
+    # AWS EKS endpoints advertise AAAA records but reject IPv6 connects from
+    # many corporate/home networks. Python's default getaddrinfo returns IPv6
+    # first and socket.create_connection then blocks for the full OS timeout
+    # (~100s) before falling back. kubectl (Go) handles this with happy-eyeballs;
+    # stdlib socket does not. Pin to IPv4 to avoid the dead-end.
+    original = socket.getaddrinfo
+
+    def ipv4_only(host, port, family=0, *args, **kwargs):
+        if family in (0, socket.AF_UNSPEC):
+            family = socket.AF_INET
+        return original(host, port, family, *args, **kwargs)
+
+    socket.getaddrinfo = ipv4_only
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _run(cluster_id: str, client: Client) -> str:
+    print(f"resolve_runner_version: cluster={cluster_id}", file=sys.stderr)
+
+    sha = osdc_sha()
+    print(f"resolve_runner_version: osdc_sha={sha}", file=sys.stderr)
+
+    history, cm_exists, rv = read_history(client)
+
+    cached = find_cached_entry(history, sha)
+    if cached is not None:
+        tag, digest = cached["tag"], cached["digest"]
+        print(f"resolve_runner_version: cache hit, {tag}@{digest}", file=sys.stderr)
+        return f"{IMAGE_REPO}:{tag}@{digest}"
+
+    if os.environ.get("OSDC_RESOLVER_READONLY"):
+        raise ValueError(
+            f"OSDC_RESOLVER_READONLY set but {CM_NAME} has no entry for osdc_sha={sha}. "
+            "Run a normal deploy (without OSDC_RESOLVER_READONLY) to populate it first."
+        )
+
+    token = os.environ.get("GITHUB_TOKEN") or None
+    tag = fetch_latest_tag(token)
+    print(f"resolve_runner_version: latest release tag={tag}", file=sys.stderr)
+
+    print("resolve_runner_version: resolving digest via crane", file=sys.stderr)
+    digest = resolve_digest(tag)
+    print(f"resolve_runner_version: resolved digest={digest}", file=sys.stderr)
+
+    for attempt in range(MAX_WRITE_ATTEMPTS):
+        if attempt > 0:
+            history, cm_exists, rv = read_history(client)
+            cached = find_cached_entry(history, sha)
+            if cached is not None:
+                tag, digest = cached["tag"], cached["digest"]
+                print(f"resolve_runner_version: lost race, returning {tag}@{digest}", file=sys.stderr)
+                return f"{IMAGE_REPO}:{tag}@{digest}"
+
+        new_history = update_history(history, sha, tag, digest, now_utc())
+        try:
+            write_history(client, new_history, cm_exists, rv)
+            print(f"resolve_runner_version: wrote ConfigMap, entries={len(new_history)}", file=sys.stderr)
+            return f"{IMAGE_REPO}:{tag}@{digest}"
+        except ApiError as e:
+            if getattr(e.status, "code", None) == 409 and attempt < MAX_WRITE_ATTEMPTS - 1:
+                print(
+                    f"resolve_runner_version: write conflict (attempt {attempt + 1}), retrying",
+                    file=sys.stderr,
+                )
+                continue
+            raise
+
+    raise RuntimeError(f"write retries exhausted after {MAX_WRITE_ATTEMPTS} attempts")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: resolve_runner_version.py <cluster-id>", file=sys.stderr)
+        return 2
+    cluster_id = argv[1]
+
+    try:
+        client = build_client()
+        image_ref = _run(cluster_id, client)
+    except requests.RequestException as e:
+        print(f"resolve_runner_version: GitHub API request failed: {e}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        print(f"resolve_runner_version: subprocess failed ({e.cmd[0]}): {stderr or e}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"resolve_runner_version: ConfigMap history.json is not valid JSON: {e}", file=sys.stderr)
+        return 1
+    except ApiError as e:
+        print(f"resolve_runner_version: kubernetes API error: {e}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"resolve_runner_version: {e}", file=sys.stderr)
+        return 1
+
+    print(image_ref)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/test_generate_runners.py
@@ -152,9 +152,6 @@ def real_template():
 
 FAKE_CLUSTERS_YAML = {
     "defaults": {
-        "arc": {
-            "runner_image_tag": "2.333.1",
-        },
         "arc-runners": {
             "github_config_url": "https://github.com/default-org",
             "github_secret_name": "default-secret",
@@ -2004,6 +2001,13 @@ class TestRealTemplate:
 
 
 class TestMain:
+    @pytest.fixture(autouse=True)
+    def _runner_image_env(self, monkeypatch):
+        monkeypatch.setenv(
+            "RUNNER_IMAGE",
+            "ghcr.io/actions/actions-runner:2.333.1@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        )
+
     def test_no_args_exits_1(self):
         with patch.object(sys, "argv", ["generate_runners.py"]):
             assert main() == 1
@@ -2080,6 +2084,33 @@ class TestMain:
         assert generated[0].name == "runner-a.yaml"
         assert generated[1].name == "runner-b.yaml"
 
+    def test_runner_image_from_env(self, tmp_path, monkeypatch):
+        """main() renders RUNNER_IMAGE env var into the runner template; no clusters.yaml key needed."""
+        p = tmp_path / "clusters.yaml"
+        p.write_text(yaml.dump(FAKE_CLUSTERS_YAML, default_flow_style=False))
+
+        defs_dir = tmp_path / "defs"
+        defs_dir.mkdir()
+        make_def_file(defs_dir, "runner-a", "m6i.32xlarge", 2, 4)
+        make_nodepool_defs(tmp_path, ["m6i.32xlarge"])
+
+        output_dir = tmp_path / "out"
+
+        explicit_ref = "ghcr.io/actions/actions-runner:2.999.0@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        monkeypatch.setenv("RUNNER_IMAGE", explicit_ref)
+        monkeypatch.setenv("OSDC_ROOT", str(tmp_path))
+        monkeypatch.setenv("ARC_RUNNERS_DEFS_DIR", str(defs_dir))
+        monkeypatch.setenv("ARC_RUNNERS_TEMPLATE", str(tmp_path / "tpl.yaml"))
+        monkeypatch.setenv("ARC_RUNNERS_OUTPUT_DIR", str(output_dir))
+
+        (tmp_path / "tpl.yaml").write_text(MINIMAL_TEMPLATE)
+
+        with patch.object(sys, "argv", ["generate_runners.py", "staging"]):
+            assert main() == 0
+
+        rendered = (output_dir / "runner-a.yaml").read_text()
+        assert explicit_ref in rendered
+
     def test_output_dir_cleaned(self, tmp_path, monkeypatch):
         """Output dir is cleaned before generation so stale files are removed."""
         p = tmp_path / "clusters.yaml"
@@ -2135,7 +2166,6 @@ class TestMain:
         """main() does NOT force proactive_capacity to zero for production clusters."""
         prod_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2183,7 +2213,6 @@ class TestMain:
         """main() honors proactive_capacity_max: 0 in clusters.yaml."""
         prod_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2232,7 +2261,6 @@ class TestMain:
         """main() exits 1 when proactive_capacity_max is not a non-negative integer."""
         invalid_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",
@@ -2275,7 +2303,6 @@ class TestMain:
         """main() honors cluster-level pause_runners=true by forcing maxRunners: 0."""
         paused_config = {
             "defaults": {
-                "arc": {"runner_image_tag": "2.333.1"},
                 "arc-runners": {
                     "github_config_url": "https://github.com/prod-org",
                     "github_secret_name": "prod-secret",

--- a/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
@@ -1,0 +1,856 @@
+"""Tests for resolve_runner_version.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+import resolve_runner_version as rrv
+from lightkube.core.exceptions import ApiError
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+_SHA_C = "c" * 40
+
+
+def _api_error(code: int) -> ApiError:
+    err = ApiError.__new__(ApiError)
+    err.status = MagicMock(code=code)
+    return err
+
+
+def _release_response(tag: str = "v2.335.0") -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"tag_name": tag}
+    return resp
+
+
+def _configmap(history: list[dict[str, str]] | str, resource_version: str | None = "100") -> MagicMock:
+    cm = MagicMock()
+    cm.data = {rrv.CM_KEY: history if isinstance(history, str) else json.dumps(history)}
+    cm.metadata = MagicMock(resourceVersion=resource_version)
+    return cm
+
+
+def _crane_result(digest: str = "sha256:abc123") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["crane", "digest", "x"], returncode=0, stdout=f"{digest}\n", stderr="")
+
+
+def _entry(sha: str, tag: str, digest: str, resolved_at: str = "2026-06-01T00:00:00Z") -> dict[str, str]:
+    return {"osdc_sha": sha, "tag": tag, "digest": digest, "resolved_at": resolved_at}
+
+
+@pytest.fixture
+def fixed_now():
+    return datetime(2026, 6, 15, 17, 42, 11, tzinfo=UTC)
+
+
+@pytest.fixture
+def patched(monkeypatch, fixed_now):
+    monkeypatch.setattr(rrv, "now_utc", lambda: fixed_now)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("OSDC_RESOLVER_READONLY", raising=False)
+    return monkeypatch
+
+
+# --- osdc_root ---
+
+
+class TestOsdcRoot:
+    def test_env_var_present(self, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", "/custom/path")
+        assert rrv.osdc_root() == "/custom/path"
+
+    def test_env_var_absent_falls_back_to_script_parent(self, monkeypatch):
+        monkeypatch.delenv("OSDC_UPSTREAM", raising=False)
+        expected = str(Path(rrv.__file__).resolve().parents[3])
+        assert rrv.osdc_root() == expected
+
+    def test_env_var_empty_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", "")
+        expected = str(Path(rrv.__file__).resolve().parents[3])
+        assert rrv.osdc_root() == expected
+
+
+# --- osdc_sha ---
+
+
+class TestOsdcSha:
+    def test_returns_stripped_sha(self, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", "/fake/root")
+        captured = {}
+
+        def fake_run(cmd, check, capture_output, text):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=f"{_SHA_A}\n", stderr="")
+
+        monkeypatch.setattr(rrv.subprocess, "run", fake_run)
+        assert rrv.osdc_sha() == _SHA_A
+        assert captured["cmd"] == ["git", "-C", "/fake/root", "log", "-1", "--format=%H", "--", rrv.OSDC_PATH]
+        assert rrv.OSDC_PATH == "."
+
+    def test_empty_output_raises(self, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", "/fake/root")
+        monkeypatch.setattr(
+            rrv.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=a[0], returncode=0, stdout="\n", stderr=""),
+        )
+        with pytest.raises(ValueError, match="no commit history under"):
+            rrv.osdc_sha()
+
+    def test_uses_osdc_root_fallback_when_env_absent(self, monkeypatch):
+        monkeypatch.delenv("OSDC_UPSTREAM", raising=False)
+        captured = {}
+
+        def fake_run(cmd, check, capture_output, text):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=f"{_SHA_A}\n", stderr="")
+
+        monkeypatch.setattr(rrv.subprocess, "run", fake_run)
+        rrv.osdc_sha()
+        expected_root = str(Path(rrv.__file__).resolve().parents[3])
+        assert captured["cmd"][2] == expected_root
+
+    def test_subprocess_error_propagates(self, monkeypatch):
+        monkeypatch.setenv("OSDC_UPSTREAM", "/fake/root")
+
+        def fake_run(*a, **kw):
+            raise subprocess.CalledProcessError(returncode=128, cmd=a[0], stderr="not a git repo")
+
+        monkeypatch.setattr(rrv.subprocess, "run", fake_run)
+        with pytest.raises(subprocess.CalledProcessError):
+            rrv.osdc_sha()
+
+
+# --- fetch_latest_tag ---
+
+
+class TestFetchLatestTag:
+    def test_no_token_no_auth_header(self, patched):
+        captured = {}
+
+        def fake_get(url, headers, timeout):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _release_response("v2.335.0")
+
+        patched.setattr(rrv.requests, "get", fake_get)
+        tag = rrv.fetch_latest_tag(None)
+        assert tag == "2.335.0"
+        assert "Authorization" not in captured["headers"]
+        assert captured["url"] == rrv.GITHUB_RELEASES_URL
+        assert captured["timeout"] == rrv.REQUEST_TIMEOUT_SECONDS
+
+    def test_token_present_adds_bearer_header(self, patched):
+        captured = {}
+
+        def fake_get(url, headers, timeout):
+            captured["headers"] = headers
+            return _release_response("2.335.0")
+
+        patched.setattr(rrv.requests, "get", fake_get)
+        tag = rrv.fetch_latest_tag("ghp_xyz")
+        assert tag == "2.335.0"
+        assert captured["headers"]["Authorization"] == "Bearer ghp_xyz"
+
+    def test_missing_tag_name_raises(self, patched):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"name": "no-tag"}
+        patched.setattr(rrv.requests, "get", lambda *a, **kw: resp)
+        with pytest.raises(ValueError, match="tag_name"):
+            rrv.fetch_latest_tag(None)
+
+    def test_empty_tag_name_raises(self, patched):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"tag_name": ""}
+        patched.setattr(rrv.requests, "get", lambda *a, **kw: resp)
+        with pytest.raises(ValueError, match="tag_name"):
+            rrv.fetch_latest_tag(None)
+
+
+# --- read_history ---
+
+
+class TestReadHistory:
+    def test_404_returns_empty_and_false_and_none_rv(self):
+        client = MagicMock()
+        client.get.side_effect = _api_error(404)
+        history, exists, rv = rrv.read_history(client)
+        assert history == []
+        assert exists is False
+        assert rv is None
+
+    def test_non_404_api_error_reraised(self):
+        client = MagicMock()
+        client.get.side_effect = _api_error(403)
+        with pytest.raises(ApiError):
+            rrv.read_history(client)
+
+    def test_parses_valid_history_and_returns_resource_version(self):
+        entries = [_entry(_SHA_A, "2.335.0", "sha256:aaa", "2026-06-15T17:42:11Z")]
+        client = MagicMock()
+        client.get.return_value = _configmap(entries, resource_version="12345")
+        history, exists, rv = rrv.read_history(client)
+        assert history == entries
+        assert exists is True
+        assert rv == "12345"
+
+    def test_missing_data_key_returns_empty_exists(self):
+        client = MagicMock()
+        cm = MagicMock()
+        cm.data = {}
+        cm.metadata = MagicMock(resourceVersion="77")
+        client.get.return_value = cm
+        history, exists, rv = rrv.read_history(client)
+        assert history == []
+        assert exists is True
+        assert rv == "77"
+
+    def test_none_data_returns_empty_exists(self):
+        client = MagicMock()
+        cm = MagicMock()
+        cm.data = None
+        cm.metadata = MagicMock(resourceVersion="78")
+        client.get.return_value = cm
+        history, exists, rv = rrv.read_history(client)
+        assert history == []
+        assert exists is True
+        assert rv == "78"
+
+    def test_none_metadata_returns_none_rv(self):
+        client = MagicMock()
+        cm = MagicMock()
+        cm.data = None
+        cm.metadata = None
+        client.get.return_value = cm
+        history, exists, rv = rrv.read_history(client)
+        assert history == []
+        assert exists is True
+        assert rv is None
+
+    def test_malformed_json_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap("not-json{")
+        with pytest.raises(json.JSONDecodeError):
+            rrv.read_history(client)
+
+    def test_non_list_json_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap("{}")
+        with pytest.raises(ValueError, match="must contain a JSON list"):
+            rrv.read_history(client)
+
+    def test_entry_missing_osdc_sha_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap([{"tag": "2.0", "digest": "sha256:x"}])
+        with pytest.raises(ValueError, match="osdc_sha"):
+            rrv.read_history(client)
+
+    def test_entry_missing_tag_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap([{"osdc_sha": _SHA_A, "digest": "sha256:x"}])
+        with pytest.raises(ValueError, match="osdc_sha"):
+            rrv.read_history(client)
+
+    def test_entry_missing_digest_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap([{"osdc_sha": _SHA_A, "tag": "2.0"}])
+        with pytest.raises(ValueError, match="osdc_sha"):
+            rrv.read_history(client)
+
+    def test_entry_not_object_raises(self):
+        client = MagicMock()
+        client.get.return_value = _configmap(["not-an-object"])
+        with pytest.raises(ValueError, match="must be objects"):
+            rrv.read_history(client)
+
+
+# --- find_cached_entry ---
+
+
+class TestFindCachedEntry:
+    def test_hit_returns_full_entry(self):
+        e1 = _entry(_SHA_A, "2.335.0", "sha256:aaa")
+        e2 = _entry(_SHA_B, "2.334.0", "sha256:bbb")
+        assert rrv.find_cached_entry([e1, e2], _SHA_B) == e2
+
+    def test_miss_returns_none(self):
+        assert rrv.find_cached_entry([_entry(_SHA_A, "2.335.0", "sha256:aaa")], _SHA_C) is None
+
+    def test_empty_returns_none(self):
+        assert rrv.find_cached_entry([], _SHA_A) is None
+
+
+# --- update_history ---
+
+
+class TestUpdateHistory:
+    def test_prepends_new_entry(self, fixed_now):
+        existing = [_entry(_SHA_A, "2.334.0", "sha256:bbb", "2026-06-08T09:03:55Z")]
+        result = rrv.update_history(existing, _SHA_B, "2.335.0", "sha256:aaa", fixed_now)
+        assert result[0] == _entry(_SHA_B, "2.335.0", "sha256:aaa", "2026-06-15T17:42:11Z")
+        assert result[1] == existing[0]
+
+    def test_dedupes_existing_sha(self, fixed_now):
+        existing = [
+            _entry(_SHA_A, "2.334.0", "sha256:old1", "2026-05-01T00:00:00Z"),
+            _entry(_SHA_B, "2.335.0", "sha256:zzz", "2026-06-01T00:00:00Z"),
+            _entry(_SHA_C, "2.336.0", "sha256:other", "2026-06-10T00:00:00Z"),
+        ]
+        result = rrv.update_history(existing, _SHA_B, "2.337.0", "sha256:new", fixed_now)
+        shas = [e["osdc_sha"] for e in result]
+        assert shas.count(_SHA_B) == 1
+        assert result[0]["osdc_sha"] == _SHA_B
+        assert result[0]["tag"] == "2.337.0"
+        assert result[0]["digest"] == "sha256:new"
+        assert result[0]["resolved_at"] == "2026-06-15T17:42:11Z"
+        assert shas == [_SHA_B, _SHA_A, _SHA_C]
+
+    def test_does_not_dedupe_on_tag(self, fixed_now):
+        existing = [
+            _entry(_SHA_A, "2.335.0", "sha256:aaa", "2026-05-01T00:00:00Z"),
+            _entry(_SHA_B, "2.335.0", "sha256:bbb", "2026-06-01T00:00:00Z"),
+        ]
+        result = rrv.update_history(existing, _SHA_C, "2.335.0", "sha256:ccc", fixed_now)
+        tags = [e["tag"] for e in result]
+        assert tags == ["2.335.0", "2.335.0", "2.335.0"]
+        shas = [e["osdc_sha"] for e in result]
+        assert shas == [_SHA_C, _SHA_A, _SHA_B]
+
+    def test_trims_to_max(self, fixed_now):
+        existing = [_entry(f"{i:040x}", f"2.{i}.0", f"sha256:{i:03d}", "") for i in range(25)]
+        result = rrv.update_history(existing, _SHA_A, "9.0.0", "sha256:new", fixed_now)
+        assert len(result) == rrv.HISTORY_MAX
+        assert result[0]["osdc_sha"] == _SHA_A
+        assert result[0]["tag"] == "9.0.0"
+
+
+# --- resolve_digest ---
+
+
+class TestResolveDigest:
+    def test_strips_and_returns_digest(self, patched):
+        patched.setattr(rrv.subprocess, "run", lambda *a, **kw: _crane_result("sha256:abc"))
+        assert rrv.resolve_digest("2.335.0") == "sha256:abc"
+
+    def test_unexpected_output_raises(self, patched):
+        patched.setattr(
+            rrv.subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=0, stdout="not-a-digest\n", stderr=""),
+        )
+        with pytest.raises(ValueError, match="unexpected"):
+            rrv.resolve_digest("2.335.0")
+
+    def test_crane_nonzero_exit_raises_called_process_error(self, patched):
+        def fake_run(*a, **kw):
+            raise subprocess.CalledProcessError(returncode=1, cmd=a[0], stderr="unauthorized\n")
+
+        patched.setattr(rrv.subprocess, "run", fake_run)
+        with pytest.raises(subprocess.CalledProcessError):
+            rrv.resolve_digest("2.335.0")
+
+
+# --- write_history ---
+
+
+class TestWriteHistory:
+    def test_creates_when_not_exists(self):
+        client = MagicMock()
+        history = [_entry(_SHA_A, "2.335.0", "sha256:aaa", "2026-06-15T17:42:11Z")]
+        rrv.write_history(client, history, cm_exists=False, resource_version=None)
+        client.create.assert_called_once()
+        client.replace.assert_not_called()
+        cm_arg = client.create.call_args[0][0]
+        assert cm_arg.metadata.name == rrv.CM_NAME
+        assert cm_arg.metadata.namespace == rrv.CM_NAMESPACE
+        assert cm_arg.metadata.labels == rrv.CM_LABELS
+        assert getattr(cm_arg.metadata, "resourceVersion", None) is None
+        assert json.loads(cm_arg.data[rrv.CM_KEY]) == history
+
+    def test_replaces_when_exists_sets_resource_version(self):
+        client = MagicMock()
+        rrv.write_history(client, [_entry(_SHA_A, "x", "sha256:y", "z")], cm_exists=True, resource_version="42")
+        client.replace.assert_called_once()
+        client.create.assert_not_called()
+        cm_arg = client.replace.call_args[0][0]
+        assert cm_arg.metadata.resourceVersion == "42"
+
+    def test_create_ignores_resource_version_when_not_exists(self):
+        client = MagicMock()
+        rrv.write_history(client, [_entry(_SHA_A, "x", "sha256:y", "z")], cm_exists=False, resource_version="99")
+        client.create.assert_called_once()
+        cm_arg = client.create.call_args[0][0]
+        assert getattr(cm_arg.metadata, "resourceVersion", None) is None
+
+    def test_replace_with_none_resource_version_omits_field(self):
+        client = MagicMock()
+        rrv.write_history(client, [_entry(_SHA_A, "x", "sha256:y", "z")], cm_exists=True, resource_version=None)
+        client.replace.assert_called_once()
+        cm_arg = client.replace.call_args[0][0]
+        assert getattr(cm_arg.metadata, "resourceVersion", None) is None
+
+
+# --- main() end-to-end (mocking module boundaries) ---
+
+
+class _Env:
+    """Holds the mocked module boundaries for an end-to-end main() run."""
+
+    def __init__(
+        self,
+        monkeypatch,
+        *,
+        sha: str = _SHA_A,
+        tag: str = "2.335.0",
+        digest: str = "sha256:abc",
+        history: list[dict[str, str]] | None = None,
+        history_exists: bool = True,
+        resource_version: str | None = "100",
+    ):
+        self.client = MagicMock()
+        self.fetched_token: list[str | None] = []
+        self.crane_calls: list[str] = []
+        self.history = history if history is not None else []
+        self.history_exists = history_exists
+        self.resource_version = resource_version if history_exists else None
+        self.sha = sha
+
+        def fake_fetch(token):
+            self.fetched_token.append(token)
+            return tag
+
+        def fake_read(_client):
+            return list(self.history), self.history_exists, self.resource_version
+
+        def fake_resolve(_tag):
+            self.crane_calls.append(_tag)
+            return digest
+
+        monkeypatch.setattr(rrv, "fetch_latest_tag", fake_fetch)
+        monkeypatch.setattr(rrv, "read_history", fake_read)
+        monkeypatch.setattr(rrv, "resolve_digest", fake_resolve)
+        monkeypatch.setattr(rrv, "build_client", lambda: self.client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: self.sha)
+        monkeypatch.setattr(rrv, "now_utc", lambda: datetime(2026, 6, 15, 17, 42, 11, tzinfo=UTC))
+
+
+class TestMain:
+    def test_usage_when_no_args(self, capsys):
+        rc = rrv.main(["resolve_runner_version.py"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err
+
+    def test_configmap_missing_first_deploy(self, monkeypatch, capsys):
+        env = _Env(monkeypatch, sha=_SHA_A, history=[], history_exists=False)
+        rc = rrv.main(["resolve_runner_version.py", "test-cluster"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.335.0@sha256:abc"
+        env.client.create.assert_called_once()
+        env.client.replace.assert_not_called()
+        assert env.crane_calls == ["2.335.0"]
+        cm = env.client.create.call_args[0][0]
+        history = json.loads(cm.data[rrv.CM_KEY])
+        assert history[0]["osdc_sha"] == _SHA_A
+        assert history[0]["tag"] == "2.335.0"
+        assert history[0]["digest"] == "sha256:abc"
+
+    def test_sha_hit_no_api_no_crane_no_write(self, monkeypatch, capsys):
+        env = _Env(
+            monkeypatch,
+            sha=_SHA_A,
+            history=[_entry(_SHA_A, "2.334.0", "sha256:cached", "2026-05-01T00:00:00Z")],
+        )
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.334.0@sha256:cached"
+        env.client.create.assert_not_called()
+        env.client.replace.assert_not_called()
+        assert env.crane_calls == []
+        assert env.fetched_token == []
+
+    def test_sha_miss_prepends_and_writes(self, monkeypatch, capsys):
+        env = _Env(
+            monkeypatch,
+            sha=_SHA_C,
+            tag="2.335.0",
+            digest="sha256:newdigest",
+            history=[_entry(_SHA_A, "2.334.0", "sha256:old", "2026-05-01T00:00:00Z")],
+            resource_version="500",
+        )
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        env.client.replace.assert_called_once()
+        cm = env.client.replace.call_args[0][0]
+        assert cm.metadata.resourceVersion == "500"
+        history = json.loads(cm.data[rrv.CM_KEY])
+        assert history[0] == _entry(_SHA_C, "2.335.0", "sha256:newdigest", "2026-06-15T17:42:11Z")
+        assert history[1]["osdc_sha"] == _SHA_A
+        capsys.readouterr()
+
+    def test_sha_miss_with_existing_history_for_other_shas(self, monkeypatch):
+        existing = [
+            _entry(_SHA_A, "2.333.0", "sha256:a", "2026-04-01T00:00:00Z"),
+            _entry(_SHA_B, "2.334.0", "sha256:b", "2026-05-01T00:00:00Z"),
+        ]
+        env = _Env(monkeypatch, sha=_SHA_C, tag="2.335.0", digest="sha256:c", history=existing)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        cm = env.client.replace.call_args[0][0]
+        history = json.loads(cm.data[rrv.CM_KEY])
+        assert len(history) == 3
+        assert history[0]["osdc_sha"] == _SHA_C
+        assert history[1] == existing[0]
+        assert history[2] == existing[1]
+
+    def test_history_trimmed_to_20_after_new_miss(self, monkeypatch):
+        existing = [_entry(f"{i:040x}", f"2.{i}.0", f"sha256:{i:03d}", "") for i in range(20)]
+        env = _Env(monkeypatch, sha=_SHA_A, tag="new", digest="sha256:n", history=existing)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        cm = env.client.replace.call_args[0][0]
+        history = json.loads(cm.data[rrv.CM_KEY])
+        assert len(history) == rrv.HISTORY_MAX
+        assert history[0]["osdc_sha"] == _SHA_A
+        assert history[0]["tag"] == "new"
+
+    def test_dedupe_on_osdc_sha_not_tag(self, monkeypatch):
+        existing = [
+            _entry(_SHA_A, "2.335.0", "sha256:a", "2026-04-01T00:00:00Z"),
+            _entry(_SHA_B, "2.335.0", "sha256:b", "2026-05-01T00:00:00Z"),
+        ]
+        env = _Env(monkeypatch, sha=_SHA_C, tag="2.335.0", digest="sha256:c", history=existing)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        cm = env.client.replace.call_args[0][0]
+        history = json.loads(cm.data[rrv.CM_KEY])
+        assert len(history) == 3
+        tags = [e["tag"] for e in history]
+        assert tags == ["2.335.0", "2.335.0", "2.335.0"]
+        shas = [e["osdc_sha"] for e in history]
+        assert shas == [_SHA_C, _SHA_A, _SHA_B]
+
+    def test_readonly_with_matching_sha_returns_cached(self, monkeypatch, capsys):
+        monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
+        env = _Env(
+            monkeypatch,
+            sha=_SHA_A,
+            history=[
+                _entry(_SHA_A, "2.336.0", "sha256:new", "2026-06-10T00:00:00Z"),
+                _entry(_SHA_B, "2.335.0", "sha256:old", "2026-05-01T00:00:00Z"),
+            ],
+        )
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.336.0@sha256:new"
+        assert env.fetched_token == []
+        assert env.crane_calls == []
+        env.client.create.assert_not_called()
+        env.client.replace.assert_not_called()
+
+    def test_readonly_with_unknown_sha_fails(self, monkeypatch, capsys):
+        monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
+        env = _Env(
+            monkeypatch,
+            sha=_SHA_C,
+            history=[_entry(_SHA_A, "2.335.0", "sha256:a", "2026-05-01T00:00:00Z")],
+        )
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "OSDC_RESOLVER_READONLY" in captured.err
+        assert _SHA_C in captured.err
+        assert env.fetched_token == []
+        assert env.crane_calls == []
+        env.client.create.assert_not_called()
+        env.client.replace.assert_not_called()
+
+    def test_readonly_empty_history_fails(self, monkeypatch, capsys):
+        monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
+        env = _Env(monkeypatch, sha=_SHA_A, history=[], history_exists=False)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "OSDC_RESOLVER_READONLY" in captured.err
+        assert env.fetched_token == []
+        assert env.crane_calls == []
+        env.client.create.assert_not_called()
+
+    def test_github_api_http_error_exits_nonzero_no_mutation(self, monkeypatch, capsys):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+
+        def fake_fetch(_token):
+            raise requests.HTTPError("503 Service Unavailable")
+
+        monkeypatch.setattr(rrv, "fetch_latest_tag", fake_fetch)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        assert "GitHub API" in capsys.readouterr().err
+        client.create.assert_not_called()
+        client.replace.assert_not_called()
+
+    def test_github_api_missing_tag_name_exits_nonzero(self, monkeypatch, capsys, patched):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {}
+        patched.setattr(rrv.requests, "get", lambda *a, **kw: resp)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        assert "tag_name" in capsys.readouterr().err
+        client.create.assert_not_called()
+        client.replace.assert_not_called()
+
+    def test_crane_failure_exits_nonzero_no_mutation(self, monkeypatch, capsys):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        monkeypatch.setattr(rrv, "fetch_latest_tag", lambda _t: "2.335.0")
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+
+        def fake_resolve(_tag):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["crane"], stderr="unauthorized")
+
+        monkeypatch.setattr(rrv, "resolve_digest", fake_resolve)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        assert "crane" in capsys.readouterr().err
+        client.create.assert_not_called()
+        client.replace.assert_not_called()
+
+    def test_git_log_empty_exits_nonzero(self, monkeypatch, capsys):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        def fake_sha():
+            raise ValueError("git log returned no commit history under /fake/root")
+
+        monkeypatch.setattr(rrv, "osdc_sha", fake_sha)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        assert "git log" in capsys.readouterr().err
+        client.create.assert_not_called()
+
+    def test_malformed_configmap_history_exits_nonzero_no_mutation(self, monkeypatch, capsys):
+        client = MagicMock()
+        client.get.return_value = _configmap("not json {")
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        monkeypatch.setattr(rrv, "fetch_latest_tag", lambda _t: "2.335.0")
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "history.json" in err or "JSON" in err
+        client.create.assert_not_called()
+        client.replace.assert_not_called()
+
+    def test_configmap_write_failure_propagates_exit_nonzero(self, monkeypatch, capsys):
+        client = MagicMock()
+        client.create.side_effect = _api_error(500)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        monkeypatch.setattr(rrv, "fetch_latest_tag", lambda _t: "2.335.0")
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+        monkeypatch.setattr(rrv, "resolve_digest", lambda _t: "sha256:abc")
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 1
+        assert "kubernetes API" in capsys.readouterr().err
+
+    def test_github_token_env_var_passed_through(self, monkeypatch):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        seen = []
+
+        def fake_fetch(token):
+            seen.append(token)
+            return "2.335.0"
+
+        monkeypatch.setattr(rrv, "fetch_latest_tag", fake_fetch)
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+        monkeypatch.setattr(rrv, "resolve_digest", lambda _t: "sha256:abc")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test_token")
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        assert seen == ["ghp_test_token"]
+
+    def test_github_token_absent(self, monkeypatch):
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: _SHA_A)
+        seen = []
+
+        def fake_fetch(token):
+            seen.append(token)
+            return "2.335.0"
+
+        monkeypatch.setattr(rrv, "fetch_latest_tag", fake_fetch)
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], False, None))
+        monkeypatch.setattr(rrv, "resolve_digest", lambda _t: "sha256:abc")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        assert rc == 0
+        assert seen == [None]
+
+
+# --- concurrency retry loop in _run ---
+
+
+class TestWriteRetryConcurrency:
+    def _common_patches(self, monkeypatch, sha):
+        monkeypatch.setattr(rrv, "fetch_latest_tag", lambda _t: "2.335.0")
+        monkeypatch.setattr(rrv, "resolve_digest", lambda _t: "sha256:our")
+        monkeypatch.setattr(rrv, "osdc_sha", lambda: sha)
+        monkeypatch.setattr(rrv, "now_utc", lambda: datetime(2026, 6, 15, 17, 42, 11, tzinfo=UTC))
+        monkeypatch.delenv("OSDC_RESOLVER_READONLY", raising=False)
+
+    def test_write_409_then_winner_pinned_returns_winner(self, monkeypatch, capsys):
+        self._common_patches(monkeypatch, _SHA_A)
+        client = MagicMock()
+        winner_entry = _entry(_SHA_A, "2.335.0", "sha256:winner", "2026-06-15T17:00:00Z")
+        reads = [
+            ([], True, "100"),
+            ([winner_entry], True, "101"),
+        ]
+        monkeypatch.setattr(rrv, "read_history", MagicMock(side_effect=reads))
+        writes = MagicMock(side_effect=[_api_error(409)])
+
+        def fake_write(_client, history, cm_exists, rv):
+            return writes(history, cm_exists, rv)
+
+        monkeypatch.setattr(rrv, "write_history", fake_write)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.335.0@sha256:winner"
+        assert writes.call_count == 1
+
+    def test_write_409_then_winner_pinned_different_image_returns_winner(self, monkeypatch, capsys):
+        self._common_patches(monkeypatch, _SHA_A)
+        client = MagicMock()
+        winner_entry = _entry(_SHA_A, "2.999.0", "sha256:totally-different", "2026-06-15T17:00:00Z")
+        reads = [
+            ([], True, "100"),
+            ([winner_entry], True, "101"),
+        ]
+        monkeypatch.setattr(rrv, "read_history", MagicMock(side_effect=reads))
+        write_calls = []
+
+        def fake_write(_client, history, cm_exists, rv):
+            write_calls.append((history, cm_exists, rv))
+            if len(write_calls) == 1:
+                raise _api_error(409)
+
+        monkeypatch.setattr(rrv, "write_history", fake_write)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.999.0@sha256:totally-different"
+        assert len(write_calls) == 1
+
+    def test_write_409_then_we_still_miss_retry_succeeds(self, monkeypatch, capsys):
+        self._common_patches(monkeypatch, _SHA_A)
+        client = MagicMock()
+        unrelated_entry = _entry(_SHA_B, "2.334.0", "sha256:other", "2026-06-15T17:00:00Z")
+        reads = [
+            ([], True, "100"),
+            ([unrelated_entry], True, "101"),
+        ]
+        monkeypatch.setattr(rrv, "read_history", MagicMock(side_effect=reads))
+        write_calls = []
+
+        def fake_write(_client, history, cm_exists, rv):
+            write_calls.append((history, cm_exists, rv))
+            if len(write_calls) == 1:
+                raise _api_error(409)
+
+        monkeypatch.setattr(rrv, "write_history", fake_write)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.335.0@sha256:our"
+        assert len(write_calls) == 2
+        assert write_calls[1][2] == "101"
+        retry_history = write_calls[1][0]
+        assert retry_history[0]["osdc_sha"] == _SHA_A
+        assert retry_history[0]["digest"] == "sha256:our"
+        assert any(e["osdc_sha"] == _SHA_B for e in retry_history)
+
+    def test_write_409_retries_exhausted(self, monkeypatch, capsys):
+        self._common_patches(monkeypatch, _SHA_A)
+        client = MagicMock()
+        reads = [([], True, str(100 + i)) for i in range(rrv.MAX_WRITE_ATTEMPTS + 1)]
+        monkeypatch.setattr(rrv, "read_history", MagicMock(side_effect=reads))
+        write_calls = []
+
+        def fake_write(_client, history, cm_exists, rv):
+            write_calls.append((history, cm_exists, rv))
+            raise _api_error(409)
+
+        monkeypatch.setattr(rrv, "write_history", fake_write)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert len(write_calls) == rrv.MAX_WRITE_ATTEMPTS
+        assert "kubernetes API" in captured.err
+
+    def test_non_409_apierror_propagates(self, monkeypatch, capsys):
+        self._common_patches(monkeypatch, _SHA_A)
+        client = MagicMock()
+        monkeypatch.setattr(rrv, "read_history", lambda _c: ([], True, "100"))
+        write_calls = []
+
+        def fake_write(_client, history, cm_exists, rv):
+            write_calls.append((history, cm_exists, rv))
+            raise _api_error(403)
+
+        monkeypatch.setattr(rrv, "write_history", fake_write)
+        monkeypatch.setattr(rrv, "build_client", lambda: client)
+
+        rc = rrv.main(["resolve_runner_version.py", "c"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert len(write_calls) == 1
+        assert "kubernetes API" in captured.err
+
+
+# --- module-boundary helpers (small smoke for build_client / now_utc) ---
+
+
+class TestModuleBoundaries:
+    def test_now_utc_returns_aware_datetime(self):
+        result = rrv.now_utc()
+        assert result.tzinfo is not None
+
+    def test_build_client_constructs_client(self):
+        with patch.object(rrv, "Client") as mock_client_cls, patch.object(rrv, "_force_ipv4") as mock_force:
+            rrv.build_client()
+            mock_force.assert_called_once_with()
+            mock_client_cls.assert_called_once_with()

--- a/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runner_version_lock.py
@@ -1,0 +1,220 @@
+"""Smoke tests for the deploy-time runner-image resolver.
+
+Verifies the `arc-runner-version-lock` ConfigMap (written by
+`resolve_runner_version.py` during `just deploy-module <cluster> arc-runners`)
+matches the runner image actually deployed in the cluster's
+AutoscalingRunnerSets.
+
+Skipped on clusters that pin `arc.runner_image_tag` in clusters.yaml
+(rollback path — the resolver is bypassed and no ConfigMap is written).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from helpers import retry_with_backoff, run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+LOCK_CM_NAME = "arc-runner-version-lock"
+LOCK_CM_NAMESPACE = "osdc-system"
+LOCK_CM_KEY = "history.json"
+HISTORY_MAX = 20
+
+EXPECTED_LABELS = {
+    "app.kubernetes.io/managed-by": "osdc-deploy-log",
+    "osdc.io/lock-kind": "arc-runner-version",
+}
+
+IMAGE_REPO = "ghcr.io/actions/actions-runner"
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+ARS_RESOURCE = "autoscalingrunnersets.actions.github.com"
+ARS_NAMESPACE = "arc-runners"
+RUNNER_CONTAINER_NAME = "runner"
+
+OSDC_PATH = "."
+
+
+def _parse_iso8601_utc(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _osdc_root() -> Path:
+    env_root = os.environ.get("OSDC_UPSTREAM")
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[4]
+
+
+def _current_osdc_sha() -> str:
+    root = _osdc_root()
+    result = subprocess.run(
+        ["git", "-C", str(root), "log", "-1", "--format=%H", "--", OSDC_PATH],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip()
+    if not sha:
+        pytest.fail(
+            f"git log returned no commit history under {root} — "
+            "shallow clone? Refetch with full history before running this smoke test."
+        )
+    return sha
+
+
+def _fetch_lock_configmap() -> dict:
+    return run_kubectl(["get", "configmap", LOCK_CM_NAME], namespace=LOCK_CM_NAMESPACE)
+
+
+def _fetch_arc_runner_sets() -> list[dict]:
+    result = run_kubectl(["get", ARS_RESOURCE], namespace=ARS_NAMESPACE)
+    return result.get("items", []) or []
+
+
+def _runner_image_from_ars(ars: dict) -> str | None:
+    containers = ars.get("spec", {}).get("template", {}).get("spec", {}).get("containers", []) or []
+    for c in containers:
+        if c.get("name") == RUNNER_CONTAINER_NAME:
+            return c.get("image")
+    return None
+
+
+@pytest.fixture(scope="module")
+def explicit_runner_tag(resolve_config) -> str | None:
+    val = resolve_config("arc.runner_image_tag")
+    if val is None or val == "":
+        return None
+    return str(val)
+
+
+@pytest.fixture(scope="module")
+def lock_history(explicit_runner_tag: str | None) -> list[dict]:
+    if explicit_runner_tag is not None:
+        pytest.skip(
+            f"arc.runner_image_tag={explicit_runner_tag!r} pinned in clusters.yaml — "
+            f"resolver bypassed, no {LOCK_CM_NAME} ConfigMap expected"
+        )
+
+    def _load() -> tuple[dict, list]:
+        cm = _fetch_lock_configmap()
+        raw = (cm.get("data") or {}).get(LOCK_CM_KEY)
+        assert raw, f"{LOCK_CM_NAME}.data[{LOCK_CM_KEY!r}] is empty or missing"
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list), f"{LOCK_CM_KEY} must be a JSON list, got {type(parsed).__name__}"
+        assert len(parsed) >= 1, f"{LOCK_CM_KEY} has zero entries — at least one expected after a deploy"
+        return cm, parsed
+
+    try:
+        cm, history = retry_with_backoff(_load)
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Failed to read ConfigMap {LOCK_CM_NAMESPACE}/{LOCK_CM_NAME}: {e.stderr or e}. "
+            f"If this cluster has never deployed arc-runners after the resolver landed, "
+            f"run `just deploy-module {{cluster}} arc-runners` first."
+        )
+
+    labels = cm.get("metadata", {}).get("labels", {}) or {}
+    for k, v in EXPECTED_LABELS.items():
+        assert labels.get(k) == v, f"{LOCK_CM_NAME} label {k!r}={labels.get(k)!r}, expected {v!r}"
+
+    return history
+
+
+class TestLockConfigMapShape:
+    def test_history_length_within_cap(self, lock_history: list[dict]) -> None:
+        assert len(lock_history) <= HISTORY_MAX, f"history.json has {len(lock_history)} entries, cap is {HISTORY_MAX}"
+
+    def test_history_entries_well_formed(self, lock_history: list[dict]) -> None:
+        problems: list[str] = []
+        for i, entry in enumerate(lock_history):
+            if not isinstance(entry, dict):
+                problems.append(f"[{i}] not an object: {entry!r}")
+                continue
+
+            osdc_sha = entry.get("osdc_sha")
+            if not isinstance(osdc_sha, str) or not SHA_RE.match(osdc_sha):
+                problems.append(f"[{i}] osdc_sha must match 40-char hex, got {osdc_sha!r}")
+
+            tag = entry.get("tag")
+            if not isinstance(tag, str) or not tag:
+                problems.append(f"[{i}] tag must be a non-empty string, got {tag!r}")
+
+            digest = entry.get("digest")
+            if not isinstance(digest, str) or not DIGEST_RE.match(digest):
+                problems.append(f"[{i}] digest must match sha256:<64-hex>, got {digest!r}")
+
+            resolved_at = entry.get("resolved_at")
+            if not isinstance(resolved_at, str):
+                problems.append(f"[{i}] resolved_at must be a string, got {resolved_at!r}")
+            else:
+                try:
+                    parsed = _parse_iso8601_utc(resolved_at)
+                except ValueError as e:
+                    problems.append(f"[{i}] resolved_at not ISO8601: {resolved_at!r} ({e})")
+                else:
+                    if parsed.tzinfo is None:
+                        problems.append(f"[{i}] resolved_at missing tz info: {resolved_at!r}")
+
+        assert not problems, "Malformed history entries:\n" + "\n".join(problems)
+
+    def test_osdc_shas_are_unique(self, lock_history: list[dict]) -> None:
+        shas = [e["osdc_sha"] for e in lock_history if isinstance(e, dict) and isinstance(e.get("osdc_sha"), str)]
+        dupes = sorted({s for s in shas if shas.count(s) > 1})
+        assert not dupes, f"Duplicate osdc_sha in history (resolver should dedupe on SHA): {dupes}"
+
+
+class TestLockMatchesDeployedRunners:
+    def test_current_sha_entry_matches_ars_runner_image(
+        self,
+        lock_history: list[dict],
+        enabled_modules: list[str],
+    ) -> None:
+        if "arc-runners" not in enabled_modules:
+            pytest.skip("arc-runners module not enabled")
+
+        current_sha = _current_osdc_sha()
+        matching = [e for e in lock_history if e.get("osdc_sha") == current_sha]
+        assert matching, (
+            f"No entry in {LOCK_CM_NAME}.{LOCK_CM_KEY} matches the current osdc_sha={current_sha} "
+            f"(most recent commit touching anything under {OSDC_PATH}). The cluster is running a stale "
+            f"image, or the most recent `just deploy-module <cluster> arc-runners` did not complete. "
+            f"Re-run the deploy to populate the entry."
+        )
+        entry = matching[0]
+        expected_image = f"{IMAGE_REPO}:{entry['tag']}@{entry['digest']}"
+
+        try:
+            ars_list = retry_with_backoff(_fetch_arc_runner_sets)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(f"Failed to list {ARS_RESOURCE} in {ARS_NAMESPACE}: {e.stderr or e}")
+
+        assert len(ars_list) >= 1, (
+            f"No {ARS_RESOURCE} found in '{ARS_NAMESPACE}' — arc-runners module enabled but no scale-sets deployed?"
+        )
+
+        mismatches: list[str] = []
+        for ars in ars_list:
+            name = ars.get("metadata", {}).get("name", "?")
+            image = _runner_image_from_ars(ars)
+            if image is None:
+                mismatches.append(f"{name}: no '{RUNNER_CONTAINER_NAME}' container in pod template")
+                continue
+            if image != expected_image:
+                mismatches.append(f"{name}: image={image!r}, expected {expected_image!r}")
+
+        assert not mismatches, (
+            f"AutoscalingRunnerSet runner image does not match the entry for current osdc_sha={current_sha} "
+            f"({expected_image!r}):\n" + "\n".join(mismatches)
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #766
* #765
* #764

**Impact:** adds `just smoke` validation for the runner-version lock ConfigMap and an operator doc. No runtime behavior change.
**Risk:** low

## What
Adds the live-cluster smoke test that validates the `arc-runner-version-lock` ConfigMap (written by `resolve_runner_version.py`) has an entry matching the current OSDC SHA and that the recorded `tag@digest` matches the runner image actually deployed in every `AutoscalingRunnerSet`. Adds a short operator doc covering the per-commit pinning model, the 20-SHA window, rollback flow, and failure modes.

## Why
PR 1 added the resolver script (keyed by OSDC commit SHA). PR 2 wired it into `deploy.sh` and switched `generate_runners.py` to read `$RUNNER_IMAGE`. This PR closes the loop:
- Smoke validates that the entry the resolver wrote for THIS commit's SHA is the same `tag@digest` actually running in pod manifests (drift detection between the lock and deployed state for this commit).
- The operator doc gives one page to look at when something fails.

## Notes
- The smoke test lives under `modules/arc-runners/tests/smoke/` so `just test` skips it (per the existing `find ... -path '*/modules/*/tests/smoke' -prune` rule). It runs only under `just smoke <cluster>`.
- AutoscalingRunnerSet is the CRD the chart produces; the runner container is named `runner` in `spec.template.spec.containers`. The test reuses `run_kubectl` rather than rolling its own k8s client to keep the surface identical to every other smoke test.