### PR TITLE
osdc: auto-create TF_PLUGIN_CACHE_DIR so tofu works on fresh worktrees

### DIFF
--- a/osdc/scripts/mise-activate.sh
+++ b/osdc/scripts/mise-activate.sh
@@ -13,3 +13,13 @@ if command -v mise &>/dev/null; then
   eval "$(mise env -s bash -C "$_MISE_ROOT" 2>/dev/null)" || true
   unset _MISE_ROOT
 fi
+
+# Ensure the OpenTofu plugin cache dir exists before any `tofu init`.
+# mise.toml points TF_PLUGIN_CACHE_DIR at {{config_root}}/.terraform.d/plugin-cache,
+# but tofu requires the directory to pre-exist (it won't create it) and aborts
+# init with "plugin cache dir ... cannot be opened" otherwise. Since .terraform.d/
+# is gitignored, a fresh `git worktree` checkout starts without it — so create it
+# idempotently here, the single chokepoint every tofu-running recipe sources.
+if [[ -n "${TF_PLUGIN_CACHE_DIR:-}" ]]; then
+  mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+fi


### PR DESCRIPTION
## Problem

Running any tofu-backed recipe (`just deploy-base`, `deploy-module`, `plan`, `remove-module`) from a **fresh `git worktree`** fails at `tofu init`:

```
Error: The specified plugin cache dir .../osdc/.terraform.d/plugin-cache cannot be opened:
       ... no such file or directory
```

`osdc/mise.toml` sets `TF_PLUGIN_CACHE_DIR = "{{config_root}}/.terraform.d/plugin-cache"`. OpenTofu **requires that directory to already exist** (it won't create it). `.terraform.d/` is gitignored, so `git worktree add` never materializes it — the main checkout only has the dir because some earlier `tofu init` created it and it persisted. First tofu run in a new worktree therefore always trips this.

## Fix

Create the dir idempotently in `scripts/mise-activate.sh`, right after `mise env` exports the variable. This is the single chokepoint sourced by every tofu-running recipe, so one edit covers all of them (and standalone scripts that source it), rather than sprinkling `mkdir` across the seven `tofu init` call sites.

```bash
if [[ -n "${TF_PLUGIN_CACHE_DIR:-}" ]]; then
  mkdir -p "${TF_PLUGIN_CACHE_DIR}"
fi
```

`${VAR:-}` keeps it safe under `set -u`; no-op when the var is unset.

## Test plan

- Fresh worktree with no `.terraform.d/`: sourcing `mise-activate.sh` now creates `$TF_PLUGIN_CACHE_DIR`. ✅
- `shellcheck scripts/mise-activate.sh` — clean ✅
- `just lint` — 13/13 passed ✅
- `just test` — all passed, 98.69% coverage ✅