### PR TITLE
osdc: enable hf-cache on the rest of the meta prod fleet (ue1, ue2)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -428,6 +428,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - bin-pack-scheduler
       - arc-runners
@@ -491,6 +492,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - nodepools-b200
       - nodepools-h100


### PR DESCRIPTION
Enable the shared HuggingFace model cache (`hf-cache`) on the remaining **meta** production clusters — `meta-prod-aws-ue1` and `meta-prod-aws-ue2` — completing the fleet after #863 (uw1) and the staging clusters. Inserted before `nodepools` so the rclone mount is up before nodepools emit the node-init gate taint.

Cache starts empty; seed via `scripts/hf-cache-seed.py` after deploy. `lf-prod-*` are a separate (LF) fleet and are intentionally left out.
