### PR TITLE
Update AWS Linux AMI filter to be less restrictive

### DIFF
--- a/ali/aws/391835788720/us-east-1/variables.tf
+++ b/ali/aws/391835788720/us-east-1/variables.tf
@@ -38,13 +38,13 @@ variable "aws_canary_vpc_suffixes" {
 variable "ami_filter_linux" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.10.*-kernel-6.1-x86_64"]
+  default     = ["al2023-ami-2023.*-kernel-6.1-x86_64"]
 }
 
 variable "ami_filter_linux_arm64" {
   description = "AMI for linux"
   type        = list
-  default     = ["al2023-ami-2023.10.*-kernel-6.1-arm64"]
+  default     = ["al2023-ami-2023.*-kernel-6.1-arm64"]
 }
 
 variable "ami_filter_windows" {


### PR DESCRIPTION
Every few months we end up just bumping the version here. Lets just make the filter wider to save us this dance every couple of months.