### PR TITLE
osdc: enable hf-cache on the lf prod fleet (ue1, ue2)

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -529,6 +529,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - bin-pack-scheduler
       - arc-runners
@@ -561,6 +562,7 @@ clusters:
     modules:
       - karpenter
       - arc
+      - hf-cache              # before nodepools: mount must be up before the node-init gate taint
       - nodepools
       - bin-pack-scheduler
       - arc-runners


### PR DESCRIPTION
Enable the shared HuggingFace model cache (`hf-cache`) on both LF production clusters — `lf-prod-aws-ue1` and `lf-prod-aws-ue2` — inserted before `nodepools` so the rclone mount is up before the node-init gate taint (mirrors #863 for the meta fleet). Cache starts empty; seed via `scripts/hf-cache-seed.py` after deploy.
