### PR TITLE
osdc/hf-cache: shared HuggingFace model cache for OSDC runners (gated, not enabled)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -110,6 +110,16 @@ defaults:
       - "x86_64"
       - "aarch64"
     target_manylinux: "2_28"
+  hf_cache:
+    # Shared HuggingFace model cache (modules/hf-cache). Not enabled on any
+    # cluster by default — add "hf-cache" to a cluster's modules list to turn it
+    # on. The model data lives in a single shared, private S3 bucket
+    # (pytorch-hf-model-cache in us-east-2); these are just the knobs.
+    namespace: hf-cache
+    bucket_region: us-east-2          # region of the shared model-cache bucket
+    rclone_image: "rclone/rclone:1.69.1"
+    vfs_cache_max_size: 200G          # per-node NVMe cap for the rclone read cache
+    refresh_schedule: "0 7 * * *"     # daily 07:00 UTC
 
 clusters:
   meta-staging-aws-uw1:

--- a/osdc/modules/arc-runners/scripts/python/generate_runners.py
+++ b/osdc/modules/arc-runners/scripts/python/generate_runners.py
@@ -173,13 +173,26 @@ def resolve_max_runners(value, def_file, cluster_id):
     return value
 
 
-def generate_runner(def_file, template_content, cluster_config, output_dir, module_name, pypi_cache_enabled=True):
+def generate_runner(
+    def_file,
+    template_content,
+    cluster_config,
+    output_dir,
+    module_name,
+    pypi_cache_enabled=True,
+    hf_cache_enabled=False,
+):
     """Generate a single runner config from its definition.
 
     pypi_cache_enabled controls whether the `# BEGIN_PYPI_CACHE` / `# END_PYPI_CACHE`
     block in the template is preserved (True) or stripped (False). Strip when the
     cluster does not deploy the pypi-cache module — the env vars would otherwise
     point at a Service that doesn't exist on this cluster.
+
+    hf_cache_enabled does the same for the `# BEGIN_HF_CACHE` / `# END_HF_CACHE`
+    block (HF_HOME env + the read-only /mnt/hf_cache hostPath mount). Strip when the
+    cluster does not deploy the hf-cache module — the hostPath would otherwise be
+    empty and HF_HUB_OFFLINE=1 would make every model load fail.
     """
     with open(def_file) as f:
         data = yaml.safe_load(f)
