### PR TITLE
Enable KEDA module on LF production clusters (us-east-1, us-east-2)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -428,6 +428,7 @@ clusters:
       - arc
       - nodepools
       - arc-runners
+      - keda
       - buildkit
       - pypi-cache
       - cache-enforcer
@@ -474,6 +475,7 @@ clusters:
       - arc
       - nodepools
       - arc-runners
+      - keda
       - buildkit
       - pypi-cache
       - cache-enforcer


### PR DESCRIPTION
**Impact:** LF production clusters `lf-prod-aws-ue1` and `lf-prod-aws-ue2`

**Risk:** low

## What
Adds the `keda` module to the module lists for the two LF production clusters that were missing it. Deployments are failing: https://github.com/pytorch/ci-infra/actions/runs/27648400909/job/81766069954

## Why
KEDA is already deployed on all other clusters (meta-prod, meta-staging, lf-staging, lf-prod-aws-uw2) and configured at the defaults level. The two US-East LF prod clusters were the only ones not yet opted in.