### PR TITLE
osdc/hf-cache: raise rclone memory limit on large-GPU nodes

### DIFF
--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -30,6 +30,14 @@ RCLONE_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_image "rclone/rclone:1.6
 TAINT_REMOVER_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.taint_remover_image \
   "public.ecr.aws/amazonlinux/amazonlinux:2023")
 VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
+# Only large-GPU nodes pull multi-GB models and OOM rclone, so only the -largegpu
+# DaemonSet gets the raised limit; standard nodes keep the modest default. Which GPUs
+# count as "large" is the instance-gpu-name set below (comma-separated in config).
+RCLONE_MEMORY_LIMIT=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_memory_limit "1Gi")
+RCLONE_MEMORY_LIMIT_LARGEGPU=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_memory_limit_largegpu "4Gi")
+# h100,b200 -> ["h100","b200"] for the node-affinity values list.
+LARGE_GPU_NAMES=$(uv run "$CFG" "$CLUSTER" hf_cache.large_gpu_names "h100,b200")
+LARGE_GPU_VALUES="[\"${LARGE_GPU_NAMES//,/\",\"}\"]"
 BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
 # Bucket is in the cluster's region, so rclone's S3 region is the cluster region.
 BUCKET_REGION="$REGION"
@@ -68,23 +76,39 @@ kubectl create configmap node-taint-remover-lib \
   -n "$NAMESPACE" --dry-run=client -o yaml \
   | kubectl_apply_if_changed -f -
 