@@ -338,6 +351,7 @@ def generate_runner(def_file, template_content, cluster_config, output_dir, modu
     # Replace all template placeholders
     output_content = template_content
     output_content = strip_conditional_block(output_content, "PYPI_CACHE", keep=pypi_cache_enabled)
+    output_content = strip_conditional_block(output_content, "HF_CACHE", keep=hf_cache_enabled)
     replacements = {
         "{{GITHUB_CONFIG_URL}}": github_url,
         "{{GITHUB_SECRET_NAME}}": k8s_secret_ref,
@@ -499,9 +513,22 @@ def main():
     # that doesn't exist on this cluster.
     pypi_cache_enabled = "pypi-cache" in (cluster_cfg.get("modules") or [])
 
+    # hf-cache module is cluster-scoped: when absent, strip the HF_CACHE env vars
+    # and the /mnt/hf_cache hostPath mount from the workflow pod template so jobs
+    # don't mount an empty path and fail offline model loads.
+    hf_cache_enabled = "hf-cache" in (cluster_cfg.get("modules") or [])
+
     count = 0
     for def_file in def_files:
-        if generate_runner(def_file, template_content, cluster_config, output_dir, module_name, pypi_cache_enabled):
+        if generate_runner(
+            def_file,
+            template_content,
+            cluster_config,
+            output_dir,
+            module_name,
+            pypi_cache_enabled,
+            hf_cache_enabled,
+        ):
             count += 1
 
     print()

--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -437,6 +437,18 @@ data:
             - name: PYPI_CACHE_WHL_URL
               value: "http://pypi-cache-cpu.pypi-cache.svc.cluster.local:8080/whl/cpu/"
             # END_PYPI_CACHE
+            # BEGIN_HF_CACHE
+            - name: HF_HOME
+              value: "/mnt/hf_cache"
+            - name: HF_HUB_CACHE
+              value: "/mnt/hf_cache/hub"
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: TRANSFORMERS_OFFLINE
+              value: "1"
+            - name: HF_DATASETS_OFFLINE
+              value: "1"
+            # END_HF_CACHE
             - name: TORCH_CI_MAX_MEMORY
               value: "{{MEMORY_BYTES}}"
           # Workflow container gets the actual compute resources
@@ -450,6 +462,15 @@ data:
               memory: "{{MEMORY}}"
               ephemeral-storage: "{{DISK_SIZE}}"{{GPU_LIMIT}}
           volumeMounts:
+            # BEGIN_HF_CACHE
+            # Shared HuggingFace model cache. The hf-cache mount DaemonSet keeps
+            # this FUSE mount alive on the host; HostToContainer propagation lets
+            # the job pod see it. Read-only — refresh is a separate writer job.
+            - name: hf-cache
+              mountPath: /mnt/hf_cache
+              readOnly: true
+              mountPropagation: HostToContainer
+            # END_HF_CACHE
             # K8s default /dev/shm is 64Mi (container runtime tmpfs). NCCL
             # blows past that on multi-GPU workloads; PyTorch docker-based CI
             # also runs with --shm-size=1g-2g, so match that ceiling for all
@@ -461,6 +482,12 @@ data:
           emptyDir:
             medium: Memory
             sizeLimit: 2Gi
+        # BEGIN_HF_CACHE
+        - name: hf-cache
+          hostPath:
+            path: /mnt/hf_cache
+            type: DirectoryOrCreate
+        # END_HF_CACHE
   wrapper.js: |
     #!/usr/bin/env node
     'use strict';

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -1,0 +1,77 @@
+# hf-cache — shared HuggingFace model cache
+
+Gives OSDC runners a shared, read-only HuggingFace model cache at `/mnt/hf_cache`,
+the OSDC equivalent of the old EC2 CI `/mnt/hf_cache` mount. Jobs read model
+weights from a local cache instead of downloading from the Hub on every run.
+
+## Design in one paragraph
+
+The model cache is stored as **plain, symlink-free HuggingFace cache-layout files
+in a single shared S3 bucket** (the portable source of truth — any object store
+can host the same layout). A privileged per-node **rclone FUSE mount**
+(`mount-daemonset`) exposes that bucket **read-only** at the host path
+`/mnt/hf_cache`; reads are lazy and cached on node-local NVMe, so a cold Karpenter
+node only pulls the models its jobs touch. Job pods (ARC kubernetes mode) get the
+path bind-mounted via the gated `# BEGIN_HF_CACHE` block in
+`modules/arc-runners/templates/runner.yaml.tpl`. A **refresh CronJob** is the only
+writer: it downloads the curated model set and publishes a symlink-free copy to S3.
+
+No metadata engine, no EFS — just S3 + rclone, which keeps it cloud-portable.
+
+## Components
+
+| Component | What it does |
+|-----------|--------------|
+| `terraform/hf-cache-bucket/` | Shared, private S3 bucket `pytorch-hf-model-cache` (one-time, manual apply) |
+| `terraform/` | Per-cluster IRSA roles: `hf-cache-mount` (read-only), `hf-cache-refresh` (read/write) |
+| `kubernetes/mount-daemonset.yaml.tpl` | rclone FUSE mount → read-only `/mnt/hf_cache` on every runner/workflow node |
+| `kubernetes/refresh-cronjob.yaml.tpl` | Downloads `models.txt` from the Hub, publishes symlink-free to S3 |
+| `scripts/python/refresh_cache.py` | Refresh driver (download + `rclone copy -L`, dropping `blobs/`) |
+| `models.txt` | Curated model manifest (kept in sync with pytorch/pytorch CI pins) |
+
+## Runner consumption
+
+When `hf-cache` is in a cluster's `modules:` list, `generate_runners.py` keeps the
+`# BEGIN_HF_CACHE` block, which adds to every job pod:
+
+- volume + read-only `hostPath` mount of `/mnt/hf_cache` (`HostToContainer` propagation)
+- env: `HF_HOME=/mnt/hf_cache`, `HF_HUB_CACHE=/mnt/hf_cache/hub`, `HF_HUB_OFFLINE=1`,
+  `TRANSFORMERS_OFFLINE=1`, `HF_DATASETS_OFFLINE=1`
+
+`from_pretrained(...)` / `vllm.LLM(model=...)` then resolve from the cache with no
+code changes. When the module is absent the block is stripped, so this is a no-op
+for clusters that don't enable it.
+
+## Enable on a cluster
+
+1. One-time (per account): apply the shared bucket
+   ```
+   cd modules/hf-cache/terraform/hf-cache-bucket
+   tofu init -backend-config=... && tofu apply
+   ```
+2. (Optional) create the gated/private-model token Secret:
+   ```
+   kubectl create secret generic hf-cache-token -n hf-cache --from-literal=token=hf_xxx
+   ```
+3. Add `hf-cache` to the cluster's `modules:` list in `clusters.yaml` (after
+   `arc-runners`), then redeploy:
+   ```
+   just deploy-module <cluster> hf-cache
+   just deploy-module <cluster> arc-runners   # re-render job pods with the HF_CACHE block
+   ```
+4. Populate the cache immediately (otherwise it waits for the CronJob):
+   ```
+   kubectl create job -n hf-cache --from=cronjob/hf-cache-refresh hf-cache-refresh-manual
+   ```
+
+## Open items (see PR description)
+
+- **Symlink-free layout** is assumed to resolve transparently via `from_pretrained`
+  from an `rclone -L`, `blobs/`-excluded layout — needs a validation spike before
+  enabling on a real cluster.
+- The mount DaemonSet is **privileged** (FUSE + Bidirectional propagation); confirm
+  this is acceptable under the cluster's Pod Security posture.
+- Single shared bucket in `us-east-2` means cross-region S3 reads for other regions
+  (node-local cache absorbs repeats). Per-region buckets / replication is a follow-up.
+- Strict-offline (`HF_HUB_OFFLINE=1`): an uncached model errors out (matches EC2).
+  Graceful online fallback (overlay) is a possible enhancement.

--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# HF cache module deploy script.
+# Called by: just deploy-module <cluster> hf-cache
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+#
+# Deploys:
+#   1. hf-cache namespace + ServiceAccounts (kustomize)
+#   2. IRSA annotations on the mount/refresh ServiceAccounts (terraform outputs)
+#   3. ConfigMaps (refresh script + model manifest)
+#   4. Mount DaemonSet (rclone FUSE → read-only /mnt/hf_cache on each runner node)
+#   5. Refresh CronJob (downloads curated models → publishes to shared S3 bucket)
+#
+# The model cache data lives in a single shared S3 bucket (see
+# terraform/hf-cache-bucket/). This per-cluster deploy only wires the IRSA roles,
+# the node mount, and the refresh job.
+
+CLUSTER="$1"
+export CNAME="$2"
+export REGION="$3"
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/kubectl-apply.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
+CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
+
+# --- Read hf_cache config (with defaults) ---
+NAMESPACE=$(uv run "$CFG" "$CLUSTER" hf_cache.namespace hf-cache)
+BUCKET_REGION=$(uv run "$CFG" "$CLUSTER" hf_cache.bucket_region us-east-2)
+RCLONE_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_image "rclone/rclone:1.69.1")
+VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size 200G)
+REFRESH_SCHEDULE=$(uv run "$CFG" "$CLUSTER" hf_cache.refresh_schedule "0 7 * * *")
+BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
+
+# --- Read terraform outputs: IRSA role ARNs + bucket name ---
+echo "[hf-cache] Reading terraform outputs..."
+cd "$MODULE_DIR/terraform"
+tofu init -reconfigure \
+  -backend-config="bucket=${BUCKET_CFG}" \
+  -backend-config="key=${CLUSTER}/hf-cache/terraform.tfstate" \
+  -backend-config="region=${STATE_REGION}" \
+  -backend-config="dynamodb_table=ciforge-terraform-locks" \
+  >/dev/null 2>&1
+MOUNT_ROLE_ARN=$(tofu output -raw mount_role_arn)
+REFRESH_ROLE_ARN=$(tofu output -raw refresh_role_arn)
+BUCKET=$(tofu output -raw hf_cache_bucket)
+cd - >/dev/null
+echo "[hf-cache] Bucket: ${BUCKET} (${BUCKET_REGION})"
+echo "[hf-cache] Mount role ARN: ${MOUNT_ROLE_ARN}"
+echo "[hf-cache] Refresh role ARN: ${REFRESH_ROLE_ARN}"
+
+# --- Apply base k8s resources (namespace, ServiceAccounts) ---
+echo "[hf-cache] Applying base resources (namespace, ServiceAccounts)..."
+kubectl_apply_if_changed -k "$MODULE_DIR/kubernetes/"
+
+echo "[hf-cache] Annotating ServiceAccounts with IRSA roles..."
+kubectl annotate sa hf-cache-mount -n "$NAMESPACE" \
+  eks.amazonaws.com/role-arn="$MOUNT_ROLE_ARN" --overwrite
+kubectl annotate sa hf-cache-refresh -n "$NAMESPACE" \
+  eks.amazonaws.com/role-arn="$REFRESH_ROLE_ARN" --overwrite
+
+# --- ConfigMaps (refresh script + model manifest) ---
+echo "[hf-cache] Creating hf-cache-refresh-scripts ConfigMap..."
+kubectl create configmap hf-cache-refresh-scripts \
+  --from-file=refresh_cache.py="$MODULE_DIR/scripts/python/refresh_cache.py" \
+  -n "$NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap hf-cache-refresh-scripts -n "$NAMESPACE" \
+  osdc.io/module=hf-cache --overwrite
+
+echo "[hf-cache] Creating hf-cache-models ConfigMap..."
+kubectl create configmap hf-cache-models \
+  --from-file=models.txt="$MODULE_DIR/models.txt" \
+  -n "$NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap hf-cache-models -n "$NAMESPACE" \
+  osdc.io/module=hf-cache --overwrite
+
+# --- Render + apply the mount DaemonSet ---
+echo "[hf-cache] Applying mount DaemonSet..."
+sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
+  -e "s|__BUCKET__|${BUCKET}|g" \
+  -e "s|__REGION__|${BUCKET_REGION}|g" \
+  -e "s|__RCLONE_IMAGE__|${RCLONE_IMAGE}|g" \
+  -e "s|__VFS_CACHE_MAX_SIZE__|${VFS_CACHE_MAX_SIZE}|g" \
+  "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl" \
+  | kubectl_apply_if_changed -f -
+
+# --- Render + apply the refresh CronJob ---
+echo "[hf-cache] Applying refresh CronJob..."
+sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
+  -e "s|__BUCKET__|${BUCKET}|g" \
+  -e "s|__REGION__|${BUCKET_REGION}|g" \
+  -e "s|__RCLONE_IMAGE__|${RCLONE_IMAGE}|g" \
+  -e "s|__SCHEDULE__|${REFRESH_SCHEDULE}|g" \
+  "$MODULE_DIR/kubernetes/refresh-cronjob.yaml.tpl" \
+  | kubectl_apply_if_changed -f -
+
+# --- Wait for the mount DaemonSet to roll out ---
+echo "[hf-cache] Waiting for mount DaemonSet rollout..."
+kubectl rollout status daemonset hf-cache-mount \
+  -n "$NAMESPACE" --timeout=300s || {
+  echo "[hf-cache] WARNING: mount DaemonSet rollout did not complete within timeout"
+  echo "[hf-cache] Check: kubectl get pods -n $NAMESPACE -l app=hf-cache-mount"
+}
+
+echo "[hf-cache] Deployed — rclone mount serving read-only /mnt/hf_cache on runner nodes."
+echo "[hf-cache] To populate now: kubectl create job -n $NAMESPACE --from=cronjob/hf-cache-refresh hf-cache-refresh-manual"

