### PR TITLE
osdc/arc: point runner-container-hooks warmer at fork v0.8.17

### DIFF
--- a/osdc/modules/arc/kubernetes/hooks-warmer.yaml
+++ b/osdc/modules/arc/kubernetes/hooks-warmer.yaml
@@ -2,8 +2,10 @@
 # Downloads the patched runner-container-hooks zip once per node to NVMe,
 # so runner pods can mount it read-only without per-pod downloads.
 #
-# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.16
-# Remove this when upstream merges the fixes into actions/runner-container-hooks
+# See: https://github.com/jeanschmidt/runner-container-hooks/releases/tag/v0.8.17
+# v0.8.17 drops the stream-buffers dependency whose WritableStreamBuffer used the
+# deprecated Buffer() constructor (per-step DEP0005 warning), via
+# jeanschmidt/runner-container-hooks#12. Remove this when the fix lands upstream.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -54,7 +56,7 @@ spec:
             - -c
             - |
               set -eu
-              HOOKS_VERSION="0.8.16"
+              HOOKS_VERSION="0.8.17"
               HOOKS_URL="https://github.com/jeanschmidt/runner-container-hooks/releases/download/v${HOOKS_VERSION}/actions-runner-hooks-k8s-${HOOKS_VERSION}.zip"
               DEST="/mnt/runner-container-hooks"
               MARKER="$DEST/.version"


### PR DESCRIPTION
Point the runner-container-hooks warmer at **v0.8.17** in `hooks-warmer.yaml`.

v0.8.17 drops the `stream-buffers` dependency whose `WritableStreamBuffer` used the deprecated `Buffer()` constructor, which printed a Node `DEP0005` warning once per containerized step (every job's `Initialize containers` log). Fork PR: jeanschmidt/runner-container-hooks#12 · upstream issue: actions/runner-container-hooks#261.

**Source:** jeanschmidt/runner-container-hooks#12 has landed and is released as `jeanschmidt/runner-container-hooks` v0.8.17, so the warmer now pulls the release zip directly from the `jeanschmidt` fork. Remove the fork pin once the fix lands in `actions/runner-container-hooks` upstream. Deploy to a staging cluster and confirm no DEP0005 before prod.