### PR TITLE
osdc: enable hf-cache on meta-prod-aws-ue1 (us-east-1)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -428,6 +428,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - bin-pack-scheduler
       - arc-runners


### PR DESCRIPTION
Enable the shared HuggingFace model cache (`hf-cache`) on `meta-prod-aws-ue1`, inserted before `nodepools` so the rclone mount is up before the node-init gate taint (mirrors #863 for uw1). Cache starts empty; seed via `scripts/hf-cache-seed.py` after deploy.