--- a/osdc/modules/hf-cache/kubernetes/kustomization.yaml
+++ b/osdc/modules/hf-cache/kubernetes/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base resources only. The mount DaemonSet and refresh CronJob are rendered
+# from templates by deploy.sh (they need terraform outputs and per-cluster
+# config substituted in), so they are not part of this kustomization.
+resources:
+  - namespace.yaml
+  - serviceaccounts.yaml

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -1,0 +1,140 @@
+# HF cache mount DaemonSet.
+#
+# Runs one rclone FUSE mount per node that can host workflow (job) pods,
+# exposing the shared S3 model cache read-only at the host path /mnt/hf_cache.
+# Job pods hostPath-mount that path (HostToContainer propagation) so the cache
+# appears inside the job container — see the BEGIN_HF_CACHE block in
+# modules/arc-runners/templates/runner.yaml.tpl.
+#
+# Reads are lazy: rclone fetches a file from S3 on first open and caches it on
+# node-local NVMe (--cache-dir), bounded by --vfs-cache-max-size with LRU
+# eviction. A cold Karpenter node therefore only pulls the models its jobs
+# actually touch, never the whole bucket.
+#
+# Placeholders substituted by deploy.sh: __NAMESPACE__ __BUCKET__ __REGION__
+# __RCLONE_IMAGE__ __VFS_CACHE_MAX_SIZE__
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hf-cache-mount
+  namespace: __NAMESPACE__
+  labels:
+    osdc.io/module: hf-cache
+    app.kubernetes.io/name: hf-cache
+    app.kubernetes.io/component: mount
+spec:
+  selector:
+    matchLabels:
+      app: hf-cache-mount
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+
+  template:
+    metadata:
+      labels:
+        app: hf-cache-mount
+        osdc.io/module: hf-cache
+    spec:
+      serviceAccountName: hf-cache-mount
+      priorityClassName: system-node-critical
+
+      # Run on every node that can host workflow/job pods. ARC runner and
+      # workflow nodes are labelled workload-type=github-runner.
+      nodeSelector:
+        workload-type: github-runner
+
+      # Tolerate every taint a runner/workflow node may carry, including the
+      # graceful-refresh taint, so the mount is present before jobs land.
+      tolerations:
+        - key: node-fleet
+          operator: Exists
+          effect: NoSchedule
+        - key: instance-type
+          operator: Exists
+          effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: deploy.osdc.io/refresh-pending
+          operator: Exists
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
+
+      containers:
+        - name: rclone
+          image: __RCLONE_IMAGE__
+          # FUSE mount requires /dev/fuse and the ability to share the mount
+          # back to the host (Bidirectional propagation) — both need privileged.
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              MOUNT=/mnt/hf_cache
+              CACHE=/mnt/hf-cache-vfs
+              mkdir -p "$MOUNT" "$CACHE"
+
+              # IRSA supplies credentials via the AWS SDK env chain (env_auth).
+              exec rclone mount \
+                ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
+                "$MOUNT" \
+                --read-only \
+                --allow-other \
+                --dir-cache-time 1h \
+                --poll-interval 0 \
+                --vfs-cache-mode full \
+                --vfs-cache-max-size __VFS_CACHE_MAX_SIZE__ \
+                --vfs-cache-max-age 24h \
+                --vfs-read-chunk-size 128M \
+                --cache-dir "$CACHE" \
+                --no-modtime \
+                --umask 022 \
+                --log-level INFO
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "fusermount -uz /mnt/hf_cache || umount -l /mnt/hf_cache || true"
+          # A hung FUSE mount makes this exec block until the probe times out,
+          # which restarts the pod and re-establishes the mount.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "ls /mnt/hf_cache >/dev/null"
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /mnt/hf_cache
+              mountPropagation: Bidirectional
+            - name: hf-cache-vfs
+              mountPath: /mnt/hf-cache-vfs
+
+      volumes:
+        - name: hf-cache
+          hostPath:
+            path: /mnt/hf_cache
+            type: DirectoryOrCreate
+        - name: hf-cache-vfs
+          hostPath:
+            path: /mnt/hf-cache-vfs
+            type: DirectoryOrCreate

