### PR TITLE
Enable bin-pack-scheduler on all Meta production clusters

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -352,6 +352,7 @@ clusters:
       github_secret_name: meta-prod-aws-uw1
       runner_name_prefix: "mt-"
       runner_group: "meta-prod-aws-uw1"   # distinct from us-east-2's "default" — see doc
+      scheduler_name: bin-pack-scheduler
     nodepools-h100:
       # us-west-1 H100 capacity reservations (p5.48xlarge, 8× H100 each):
       #   cr-04d3d1d84e127a562 — 2 nodes (16 H100 GPUs)
@@ -369,6 +370,7 @@ clusters:
       - arc
       - nodepools
       - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
+      - bin-pack-scheduler
       - arc-runners-h100
       - zombie-cleanup
       - harbor-cache-recovery
@@ -405,10 +407,12 @@ clusters:
       github_secret_name: meta-prod-aws-ue1
       runner_name_prefix: "mt-"
       runner_group: "meta-prod-aws-ue1"
+      scheduler_name: bin-pack-scheduler
     modules:
       - karpenter
       - arc
       - nodepools
+      - bin-pack-scheduler
       - arc-runners
       - keda
       - buildkit
@@ -449,6 +453,7 @@ clusters:
       github_secret_name: meta-prod-aws-ue2
       runner_name_prefix: "mt-"
       runner_group: "meta-prod-aws-ue2"   # moved off the shared "default"/"release-runners" groups
+      scheduler_name: bin-pack-scheduler
     nodepools-h100:
       # us-east-2 H100 capacity reservation (p5.48xlarge, 8× H100).
       capacity_reservation_ids:
@@ -467,6 +472,7 @@ clusters:
       - nodepools
       - nodepools-b200
       - nodepools-h100
+      - bin-pack-scheduler
       - arc-runners
       - arc-runners-b200
       - arc-runners-h100


### PR DESCRIPTION
**Impact:** Meta prod fleet (uw1, ue1, ue2) — runner workflow pod scheduling
**Risk:** low

## What
Deploy the `bin-pack-scheduler` module and set `scheduler_name: bin-pack-scheduler` on the three Meta production clusters (meta-prod-aws-uw1, meta-prod-aws-ue1, meta-prod-aws-ue2). This makes runner workflow pods use the MostAllocated bin-packing scheduler instead of the default kube-scheduler.

## Why
The bin-pack-scheduler packs workflow pods onto the fullest nodes first, improving node utilization and reducing the number of partially-used nodes. It has been running on all staging clusters and both LF production clusters; this promotes it to the remaining Meta production fleet.

# Notes
- Requires deploying the `bin-pack-scheduler` module to each cluster before the arc-runners config takes effect (the generator silently drops `scheduler_name` if the module isn't in the cluster's module list).
- Module ordering in the list matters — `bin-pack-scheduler` is placed before `arc-runners` entries so it deploys first.