### PR TITLE
osdc: enable hf-cache on meta-prod-aws-ue2 (us-east-2)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -491,6 +491,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - nodepools-b200
       - nodepools-h100


### PR DESCRIPTION
Enable the shared HuggingFace model cache (`hf-cache`) on `meta-prod-aws-ue2`, inserted before `nodepools` so the rclone mount is up before the node-init gate taint (mirrors #863 for uw1). Cache starts empty; seed via `scripts/hf-cache-seed.py` after deploy.