--- a/osdc/modules/hf-cache/kubernetes/namespace.yaml
+++ b/osdc/modules/hf-cache/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hf-cache
+  labels:
+    osdc.io/module: hf-cache
+    app.kubernetes.io/name: hf-cache

--- a/osdc/modules/hf-cache/kubernetes/refresh-cronjob.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/refresh-cronjob.yaml.tpl
@@ -1,0 +1,108 @@
+# HF cache refresh CronJob.
+#
+# Downloads the curated model set (modules/hf-cache/models.txt) from the
+# HuggingFace Hub and publishes a symlink-free copy to the shared S3 bucket,
+# which the mount DaemonSet then serves to runners. This is the only writer.
+#
+# Placeholders substituted by deploy.sh: __NAMESPACE__ __BUCKET__ __REGION__
+# __RCLONE_IMAGE__ __SCHEDULE__
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hf-cache-refresh
+  namespace: __NAMESPACE__
+  labels:
+    osdc.io/module: hf-cache
+    app.kubernetes.io/name: hf-cache
+    app.kubernetes.io/component: refresh
+spec:
+  schedule: "__SCHEDULE__"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    metadata:
+      labels:
+        osdc.io/module: hf-cache
+        app.kubernetes.io/name: hf-cache
+        app.kubernetes.io/component: refresh
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 21600  # 6h
+      template:
+        metadata:
+          labels:
+            app: hf-cache-refresh
+            osdc.io/module: hf-cache
+        spec:
+          serviceAccountName: hf-cache-refresh
+          restartPolicy: OnFailure
+          # Run on the runner fleet; tolerate its taints.
+          nodeSelector:
+            workload-type: github-runner
+          tolerations:
+            - key: node-fleet
+              operator: Exists
+              effect: NoSchedule
+            - key: instance-type
+              operator: Exists
+              effect: NoSchedule
+          containers:
+            - name: refresh
+              image: __RCLONE_IMAGE__
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache python3 py3-pip >/dev/null
+                  pip install --no-cache-dir --break-system-packages \
+                    'huggingface_hub>=0.24' >/dev/null
+                  exec python3 /scripts/refresh_cache.py \
+                    --models /config/models.txt \
+                    --bucket "$HF_CACHE_BUCKET" \
+                    --region "$AWS_REGION" \
+                    --cache-dir /work/hub \
+                    --prefix hub
+              env:
+                - name: HF_CACHE_BUCKET
+                  value: "__BUCKET__"
+                - name: AWS_REGION
+                  value: "__REGION__"
+                # Token for gated/private models. Optional — public models work
+                # without it. Create with:
+                #   kubectl create secret generic hf-cache-token \
+                #     -n __NAMESPACE__ --from-literal=token=hf_xxx
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hf-cache-token
+                      key: token
+                      optional: true
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 4Gi
+                  ephemeral-storage: 50Gi
+                limits:
+                  cpu: "4"
+                  memory: 8Gi
+                  ephemeral-storage: 200Gi
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: models
+                  mountPath: /config
+                - name: work
+                  mountPath: /work
+          volumes:
+            - name: scripts
+              configMap:
+                name: hf-cache-refresh-scripts
+            - name: models
+              configMap:
+                name: hf-cache-models
+            - name: work
+              emptyDir:
+                sizeLimit: 200Gi

