### PR TITLE
osdc: remove keda and buildkit from lf clusters (ue1 and ue2)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -501,27 +501,12 @@ clusters:
       runner_name_prefix: "lf-"
       runner_group: lf-prod-aws-ue1
       scheduler_name: bin-pack-scheduler
-    buildkit:
-      amd64_instance_type: m6id.24xlarge
-      amd64_pods_per_node: 2
-      arm64_instance_type: m7gd.16xlarge
-      arm64_pods_per_node: 4
-      autoscaling:
-        enabled: true
-        amd64_min: 4
-        amd64_max: 64
-        arm64_min: 4
-        arm64_max: 64
-        amd64_fallback: 12
-        arm64_fallback: 4
     modules:
       - karpenter
       - arc
       - nodepools
       - bin-pack-scheduler
       - arc-runners
-      - keda
-      - buildkit
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring
@@ -547,27 +532,12 @@ clusters:
       runner_name_prefix: "lf-"
       runner_group: lf-prod-aws-ue2
       scheduler_name: bin-pack-scheduler
-    buildkit:
-      amd64_instance_type: m6id.24xlarge
-      amd64_pods_per_node: 2
-      arm64_instance_type: m7gd.16xlarge
-      arm64_pods_per_node: 4
-      autoscaling:
-        enabled: true
-        amd64_min: 4
-        amd64_max: 64
-        arm64_min: 4
-        arm64_max: 64
-        amd64_fallback: 12
-        arm64_fallback: 4
     modules:
       - karpenter
       - arc
       - nodepools
       - bin-pack-scheduler
       - arc-runners
-      - keda
-      - buildkit
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring


### PR DESCRIPTION
## Summary

Removes the `keda` and `buildkit` modules from the **lf** production clusters `lf-prod-aws-ue1` (us-east-1) and `lf-prod-aws-ue2` (us-east-2) in `osdc/clusters.yaml`:

- Drop `keda` and `buildkit` from each cluster's `modules:` list.
- Remove the per-cluster `buildkit:` config block (instance types, pods-per-node, autoscaling min/max/fallback) from both clusters.

`buildkit` depends on `keda` — the `keda` module provides the `ScaledObject`/`TriggerAuthentication` CRDs that buildkit autoscaling uses. Nothing else in these clusters consumes `keda`, so both modules are removed together.

No shared module code (`osdc/modules/keda/`, `osdc/modules/buildkit/`) is touched — those remain in place for the `meta-*` clusters that still use them.

## Operational note

Editing `clusters.yaml` only stops **future** deploys from managing these modules; it does not uninstall already-deployed resources. To tear down the live resources on each cluster, an operator should run (after the PR lands):

```
just remove-module lf-prod-aws-ue1 buildkit
just remove-module lf-prod-aws-ue1 keda
just remove-module lf-prod-aws-ue2 buildkit
just remove-module lf-prod-aws-ue2 keda
```

## Test plan

- `just lint` passes.
- `uv run scripts/cluster-config.py <cluster> has-module keda|buildkit` now reports both modules absent for both lf clusters; the `modules` list resolves correctly without them.