### PR TITLE
Remove per-cluster proactive_capacity_max overrides

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -117,7 +117,6 @@ clusters:
     region: us-west-1
     cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
-    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
     state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
@@ -321,7 +320,6 @@ clusters:
   lf-prod-aws-ue1:
     region: us-east-1
     cluster_name: lf-prod-aws-ue1
-    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
@@ -368,7 +366,6 @@ clusters:
   lf-prod-aws-ue2:
     region: us-east-2
     cluster_name: lf-prod-aws-ue2
-    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue2
     access_config:
       authentication_mode: API_AND_CONFIG_MAP

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -117,6 +117,7 @@ clusters:
     region: us-west-1
     cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
+    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
     state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -163,7 +163,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | Env Var | Code default | Template value | Description |
 |---------|--------------|----------------|-------------|
 | `CAPACITY_AWARE_ENABLED` | `false` | `true` | Enable the capacity monitor goroutine |
-| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set — staging sets `0` to disable warm-pool pre-provisioning) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
+| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
 | `CAPACITY_AWARE_MAX_BURST_CAPACITY` | `0` | `{{MAX_BURST_CAPACITY}}` (from runner def) | Caps the maximum total placeholder pairs (running + pending) the provisioner will create per cycle. `0` means unlimited. Used to prevent burst node provisioning from overloading downstream services (Harbor, pypi-cache) |
 | `CAPACITY_AWARE_RECALCULATE_INTERVAL` | `30s` | `30s` | Fallback reconciliation interval (event-driven is primary) |
 | `CAPACITY_AWARE_REPORT_INTERVAL` | `5s` | _(unset — uses code default)_ | How often the monitor reports state via `X-ScaleSetMaxCapacity` |
@@ -182,7 +182,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
 
-Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. The staging cluster sets `proactive_capacity_max: 0`, so no placeholders are pre-provisioned there — only on-demand pairs created for in-flight jobs.
+Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. No cluster currently sets `proactive_capacity_max`, so def values pass through unchanged.
 
 ## Creating the HUD API Secret
 

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -163,7 +163,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | Env Var | Code default | Template value | Description |
 |---------|--------------|----------------|-------------|
 | `CAPACITY_AWARE_ENABLED` | `false` | `true` | Enable the capacity monitor goroutine |
-| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
+| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set — staging sets `0` to disable warm-pool pre-provisioning) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
 | `CAPACITY_AWARE_MAX_BURST_CAPACITY` | `0` | `{{MAX_BURST_CAPACITY}}` (from runner def) | Caps the maximum total placeholder pairs (running + pending) the provisioner will create per cycle. `0` means unlimited. Used to prevent burst node provisioning from overloading downstream services (Harbor, pypi-cache) |
 | `CAPACITY_AWARE_RECALCULATE_INTERVAL` | `30s` | `30s` | Fallback reconciliation interval (event-driven is primary) |
 | `CAPACITY_AWARE_REPORT_INTERVAL` | `5s` | _(unset — uses code default)_ | How often the monitor reports state via `X-ScaleSetMaxCapacity` |
@@ -182,7 +182,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
 
-Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. No cluster currently sets `proactive_capacity_max`, so def values pass through unchanged.
+Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. The staging cluster sets `proactive_capacity_max: 0`, so no placeholders are pre-provisioned there — only on-demand pairs created for in-flight jobs. Other clusters do not set the cap and use def values directly.
 
 ## Creating the HUD API Secret
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #772
* __->__ #771

**Impact:** staging (meta-staging-aws-uw1) and LF prod clusters (lf-prod-aws-ue1, lf-prod-aws-ue2)
**Risk:** medium

## What
Removes the `proactive_capacity_max` cap from all three clusters that had it set in `clusters.yaml`, so every cluster uses the proactive capacity values defined in each runner def without any cluster-level clamp.

## Why
All clusters should have the same warm-pool pre-provisioning behavior. Staging was previously set to `0` (no placeholders at all) and the two LF prod clusters were capped at `4`, meaning they could behave differently from the main prod clusters under identical runner definitions. Removing these overrides makes capacity characteristics uniform across the fleet.

## Notes
- The `proactive_capacity_max` mechanism in `generate_runners.py` remains intact — it just has no clusters using it currently. Existing unit and smoke tests for the feature still pass.
- Staging will now pre-provision warm-pool placeholders like prod clusters do; monitor for any unexpected node scale-up in staging after deploy.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>