### PR TITLE
Add drain/undrain CI workflows for OSDC clusters

### DIFF
--- a/.github/workflows/osdc-drain-prod.yml
+++ b/.github/workflows/osdc-drain-prod.yml
@@ -1,0 +1,101 @@
+name: "OSDC: Drain cluster"
+
+# Manual cordon for an OSDC cluster before maintenance. Two independent
+# checkboxes: drain-runners scales every AutoscalingRunnerSet to maxRunners=0
+# and waits for in-flight runner pods to finish; taint-nodes applies
+# deploy.osdc.io/refresh-pending:NoSchedule to runner nodes so the scheduler
+# stops placing new pods on them. Default = both enabled (typical pre-maintenance
+# flow). Per-cluster concurrency group serializes against the deploy and plan
+# workflows on the same cluster. Reverse with `osdc-undrain-prod.yml`.
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "Cluster to drain"
+        required: true
+        type: choice
+        default: "-- select cluster --"
+        options:
+          - "-- select cluster --"
+          - meta-staging-aws-uw1
+          - meta-staging-aws-ue1
+          - arc-cbr-production-uw1
+          - arc-cbr-production
+          - meta-prod-aws-ue1
+          - lf-prod-aws-ue1
+          - lf-prod-aws-ue2
+      run_drain_runners:
+        description: "Patch AutoscalingRunnerSets to maxRunners=0 and wait for in-flight pods to drain"
+        required: false
+        type: boolean
+        default: true
+      run_taint_nodes:
+        description: "Taint runner nodes with deploy.osdc.io/refresh-pending:NoSchedule to block new pod scheduling"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: osdc-tofu-${{ inputs.cluster }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  drain:
+    name: Drain ${{ inputs.cluster }}
+    runs-on: ubuntu-latest
+    environment: osdc-production
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.cluster }}" = "-- select cluster --" ]; then
+            echo "::error::No cluster selected. Pick a cluster from the dropdown before running."
+            exit 1
+          fi
+          if [ "${{ inputs.run_drain_runners }}" != "true" ] && [ "${{ inputs.run_taint_nodes }}" != "true" ]; then
+            echo "::error::Both run_drain_runners and run_taint_nodes are disabled — nothing to do."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: "2026.5.11"
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: ${{ startsWith(inputs.cluster, 'lf-') && secrets.LF_AWS_DEPLOY_ROLE_ARN || format('arn:aws:iam::{0}:role/{1}', secrets.META_AWS_ACC_ID, secrets.META_AWS_DEPLOY_ROLE) }}
+          aws-region: us-west-1
+          role-duration-seconds: 7200
+
+      - name: Drain runners (maxRunners=0 + wait for in-flight pods)
+        if: ${{ inputs.run_drain_runners }}
+        run: just drain-runners "${{ inputs.cluster }}"
+        env:
+          OSDC_TAINT_NODES: "no"
+
+      - name: Sleep 180s for nodes to settle after drain
+        if: ${{ inputs.run_drain_runners && inputs.run_taint_nodes }}
+        run: sleep 180
+
+      - name: Taint runner nodes (NoSchedule)
+        if: ${{ inputs.run_taint_nodes }}
+        run: just taint-nodes "${{ inputs.cluster }}"

