### PR TITLE
Target integration test jobs to cluster-specific runner groups

### DIFF
--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -233,6 +233,8 @@ def generate_workflow(
     release_enabled: bool = False,
     pypi_cache_slugs: str = "cpu cu121 cu124",
     pypi_cache_cuda_version: str = "12.8",
+    runner_group: str = "default",
+    release_runner_group: str = "release-runners",
 ) -> str:
     """Generate the integration test workflow from template."""
     template_path = upstream_dir / "integration-tests" / "workflows" / "integration-test.yaml.tpl"
@@ -240,6 +242,8 @@ def generate_workflow(
 
     # Substitute template variables
     content = content.replace("{{PREFIX}}", prefix)
+    content = content.replace("{{RUNNER_GROUP}}", runner_group)
+    content = content.replace("{{RELEASE_RUNNER_GROUP}}", release_runner_group)
     content = content.replace("{{CLUSTER_ID}}", cluster_id)
     content = content.replace("{{CLUSTER_NAME}}", cluster_name)
     content = content.replace("{{PYPI_CACHE_SLUGS}}", pypi_cache_slugs)

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -208,6 +208,9 @@ def main():
     cfg = load_cluster_config(args.clusters_yaml, args.cluster_id)
     cluster_name = resolve(cfg, "cluster_name")
     prefix = resolve(cfg, "arc-runners.runner_name_prefix", "")
+    cluster_runner_group = resolve(cfg, "arc-runners.runner_group")
+    runner_group = cluster_runner_group or "default"
+    release_runner_group = cluster_runner_group or "release-runners"
     b200_enabled = has_module(cfg, "nodepools-b200") and has_module(cfg, "arc-runners-b200")
     cache_enforcer_enabled = has_module(cfg, "cache-enforcer")
     release_enabled = has_module(cfg, "arc-runners")
@@ -230,6 +233,8 @@ def main():
 
     log.info("Integration test for cluster: %s (%s)", args.cluster_id, cluster_name)
     log.info("  Runner prefix: '%s'", prefix)
+    log.info("  Runner group: '%s'", runner_group)
+    log.info("  Release runner group: '%s'", release_runner_group)
     log.info("  B200 enabled: %s", b200_enabled)
     log.info("  Release runners: %s", release_enabled)
     log.info("  Cache enforcer: %s", cache_enforcer_enabled)
@@ -264,6 +269,8 @@ def main():
             b200_enabled,
             cache_enforcer_enabled=cache_enforcer_enabled,
             release_enabled=release_enabled,
+            runner_group=runner_group,
+            release_runner_group=release_runner_group,
             pypi_cache_slugs=pypi_cache_slugs,
             pypi_cache_cuda_version=pypi_cache_cuda_version,
         )

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -43,6 +43,7 @@ def clusters_yaml(tmp_path):
                 "modules": ["eks", "karpenter", "nodepools", "arc", "arc-runners"],
                 "harbor": {"core_replicas": 1},
                 "monitoring": {"grafana_cloud_url": "https://staging.example.com"},
+                "arc-runners": {"runner_group": "meta-prod-rg"},
             },
             "arc-cbr-production": {
                 "cluster_name": "pytorch-arc-cbr-production",
@@ -90,21 +91,27 @@ def workflow_template(tmp_path):
         "on: push\n"
         "jobs:\n"
         "  basic:\n"
-        "    runs-on: {{CLUSTER_NAME}}\n"
+        "    runs-on: { group: \"{{RUNNER_GROUP}}\", labels: [\"{{CLUSTER_NAME}}\"] }\n"
         "    steps:\n"
         "      - run: echo {{CLUSTER_ID}}\n"
         "  # BEGIN_B200\n"
         "  b200-job:\n"
-        "    runs-on: {{PREFIX}}b200-runner\n"
+        "    runs-on: { group: \"{{RUNNER_GROUP}}\", labels: [\"{{PREFIX}}b200-runner\"] }\n"
         "    steps:\n"
         "      - run: echo B200\n"
         "  # END_B200\n"
         "  # BEGIN_CACHE_ENFORCER\n"
         "  cache-enforcer-job:\n"
-        "    runs-on: {{PREFIX}}enforcer-runner\n"
+        "    runs-on: { group: \"{{RUNNER_GROUP}}\", labels: [\"{{PREFIX}}enforcer-runner\"] }\n"
         "    steps:\n"
         "      - run: echo enforcer\n"
         "  # END_CACHE_ENFORCER\n"
+        "  # BEGIN_RELEASE\n"
+        "  release-job:\n"
+        "    runs-on: { group: \"{{RELEASE_RUNNER_GROUP}}\", labels: [\"{{PREFIX}}rel-runner\"] }\n"
+        "    steps:\n"
+        "      - run: echo release\n"
+        "  # END_RELEASE\n"
         "  pypi-job:\n"
         "    steps:\n"
         "      - run: echo {{PYPI_CACHE_SLUGS}}\n"
@@ -187,10 +194,13 @@ class TestGenerateWorkflow:
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
             b200_enabled=True,
+            runner_group="my-rg",
         )
         assert "name: cbr integration test" in result
