### PR TITLE
bin-pack-scheduler: enable on meta-staging-aws-ue1

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -246,6 +246,7 @@ clusters:
       - karpenter
       - arc
       - nodepools
+      - bin-pack-scheduler
       - arc-runners
       - keda
       - buildkit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #807
* #804
* #803

Add bin-pack-scheduler to the meta-staging-aws-ue1 module list. Split out from
the module-definition PR (#803) and the arc-runners scheduler_name knob (#804)
so landing the code and the per-def capability does not by itself change what is
deployed; this PR is the single switch that turns the scheduler on in staging.
The module stays inert until a runner def opts in via scheduler_name.