--- a/osdc/modules/hf-cache/kubernetes/serviceaccounts.yaml
+++ b/osdc/modules/hf-cache/kubernetes/serviceaccounts.yaml
@@ -1,0 +1,22 @@
+# Service accounts for the HF cache module. The IRSA role-arn annotation is
+# applied at deploy time by deploy.sh (read from terraform outputs), mirroring
+# the pattern used by other modules.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hf-cache-mount
+  namespace: hf-cache
+  labels:
+    osdc.io/module: hf-cache
+    app.kubernetes.io/name: hf-cache
+    app.kubernetes.io/component: mount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hf-cache-refresh
+  namespace: hf-cache
+  labels:
+    osdc.io/module: hf-cache
+    app.kubernetes.io/name: hf-cache
+    app.kubernetes.io/component: refresh

--- a/osdc/modules/hf-cache/models.txt
+++ b/osdc/modules/hf-cache/models.txt
@@ -1,0 +1,20 @@
+# Curated HuggingFace model manifest for the shared OSDC cache.
+#
+# One entry per line: `repo_id` or `repo_id@revision`. Blank lines and `#`
+# comments (full-line or trailing) are ignored. The refresh CronJob downloads
+# every listed repo and publishes it to the shared S3 bucket; runners then read
+# these models offline from /mnt/hf_cache.
+#
+# Keep this in sync with the model pins that drive pytorch/pytorch CI's
+# `ci-refresh-hf-cache` label:
+#   .github/ci_commit_pins/vllm.txt
+#   .ci/docker/ci_commit_pins/timm.txt
+#   .ci/docker/ci_commit_pins/huggingface-requirements.txt
+#   .ci/docker/ci_commit_pins/torchbench.txt
+#
+# Gated/private repos require a token — see README.md (hf-cache-token Secret).
+#
+# Examples (uncomment / extend as the consuming workflows require):
+# meta-llama/Llama-3.1-8B-Instruct
+# Qwen/Qwen2.5-7B-Instruct
+# openai/clip-vit-base-patch32

