### PR TITLE
Fix smoke and integration tests for clusters without pypi-cache

### DIFF
--- a/osdc/docs/runner-image-autoresolve.md
+++ b/osdc/docs/runner-image-autoresolve.md
@@ -98,6 +98,17 @@ up.
    GitHub API call, no `crane` call, ConfigMap untouched. Removing
    the key on a later deploy returns the cluster to auto-resolution.
 
+## Read-only mode (smoke tests)
+
+Setting `OSDC_RESOLVER_READONLY=1` disables every write path: no GitHub
+API call, no `crane` call, no ConfigMap mutation. The resolver prefers
+an exact match for the current OSDC SHA; if the SHA is not in the lock
+(e.g. when iterating on test code without a fresh deploy) it falls back
+to the newest entry in the history and prints a warning to stderr
+naming the fallback SHA. If the history is empty it errors out — there
+is nothing to fall back to. This mode is set by `just smoke` so smoke
+runs exercise whatever the live deploy already pinned.
+
 ## Failure modes
 
 Each of these aborts the deploy with a non-zero exit and a single-line

--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -37,6 +37,10 @@ TAG_REQUIREMENTS: dict[str, list[str]] = {
     "RELEASE": ["arc-runners"],
 }
 
+INVERSE_TAG_EXCLUSIONS: dict[str, list[str]] = {
+    "NO_CACHE_ENFORCER": ["cache-enforcer"],
+}
+
 
 def ensure_canary_repo(upstream_dir: Path) -> Path:
     """Clone or update pytorch-canary into .scratch/ and return its path."""
@@ -278,6 +282,10 @@ def generate_workflow(
     modules_set = set(cluster_modules)
     for tag, required in TAG_REQUIREMENTS.items():
         keep = all(m in modules_set for m in required)
+        content = strip_conditional_block(content, tag, keep=keep)
+
+    for tag, excluded in INVERSE_TAG_EXCLUSIONS.items():
+        keep = not any(m in modules_set for m in excluded)
         content = strip_conditional_block(content, tag, keep=keep)
 
     if not _has_any_job(content):

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -137,6 +137,12 @@ def workflow_template(tmp_path):
         "    steps:\n"
         "      - run: echo enforcer\n"
         "  # END_CACHE_ENFORCER\n"
+        "  # BEGIN_NO_CACHE_ENFORCER\n"
+        "  no-cache-enforcer-job:\n"
+        '    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}upstream-runner"] }\n'
+        "    steps:\n"
+        "      - run: echo upstream\n"
+        "  # END_NO_CACHE_ENFORCER\n"
         "  # BEGIN_RELEASE\n"
         "  release-job:\n"
         '    runs-on: { group: "{{RELEASE_RUNNER_GROUP}}", labels: ["{{PREFIX}}rel-runner"] }\n'
@@ -293,10 +299,35 @@ class TestGenerateWorkflow:
             "pytorch-arc-cbr-production",
             cluster_modules=[m for m in ALL_MODULES if m != "cache-enforcer"],
         )
-        assert "cache-enforcer-job" not in result
+        assert "  cache-enforcer-job:" not in result
         assert "BEGIN_CACHE_ENFORCER" not in result
         assert "END_CACHE_ENFORCER" not in result
         assert "arc-job" in result
+
+    def test_no_cache_enforcer_kept_when_cache_enforcer_absent(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            cluster_modules=[m for m in ALL_MODULES if m != "cache-enforcer"],
+        )
+        assert "no-cache-enforcer-job" in result
+        assert "BEGIN_NO_CACHE_ENFORCER" not in result
+        assert "END_NO_CACHE_ENFORCER" not in result
+
+    def test_no_cache_enforcer_stripped_when_cache_enforcer_present(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "arc-cbr-production",
+            "pytorch-arc-cbr-production",
+            cluster_modules=ALL_MODULES,
+        )
+        assert "no-cache-enforcer-job" not in result
+        assert "BEGIN_NO_CACHE_ENFORCER" not in result
+        assert "END_NO_CACHE_ENFORCER" not in result
+        assert "cache-enforcer-job" in result
 
     def test_b200_requires_both_modules(self, workflow_template):
         result = generate_workflow(
@@ -531,7 +562,7 @@ class TestGenerateWorkflowNoopFallback:
             "cbr",
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
-            cluster_modules=[],
+            cluster_modules=["cache-enforcer"],
         )
         assert "no-op:" in result
         assert "ubuntu-latest" in result
@@ -545,7 +576,7 @@ class TestGenerateWorkflowNoopFallback:
             "cbr",
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
-            cluster_modules=["arc-runners-h100"],
+            cluster_modules=["arc-runners-h100", "cache-enforcer"],
         )
         assert "no-op:" in result
         assert "arc-job" not in result
