### PR TITLE
Downsize base nodes on LF prod clusters to m7i.8xlarge

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -411,6 +411,7 @@ clusters:
         - lf_osdc_admin
     base:
       base_node_count: 4
+      base_node_instance_type: m7i.8xlarge
       vpc_cidr: "10.12.0.0/16"
     node_compactor:
       min_node_age_seconds: 900
@@ -454,6 +455,7 @@ clusters:
         - lf_osdc_admin
     base:
       base_node_count: 4
+      base_node_instance_type: m7i.8xlarge
       vpc_cidr: "10.16.0.0/16"
     node_compactor:
       min_node_age_seconds: 900


### PR DESCRIPTION
**Impact:** LF prod clusters (lf-prod-aws-ue1, lf-prod-aws-ue2) **Risk:** low

## What
Overrides the base node instance type from the platform default `m7i.12xlarge` (48 vCPU / 192 GiB) to `m7i.8xlarge` (32 vCPU / 128 GiB) on both LF prod clusters.

## Why
With pypi-cache no longer running on these clusters, the base nodes have excess capacity. Downsizing saves cost while still leaving plenty of headroom for the remaining base workloads (Harbor, monitoring, ARC controller, etc.). The node count stays at 4 for redundancy.