--- a/osdc/modules/hf-cache/scripts/python/refresh_cache.py
+++ b/osdc/modules/hf-cache/scripts/python/refresh_cache.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["huggingface_hub>=0.24"]
+# ///
+"""Refresh the shared HuggingFace model cache.
+
+Downloads a curated set of model repos from the HuggingFace Hub into a local
+HF cache directory, then publishes a *symlink-free* copy to the shared S3
+bucket. Runners mount that bucket read-only at /mnt/hf_cache and read models
+offline (HF_HUB_OFFLINE=1), so this job is the only writer.
+
+Why symlink-free: the default HF cache stores snapshots/<rev>/<file> as symlinks
+into blobs/<sha>. Object storage has no symlinks, so we dereference them on the
+way out (`rclone copy -L`) and drop the now-redundant blobs/, leaving real files
+under snapshots/. That keeps `from_pretrained("org/model")` working transparently
+without needing a POSIX metadata layer over S3.
+
+Run locally:  uv run refresh_cache.py --models models.txt --bucket B --region R
+In-cluster:   driven by the refresh CronJob (see kubernetes/refresh-cronjob.yaml.tpl)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_manifest(text: str) -> list[tuple[str, str | None]]:
+    """Parse a model manifest into (repo_id, revision) pairs.
+
+    Format: one entry per line, ``repo_id`` or ``repo_id@revision``. Blank lines
+    and ``#`` comments (full-line or trailing) are ignored.
+
+    >>> parse_manifest("# header\\nmeta-llama/Llama-3.1-8B\\nopenai/clip@abc123  # pin\\n")
+    [('meta-llama/Llama-3.1-8B', None), ('openai/clip', 'abc123')]
+    """
+    entries: list[tuple[str, str | None]] = []
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if "@" in line:
+            repo_id, revision = line.split("@", 1)
+            entries.append((repo_id.strip(), revision.strip() or None))
+        else:
+            entries.append((line, None))
+    return entries
+
+
+def download_models(
+    entries: list[tuple[str, str | None]],
+    cache_dir: Path,
+    token: str | None,
+) -> None:
+    """Download each manifest entry into the HF cache layout at *cache_dir*."""
+    # Imported lazily so the module (and its unit tests) load without the
+    # huggingface_hub dependency present.
+    from huggingface_hub import snapshot_download
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    for repo_id, revision in entries:
+        label = repo_id if revision is None else f"{repo_id}@{revision}"
+        print(f"[hf-cache] downloading {label} ...", flush=True)
+        snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            cache_dir=str(cache_dir),
+            token=token,
+        )
+    print(f"[hf-cache] downloaded {len(entries)} repo(s) into {cache_dir}", flush=True)
+
+
+def build_rclone_args(
+    cache_dir: Path,
+    bucket: str,
+    region: str,
+    prefix: str,
+    prune: bool,
+) -> list[str]:
+    """Build the rclone command that publishes *cache_dir* to S3.
+
+    ``-L`` dereferences HF's snapshot symlinks into real objects; ``blobs/`` is
+    excluded because those bytes are duplicated into snapshots by ``-L``. Uses
+    ``copy`` (additive) by default; ``sync`` (mirrors, deletes de-listed models)
+    only when *prune* is set, since a partial download must never delete S3 data.
+
+    >>> build_rclone_args(Path("/work/hub"), "b", "us-east-2", "hub", False)[:2]
+    ['rclone', 'copy']
+    """
+    remote = f":s3,provider=AWS,env_auth=true,region={region}:{bucket}/{prefix}"
+    return [
+        "rclone",
+        "sync" if prune else "copy",
+        "-L",
+        "--exclude",
+        "blobs/**",
+        "--transfers",
+        "8",
+        "--checkers",
+        "16",
+        "--fast-list",
+        str(cache_dir),
+        remote,
+    ]
+
+
+def publish(
+    cache_dir: Path,
+    bucket: str,
+    region: str,
+    prefix: str,
+    prune: bool,
+    dry_run: bool,
+) -> None:
+    """Publish the local cache to S3 via rclone."""
+    args = build_rclone_args(cache_dir, bucket, region, prefix, prune)
+    if dry_run:
+        args.append("--dry-run")
+    print(f"[hf-cache] publishing: {' '.join(args)}", flush=True)
+    subprocess.run(args, check=True)
+    print("[hf-cache] publish complete", flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Refresh the shared HuggingFace model cache")
+    parser.add_argument("--models", required=True, type=Path, help="Path to the model manifest")
+    parser.add_argument("--bucket", required=True, help="Target S3 bucket")
+    parser.add_argument("--region", required=True, help="S3 bucket region")
+    parser.add_argument("--cache-dir", required=True, type=Path, help="Local HF cache dir (the 'hub' dir)")
+    parser.add_argument("--prefix", default="hub", help="Key prefix within the bucket (default: hub)")
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help="Mirror with rclone sync (deletes de-listed models). Default is additive copy.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Download but do not write to S3")
+
+    args = parser.parse_args(argv)
+
+    entries = parse_manifest(args.models.read_text())
+    if not entries:
+        print(f"[hf-cache] no models listed in {args.models}; nothing to do", file=sys.stderr)
+        return 0
+
+    token = os.environ.get("HF_TOKEN") or None
+    download_models(entries, args.cache_dir, token)
+    publish(args.cache_dir, args.bucket, args.region, args.prefix, args.prune, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/osdc/modules/hf-cache/scripts/python/test_refresh_cache.py
+++ b/osdc/modules/hf-cache/scripts/python/test_refresh_cache.py
@@ -1,0 +1,112 @@
+"""Unit tests for refresh_cache pure helpers (no network, no huggingface_hub)."""
+
+import sys
+import types
+from pathlib import Path
+
+import refresh_cache
+from refresh_cache import build_rclone_args, download_models, main, parse_manifest, publish
+
+
+def test_parse_manifest_basic():
+    text = "meta-llama/Llama-3.1-8B\nopenai/clip-vit-base-patch32\n"
+    assert parse_manifest(text) == [
+        ("meta-llama/Llama-3.1-8B", None),
+        ("openai/clip-vit-base-patch32", None),
+    ]
+
+
+def test_parse_manifest_revision_and_comments():
+    text = "# curated models\n\norg/model-a@abc123\n   org/model-b   # trailing comment\n# full-line comment\n"
+    assert parse_manifest(text) == [
+        ("org/model-a", "abc123"),
+        ("org/model-b", None),
+    ]
+
+
+def test_parse_manifest_empty():
+    assert parse_manifest("\n#only comments\n   \n") == []
+
+
+def test_build_rclone_args_copy_default():
+    args = build_rclone_args(Path("/work/hub"), "my-bucket", "us-east-2", "hub", prune=False)
+    assert args[0] == "rclone"
+    assert args[1] == "copy"
+    assert "-L" in args
+    assert "blobs/**" in args
+    assert args[-1] == ":s3,provider=AWS,env_auth=true,region=us-east-2:my-bucket/hub"
+    assert args[-2] == "/work/hub"
+
+
+def test_build_rclone_args_prune_uses_sync():
+    args = build_rclone_args(Path("/work/hub"), "b", "us-west-2", "hub", prune=True)
+    assert args[1] == "sync"
+
+
+def test_download_models_calls_snapshot(monkeypatch, tmp_path):
+    calls = []
+    fake = types.ModuleType("huggingface_hub")
+    fake.snapshot_download = lambda **kwargs: calls.append(kwargs)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+
+    entries = [("org/a", None), ("org/b", "rev1")]
+    download_models(entries, tmp_path / "hub", token="tok")
+
+    assert [c["repo_id"] for c in calls] == ["org/a", "org/b"]
+    assert calls[1]["revision"] == "rev1"
+    assert calls[0]["token"] == "tok"  # noqa: S105
+    assert (tmp_path / "hub").is_dir()
+
+
+def test_publish_invokes_rclone_copy(monkeypatch, tmp_path):
+    seen = {}
+
+    def fake_run(args, check):
+        seen["args"] = args
+        seen["check"] = check
+
+    monkeypatch.setattr(refresh_cache.subprocess, "run", fake_run)
+    publish(tmp_path, "b", "us-east-2", "hub", prune=False, dry_run=False)
+
+    assert seen["args"][1] == "copy"
+    assert seen["check"] is True
+    assert "--dry-run" not in seen["args"]
+
+
+def test_publish_dry_run_appends_flag(monkeypatch, tmp_path):
+    seen = {}
+    monkeypatch.setattr(refresh_cache.subprocess, "run", lambda args, check: seen.setdefault("args", args))
+    publish(tmp_path, "b", "r", "hub", prune=True, dry_run=True)
+
+    assert seen["args"][1] == "sync"
+    assert seen["args"][-1] == "--dry-run"
+
+
+def test_main_empty_manifest_is_noop(tmp_path):
+    manifest = tmp_path / "models.txt"
+    manifest.write_text("# nothing here\n")
+    rc = main(["--models", str(manifest), "--bucket", "b", "--region", "r", "--cache-dir", str(tmp_path / "hub")])
+    assert rc == 0
+
+
+def test_main_happy_path(monkeypatch, tmp_path):
+    manifest = tmp_path / "models.txt"
+    manifest.write_text("org/a\norg/b@rev\n")
+    downloaded = []
+    published = []
+    monkeypatch.setattr(
+        refresh_cache,
+        "download_models",
+        lambda entries, cache_dir, token: downloaded.append((entries, cache_dir, token)),
+    )
+    monkeypatch.setattr(refresh_cache, "publish", lambda *a, **k: published.append((a, k)))
+    monkeypatch.setenv("HF_TOKEN", "secret")
+
+    rc = main(
+        ["--models", str(manifest), "--bucket", "bk", "--region", "us-east-2", "--cache-dir", str(tmp_path / "hub")]
+    )
+
+    assert rc == 0
+    assert downloaded[0][2] == "secret"
+    assert len(downloaded[0][0]) == 2
+    assert published

--- a/osdc/modules/hf-cache/terraform/backend.tf
+++ b/osdc/modules/hf-cache/terraform/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/osdc/modules/hf-cache/terraform/hf-cache-bucket/backend.tf
+++ b/osdc/modules/hf-cache/terraform/hf-cache-bucket/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/osdc/modules/hf-cache/terraform/hf-cache-bucket/main.tf
+++ b/osdc/modules/hf-cache/terraform/hf-cache-bucket/main.tf
@@ -1,0 +1,67 @@
+# Standalone terraform root for the shared HuggingFace model-cache S3 bucket.
+#
+# This bucket is shared across all clusters — it lives outside the per-cluster
+# terraform state to avoid multiple states managing the same resource. It holds
+# the model cache as plain HuggingFace cache-layout files (symlink-free), which
+# are the portable source of truth: any object store / cloud can host the same
+# layout and be `rclone sync`'d here or away.
+#
+# Unlike the pypi wheel cache, this bucket is PRIVATE — access is granted only
+# through the per-cluster IRSA roles in ../main.tf. No public read.
+#
+# One-time setup:
+#   tofu init -backend-config=... && tofu apply
+
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_s3_bucket" "hf_cache" {
+  bucket = "pytorch-hf-model-cache"
+}
+
+resource "aws_s3_bucket_public_access_block" "hf_cache" {
+  bucket = aws_s3_bucket.hf_cache.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "hf_cache" {
+  bucket = aws_s3_bucket.hf_cache.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Reap incomplete multipart uploads left behind by interrupted refresh runs.
+resource "aws_s3_bucket_lifecycle_configuration" "hf_cache" {
+  bucket = aws_s3_bucket.hf_cache.id
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/osdc/modules/hf-cache/terraform/main.tf
+++ b/osdc/modules/hf-cache/terraform/main.tf
@@ -1,0 +1,156 @@
+# HF Cache module: per-cluster IAM (IRSA) for the shared HuggingFace model cache.
+#
+# The model cache data lives in a single shared S3 bucket (managed out-of-band by
+# terraform/hf-cache-bucket/). This per-cluster root only creates the two IRSA
+# roles that the in-cluster service accounts assume:
+#
+#   * hf-cache-mount    — read-only. The rclone-mount DaemonSet uses it to expose
+#                         the bucket as a read-only FUSE mount on each node.
+#   * hf-cache-refresh  — read/write. The refresh CronJob uses it to publish newly
+#                         downloaded models back to the bucket.
+#
+# Reads base infrastructure outputs (OIDC provider) via terraform_remote_state.
+
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "base" {
+  backend = "s3"
+
+  config = {
+    bucket         = var.state_bucket
+    key            = "${var.cluster_id}/base/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "ciforge-terraform-locks"
+  }
+}
+
+locals {
+  oidc_provider_arn = data.terraform_remote_state.base.outputs.oidc_provider_arn
+  oidc_provider     = data.terraform_remote_state.base.outputs.oidc_provider
+
+  namespace   = "hf-cache"
+  bucket_arn  = "arn:aws:s3:::${var.hf_cache_bucket}"
+  objects_arn = "arn:aws:s3:::${var.hf_cache_bucket}/*"
+
+  tags = {
+    Cluster = var.cluster_name
+    Project = "ciforge"
+  }
+}
+
+# --- Mount (reader) IAM Role (IRSA) ---
+
+resource "aws_iam_role" "mount" {
+  name = "${var.cluster_name}-hf-cache-mount-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Effect = "Allow"
+      Principal = {
+        Federated = local.oidc_provider_arn
+      }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+          "${local.oidc_provider}:sub" = "system:serviceaccount:${local.namespace}:hf-cache-mount"
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "mount" {
+  name = "${var.cluster_name}-hf-cache-mount-s3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:ListBucket",
+      ]
+      Resource = [
+        local.bucket_arn,
+        local.objects_arn,
+      ]
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "mount" {
+  policy_arn = aws_iam_policy.mount.arn
+  role       = aws_iam_role.mount.name
+}
+
+# --- Refresh (writer) IAM Role (IRSA) ---
+
+resource "aws_iam_role" "refresh" {
+  name = "${var.cluster_name}-hf-cache-refresh-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Effect = "Allow"
+      Principal = {
+        Federated = local.oidc_provider_arn
+      }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+          "${local.oidc_provider}:sub" = "system:serviceaccount:${local.namespace}:hf-cache-refresh"
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "refresh" {
+  name = "${var.cluster_name}-hf-cache-refresh-s3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+      ]
+      Resource = [
+        local.bucket_arn,
+        local.objects_arn,
+      ]
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "refresh" {
+  policy_arn = aws_iam_policy.refresh.arn
+  role       = aws_iam_role.refresh.name
+}

--- a/osdc/modules/hf-cache/terraform/outputs.tf
+++ b/osdc/modules/hf-cache/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "mount_role_arn" {
+  description = "IAM role ARN for the hf-cache-mount service account (IRSA, read-only)"
+  value       = aws_iam_role.mount.arn
+}
+
+output "refresh_role_arn" {
+  description = "IAM role ARN for the hf-cache-refresh service account (IRSA, read/write)"
+  value       = aws_iam_role.refresh.arn
+}
+
+output "hf_cache_bucket" {
+  description = "Shared S3 bucket holding the HuggingFace model cache"
+  value       = var.hf_cache_bucket
+}

--- a/osdc/modules/hf-cache/terraform/variables.tf
+++ b/osdc/modules/hf-cache/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "state_bucket" {
+  description = "S3 bucket for terraform state (used to read base outputs)"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "Cluster identifier in clusters.yaml (e.g. meta-staging-aws-uw1)"
+  type        = string
+}
+
+variable "hf_cache_bucket" {
+  description = "Shared S3 bucket holding the HuggingFace model cache (plain files). Managed by terraform/hf-cache-bucket/, referenced here only for IAM scoping."
+  type        = string
+  default     = "pytorch-hf-model-cache"
+}


### PR DESCRIPTION
## What

Adds a new `hf-cache` module giving OSDC runners a **shared, read-only HuggingFace model cache at `/mnt/hf_cache`** — the OSDC equivalent of the old EC2 CI mount. Jobs read model weights from a local cache (`HF_HOME=/mnt/hf_cache`, offline mode) instead of pulling from the Hub on every run.

> [!IMPORTANT]
> **This is a draft and changes behavior on ZERO clusters.** The runner integration is gated behind a `# BEGIN_HF_CACHE` block that is stripped unless a cluster lists `hf-cache` in its `modules:`. No cluster's `modules:` list is modified here.

## Design

Cloud-portable, no metadata engine, no EFS — just S3 + rclone:

- **Truth:** plain, **symlink-free** HF cache-layout files in a single shared, **private** S3 bucket (`pytorch-hf-model-cache`). Any object store can host the same layout; migration is a plain `rclone sync`.
- **Mount:** a privileged per-node **rclone FUSE DaemonSet** exposes the bucket read-only at host `/mnt/hf_cache`. Reads are lazy and cached on node-local NVMe (`--vfs-cache-mode full`, bounded by `--vfs-cache-max-size` + LRU), so a cold Karpenter node only pulls the models its jobs touch — TB in S3, small subset on disk.
- **Refresh:** a CronJob is the only writer — downloads the curated `models.txt` set (with `HF_TOKEN` for gated models) and publishes a symlink-free copy to S3 (`rclone copy -L`, excluding `blobs/`).
- **IAM:** per-cluster IRSA — `hf-cache-mount` (read-only), `hf-cache-refresh` (read/write).

```
S3 (plain model files) ──rclone FUSE DaemonSet (NVMe cache)──> /mnt/hf_cache (RO) ──hostPath──> job pods
        ▲── refresh CronJob (HF Hub → rclone copy -L)
```

## Runner integration (ARC kubernetes mode)

`generate_runners.py` keeps/strips a `# BEGIN_HF_CACHE` block in the job-pod hook template based on module presence (same mechanism as `pypi-cache`). When enabled, every job pod gets the read-only `/mnt/hf_cache` hostPath mount (`HostToContainer` propagation) + `HF_HOME`/`HF_HUB_CACHE`/offline env. `from_pretrained(...)` / `vllm.LLM(model=...)` resolve transparently, no code changes.

## Files

- `modules/hf-cache/` — terraform (shared bucket + per-cluster IRSA), `deploy.sh`, mount DaemonSet + refresh CronJob templates, `refresh_cache.py` + unit tests, `models.txt`, README.
- `modules/arc-runners/templates/runner.yaml.tpl` + `generate_runners.py` — gated `HF_CACHE` block + module gate.
- `clusters.yaml` — `hf_cache` defaults (not enabled on any cluster).

## Testing

- `just lint` — 13/13 pass.
- `just test` — pass, 98.71% coverage.
- Verified the gated template renders valid YAML both ways: disabled = no HF env/mount/volume (byte-identical job pod to today); enabled = mount + env present.

## Open items (intentionally a draft)

1. **Symlink-free layout** — validate `from_pretrained`/vLLM resolve correctly from an `rclone -L`, `blobs/`-excluded layout (spike before enabling on a real cluster).
2. **Privileged FUSE DaemonSet** — confirm acceptable under the cluster's Pod Security posture.
3. **Single shared bucket in `us-east-2`** — cross-region S3 reads for other regions (node cache absorbs repeats); per-region buckets / replication is a follow-up.
4. **Strict-offline** (`HF_HUB_OFFLINE=1`): uncached model errors out (matches EC2). Online-fallback overlay is a possible enhancement.

Design doc: (Google Doc link to be added)
