### PR TITLE
Disable proactive capacity for all runner types

### DIFF
--- a/osdc/modules/arc-runners/defs/l-arm64g2-6-25.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g2-6-25.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 6
   memory: 25Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-16-62.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 62Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 61
   memory: 463Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g4-16-62.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 62Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g3-62-226.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 62
   memory: 226Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-62-226.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 62
   memory: 226Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-barm64g4-94-344.yaml
+++ b/osdc/modules/arc-runners/defs/l-barm64g4-94-344.yaml
@@ -9,6 +9,6 @@ runner:
   vcpu: 94
   memory: 344Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 29
   memory: 113Gi
   gpu: 1
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-14-27.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 14
   memory: 27Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-16-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-22-41.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 22
   memory: 41Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-32-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 32
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-46-84.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 46
   memory: 84Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-16.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 16Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-32.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iamx-8-64.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 64Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-40-160.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 40
   memory: 160Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx2-8-32.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-128.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 16
   memory: 128Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-16-32.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 16
   memory: 32Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-2-4.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 2
   memory: 4Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -10,6 +10,6 @@ runner:
   vcpu: 29
   memory: 115Gi
   gpu: 1
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 60

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-32-256.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 32
   memory: 256Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-37-68.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 37
   memory: 68Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-46-85.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 46
   memory: 85Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-48-384.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 48
   memory: 384Gi
   gpu: 0
-  proactive_capacity: 1
+  proactive_capacity: 0
   hud_failure_base_capacity: 30
   max_burst_capacity: 250

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-16.yaml
@@ -8,6 +8,6 @@ runner:
   vcpu: 8
   memory: 16Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-8-64.yaml
@@ -7,6 +7,6 @@ runner:
   vcpu: 8
   memory: 64Gi
   gpu: 0
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-arm64g4-16-62.yaml
@@ -10,6 +10,6 @@ runner:
   gpu: 0
   runner_group: release-runners
   runner_class: release
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000

--- a/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-x86iavx512-8-64.yaml
@@ -10,6 +10,6 @@ runner:
   gpu: 0
   runner_group: release-runners
   runner_class: release
-  proactive_capacity: 5
+  proactive_capacity: 0
   hud_failure_base_capacity: 90
   max_burst_capacity: 2000


### PR DESCRIPTION
**Impact:** All OSDC ARC runner scale sets (31 runner definitions across x86, ARM64, GPU, and release runners) **Risk:** medium

## What
Sets `proactive_capacity` to `0` for every runner definition, eliminating all pre-warmed idle runner pods.

## Why
Proactive capacity keeps a baseline of idle runner pods running at all times to reduce job startup latency. Zeroing it out means runners will only scale up in response to actual queued jobs, reducing idle compute costs across the fleet. Jobs will see slightly higher cold-start latency when no warm pods are available.