### PR TITLE
Fix Alloy relabel replacement syntax for CRI log path discovery

### DIFF
--- a/osdc/modules/logging/pipelines/base.alloy
+++ b/osdc/modules/logging/pipelines/base.alloy
@@ -75,7 +75,7 @@ discovery.relabel "pod_logs" {
         source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name", "__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator     = "/"
         regex         = "(.+)/(.+)/(.+)/(.+)"
-        replacement   = "/var/log/pods/$1_$2_$3/$4/*.log"
+        replacement   = "/var/log/pods/${1}_${2}_${3}/${4}/*.log"
         target_label  = "__path__"
     }
 }


### PR DESCRIPTION
**Impact:** All pod log collection across OSDC clusters
**Risk:** low

detected when smoke tests showed flakiness on release: https://github.com/pytorch/ci-infra/actions/runs/28191236087/job/83508167634

## What
Fixes the capture group interpolation syntax in the `discovery.relabel` rule that builds the CRI log file path (`__path__`), changing `$1` to `${1}` (and likewise for groups 2–4).

## Why
The bare `$1`-style backreferences are ambiguous when immediately followed by an underscore — the regex engine can interpret `$1_` as referencing a capture group named `1_`, which doesn't exist, producing an empty substitution. The braced `${1}_` form removes the ambiguity. This was a latent bug caught by smoke tests; in practice it could cause Alloy to construct an incorrect `/var/log/pods/` path and silently miss pod logs.