@@ -557,7 +588,7 @@ class TestGenerateWorkflowNoopFallback:
             "cbr",
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
-            cluster_modules=["arc-runners-b200"],
+            cluster_modules=["arc-runners-b200", "cache-enforcer"],
         )
         assert "no-op:" in result
         assert "b200-job" not in result
@@ -569,7 +600,7 @@ class TestGenerateWorkflowNoopFallback:
             "cbr",
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
-            cluster_modules=[],
+            cluster_modules=["cache-enforcer"],
         )
         assert "name: cbr integration test" in result
         assert "on: push" in result
@@ -580,7 +611,7 @@ class TestGenerateWorkflowNoopFallback:
             "cbr",
             "arc-cbr-production",
             "pytorch-arc-cbr-production",
-            cluster_modules=[],
+            cluster_modules=["cache-enforcer"],
         )
         lines = result.split("\n")
         jobs_idx = next(i for i, line in enumerate(lines) if line.rstrip() == "jobs:")

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -212,6 +212,29 @@ jobs:
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
   # END_ARC_RUNNERS
 
+  # BEGIN_NO_CACHE_ENFORCER
+  test-pip-install-upstream:
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
+    container:
+      image: python:3.12-slim
+    steps:
+      - name: Verify pip install from upstream pypi.org
+        run: |
+          echo "=== Upstream pip install Test ==="
+          pip install --no-cache-dir six packaging typing-extensions
+          python -c "import six, packaging, typing_extensions; print('PASS: pip install + import from upstream pypi.org')"
+
+      - name: Install uv
+        run: pip install --no-cache-dir uv
+
+      - name: Verify uv pip install from upstream pypi.org
+        run: |
+          echo "=== Upstream uv pip install Test ==="
+          pip uninstall -y six packaging typing-extensions >/dev/null 2>&1 || true
+          uv pip install --system --no-cache six packaging typing-extensions
+          python -c "import six, packaging, typing_extensions; print('PASS: uv pip install + import from upstream pypi.org')"
+  # END_NO_CACHE_ENFORCER
+
   # BEGIN_PYPI_CACHE
   # ── PyPI Cache: Default Pod Environment ─────────────────────────────
   # Validates runner pod-level defaults: pip install, uv install,

--- a/osdc/integration-tests/workload-test/scripts/python/test_workload_run.py
+++ b/osdc/integration-tests/workload-test/scripts/python/test_workload_run.py
@@ -981,7 +981,7 @@ class TestMain:
             with pytest.raises(SystemExit):
                 main()
 
-        mock_instrument.assert_called_once_with(canary, "cbr-")
+        mock_instrument.assert_called_once_with(canary, "cbr-", pypi_cache_enabled=False)
 
     @patch("workload_run.close_pr")
     @patch("workload_run.print_workload_report")
@@ -1218,7 +1218,7 @@ class TestMain:
                 main()
 
         # instrument_workflows should receive "" as prefix
-        mock_instrument.assert_called_once_with(Path("/tmp/canary"), "")
+        mock_instrument.assert_called_once_with(Path("/tmp/canary"), "", pypi_cache_enabled=False)
 
 
 # ── Constants ───────────────────────────────────────────────────────────

--- a/osdc/integration-tests/workload-test/scripts/python/workload_phases.py
+++ b/osdc/integration-tests/workload-test/scripts/python/workload_phases.py
@@ -140,6 +140,7 @@ def instrument_workflows(
     canary_path: Path,
     target_prefix: str,
     keep_workflows: list[str] | None = None,
+    pypi_cache_enabled: bool = True,
 ) -> None:
     """Run all instrumentation steps on the mirrored canary repo."""
     if keep_workflows is None:
@@ -192,11 +193,14 @@ def instrument_workflows(
     )
 
     # 3g: Inject PyPI cache setup into all workflows with steps
-    log.info("  3g: Injecting PyPI cache setup (auto-detect from build-environment)...")
-    apply_to_all_workflows(
-        workflows_dir,
-        lambda c: inject_pypi_cache_step(c, PYPI_CACHE_ACTION_REF),
-    )
+    if pypi_cache_enabled:
+        log.info("  3g: Injecting PyPI cache setup (auto-detect from build-environment)...")
+        apply_to_all_workflows(
+            workflows_dir,
+            lambda c: inject_pypi_cache_step(c, PYPI_CACHE_ACTION_REF),
+        )
+    else:
+        log.info("  3g: Skipping PyPI cache injection (cluster does not deploy pypi-cache module)")
 
 
 # ── Phase 4: Create PR ───────────────────────────────────────────────

