### PR TITLE
OSDC: Add meta-staging-aws-ue1 staging cluster (us-east-1)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -254,8 +254,6 @@ clusters:
       - arc-runners
       - keda
       - buildkit
-      - pypi-cache
-      - cache-enforcer
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -186,6 +186,81 @@ clusters:
       - monitoring
       - logging
 
+  meta-staging-aws-ue1:
+    # Second staging region — mirrors meta-staging-aws-uw1 (us-west-1) in us-east-1.
+    # Kept long-term alongside uw1 staging for broader region coverage.
+    region: us-east-1
+    cluster_name: meta-staging-aws-ue1
+    recycle_karpenter_nodes: true
+    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
+    state_bucket: ciforge-tfstate-meta-staging-aws-ue1
+    access_config:
+      authentication_mode: API_AND_CONFIG_MAP
+      cluster_admin_role_names:
+        - osdc_gha_staging
+    base:
+      base_node_count: 2
+      base_node_instance_type: m5.4xlarge
+      base_node_max_unavailable_percentage: 100  # all-at-once for staging
+      single_nat_gateway: true       # cost optimization for staging
+      vpc_cidr: "10.20.0.0/16"
+    coredns:
+      replicas: 2
+    harbor:
+      core_replicas: 1
+      registry_replicas: 1
+      nginx_replicas: 1
+      pdb_max_unavailable: "100%"  # aggressive: staging has 1 replica each
+    karpenter:
+      replicas: 1
+      log_level: debug
+      pdb_enabled: false
+      pdb_min_available: 0
+    arc:
+      replica_count: 1
+      log_level: debug
+      controller_cpu_request: "500m"
+      controller_cpu_limit: "1"
+      controller_memory_request: "1Gi"
+      controller_memory_limit: "1Gi"
+    node_compactor:
+      dry_run: true
+    nodepools:
+      gpu_consolidate_after: "10s"
+      cpu_consolidate_after: "10s"
+    arc-runners:
+      # Org-wide (was github.com/pytorch/pytorch-canary). A repo-scoped URL forces
+      # runner_group → "default" in generate_runners.py, so the org URL is required
+      # for the runner_group below to take effect.
+      github_config_url: "https://github.com/pytorch"
+      github_secret_name: meta-staging-aws-ue1
+      runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
+      runner_group: "meta-staging-aws-ue1"
+    buildkit:
+      arm64_instance_type: m7gd.16xlarge
+      arm64_pods_per_node: 4
+      autoscaling:
+        enabled: true
+        amd64_min: 2  # 1x m6id.24xlarge (2 pods/node)
+        amd64_max: 8
+        arm64_min: 4  # 1x m7gd.16xlarge (4 pods/node)
+        arm64_max: 8
+    pypi_cache:
+      replicas: 1
+    modules:
+      - karpenter
+      - arc
+      - nodepools
+      - arc-runners
+      - keda
+      - buildkit
+      - pypi-cache
+      - cache-enforcer
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
+
   arc-cbr-production-uw1:
     cluster_name: pytorch-arc-cbr-production-uw1
     region: us-west-1

--- a/osdc/modules/arc/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc/kubernetes/hooks-warmer.yaml
@@ -4,6 +4,11 @@
 #
 # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.15
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
+#
+# [STAGING TEST — DO NOT MERGE / DO NOT DEPLOY TO PROD] Temporarily points at a
+# fork test build (huydhn/runner-container-hooks v0.8.15-podreason.1) that adds
+# pod-failure-reason surfacing in waitForPodPhases (PR jeanschmidt/runner-
+# container-hooks#10). Revert to jeanschmidt v0.8.14 after staging validation.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -54,8 +59,8 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.15"
-              HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
+              HOOKS_VERSION="0.8.15-podreason.1"  # STAGING TEST — revert to 0.8.15 after validation
+              HOOKS_URL="https://github.com/huydhn/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"
 

--- a/osdc/modules/arc/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc/kubernetes/hooks-warmer.yaml
@@ -4,11 +4,6 @@
 #
 # See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.15
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
-#
-# [STAGING TEST — DO NOT MERGE / DO NOT DEPLOY TO PROD] Temporarily points at a
-# fork test build (huydhn/runner-container-hooks v0.8.15-podreason.1) that adds
-# pod-failure-reason surfacing in waitForPodPhases (PR jeanschmidt/runner-
-# container-hooks#10). Revert to jeanschmidt v0.8.14 after staging validation.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -59,8 +54,8 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.15-podreason.1"  # STAGING TEST — revert to 0.8.15 after validation
-              HOOKS_URL="https://github.com/huydhn/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
+              HOOKS_VERSION="0.8.15"
+              HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"
 


### PR DESCRIPTION
Adds a second long-term staging cluster `meta-staging-aws-ue1` in us-east-1, a verbatim mirror of `meta-staging-aws-uw1`. Only region-specific values differ:

- `region`: us-east-1
- `state_bucket`: ciforge-tfstate-meta-staging-aws-ue1
- `base.vpc_cidr`: 10.20.0.0/16 (non-overlapping)
- `arc-runners.github_secret_name` / `runner_group`: meta-staging-aws-ue1

Everything else (modules, sizing, buildkit autoscaling, `c-mt-` prefix, `osdc_gha_staging` role) matches uw1.

`just lint` and `just test` pass; `cluster-config.py` resolves correct tfvars.

## Out-of-band operator steps (before deploy)
- [ ] Confirm `osdc_gha_staging` role exists/trusted in the us-east-1 account
- [ ] `just bootstrap meta-staging-aws-ue1`
- [ ] Create `meta-staging-aws-ue1` runner group in pytorch org
- [ ] Create `meta-staging-aws-ue1` Secret in `arc-runners` ns
- [ ] `just deploy meta-staging-aws-ue1`