### PR TITLE
OSDC: Add meta-staging-aws-ue2 staging cluster (us-east-2)

### DIFF
--- a/.github/workflows/osdc-drain.yml
+++ b/.github/workflows/osdc-drain.yml
@@ -19,6 +19,7 @@ on:
           - "-- select cluster --"
           - meta-staging-aws-uw1
           - meta-staging-aws-ue1
+          - meta-staging-aws-ue2
           - meta-prod-aws-uw1
           - arc-cbr-production
           - meta-prod-aws-ue1

--- a/.github/workflows/osdc-undrain.yml
+++ b/.github/workflows/osdc-undrain.yml
@@ -20,6 +20,7 @@ on:
           - "-- select cluster --"
           - meta-staging-aws-uw1
           - meta-staging-aws-ue1
+          - meta-staging-aws-ue2
           - meta-prod-aws-uw1
           - arc-cbr-production
           - meta-prod-aws-ue1

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -258,6 +258,81 @@ clusters:
       - monitoring
       - logging
 
+  meta-staging-aws-ue2:
+    # Third staging region — mirrors meta-staging-aws-ue1 (us-east-1) in us-east-2.
+    # Kept long-term alongside uw1/ue1 staging for broader region coverage.
+    region: us-east-2
+    cluster_name: meta-staging-aws-ue2
+    recycle_karpenter_nodes: true
+    proactive_capacity_max: 0  # disable warm-pool pre-provisioning — staging only creates pairs on demand for in-flight jobs
+    state_bucket: ciforge-tfstate-meta-staging-aws-ue2
+    access_config:
+      authentication_mode: API_AND_CONFIG_MAP
+      cluster_admin_role_names:
+        - osdc_gha_staging
+    base:
+      base_node_count: 2
+      base_node_instance_type: m5.4xlarge
+      base_node_max_unavailable_percentage: 100  # all-at-once for staging
+      single_nat_gateway: true       # cost optimization for staging
+      vpc_cidr: "10.24.0.0/16"
+    coredns:
+      replicas: 2
+    harbor:
+      core_replicas: 1
+      registry_replicas: 1
+      nginx_replicas: 1
+      pdb_max_unavailable: "100%"  # aggressive: staging has 1 replica each
+    karpenter:
+      replicas: 1
+      log_level: debug
+      pdb_enabled: false
+      pdb_min_available: 0
+    arc:
+      replica_count: 1
+      log_level: debug
+      controller_cpu_request: "500m"
+      controller_cpu_limit: "1"
+      controller_memory_request: "1Gi"
+      controller_memory_limit: "1Gi"
+    node_compactor:
+      dry_run: true
+    nodepools:
+      gpu_consolidate_after: "10s"
+      cpu_consolidate_after: "10s"
+    arc-runners:
+      # Org-wide (was github.com/pytorch/pytorch-canary). A repo-scoped URL forces
+      # runner_group → "default" in generate_runners.py, so the org URL is required
+      # for the runner_group below to take effect.
+      github_config_url: "https://github.com/pytorch"
+      github_secret_name: meta-staging-aws-ue2
+      runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
+      runner_group: "meta-staging-aws-ue2"
+      scheduler_name: bin-pack-scheduler
+    buildkit:
+      arm64_instance_type: m7gd.16xlarge
+      arm64_pods_per_node: 4
+      autoscaling:
+        enabled: true
+        amd64_min: 2  # 1x m6id.24xlarge (2 pods/node)
+        amd64_max: 8
+        arm64_min: 4  # 1x m7gd.16xlarge (4 pods/node)
+        arm64_max: 8
+    pypi_cache:
+      replicas: 1
+    modules:
+      - karpenter
+      - arc
+      - nodepools
+      - bin-pack-scheduler
+      - arc-runners
+      - keda
+      - buildkit
+      - zombie-cleanup
+      - harbor-cache-recovery
+      - monitoring
+      - logging
+
   meta-prod-aws-uw1:
     cluster_name: meta-prod-aws-uw1
     region: us-west-1


### PR DESCRIPTION
Adds a third long-term staging cluster `meta-staging-aws-ue2` in us-east-2, a verbatim mirror of `meta-staging-aws-ue1`. Only region-specific values differ:

- `region`: us-east-2
- `state_bucket`: ciforge-tfstate-meta-staging-aws-ue2
- `base.vpc_cidr`: 10.24.0.0/16 (next free /16, non-overlapping)
- `arc-runners.github_secret_name` / `runner_group`: meta-staging-aws-ue2

Everything else (modules incl. `bin-pack-scheduler`, sizing, buildkit autoscaling, `c-mt-` prefix, `osdc_gha_staging` role) matches ue1.

Also adds `meta-staging-aws-ue2` to the `osdc-drain` / `osdc-undrain` cluster dropdowns so operators can drain/undrain it from the Actions UI (mirrors how ue1 was onboarded in #788).

## Deployment workflows — no change needed
Staging clusters are not deployed via CI: `osdc-deploy-prod` / `osdc-plan-prod` are prod-only, and `osdc-pre-merge` is intentionally pinned to `meta-staging-aws-uw1` as the pre-merge test target. Staging clusters are deployed manually via `just deploy <cluster>`. The Grafana dashboard (`grafana/osdc.json`) enumerates prod runner groups only. The drain/undrain dropdowns are the only workflows that list staging clusters.

`just test` passes (98.7% cov); `cluster-config.py` resolves correct tfvars (`aws_region=us-east-2`, `vpc_cidr=10.24.0.0/16`) and module list.

## Out-of-band operator steps (before deploy)
- [x] Confirm `osdc_gha_staging` role exists/trusted in the us-east-2 account
- [x] `just bootstrap meta-staging-aws-ue2`
- [x] Create `meta-staging-aws-ue2` runner group in pytorch org
- [x] Create `meta-staging-aws-ue2` Secret in `arc-runners` ns
- [x] `just deploy meta-staging-aws-ue2`

🤖 Generated with Claude Code
