### PR TITLE
OSDC: bump runner-container-hooks to v0.8.16

### DIFF
--- a/osdc/modules/arc/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc/kubernetes/hooks-warmer.yaml
@@ -2,7 +2,7 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.15
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.16
 # Remove this when upstream merges the fixes into actions/runner-container-hooks
 apiVersion: apps/v1
 kind: DaemonSet
@@ -54,7 +54,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.15"
+              HOOKS_VERSION="0.8.16"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"


### PR DESCRIPTION
## What

Bump the runner-container-hooks version downloaded by the `runner-hooks-warmer` DaemonSet from **0.8.15 → 0.8.16**.

## Why

v0.8.16 lands the k8s hook change that surfaces the pod failure reason in `waitForPodPhases` — instead of a duplicated, contentless `phase status Failed`, the Actions log now shows the actual cause (pod-level `reason`/`message` and container `terminated`/`waiting` reasons, plus `lastState.terminated` for crash-looping containers). This makes failures like `TopologyAffinityError`, `OOMKilled`, and admission rejections diagnosable directly from the job log.

Upstream release: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.16

## Change

`osdc/modules/arc/kubernetes/hooks-warmer.yaml` — `HOOKS_VERSION="0.8.16"` and the reference comment. The warmer re-downloads the new zip on rollout (the `.version` marker triggers a re-fetch), then runner pods snapshot it via the existing `wait-for-hooks` init container.