-# --- Render + apply the mount DaemonSet ---
-echo "[hf-cache] Applying mount DaemonSet..."
-sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
-  -e "s|__BUCKET__|${BUCKET}|g" \
-  -e "s|__REGION__|${BUCKET_REGION}|g" \
-  -e "s|__RCLONE_IMAGE__|${RCLONE_IMAGE}|g" \
-  -e "s|__VFS_CACHE_MAX_SIZE__|${VFS_CACHE_MAX_SIZE}|g" \
-  -e "s|__TAINT_REMOVER_IMAGE__|${TAINT_REMOVER_IMAGE}|g" \
-  "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl" \
-  | kubectl_apply_if_changed -f -
-
-echo "[hf-cache] Waiting for mount DaemonSet rollout..."
-kubectl rollout status daemonset hf-cache-mount \
-  -n "$NAMESPACE" --timeout=300s || {
-  echo "[hf-cache] WARNING: mount DaemonSet rollout did not complete within timeout"
-  echo "[hf-cache] Check: kubectl get pods -n $NAMESPACE -l app=hf-cache-mount"
+# --- Render + apply the mount DaemonSet(s) ---
+# One template, two DaemonSets (standard + -largegpu); the __GPU_OP__ affinity keeps
+# them mutually exclusive so exactly one rclone mount runs per node.
+render_mount_ds() {
+  # $1 = DaemonSet name, $2 = gpu affinity operator, $3 = rclone memory limit
+  sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
+    -e "s|__BUCKET__|${BUCKET}|g" \
+    -e "s|__REGION__|${BUCKET_REGION}|g" \
+    -e "s|__RCLONE_IMAGE__|${RCLONE_IMAGE}|g" \
+    -e "s|__VFS_CACHE_MAX_SIZE__|${VFS_CACHE_MAX_SIZE}|g" \
+    -e "s|__TAINT_REMOVER_IMAGE__|${TAINT_REMOVER_IMAGE}|g" \
+    -e "s|__DS_NAME__|${1}|g" \
+    -e "s|__GPU_OP__|${2}|g" \
+    -e "s|__RCLONE_MEMORY_LIMIT__|${3}|g" \
+    -e "s|__LARGE_GPU_NAMES__|${LARGE_GPU_VALUES}|g" \
+    "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl"
 }
+
+echo "[hf-cache] Applying mount DaemonSets (standard + large-GPU)..."
+{
+  render_mount_ds "hf-cache-mount" "NotIn" "${RCLONE_MEMORY_LIMIT}"
+  echo "---"
+  render_mount_ds "hf-cache-mount-largegpu" "In" "${RCLONE_MEMORY_LIMIT_LARGEGPU}"
+} | kubectl_apply_if_changed -f -
+
+echo "[hf-cache] Waiting for mount DaemonSet rollouts..."
+for DS in hf-cache-mount hf-cache-mount-largegpu; do
+  kubectl rollout status daemonset "$DS" \
+    -n "$NAMESPACE" --timeout=300s || {
+    echo "[hf-cache] WARNING: $DS rollout did not complete within timeout"
+    echo "[hf-cache] Check: kubectl get pods -n $NAMESPACE -l app=$DS"
+  }
+done
 
 echo "[hf-cache] Deployed — rclone read-only mount serving /mnt/hf_cache on runner nodes."
 echo "[hf-cache] Cache is populated by ci-refresh-hf-cache runs (GitHub OIDC write role)."

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -3,12 +3,17 @@
 # in modules/arc-runners/templates/runner.yaml.tpl. Reads are lazy and cached on
 # NVMe (LRU). Writes go via the GitHub-OIDC refresh path, not this mount.
 #
+# deploy.sh renders this twice: a standard DaemonSet and a "-largegpu" one (via
+# __GPU_OP__) scoped to H100/B200, which gets a larger rclone memory limit. The
+# instance-gpu-name affinity keeps them mutually exclusive (one mount per node).
+#
 # Placeholders (deploy.sh): __NAMESPACE__ __BUCKET__ __REGION__ __RCLONE_IMAGE__
-# __VFS_CACHE_MAX_SIZE__ __TAINT_REMOVER_IMAGE__
+# __VFS_CACHE_MAX_SIZE__ __TAINT_REMOVER_IMAGE__ __RCLONE_MEMORY_LIMIT__
+# __DS_NAME__ __GPU_OP__ __LARGE_GPU_NAMES__
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: hf-cache-mount
+  name: __DS_NAME__
   namespace: __NAMESPACE__
   labels:
     osdc.io/module: hf-cache
@@ -17,7 +22,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: hf-cache-mount
+      app: __DS_NAME__
 
   updateStrategy:
     type: RollingUpdate
@@ -27,7 +32,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hf-cache-mount
+        app: __DS_NAME__
         osdc.io/module: hf-cache
     spec:
       serviceAccountName: hf-cache-mount
@@ -38,6 +43,18 @@ spec:
 
       nodeSelector:
         workload-type: github-runner
+
+      # instance-gpu-name is absent on non-GPU nodes; NotIn matches those too, so the
+      # standard DaemonSet still covers CPU + small-GPU nodes while -largegpu takes the
+      # large-GPU names from hf_cache.large_gpu_names.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: karpenter.k8s.aws/instance-gpu-name
+                    operator: __GPU_OP__
+                    values: __LARGE_GPU_NAMES__
 
       # Schedule before the node-init.osdc.io/* taints clear, so the mount precedes
       # runner pods. operator:Exists avoids a deadlock from missing one (cf. cache-enforcer).
@@ -140,15 +157,16 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
-          # Provisional — load-test in prod and tune. An OOM-kill drops the mount
-          # node-wide, so the memory limit may need raising or removing.
+          # An rclone OOM drops the mount node-wide, so -largegpu (H100/B200) renders a
+          # raised limit; multi-GB model pulls under --vfs-cache-mode full blow past a
+          # tight cap. Configurable via hf_cache.rclone_memory_limit{,_largegpu}.
           resources:
             requests:
               cpu: 100m
               memory: 256Mi
             limits:
               cpu: "1"
-              memory: 1Gi
+              memory: __RCLONE_MEMORY_LIMIT__
           volumeMounts:
             - name: hf-cache
               mountPath: /mnt/hf_cache

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -14,9 +14,12 @@ pytestmark = [pytest.mark.live]
 
 NAMESPACE = "hf-cache"
 MOUNT_DS = "hf-cache-mount"
+MOUNT_DS_LARGEGPU = "hf-cache-mount-largegpu"
 MOUNT_SA = "hf-cache-mount"
 IRSA_KEY = "eks.amazonaws.com/role-arn"
 MOUNT_PATH = "/mnt/hf_cache"
+GPU_NAME_LABEL = "karpenter.k8s.aws/instance-gpu-name"
+LARGE_GPU_VALUES = {"h100", "b200"}
 RUNNER_NODE_SELECTOR = {"workload-type": ["github-runner"]}
 
 
@@ -130,6 +133,60 @@ class TestHfCacheMountDaemonSet:
         vols = mount_pod_spec.get("volumes", [])
         lib = [v for v in vols if v.get("configMap", {}).get("name") == "node-taint-remover-lib"]
         assert lib, "mount DaemonSet must mount the node-taint-remover-lib ConfigMap for the taint-remover."
+
+
+def _gpu_affinity_op(pod_spec: dict) -> tuple[str, set]:
+    """Return (operator, values) of the instance-gpu-name node-affinity requirement."""
+    terms = (
+        pod_spec.get("affinity", {})
+        .get("nodeAffinity", {})
+        .get("requiredDuringSchedulingIgnoredDuringExecution", {})
+        .get("nodeSelectorTerms", [])
+    )
+    for term in terms:
+        for expr in term.get("matchExpressions", []):
+            if expr.get("key") == GPU_NAME_LABEL:
+                return expr.get("operator", ""), set(expr.get("values", []))
+    return "", set()
+
+
+class TestHfCacheLargeGpuSplit:
+    """The mount runs as two DaemonSets: standard (CPU + small GPU) and -largegpu
+    (H100/B200, raised rclone memory). They must be mutually exclusive so exactly
+    one rclone mount runs per node, and only the large-GPU one carries the big limit.
+    """
+
+    def _pod_spec(self, all_daemonsets: dict, name: str) -> dict:
+        ds = filter_daemonsets(all_daemonsets, namespace=NAMESPACE, name=name)
+        assert ds, f"DaemonSet '{name}' not found in {NAMESPACE}."
+        return ds[0]["spec"]["template"]["spec"]
+
+    def _rclone_mem(self, pod_spec: dict) -> str:
+        rclone = next(c for c in pod_spec["containers"] if c.get("name") == "rclone")
+        return rclone.get("resources", {}).get("limits", {}).get("memory", "")
+
+    def test_largegpu_daemonset_targets_h100_b200(self, all_daemonsets: dict) -> None:
+        op, values = self._gpu_affinity_op(self._pod_spec(all_daemonsets, MOUNT_DS_LARGEGPU))
+        assert values == LARGE_GPU_VALUES, f"{MOUNT_DS_LARGEGPU} must target {LARGE_GPU_VALUES}; got {values}."
+        assert op == "In", f"{MOUNT_DS_LARGEGPU} must use In affinity to select large-GPU nodes; got op={op}."
+
+    def test_standard_daemonset_excludes_h100_b200(self, all_daemonsets: dict) -> None:
+        op, values = self._gpu_affinity_op(self._pod_spec(all_daemonsets, MOUNT_DS))
+        assert values == LARGE_GPU_VALUES, f"{MOUNT_DS} affinity must reference {LARGE_GPU_VALUES}; got {values}."
+        assert op == "NotIn", (
+            f"{MOUNT_DS} must use NotIn affinity so it doesn't double-mount large-GPU nodes; got op={op}."
+        )
+
+    def test_largegpu_has_more_memory(self, all_daemonsets: dict) -> None:
+        std = self._rclone_mem(self._pod_spec(all_daemonsets, MOUNT_DS))
+        big = self._rclone_mem(self._pod_spec(all_daemonsets, MOUNT_DS_LARGEGPU))
+
+        def gib(v: str) -> float:
+            return float(v[:-2]) if v.endswith("Gi") else float(v[:-2]) / 1024 if v.endswith("Mi") else float(v)
+
+        assert gib(big) > gib(std), (
+            f"{MOUNT_DS_LARGEGPU} rclone memory limit ({big}) must exceed the standard one ({std})."
+        )
 
 
 class TestHfCacheTaintGate:


### PR DESCRIPTION
rclone was OOM-killed (1Gi) on H100 nodes pulling multi-GB models under `--vfs-cache-mode full`, dropping the mount node-wide and wedging every job pod on the node. Split the mount into two DaemonSets so only large-GPU nodes (`instance-gpu-name` affinity, default h100,b200 — configurable) get a raised 4Gi limit; standard nodes keep 1Gi.