-        assert "runs-on: pytorch-arc-cbr-production" in result
+        assert "labels: [\"pytorch-arc-cbr-production\"]" in result
         assert "echo arc-cbr-production" in result
+        assert 'group: "my-rg"' in result
+        assert "{{RUNNER_GROUP}}" not in result
 
     def test_b200_removed_when_disabled(self, workflow_template):
         result = generate_workflow(
@@ -217,7 +227,7 @@ class TestGenerateWorkflow:
         assert "b200-job:" in result
         assert "echo B200" in result
         # Prefix must be substituted inside B200 block
-        assert "runs-on: cbrb200-runner" in result
+        assert "labels: [\"cbrb200-runner\"]" in result
         assert "{{PREFIX}}" not in result
         # Marker comments should be stripped
         assert "BEGIN_B200" not in result
@@ -248,7 +258,7 @@ class TestGenerateWorkflow:
         )
         assert "cache-enforcer-job:" in result
         assert "echo enforcer" in result
-        assert "runs-on: cbrenforcer-runner" in result
+        assert "labels: [\"cbrenforcer-runner\"]" in result
         assert "BEGIN_CACHE_ENFORCER" not in result
         assert "END_CACHE_ENFORCER" not in result
 
@@ -297,6 +307,75 @@ class TestGenerateWorkflow:
         )
         # Default value should be substituted
         assert "echo 12.8" in result
+
+    def test_runner_group_default(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            b200_enabled=False,
+        )
+        assert 'group: "default"' in result
+
+    def test_release_runner_group_default(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            b200_enabled=False,
+            release_enabled=True,
+        )
+        assert 'group: "release-runners"' in result
+        assert "{{RELEASE_RUNNER_GROUP}}" not in result
+
+    def test_release_runner_group_with_cluster_override(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            b200_enabled=False,
+            release_enabled=True,
+            runner_group="my-rg",
+            release_runner_group="my-rg",
+        )
+        assert 'group: "my-rg"' in result
+        assert 'group: "my-rg", labels: ["cbrrel-runner"]' in result
+        assert "{{RELEASE_RUNNER_GROUP}}" not in result
+
+    def test_release_runner_group_disabled_strips_block(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            b200_enabled=False,
+            release_enabled=False,
+        )
+        assert "release-job" not in result
+        assert "BEGIN_RELEASE" not in result
+        assert "END_RELEASE" not in result
+
+
+# ── Release runner group precedence (run.py logic) ────────────────────────
+
+
+class TestReleaseRunnerGroupResolution:
+    def test_cluster_with_override(self, cfg_staging):
+        cluster_runner_group = resolve(cfg_staging, "arc-runners.runner_group")
+        assert cluster_runner_group == "meta-prod-rg"
+        release_runner_group = cluster_runner_group or "release-runners"
+        assert release_runner_group == "meta-prod-rg"
+
+    def test_cluster_without_override(self, cfg_production):
+        cluster_runner_group = resolve(cfg_production, "arc-runners.runner_group")
+        assert cluster_runner_group is None
+        runner_group = cluster_runner_group or "default"
+        release_runner_group = cluster_runner_group or "release-runners"
+        assert runner_group == "default"
+        assert release_runner_group == "release-runners"
 
 
 # ── format_duration ───────────────────────────────────────────────────────

--- a/osdc/integration-tests/workflows/build-image.yaml
+++ b/osdc/integration-tests/workflows/build-image.yaml
@@ -16,12 +16,19 @@ on:
         required: false
         type: string
         default: "l-x86iavx512-2-4"
+      runner_group:
+        description: "Runner group to target (cluster-scoped)"
+        required: false
+        type: string
+        default: "default"
 
 jobs:
   build:
     # NOTE: Always runs on x86 — BuildKit is a *remote* builder.
     # The arch input selects which BuildKit endpoint to connect to.
-    runs-on: ${{ inputs.runner_label }}
+    runs-on:
+      group: ${{ inputs.runner_group }}
+      labels: [ "${{ inputs.runner_label }}" ]
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -83,7 +90,9 @@ jobs:
     # odd one out waits for HAProxy to add capacity, exercising the same
     # autoscaling path. The buildx-client retry tolerates the gRPC connect race
     # while the pool is coming up cold.
