### PR TITLE
osdc: remove pypi-cache and cache-enforcer from meta-prod-aws-ue1

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -405,8 +405,6 @@ clusters:
       github_secret_name: meta-prod-aws-ue1
       runner_name_prefix: "mt-"
       runner_group: "meta-prod-aws-ue1"
-    pypi_cache:
-      replicas: 10
     modules:
       - karpenter
       - arc
@@ -414,8 +412,6 @@ clusters:
       - arc-runners
       - keda
       - buildkit
-      - pypi-cache
-      - cache-enforcer
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring


### PR DESCRIPTION
## Summary

Removes the `pypi-cache` and `cache-enforcer` modules from `meta-prod-aws-ue1` in `osdc/clusters.yaml` — the only cluster that actually enabled them:

- Drop `pypi-cache` and `cache-enforcer` from the cluster's `modules:` list.
- Remove the `pypi_cache: { replicas: 10 }` per-cluster override.

`cache-enforcer` depends on `pypi-cache` (without the cache, runner pip installs are blocked with no cache to serve them), so both are removed together.

### Scope

Only `meta-prod-aws-ue1` had these modules enabled. The other meta clusters (`meta-staging-aws-ue1/ue2`, `meta-prod-aws-uw1/ue2`) and the `defaults:` block carry inert `pypi_cache:` config but never enabled the module, so they are intentionally left untouched. The shared module source (`osdc/modules/pypi-cache/`, `osdc/modules/cache-enforcer/`) is also untouched.

## Operational note

Editing `clusters.yaml` only stops **future** deploys from managing these modules; it does not uninstall already-deployed resources. To tear down the live resources, an operator should run (after the PR lands):

```
just remove-module meta-prod-aws-ue1 cache-enforcer
just remove-module meta-prod-aws-ue1 pypi-cache
```

Removing `cache-enforcer` first avoids leaving runner traffic blocked without a cache backend.

## Test plan

- `just lint` passes.
- `uv run scripts/cluster-config.py meta-prod-aws-ue1 has-module pypi-cache|cache-enforcer` now reports both absent; the remaining `modules` list resolves correctly.