--- a/osdc/integration-tests/workload-test/scripts/python/workload_run.py
+++ b/osdc/integration-tests/workload-test/scripts/python/workload_run.py
@@ -143,7 +143,7 @@ def main() -> None:
 
     # Phase 3: Instrument workflows
     log.info("Phase 3: Instrumenting workflows...")
-    instrument_workflows(canary_path, prefix)
+    instrument_workflows(canary_path, prefix, pypi_cache_enabled=has_module(cfg, "pypi-cache"))
 
     # Phase 4: Create PR
     pr_created_at = datetime.now(tz=UTC)

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -2081,8 +2081,10 @@ smoke cluster:
     # each variant's own deploy.sh, e.g. modules/arc-runners-b200/deploy.sh).
     # Generation must happen ONCE before any pytest worker starts —
     # previously the test fixture shelled out, which raced under pytest-xdist.
-    # OSDC_RESOLVER_READONLY: smoke must not mutate the lock ConfigMap or hit
-    # GitHub; it reads the newest cached entry the live deploy already wrote.
+    # OSDC_RESOLVER_READONLY: smoke must not mutate the lock ConfigMap or hit GitHub.
+    # Prefers an exact match for the current osdc SHA; falls back to the newest
+    # entry when the current SHA isn't in the lock (e.g. when iterating on test
+    # code without a fresh deploy).
     export OSDC_RESOLVER_READONLY=1
     for mod in $MODULES; do
         case "$mod" in

--- a/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/resolve_runner_version.py
@@ -206,10 +206,22 @@ def _run(cluster_id: str, client: Client) -> str:
         return f"{IMAGE_REPO}:{tag}@{digest}"
 
     if os.environ.get("OSDC_RESOLVER_READONLY"):
