### PR TITLE
Fix recurring dcgm-exporter OOMKill on dense-GPU nodes

### DIFF
--- a/osdc/modules/monitoring/kubernetes/dcgm-exporter/daemonset.yaml
+++ b/osdc/modules/monitoring/kubernetes/dcgm-exporter/daemonset.yaml
@@ -55,15 +55,18 @@ spec:
               value: "true"
             - name: DCGM_EXPORTER_LISTEN
               value: ":9400"
+            # Soft Go heap ceiling below the hard limit; native DCGM (cgo)
+            # allocations sit on top and scale with GPU count.
             - name: GOMEMLIMIT
-              value: "450MiB"
+              value: "768MiB"
           resources:
             requests:
               cpu: 100m
               memory: 256Mi
             limits:
               cpu: 200m
-              memory: 512Mi
+              # 1Gi: 512Mi OOMKills on 8-GPU nodes (one pod reads every GPU).
+              memory: 1Gi
           securityContext:
             runAsNonRoot: false
             runAsUser: 0


### PR DESCRIPTION
**Impact:** GPU monitoring/alerting on multi-GPU nodes (dcgm-exporter DaemonSet)
**Risk:** low

I notice this persistent smoke test failures on prod cluster https://github.com/pytorch/ci-infra/actions/runs/27790998116/job/82253970946

dcgm-exporter pods OOMKill-loop on multi-GPU nodes, blinding GPU monitoring/alerting there. A single pod reads every GPU on its node and the native DCGM (cgo) memory scales with GPU count, so 512Mi is too low on 8-GPU nodes (g5/g6/p4d .48xlarge). On arc-cbr-production, 13 pods have OOMKill history — all on high-GPU-count nodes; the smoke test caught one at 5 restarts ([run](https://github.com/pytorch/ci-infra/actions/runs/27790998116/job/82253970946)). The prior fix (#631) did not cover the densest nodes.

Raises the memory limit 512Mi → 1Gi and GOMEMLIMIT 450MiB → 768MiB. 1Gi is ~0.1% of these hosts' RAM, so node packing and cost are unaffected.