-    runs-on: ${{ inputs.runner_label }}
+    runs-on:
+      group: ${{ inputs.runner_group }}
+      labels: [ "${{ inputs.runner_label }}" ]
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   # ── CPU Runner Tests ──────────────────────────────────────────────────
   test-cpu-x86-avx512:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -86,7 +86,7 @@ jobs:
           echo "PASS: Required env vars present"
 
   test-cpu-x86-amx:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -152,7 +152,7 @@ jobs:
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
 
   test-cpu-arm64:
-    runs-on: {{PREFIX}}l-arm64g3-16-62
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-arm64g3-16-62"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -215,7 +215,7 @@ jobs:
   # download.pytorch.org proxy, URL rewriting, torch install, and
   # numpy wheel cache — all without the setup-pypi-cache composite action.
   test-pypi-cache-defaults:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: python:3.12-slim
     steps:
@@ -570,7 +570,7 @@ jobs:
   # Validates the composite action overrides pod-level defaults correctly
   # for CPU configuration. Runs the full test battery.
   test-pypi-cache-action-cpu:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: python:3.12-slim
     steps:
@@ -931,7 +931,7 @@ jobs:
   # pypi-cache service and pytorch wheel index. Runs the full test
   # battery on a GPU runner.
   test-pypi-cache-action-cuda:
-    runs-on: {{PREFIX}}l-x86iavx512-29-115-t4
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iavx512-29-115-t4"] }
     container:
       image: python:3.12-slim
     steps:
@@ -1319,7 +1319,7 @@ jobs:
 
   # ── GPU Runner Tests ──────────────────────────────────────────────────
   test-gpu-t4:
-    runs-on: {{PREFIX}}l-x86iavx512-29-115-t4
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iavx512-29-115-t4"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -1366,7 +1366,7 @@ jobs:
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
 
   test-gpu-t4-multi:
-    runs-on: {{PREFIX}}l-x86iavx512-45-172-t4-4
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iavx512-45-172-t4-4"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -1403,7 +1403,7 @@ jobs:
 
   # BEGIN_B200
   test-gpu-b200-2:
-    runs-on: {{PREFIX}}l-x86iamx-44-450-b200-2
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-44-450-b200-2"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -1443,16 +1443,18 @@ jobs:
     with:
       arch: amd64
       runner_label: {{PREFIX}}l-x86iamx-8-32
+      runner_group: "{{RUNNER_GROUP}}"
 
   buildkit-arm64:
     uses: ./.github/workflows/build-image.yaml
     with:
       arch: arm64
       runner_label: {{PREFIX}}l-x86iamx-8-32
+      runner_group: "{{RUNNER_GROUP}}"
 
   # ── Harbor Cache Test ─────────────────────────────────────────────────
   test-harbor:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -1474,7 +1476,7 @@ jobs:
   # BEGIN_CACHE_ENFORCER
   # ── Cache Enforcer Test ──────────────────────────────────────────────
   test-cache-enforcer:
-    runs-on: {{PREFIX}}l-x86iamx-8-32
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:
@@ -1562,7 +1564,7 @@ jobs:
   # BEGIN_RELEASE
   # ── Release Runner Tests ───────────────────────────────────────────────
   test-release-arm64:
-    runs-on: {{PREFIX}}rel-l-arm64g4-16-62
+    runs-on: { group: "{{RELEASE_RUNNER_GROUP}}", labels: ["{{PREFIX}}rel-l-arm64g4-16-62"] }
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #774
* __->__ #773

**Impact:** Integration tests only — no infrastructure or runner changes
**Risk:** low

## What
Updates all integration test workflow jobs to use `runs-on: { group: "<runner_group>", labels: ["<runner_label>"] }` instead of bare `runs-on: <runner_label>`, ensuring jobs are dispatched to the correct cluster's runner group. Release runner jobs use a separate group variable so clusters with a dedicated runner group don't accidentally target the org-wide `release-runners` group.

## Why
With multiple OSDC clusters registered under the same GitHub org, a bare `runs-on: <label>` can match runners from any cluster — integration tests meant for one cluster could land on another. Using the `group` constraint scopes job placement to the intended cluster. For clusters that define `arc-runners.runner_group` in `clusters.yaml` (e.g. `meta-staging-aws-uw1`, `arc-cbr-prod-uw1`), the release runner group must also be overridden to match — otherwise release test jobs would target a `release-runners` group that doesn't exist in that cluster's org-scoped runner group.

## Notes
- Clusters without an explicit `runner_group` default to `"default"` for regular jobs and `"release-runners"` for release jobs, preserving existing behavior for the us-east-2 production cluster.
- The `build-image.yaml` reusable workflow now accepts a `runner_group` input so callers can propagate the group constraint to BuildKit jobs.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>