### PR TITLE
relax topology_manager_policy for p5 nodepool

### DIFF
--- a/osdc/modules/nodepools-h100/defs/p5.yaml
+++ b/osdc/modules/nodepools-h100/defs/p5.yaml
@@ -9,8 +9,11 @@ nodepool:
   node_disk_size: 1000
   gpu: true
   has_nvme: true
-  topology_manager_policy: single-numa-node
-  topology_manager_scope: pod
+  # TODO: reintroduce topology constraints when NUMA-aware scheduling is available.
+  # 4xH100 jobs are susceptible to TopologyAffinityError as described in
+  # https://github.com/pytorch/ci-infra/issues/696.
+  # topology_manager_policy: single-numa-node
+  # topology_manager_scope: pod
   capacity_type: reserved
   # capacity_reservation_ids are cluster-specific (different reservations in
   # us-east-2 vs us-west-1) and live under clusters.<id>.nodepools-h100 in


### PR DESCRIPTION
the numa-scheduler has significant requirements for enumerating resources on each node type. To reduce failures for 4xH100 jobs, we're relaxing the NUMA requirements on these hosts in the meantime to address https://github.com/pytorch/ci-infra/issues/696.

```
just lint
just test
```
