### PR TITLE
osdc/hf-cache: fix mount DaemonSet CrashLoop (stale FUSE mount on restart)

### DIFF
--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -67,6 +67,10 @@ spec:
               set -eu
               MOUNT=/mnt/hf_cache
               CACHE=/mnt/hf-cache-vfs
+              # A crashed/killed container can't run preStop, so a stale FUSE mount
+              # is left on the host and rclone then fails with "directory already
+              # mounted". Clear it before remounting so restarts recover.
+              fusermount -uz "$MOUNT" 2>/dev/null || umount -l "$MOUNT" 2>/dev/null || true
               mkdir -p "$MOUNT" "$CACHE"
 
               # Credentials via IRSA (env_auth). /mnt/hf_cache/hub maps to
@@ -75,6 +79,7 @@ spec:
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
                 --read-only \
+                --allow-non-empty \
                 --allow-other \
                 --dir-cache-time 1h \
                 --poll-interval 0 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #834
* #833
* #825
* #818
* #817
* #816
* #813
* #812
* #811

The rclone mount pods were stuck in CrashLoopBackOff with "failed to mount FUSE
fs: directory already mounted" — on a crash/kill the preStop unmount doesn't run,
so the dead process's FUSE mount stays on the host and rclone refuses to mount
over it, never recovering. So /mnt/hf_cache was never mounted and every read job
failed ("model not in the cache").

Fix: clear any stale mount at container startup (fusermount -uz / umount -l)
before mounting, and add --allow-non-empty as a fallback, so restarts recover.