-        raise ValueError(
-            f"OSDC_RESOLVER_READONLY set but {CM_NAME} has no entry for osdc_sha={sha}. "
-            "Run a normal deploy (without OSDC_RESOLVER_READONLY) to populate it first."
+        if not history:
+            raise ValueError(
+                f"OSDC_RESOLVER_READONLY set but {CM_NAME} has no entry for osdc_sha={sha}. "
+                "Run a normal deploy (without OSDC_RESOLVER_READONLY) to populate it first."
+            )
+        newest = history[0]
+        newest_sha = newest.get("osdc_sha", "<unknown>")
+        newest_resolved_at = newest.get("resolved_at", "<unknown>")
+        print(
+            f"resolve_runner_version: OSDC_RESOLVER_READONLY set, no cache entry for "
+            f"osdc_sha={sha}; falling back to newest entry {newest_sha} resolved at "
+            f"{newest_resolved_at}. To pin to your exact SHA, run a normal deploy first.",
+            file=sys.stderr,
         )
+        tag, digest = newest["tag"], newest["digest"]
+        return f"{IMAGE_REPO}:{tag}@{digest}"
 
     token = os.environ.get("GITHUB_TOKEN") or None
     tag = fetch_latest_tag(token)

--- a/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
+++ b/osdc/modules/arc-runners/scripts/python/test_resolve_runner_version.py
@@ -561,18 +561,19 @@ class TestMain:
         env.client.create.assert_not_called()
         env.client.replace.assert_not_called()
 
-    def test_readonly_with_unknown_sha_fails(self, monkeypatch, capsys):
+    def test_readonly_with_unknown_sha_falls_back_to_newest(self, monkeypatch, capsys):
         monkeypatch.setenv("OSDC_RESOLVER_READONLY", "1")
-        env = _Env(
-            monkeypatch,
-            sha=_SHA_C,
-            history=[_entry(_SHA_A, "2.335.0", "sha256:a", "2026-05-01T00:00:00Z")],
-        )
+        newest = _entry(_SHA_A, "2.336.0", "sha256:newest", "2026-06-10T00:00:00Z")
+        older = _entry(_SHA_B, "2.335.0", "sha256:older", "2026-05-01T00:00:00Z")
+        env = _Env(monkeypatch, sha=_SHA_C, history=[newest, older])
         rc = rrv.main(["resolve_runner_version.py", "c"])
         captured = capsys.readouterr()
-        assert rc == 1
+        assert rc == 0
+        assert captured.out.strip() == "ghcr.io/actions/actions-runner:2.336.0@sha256:newest"
         assert "OSDC_RESOLVER_READONLY" in captured.err
-        assert _SHA_C in captured.err
+        assert "falling back to newest entry" in captured.err
+        assert _SHA_A in captured.err
+        assert "2026-06-10T00:00:00Z" in captured.err
         assert env.fetched_token == []
         assert env.crane_calls == []
         env.client.create.assert_not_called()

--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -128,6 +128,9 @@ class TestRunnerConfigMapEnvVars:
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
+        if "pypi-cache" not in enabled_modules:
+            pytest.skip("pypi-cache module not enabled — env vars are intentionally stripped from runner ConfigMaps")
+
         # Scope to arc-runners* modules actually enabled on this cluster — defs
         # from unenabled-but-present-in-codebase variants would otherwise be
         # expected as CMs that genuinely don't exist on this cluster.

--- a/osdc/modules/monitoring/tests/smoke/test_monitoring.py
+++ b/osdc/modules/monitoring/tests/smoke/test_monitoring.py
@@ -22,23 +22,23 @@ from helpers import (
 
 pytestmark = [pytest.mark.live]
 
-EXPECTED_SERVICE_MONITORS = [
-    "apiserver",
-    "arc-controller",
-    "buildkit",
-    "buildkit-haproxy",
-    "harbor",
-    "karpenter",
-    "keda",
-    "node-compactor",
-    "pypi-cache",
-    "dcgm-exporter",
-]
+EXPECTED_SERVICE_MONITORS: dict[str, str | None] = {
+    "apiserver": None,
+    "arc-controller": "arc",
+    "buildkit": "buildkit",
+    "buildkit-haproxy": "buildkit",
+    "harbor": None,
+    "karpenter": "karpenter",
+    "keda": "keda",
+    "node-compactor": None,
+    "pypi-cache": "pypi-cache",
+    "dcgm-exporter": None,
+}
 
-EXPECTED_POD_MONITORS = [
-    "arc-listeners",
-    "coredns",
-]
+EXPECTED_POD_MONITORS: dict[str, str | None] = {
+    "arc-listeners": "arc",
+    "coredns": None,
+}
 
 
 @pytest.fixture
@@ -120,11 +120,16 @@ class TestPrometheusOperator:
 class TestServiceMonitors:
     """Verify expected ServiceMonitors exist."""
 
-    def test_service_monitors_exist(self, mon_ns: str) -> None:
+    def test_service_monitors_exist(self, mon_ns: str, enabled_modules: list[str]) -> None:
         result = run_kubectl(["get", "servicemonitors"], namespace=mon_ns)
         sm_names = {item["metadata"]["name"] for item in result.get("items", [])}
 
-        missing = [name for name in EXPECTED_SERVICE_MONITORS if name not in sm_names]
+        expected = [
+            name
+            for name, required_module in EXPECTED_SERVICE_MONITORS.items()
+            if required_module is None or required_module in enabled_modules
+        ]
+        missing = [name for name in expected if name not in sm_names]
         assert not missing, f"Missing ServiceMonitors in '{mon_ns}': {missing}"
 
 
@@ -136,11 +141,16 @@ class TestServiceMonitors:
 class TestPodMonitors:
     """Verify expected PodMonitors exist."""
 
-    def test_pod_monitors_exist(self, mon_ns: str) -> None:
+    def test_pod_monitors_exist(self, mon_ns: str, enabled_modules: list[str]) -> None:
         result = run_kubectl(["get", "podmonitors"], namespace=mon_ns)
         pm_names = {item["metadata"]["name"] for item in result.get("items", [])}
 
-        missing = [name for name in EXPECTED_POD_MONITORS if name not in pm_names]
+        expected = [
+            name
+            for name, required_module in EXPECTED_POD_MONITORS.items()
+            if required_module is None or required_module in enabled_modules
+        ]
+        missing = [name for name in expected if name not in pm_names]
         assert not missing, f"Missing PodMonitors in '{mon_ns}': {missing}"
 
 


### PR DESCRIPTION
**Impact:** CI smoke tests and workload integration tests
**Risk:** low

## What
Makes smoke tests and workload instrumentation aware of whether the `pypi-cache` module is enabled on the target cluster, so tests pass on clusters that don't deploy it.

## Why
After disabling the `pypi-cache` and `cache-enforcer` modules on some clusters, several tests started failing: the monitoring smoke tests unconditionally expected a `pypi-cache` ServiceMonitor, the runner ConfigMap test expected PyPI env vars that are only injected when the module is present, and the workload instrumentation always injected the PyPI cache action step regardless of cluster config. All three now gate on the cluster's enabled modules list.

## Tests

### Smoke

* validated on `meta-staging-aws-uw1`, `meta-prod-aws-ue1` and `arc-cbr-production`

### Integration

* no pypi-cache: https://github.com/pytorch/pytorch-canary/actions/runs/27729651521/job/82033636550
* with pypi-cache: https://github.com/pytorch/pytorch-canary/actions/runs/27729946973/job/82034565247