### PR TITLE
Reduce proactive_capacity_max from 6 to 4

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -321,7 +321,7 @@ clusters:
   lf-prod-aws-ue1:
     region: us-east-1
     cluster_name: lf-prod-aws-ue1
-    proactive_capacity_max: 6
+    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
@@ -368,7 +368,7 @@ clusters:
   lf-prod-aws-ue2:
     region: us-east-2
     cluster_name: lf-prod-aws-ue2
-    proactive_capacity_max: 6
+    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue2
     access_config:
       authentication_mode: API_AND_CONFIG_MAP


### PR DESCRIPTION
Runners packing 4 per node (e.g. l-x86iavx512-46-85 on c7a.48xlarge, l-x86iavx2-40-160 on m7i.48xlarge) were spinning up 2 EC2 nodes for 5 proactive slots when 4 fills exactly 1 node. Reducing the cap to 4 aligns the warm pool with node packing boundaries.

Also saves 1 idle EC2 instance per runner type for the 1-per-node runners (single-GPU g5/g6/g4dn.8xlarge, near-full-node ARM64/x86 large runners) and reduces overflow nodes for 2-per-node runners like l-x86iamx-22-41 and l-arm64g3-16-62.

Estimated reduction: ~13 fewer warm-pool EC2 instances per production cluster (~26 total across lf-prod-aws-ue1 and lf-prod-aws-ue2).