### PR TITLE
Bump ARC chart to 0.14.1-jeanschmidt.14

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -53,7 +53,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.12"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.14"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     replica_count: 4
     log_level: info
     controller_cpu_request: "1"


### PR DESCRIPTION
Bump ARC fork chart `0.14.1-jeanschmidt.12` → `0.14.1-jeanschmidt.14` (published from jeanschmidt/actions-runner-controller).

Includes:
- jeanschmidt/actions-runner-controller#9 (.13)
- jeanschmidt/actions-runner-controller#5 (.14)
