### PR TITLE
osdc: enable hf-cache on meta-prod-aws-uw1 (us-west-1)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -383,6 +383,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - nodepools-h100        # H100 only — B200 has no capacity reservation in us-west-1
       - bin-pack-scheduler


### PR DESCRIPTION
Enable the shared HuggingFace model cache (`hf-cache`) on `meta-prod-aws-uw1`, inserted before `nodepools` so the rclone mount is up before nodepools emit the node-init gate taint (mirrors staging).

This cluster has no regular `arc-runners` (only `arc-runners-h100`), so the mount runs on the H100 nodes and the integration-test hf-cache jobs are skipped here. Cache starts empty; seed later via `scripts/hf-cache-seed.py`.
