### PR TITLE
[TEST-ONLY] Validate NUMA scheduling on A100 (p4d) in ue1 staging

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -250,6 +250,8 @@ clusters:
       - karpenter
       - arc
       - nodepools
+      - nfd                   # [TEST-ONLY] NUMA topology data for p4d (A100) nodes
+      - numa-scheduler        # [TEST-ONLY] NUMA-aware secondary scheduler
       - arc-runners
       - keda
       - buildkit
@@ -292,8 +294,6 @@ clusters:
       - arc
       - nodepools
       - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
-      - nfd                   # NUMA topology data for p5 nodes
-      - numa-scheduler        # NUMA-aware secondary scheduler
       - arc-runners-h100
       - pypi-cache
       - cache-enforcer
@@ -380,8 +380,6 @@ clusters:
       - nodepools
       - nodepools-b200
       - nodepools-h100
-      - nfd                   # NUMA topology data for p5 nodes
-      - numa-scheduler        # NUMA-aware secondary scheduler
       - arc-runners
       - arc-runners-b200
       - arc-runners-h100

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-11-125-a100.yaml
@@ -8,3 +8,7 @@ runner:
   vcpu: 11
   memory: 125Gi
   gpu: 1
+  # [TEST-ONLY] ue1 A100 NUMA validation. A 1-GPU pod always fits one zone, so this is
+  # a no-op for placement — it's the A/B knob: comment out to compare the default
+  # scheduler, or raise vcpu >48 to force an over-one-zone (TopologyAffinityError) test.
+  scheduler_name: numa-scheduler

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-44-500-a100-4.yaml
@@ -7,3 +7,7 @@ runner:
   vcpu: 44
   memory: 500Gi
   gpu: 4
+  # [TEST-ONLY] ue1 A100 NUMA validation — the 4-GPU case the numa-scheduler exists for
+  # (parallel to the H100 4-GPU). 4 GPU + 44 vCPU must align to ONE NUMA zone; the
+  # numa-scheduler reads NRT to place it, vs the default scheduler's bind-then-die.
+  scheduler_name: numa-scheduler

--- a/osdc/modules/nfd/helm/values.yaml
+++ b/osdc/modules/nfd/helm/values.yaml
@@ -23,12 +23,13 @@ topologyUpdater:
   # evaluated by the NUMA-aware scheduler.
   updateInterval: 15s
 
-  # Scoped to H100 nodes (p5 fleet) where the packed pool uses
-  # single-numa-node topology policy. Only these multi-NUMA nodes
-  # need NRT data for the numa-scheduler to prevent
-  # TopologyAffinityError on 4-GPU jobs.
+  # [TEST-ONLY] Repointed from p5 to p4d (A100) for NUMA validation on the
+  # meta-staging-aws-ue1 (us-east-1) staging cluster — real A100 hardware (the
+  # production target). p4d.24xlarge = 2 NUMA x 4 A100, single-numa-node. The
+  # existing p4d fleet is already single-numa-node, so no new pool is needed.
+  # Production: restore node-fleet: p5.
   nodeSelector:
-    node-fleet: p5
+    node-fleet: p4d
 
   # Tolerate every taint so the topology-updater schedules on p5
   # nodes regardless of their taint set (node-fleet, instance-type,

--- a/osdc/modules/nfd/kubernetes/nfd-taint-remover.yaml
+++ b/osdc/modules/nfd/kubernetes/nfd-taint-remover.yaml
@@ -67,9 +67,10 @@ spec:
     spec:
       priorityClassName: system-node-critical
 
-      # Match the same nodes as the NFD topology-updater.
+      # [TEST-ONLY] Match the NFD topology-updater selector — repointed to p4d
+      # (A100) for ue1 staging NUMA validation. Production: restore node-fleet: p5.
       nodeSelector:
-        node-fleet: p5
+        node-fleet: p4d
 
       # Tolerate every taint — same rationale as node-performance-tuning:
       # must coexist with all node-init.osdc.io/* startup taints without

--- a/osdc/modules/nodepools/scripts/python/generate_nodepools.py
+++ b/osdc/modules/nodepools/scripts/python/generate_nodepools.py
@@ -98,10 +98,11 @@ STARTUP_TAINTS: list[dict] = [
         "key": "node-init.osdc.io/nfd-topology",
         "value": "true",
         "effect": "NoSchedule",
-        # NFD topology-updater only targets p5 nodes (nodeSelector: node-fleet: p5).
+        # [TEST-ONLY] Repointed to p4d (A100) for ue1 staging NUMA validation — the NFD
+        # topology-updater + taint-remover target node-fleet: p4d. Production: restore "p5".
         # Only emit the taint on nodepools where NFD actually runs — otherwise the
         # node would be tainted with nothing to remove it.
-        "applies_when": lambda d: d.get("fleet_name") == "p5",
+        "applies_when": lambda d: d.get("fleet_name") == "p4d",
     },
 ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #748
* __->__ #778
* #740
* #759
* #739
* #738

Temporary test configuration — DO NOT MERGE. Self-contained sibling of the g4dn.metal
[TEST-ONLY] commit (now archived on numa-aware-scheduling-g4dn): the same NUMA pipeline
on REAL A100 hardware (p4d.24xlarge) in the new meta-staging-aws-ue1 (us-east-1) staging
cluster — the production-class target. Reuses the existing p4d fleet + A100 runner defs
(the p4d fleet is already single-numa-node), so no new fleet or runner defs are needed.

Prerequisite this unblocks: confirm whether A100/p4d actually PUBLISHES per-GPU NUMA
topology in the NodeResourceTopology. On g4dn.metal it did NOT (zones exposed CPU only,
so the numa-scheduler could never align a GPU pod). After confirming, vary the scheduler
and over-request beyond one NUMA zone (edit the 1-GPU def), mirroring the g4dn A/B.

- Add nfd + numa-scheduler to meta-staging-aws-ue1; remove from the two prod clusters
  so the test pipeline is isolated to staging (mirrors the g4dn commit).
- Repoint NFD topology-updater + taint-remover + the nfd-topology startup-taint gate
  from p5 to p4d. Only ue1 runs nfd now, so a single fleet target — no affinity needed.
- Add scheduler_name: numa-scheduler to the existing A100 1-GPU and 4-GPU runner defs
  (the 4-GPU is the real scenario, parallel to the H100 4-GPU; the 1-GPU is the A/B knob).

p4d.24xlarge = 2 sockets x 4 A100 40GB (2 NUMA x 4 GPU). cpuManagerPolicy=static and
Guaranteed-QoS runner pods already apply, so CPU+GPU NUMA alignment needs no workload
changes. ue1 runners carry the c-mt- staging prefix + meta-staging-aws-ue1 runner group,
so there is no overlap with prod (mt-).

Deploy (ue1 only):
  just deploy-module meta-staging-aws-ue1 nfd
  just deploy-module meta-staging-aws-ue1 numa-scheduler
  just deploy-module meta-staging-aws-ue1 nodepools
  just deploy-module meta-staging-aws-ue1 arc-runners
Then queue a canary job and inspect the NRT for per-zone nvidia.com/gpu BEFORE varying.

Cleanup: drop this commit (git reset --hard HEAD~1) + teardown nfd/numa-scheduler on ue1.