### PR TITLE
osdc/integration-tests: gate test-pip-install-upstream on arc-runners

### DIFF
--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -137,12 +137,14 @@ def workflow_template(tmp_path):
         "    steps:\n"
         "      - run: echo enforcer\n"
         "  # END_CACHE_ENFORCER\n"
+        "  # BEGIN_ARC_RUNNERS\n"
         "  # BEGIN_NO_CACHE_ENFORCER\n"
         "  no-cache-enforcer-job:\n"
         '    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}upstream-runner"] }\n'
         "    steps:\n"
         "      - run: echo upstream\n"
         "  # END_NO_CACHE_ENFORCER\n"
+        "  # END_ARC_RUNNERS\n"
         "  # BEGIN_RELEASE\n"
         "  release-job:\n"
         '    runs-on: { group: "{{RELEASE_RUNNER_GROUP}}", labels: ["{{PREFIX}}rel-runner"] }\n'
@@ -315,6 +317,22 @@ class TestGenerateWorkflow:
         assert "no-cache-enforcer-job" in result
         assert "BEGIN_NO_CACHE_ENFORCER" not in result
         assert "END_NO_CACHE_ENFORCER" not in result
+
+    def test_no_cache_enforcer_stripped_when_no_arc_runners(self, workflow_template):
+        # H100-only cluster (e.g. meta-prod-aws-uw1): no base arc-runners module
+        # and no cache-enforcer. The upstream pip test needs a CPU arc-runner, so
+        # the ARC_RUNNERS gate must strip it — otherwise it queues forever on a
+        # runner label that never exists on this cluster.
+        result = generate_workflow(
+            workflow_template,
+            "mt",
+            "meta-prod-aws-uw1",
+            "meta-prod-aws-uw1",
+            cluster_modules=["arc-runners-h100", "nodepools-h100"],
+        )
+        assert "no-cache-enforcer-job" not in result
+        assert "BEGIN_NO_CACHE_ENFORCER" not in result
+        assert "arc-job" not in result
 
     def test_no_cache_enforcer_stripped_when_cache_enforcer_present(self, workflow_template):
         result = generate_workflow(

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -210,8 +210,11 @@ jobs:
             exit 1
           fi
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
-  # END_ARC_RUNNERS
-
+  # test-pip-install-upstream runs on a CPU arc-runner (l-x86iamx-8-32), so keep
+  # it nested inside ARC_RUNNERS: emit only on clusters that deploy the base
+  # arc-runners module AND have no cache-enforcer. On H100-only clusters (e.g.
+  # meta-prod-aws-uw1, which deploys only arc-runners-h100) the outer ARC_RUNNERS
+  # gate strips it, so it can't queue forever on a runner label that never exists.
   # BEGIN_NO_CACHE_ENFORCER
   test-pip-install-upstream:
     runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
@@ -234,6 +237,7 @@ jobs:
           uv pip install --system --no-cache six packaging typing-extensions
           python -c "import six, packaging, typing_extensions; print('PASS: uv pip install + import from upstream pypi.org')"
   # END_NO_CACHE_ENFORCER
+  # END_ARC_RUNNERS
 
   # BEGIN_PYPI_CACHE
   # ── PyPI Cache: Default Pod Environment ─────────────────────────────


### PR DESCRIPTION
`test-pip-install-upstream` runs on a CPU runner (`l-x86iamx-8-32`) but was gated only on `NO_CACHE_ENFORCER`. So it renders on any cluster without cache-enforcer — including H100-only clusters like `meta-prod-aws-uw1` that deploy only `arc-runners-h100` (no base `arc-runners` module). There it has no matching runner and the job **queues forever** (it was a no-op before #795 introduced this job).

Fix: nest the `NO_CACHE_ENFORCER` block inside `BEGIN_ARC_RUNNERS`, so it's emitted only when the cluster has the base `arc-runners` module **and** no cache-enforcer. `strip_conditional_block` is line-based and tag-specific, so nesting gives the combined condition with no code change. Mirrored the nesting in the test fixture and added a regression test for the H100-only case.

`just lint` and `just test` pass.