### PR TITLE
Strip NUL bytes from fetched job logs for scripts/runner-job-watch

### DIFF
--- a/osdc/scripts/runner-job-watch/watch.py
+++ b/osdc/scripts/runner-job-watch/watch.py
@@ -252,9 +252,9 @@ def fetch_log(url: str) -> str:
         with contextlib.suppress(gzip.BadGzipFile):
             body = gzip.decompress(body)
     try:
-        return body.decode("utf-8", errors="replace")
+        return body.decode("utf-8", errors="replace").replace("\x00", "")
     except Exception:
-        return body.decode("latin-1", errors="replace")
+        return body.decode("latin-1", errors="replace").replace("\x00", "")
 
 
 def _find_must_include_lines(lines: list[str]) -> list[int]:


### PR DESCRIPTION
- Strip \x00 null bytes from decoded log text in both UTF-8 and Latin-1 decode paths of fetch_log

Null bytes in CI runner logs can break downstream
string processing and LLM classification. Logs from some runners contain embedded NUL characters from
binary artifacts or corrupted output.