### PR TITLE
Add keda module to lf-prod clusters

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -428,6 +428,7 @@ clusters:
       - arc
       - nodepools
       - arc-runners
+      - keda
       - buildkit
       - pypi-cache
       - cache-enforcer
@@ -474,6 +475,7 @@ clusters:
       - arc
       - nodepools
       - arc-runners
+      - keda
       - buildkit
       - pypi-cache
       - cache-enforcer


### PR DESCRIPTION
We missed adding these in the previous PR #700.