### PR TITLE
Increase deploy job timeout to 3 hours

### DIFF
--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -52,7 +52,7 @@ jobs:
     name: Deploy ${{ inputs.cluster }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    timeout-minutes: 60
+    timeout-minutes: 180
     # Serialize all tofu state-mutating work per cluster. Shared with
     # _osdc-plan.yml so plan and deploy against the same cluster never
     # race on the DynamoDB state lock.


### PR DESCRIPTION
- Raise timeout-minutes from 60 to 180 for the deploy job

The 60-minute timeout was too tight for larger clusters where tofu apply, node tainting, and cross-arch image builds can legitimately exceed one hour. Example: https://github.com/pytorch/ci-infra/actions/runs/27317343734/job/80812482308