### PR TITLE
[CRCR] Bump lambda release pin to v20260619-155744-custom (rate-limit 60)

### DIFF
--- a/crcr/Terrafile
+++ b/crcr/Terrafile
@@ -3,7 +3,7 @@ terraform-aws-vpc:
   rev: "3ffbd46fb1c7733e1b34d8666893280454e27436"
 crcr:
   source: "pytorch/test-infra"
-  tag: "v20260604-153951"
+  tag: "v20260619-155744-custom"
   assets:
     - "cross-repo-ci-webhook.zip"
     - "cross-repo-ci-callback.zip"


### PR DESCRIPTION
## Summary

Bump the CRCR `Terrafile` lambda release pin from `v20260604-153951` to **`v20260619-155744-custom`** so the prod deploy ships the updated `cross-repo-ci-callback.zip` / `cross-repo-ci-webhook.zip`.

## Why

`v20260619-155744-custom` (pytorch/test-infra) carries:
- the callback rate-limit bump — default `RATE_LIMIT_PER_MIN` **20 → 60** (pytorch/test-infra#8203), fixing the `429 "rate limit exceeded for ..."` callback failures, and
- a single, complete release produced by the de-raced lambda release workflow (pytorch/test-infra#8204).

Verified before pinning:
- Single published release, **13 assets** (no duplicate-tag fragmentation).
- Public download URLs resolve — `releases/download/v20260619-155744-custom/cross-repo-ci-callback.zip` and `.../cross-repo-ci-webhook.zip` both return **HTTP 200** (this is exactly what `crcr/scripts/terrafile_lambdas.py` fetches).
- The callback zip's `utils/config.py` has `RATE_LIMIT_PER_MIN", "60"`.

## Deploy

After merge, run **Terraform Apply / CRCR / Production** (`crcr-deploy-prod.yml`). `make apply` re-downloads the pinned zip; `source_code_hash` changes, so `tofu apply` updates the `crcr-callback-prod` Lambda code. The callback Lambda sets no `RATE_LIMIT_PER_MIN` env var, so the in-code default of 60 takes effect.

## Test plan

- `make -C crcr/aws plan` (or the workflow's plan) should show only the `aws_lambda_function.callback` (and `.webhook`) `source_code_hash` / code update, no other resource changes.

AI assistance (Claude) was used to prepare this change.
