### PR TITLE
[CRCR] Rename OOT → CRCR in Terraform config and README

### DIFF
--- a/crcr/README.md
+++ b/crcr/README.md
@@ -89,7 +89,7 @@ aws dynamodb create-table \
 | `availability_zone_suffixes` | `["a", "b"]` | Availability zone letter suffixes |
 | `hud_api_url` | `N/A` | URL for sending callback data to HUD |
 | `hud_bot_key` | `N/A` | Key to access to HUD (sensitive) |
-| `oot_status_ttl` | `259200` | OOT workflow run status TTL in Redis (seconds) |
+| `crcr_status_ttl` | `259200` | CRCR workflow run status TTL in Redis (seconds) |
 
 **Note:**
 
@@ -160,6 +160,6 @@ CRCR follows a four-level progression system. Each level adds more integration b
 | Level | Name | Status | Description |
 |---|---|---|---|
 | **L1** | Events Only | running | Webhook events are forwarded to downstream repos. No feedback to upstream PRs. Downstream repos receive `repository_dispatch` and run CI independently. |
-| **L2** | HUD Visibility | **Current**  | Downstream CI results are written to ClickHouse and displayed on a dedicated HUD page (`hud.pytorch.org/oot/[org]/[repo]`). Upstream PRs still show no check status. |
-| **L3** | Label-Triggered PR Checks | developing | A non-blocking Check Run appears on upstream PRs when a `ciflow/oot/<name>` label is added. This is the recommended long-term target for most downstream repos. |
+| **L2** | HUD Visibility | **Current**  | Downstream CI results are written to ClickHouse and displayed on a dedicated HUD page (`hud.pytorch.org/crcr/[org]/[repo]`). Upstream PRs still show no check status. |
+| **L3** | Label-Triggered PR Checks | developing | A non-blocking Check Run appears on upstream PRs when a `ciflow/crcr/<name>` label is added. This is the recommended long-term target for most downstream repos. |
 | **L4** | Always-On Blocking Checks | developing | Blocking Check Run auto-triggered for every PR. Reserved for critical accelerators only. Merge is blocked on failure. |

--- a/crcr/aws/callback.tf
+++ b/crcr/aws/callback.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "callback" {
       ALLOWLIST_URL           = var.allowlist_url
       ALLOWLIST_TTL_SECONDS   = tostring(var.allowlist_ttl)
       HUD_API_URL             = var.hud_api_url
-      OOT_STATUS_TTL          = tostring(var.oot_status_ttl)
+      CRCR_STATUS_TTL         = tostring(var.crcr_status_ttl)
     }
   }
 

--- a/crcr/aws/variables.tf
+++ b/crcr/aws/variables.tf
@@ -61,8 +61,8 @@ variable "hud_bot_key" {
   sensitive   = true
 }
 
-variable "oot_status_ttl" {
-  description = "OOT workflow run status TTL in Redis (seconds)"
+variable "crcr_status_ttl" {
+  description = "CRCR workflow run status TTL in Redis (seconds)"
   type        = number
   default     = 259200
 }


### PR DESCRIPTION
## Summary

Part 4 of the OOT → CRCR rename series. Renames the remaining OOT references in the CRCR Terraform configuration and README to use consistent CRCR terminology.

**Changes (3 files):**

- **`crcr/aws/variables.tf`** — `variable "oot_status_ttl"` → `variable "crcr_status_ttl"`, updated description
- **`crcr/aws/callback.tf`** — Lambda env var `OOT_STATUS_TTL` → `CRCR_STATUS_TTL`, references `var.crcr_status_ttl`
- **`crcr/README.md`** — Updated variable table entry, HUD URL path (`/oot/` → `/crcr/`), ciflow label prefix (`ciflow/oot/` → `ciflow/crcr/`)

**Deployment note:** This PR changes the Lambda environment variable name from `OOT_STATUS_TTL` to `CRCR_STATUS_TTL`. The Lambda code reading this env var is updated in test-infra PR #8217, so both must be deployed together.

## Rename series (across repos)

| PR | Repo | Scope | Link |
|----|------|-------|------|
| PR 1 | pytorch/test-infra | Lambda — Redis keys, config, tests | [#8217](https://github.com/pytorch/test-infra/pull/8217) |
| PR 2 | pytorch/test-infra | ClickHouse — schema + replicator | [#8218](https://github.com/pytorch/test-infra/pull/8218) |
| PR 3 | pytorch/test-infra | Frontend — lib, API, components, queries, tests | [#8219](https://github.com/pytorch/test-infra/pull/8219) |
| **PR 4 (this)** | pytorch/ci-infra | Terraform — config, env vars, README | This PR |

## Test plan

- [ ] `terraform plan` shows only the env var rename (no resource recreation)
- [ ] Deploy alongside test-infra PR #8217 (Lambda reads `CRCR_STATUS_TTL`)