### PR TITLE
Reduce proactive_capacity across all runner definitions

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -117,7 +117,6 @@ clusters:
     region: us-west-1
     cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
-    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
     state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
@@ -321,7 +320,6 @@ clusters:
   lf-prod-aws-ue1:
     region: us-east-1
     cluster_name: lf-prod-aws-ue1
-    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP
@@ -368,7 +366,6 @@ clusters:
   lf-prod-aws-ue2:
     region: us-east-2
     cluster_name: lf-prod-aws-ue2
-    proactive_capacity_max: 4
     state_bucket: lf-osdc-tfstate-prod-ue2
     access_config:
       authentication_mode: API_AND_CONFIG_MAP

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -117,6 +117,7 @@ clusters:
     region: us-west-1
     cluster_name: meta-staging-aws-uw1
     recycle_karpenter_nodes: true
+    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
     state_bucket: ciforge-tfstate-meta-staging-aws-uw1
     access_config:
       authentication_mode: API_AND_CONFIG_MAP

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -163,7 +163,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | Env Var | Code default | Template value | Description |
 |---------|--------------|----------------|-------------|
 | `CAPACITY_AWARE_ENABLED` | `false` | `true` | Enable the capacity monitor goroutine |
-| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set — staging sets `0` to disable warm-pool pre-provisioning) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
+| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
 | `CAPACITY_AWARE_MAX_BURST_CAPACITY` | `0` | `{{MAX_BURST_CAPACITY}}` (from runner def) | Caps the maximum total placeholder pairs (running + pending) the provisioner will create per cycle. `0` means unlimited. Used to prevent burst node provisioning from overloading downstream services (Harbor, pypi-cache) |
 | `CAPACITY_AWARE_RECALCULATE_INTERVAL` | `30s` | `30s` | Fallback reconciliation interval (event-driven is primary) |
 | `CAPACITY_AWARE_REPORT_INTERVAL` | `5s` | _(unset — uses code default)_ | How often the monitor reports state via `X-ScaleSetMaxCapacity` |
@@ -182,7 +182,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
 
-Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. The staging cluster sets `proactive_capacity_max: 0`, so no placeholders are pre-provisioned there — only on-demand pairs created for in-flight jobs.
+Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. No cluster currently sets `proactive_capacity_max`, so def values pass through unchanged.
 
 ## Creating the HUD API Secret
 

--- a/osdc/docs/arc-fork-build-deploy.md
+++ b/osdc/docs/arc-fork-build-deploy.md
@@ -163,7 +163,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | Env Var | Code default | Template value | Description |
 |---------|--------------|----------------|-------------|
 | `CAPACITY_AWARE_ENABLED` | `false` | `true` | Enable the capacity monitor goroutine |
-| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
+| `CAPACITY_AWARE_PROACTIVE_CAPACITY` | `0` | `{{PROACTIVE_CAPACITY}}` (from runner def, capped by `proactive_capacity_max` in `clusters.yaml` when set — staging sets `0` to disable warm-pool pre-provisioning) | Number of placeholder pairs to maintain ahead of demand. Hard cap of `1000` (clamped); warning logged above `100`. |
 | `CAPACITY_AWARE_MAX_BURST_CAPACITY` | `0` | `{{MAX_BURST_CAPACITY}}` (from runner def) | Caps the maximum total placeholder pairs (running + pending) the provisioner will create per cycle. `0` means unlimited. Used to prevent burst node provisioning from overloading downstream services (Harbor, pypi-cache) |
 | `CAPACITY_AWARE_RECALCULATE_INTERVAL` | `30s` | `30s` | Fallback reconciliation interval (event-driven is primary) |
 | `CAPACITY_AWARE_REPORT_INTERVAL` | `5s` | _(unset — uses code default)_ | How often the monitor reports state via `X-ScaleSetMaxCapacity` |
@@ -182,7 +182,7 @@ The capacity monitor is configured via env vars on the listener pod, set in `mod
 | `CAPACITY_AWARE_HUD_API_URL` | _(built-in default URL)_ | hardcoded PyTorch HUD `queued_jobs_aggregate` URL | HUD endpoint for queued job counts |
 | `CAPACITY_AWARE_HUD_API_TOKEN` | _(empty)_ | from K8s secret `pytorch-hud-token` (optional mount) | PyTorch HUD API token for queued job counts |
 
-Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. No cluster currently sets `proactive_capacity_max`, so def values pass through unchanged.
+Currently enabled for all runners (`CAPACITY_AWARE_ENABLED=true` is hardcoded in the template). Note: `generate_runners.py` caps `proactive_capacity` at `N` for clusters that set `proactive_capacity_max: N` in `clusters.yaml` — each scale set renders `min(def_proactive_capacity, N)`. The staging cluster sets `proactive_capacity_max: 0`, so no placeholders are pre-provisioned there — only on-demand pairs created for in-flight jobs. Other clusters do not set the cap and use def values directly.
 
 ## Creating the HUD API Secret
 

--- a/osdc/modules/arc-runners/defs/l-arm64g2-6-25.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g2-6-25.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 6
   memory: 25Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 62Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 61
   memory: 463Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 62Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 62
   memory: 226Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 62
   memory: 226Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iamx-92-167.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 92
   memory: 167Gi
   gpu: 0
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 94
   memory: 344Gi
   gpu: 8
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 189
   memory: 704Gi
   gpu: 8
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 45
   memory: 167Gi
   gpu: 4
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 45
   memory: 172Gi
   gpu: 4
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 125
   memory: 463Gi
   gpu: 0
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 14
   memory: 27Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 22
   memory: 41Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 32
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 46
   memory: 84Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 16Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 64Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 40
   memory: 160Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 16
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 2
   memory: 4Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -10,6 +10,6 @@ runner:
   vcpu: 29
   memory: 115Gi
   gpu: 1
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 32
   memory: 256Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 37
   memory: 68Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 45
   memory: 172Gi
   gpu: 4
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 46
   memory: 85Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 48
   memory: 384Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 1
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 8
   memory: 16Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 64Gi
   gpu: 0
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-192.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 94
   memory: 189Gi
   gpu: 0
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-94-768.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 94
   memory: 740Gi
   gpu: 0
-  proactive_capacity: 2
+  proactive_capacity: 0
   hud_failure_base_capacity: 15
   max_burst_capacity: 30

--- a/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
@@ -10,6 +10,6 @@ runner:
   gpu: 0
   runner_group: release-runners
   runner_class: release
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
@@ -10,6 +10,6 @@ runner:
   gpu: 0
   runner_group: release-runners
   runner_class: release
-  proactive_capacity: 15
+  proactive_capacity: 5
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #772
* #771

**Impact:** All OSDC runner scale sets across all clusters
**Risk:** medium

## What
Reduces `proactive_capacity` for all 39 runner definitions, following a tiered approach based on runner size: small/common runners (15 → 5), medium runners (5 → 1), and large/multi-GPU runners (2 → 0).

## Why
Stepping down proactive (idle warm) runner capacity toward zero. This is being done incrementally to monitor for scheduling latency regressions before further reductions. Follows the recent removal of per-cluster `proactive_capacity_max` overrides (ea486ca) and the global cap reduction from 6 to 4 (#770).

# Notes
- Large and multi-GPU runners (92+ vCPU, 4+ GPU) are now at 0 proactive capacity — they will scale purely on demand via Karpenter.
- `hud_failure_base_capacity` and `max_burst_capacity` are unchanged, so burst scaling behavior is unaffected.
- If cold-start latency becomes an issue for specific runner types, individual definitions can be bumped back up independently.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>