### PR TITLE
Add l-barm64g4-94-344 arm64 perf runner (m8g.24xlarge)

### DIFF
--- a/osdc/modules/arc-runners/defs/l-barm64g4-94-344.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-94-344.yaml
@@ -1,0 +1,14 @@
+# ARC runner definition: l-barm64g4-94-344
+# Instance type: m8g.24xlarge (dedicated node — bare-metal-equivalent runner)
+# Used for: inductor CPU perf benchmarks (aarch64), matches AWS m8g.metal-24xl (96c/384Gi)
+runner:
+  name: l-barm64g4-94-344
+  instance_type: m8g.24xlarge
+  node_fleet: m8g-large
+  disk_size: 256
+  vcpu: 94
+  memory: 344Gi
+  gpu: 0
+  proactive_capacity: 1
+  hud_failure_base_capacity: 30
+  max_burst_capacity: 250


### PR DESCRIPTION
Adds an OSDC ARC runner definition for a dedicated **96 vCPU / 384 GiB Graviton4** node (`m8g.24xlarge`) in the existing `m8g-large` fleet, sized to match the AWS `m8g.metal-24xl` runner that PyTorch's `inductor-perf-test-nightly-aarch64` workflow uses.

### Why
This is the OSDC equivalent needed to migrate that workflow off AWS: the build moves to OSDC arm64, and the perf tests need an equivalent bare-metal-class arm64 node for stable benchmark numbers. The existing `l-barm64g4-62-226` (`m8g.16xlarge`, 62 vCPU) is smaller and not size-matched, so a 24xlarge def is added. Allocatable (94 vCPU / 344Gi) follows the same convention as the other 96c/384Gi node defs (e.g. `l-bx86iavx512-94-344-t4-8`). The `m8g-large` fleet already lists `m8g.24xlarge`, so no nodepool change is required.

### Follow-up (pytorch/pytorch)
Once this deploys, a separate PR maps `linux.arm64.m8g.metal-24xl -> l-barm64g4-94-344` in `.github/arc.yaml` and flips `inductor-perf-test-nightly-aarch64` to `use-arc: true`.

### Test Plan
```
cd osdc/modules/arc-runners
PYTHONPATH="$(cd ../../scripts/python && pwd):$(pwd)/scripts/python" \
  python3 -m pytest scripts/python/test_generate_runners.py \
    scripts/python/test_validate_runner_qos.py scripts/python/test_runner_max_map.py -q
```
All pass; confirmed `node_fleet: m8g-large` is produced by the nodepools module defs.

Authored with the assistance of an AI coding agent (Claude Code).