--- a/.github/workflows/osdc-undrain-prod.yml
+++ b/.github/workflows/osdc-undrain-prod.yml
@@ -1,0 +1,96 @@
+name: "OSDC: Undrain cluster"
+
+# Reverses osdc-drain-prod.yml.
+#
+# Two independent checkboxes: untaint-nodes and resume-runners.
+# Default is both enabled (full undrain).
+#
+# Per-cluster concurrency group serializes against deploy/plan/drain
+# on the same cluster (shared osdc-tofu-<cluster> lock family).
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "Cluster to undrain"
+        required: true
+        type: choice
+        default: "-- select cluster --"
+        options:
+          - "-- select cluster --"
+          - meta-staging-aws-uw1
+          - meta-staging-aws-ue1
+          - arc-cbr-production-uw1
+          - arc-cbr-production
+          - meta-prod-aws-ue1
+          - lf-prod-aws-ue1
+          - lf-prod-aws-ue2
+      run_untaint_nodes:
+        description: "Remove deploy.osdc.io/refresh-pending:NoSchedule taint from runner nodes"
+        required: false
+        type: boolean
+        default: true
+      run_resume_runners:
+        description: "Restore AutoscalingRunnerSet maxRunners from def files"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: osdc-tofu-${{ inputs.cluster }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  undrain:
+    name: Undrain ${{ inputs.cluster }}
+    runs-on: ubuntu-latest
+    environment: osdc-production
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: osdc
+    steps:
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.cluster }}" = "-- select cluster --" ]; then
+            echo "::error::No cluster selected. Pick a cluster from the dropdown before running."
+            exit 1
+          fi
+          if [ "${{ inputs.run_untaint_nodes }}" != "true" ] && [ "${{ inputs.run_resume_runners }}" != "true" ]; then
+            echo "::error::Both run_untaint_nodes and run_resume_runners are disabled — nothing to do."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: "2026.5.11"
+          install: true
+          working_directory: osdc
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: ${{ startsWith(inputs.cluster, 'lf-') && secrets.LF_AWS_DEPLOY_ROLE_ARN || format('arn:aws:iam::{0}:role/{1}', secrets.META_AWS_ACC_ID, secrets.META_AWS_DEPLOY_ROLE) }}
+          aws-region: us-west-1
+          role-duration-seconds: 7200
+
+      - name: Untaint runner nodes
+        if: ${{ inputs.run_untaint_nodes }}
+        run: just untaint-nodes "${{ inputs.cluster }}"
+
+      - name: Resume runners (restore maxRunners from def files)
+        if: ${{ inputs.run_resume_runners }}
+        run: just resume-runners "${{ inputs.cluster }}"

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1012,9 +1012,15 @@ drain-runners cluster:
     fi
 
     echo ""
-    echo "Applying refresh taint to runner nodes..."
-    just taint-nodes "$CLUSTER"
-    TAINTED_NODES=$(kubectl get nodes -l workload-type=github-runner --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${OSDC_TAINT_NODES:-yes}" = "yes" ]; then
+        echo "Applying refresh taint to runner nodes..."
+        just taint-nodes "$CLUSTER"
+        TAINTED_NODES=$(kubectl get nodes -l workload-type=github-runner --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        TAINTED_NODES_MSG="${TAINTED_NODES} nodes tainted"
+    else
+        echo "Skipping refresh taint step (OSDC_TAINT_NODES=${OSDC_TAINT_NODES})."
+        TAINTED_NODES_MSG="taint skipped"
+    fi
 
     echo ""
     # Default 1h covers typical PyTorch suite duration; override via OSDC_DRAIN_TIMEOUT_SECS for longer/shorter windows.
@@ -1055,7 +1061,7 @@ drain-runners cluster:
     fi
 
     echo ""
-    echo "Summary: ${DRAINED} AutoscalingRunnerSets drained, ${TAINTED_NODES} nodes tainted, ${STRAGGLERS_MSG}."
+    echo "Summary: ${DRAINED} AutoscalingRunnerSets drained, ${TAINTED_NODES_MSG}, ${STRAGGLERS_MSG}."
     if [ "$ARS_FAILED" -gt 0 ]; then
         echo "Warning: ${ARS_FAILED} AutoscalingRunnerSet(s) failed to patch."
     fi


### PR DESCRIPTION
**Impact:** OSDC operators performing cluster maintenance
**Risk:** low

## What
Adds two `workflow_dispatch` workflows (`osdc-drain-prod`, `osdc-undrain-prod`) that let operators drain and restore OSDC clusters from the GitHub Actions UI, and makes node tainting optional in the `drain-runners` just recipe via `OSDC_TAINT_NODES`.

## Why
Draining a cluster before maintenance currently requires CLI access and running just recipes manually. These workflows expose the same operations (scale runners to zero, taint/untaint nodes, resume runners) behind the Actions UI with environment protection gates and proper AWS credential assumption, so any operator can safely drain or undrain a cluster without local tooling.

The `OSDC_TAINT_NODES` env var was added to `drain-runners` so the drain workflow can run the drain step and the taint step independently — the workflow calls `drain-runners` with `OSDC_TAINT_NODES=no` and handles tainting as a separate step with a 180s settle sleep in between.

## Notes
- Both workflows share the `osdc-tofu-<cluster>` concurrency group with deploy/plan to prevent concurrent mutations on the same cluster.
- Drain and taint are independently toggleable via workflow input checkboxes (default: both enabled).
- Drain timeout is 90 minutes; undrain timeout is 60 minutes.