### PR TITLE
osdc/hf-cache: self-heal rclone mount across a dead FUSE

### DIFF
--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -75,6 +75,21 @@ spec:
               set -eu
               exec /proc/1/root/usr/bin/nsenter -t 1 -m -- /bin/sh -c '
                 mkdir -p /mnt/hf_cache /mnt/hf-cache-vfs
+                # A crashed rclone leaves a dead FUSE at /mnt/hf_cache that fails to stat,
+                # wedging every pod on the node in CreateContainerError. rclone self-heals
+                # on in-place restart (it Bidirectional-mounts the parent /mnt, always a
+                # live dir), but a pod recreation only runs this init — so clear the dead
+                # endpoint here. fusermount3 is the FUSE3 binary on AL2023 hosts (fusermount
+                # is not installed); umount -l is the last-resort peel. Both leave the bind
+                # under /mnt intact.
+                while ! stat /mnt/hf_cache >/dev/null 2>&1; do
+                  fusermount3 -uz /mnt/hf_cache 2>/dev/null || umount -l /mnt/hf_cache 2>/dev/null || break
+                done
+                # rclone Bidirectional-mounts the parent /mnt, so /mnt must be a shared
+                # mountpoint: bind it first, then keep /mnt/hf_cache a shared submount so
+                # the FUSE still propagates to job pods.
+                grep -q " /mnt " /proc/mounts || mount --bind /mnt /mnt
+                mount --make-rshared /mnt
                 grep -q " /mnt/hf_cache " /proc/mounts || mount --bind /mnt/hf_cache /mnt/hf_cache
                 mount --make-rshared /mnt/hf_cache
               '
@@ -99,9 +114,10 @@ spec:
               set -eu
               MOUNT=/mnt/hf_cache
               CACHE=/mnt/hf-cache-vfs
-              # Clear a stale FUSE left by a crash (no preStop) so rclone can remount.
-              # fusermount only — `umount` would drop the host bind mount.
-              fusermount -uz "$MOUNT" 2>/dev/null || true
+              # Clear a stale FUSE left by a crash so rclone can remount. fusermount3 is
+              # the FUSE3 binary in the rclone image (fusermount is not installed); it
+              # clears just the FUSE, leaving the bind mount (a plain umount would drop it).
+              fusermount3 -uz "$MOUNT" 2>/dev/null || true
               mkdir -p "$MOUNT" "$CACHE"
 
               # "<N>%" scales the cap to N% of the cache disk; absolute (200G) as-is.
@@ -165,7 +181,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - "fusermount -uz /mnt/hf_cache || true"
+                  - "fusermount3 -uz /mnt/hf_cache || true"
           # A hung mount blocks this until timeout → pod restart.
           livenessProbe:
             exec:
@@ -188,11 +204,13 @@ spec:
               cpu: "1"
               memory: __RCLONE_MEMORY_LIMIT__
           volumeMounts:
-            - name: hf-cache
-              mountPath: /mnt/hf_cache
+            # Mount the parent /mnt, not /mnt/hf_cache: containerd stats the volume source
+            # at container-create, so a dead FUSE there would block every restart (the init
+            # container doesn't re-run on an in-place restart). rclone's fusermount3 -uz
+            # above then clears it. The vfs cache lives under /mnt too — no separate volume.
+            - name: hf-cache-parent
+              mountPath: /mnt
               mountPropagation: Bidirectional
-            - name: hf-cache-vfs
-              mountPath: /mnt/hf-cache-vfs
             - name: mount-signal
               mountPath: /run/hf-cache-signal
 
@@ -236,14 +254,11 @@ spec:
               readOnly: true
 
       volumes:
-        - name: hf-cache
+        # Parent of /mnt/hf_cache and /mnt/hf-cache-vfs — see rclone volumeMounts.
+        - name: hf-cache-parent
           hostPath:
-            path: /mnt/hf_cache
-            type: DirectoryOrCreate
-        - name: hf-cache-vfs
-          hostPath:
-            path: /mnt/hf-cache-vfs
-            type: DirectoryOrCreate
+            path: /mnt
+            type: Directory
         # taint_remover.py — deploy.sh renders this ConfigMap into the namespace.
         - name: taint-remover-lib
           configMap:

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -17,6 +17,9 @@ MOUNT_DS = "hf-cache-mount"  # the CPU/catch-all tier; also the pod-spec fixture
 MOUNT_SA = "hf-cache-mount"
 IRSA_KEY = "eks.amazonaws.com/role-arn"
 MOUNT_PATH = "/mnt/hf_cache"
+# rclone Bidirectional-mounts the parent (not MOUNT_PATH) so a dead FUSE can't wedge
+# container creation; the FUSE itself still lands at MOUNT_PATH.
+MOUNT_PARENT = "/mnt"
 GPU_COUNT_LABEL = "karpenter.k8s.aws/instance-gpu-count"
 # rclone memory is tiered by GPU count; each tier is its own DaemonSet and reserves
 # (request == limit). ds name -> (affinity op, gpu-count values, memory). Must match
@@ -102,14 +105,21 @@ class TestHfCacheMountDaemonSet:
         )
 
     def test_hostpath_bidirectional(self, mount_pod_spec: dict) -> None:
+        # rclone mounts the parent /mnt (not /mnt/hf_cache) so a dead FUSE can't block
+        # container creation — see the self-heal rationale in mount-daemonset.yaml.tpl.
         mounts = mount_pod_spec["containers"][0].get("volumeMounts", [])
-        hf = [m for m in mounts if m.get("mountPath") == MOUNT_PATH]
-        assert hf, f"rclone container missing {MOUNT_PATH} volume mount."
-        assert hf[0].get("mountPropagation") == "Bidirectional", (
-            f"{MOUNT_PATH} must use Bidirectional propagation so job pods see the FUSE mount."
+        parent = [m for m in mounts if m.get("mountPath") == MOUNT_PARENT]
+        assert parent, f"rclone container must mount the parent {MOUNT_PARENT} (self-heal across a dead FUSE)."
+        assert parent[0].get("mountPropagation") == "Bidirectional", (
+            f"{MOUNT_PARENT} must use Bidirectional propagation so job pods see the FUSE mount."
         )
-        host_vols = [v for v in mount_pod_spec.get("volumes", []) if v.get("hostPath", {}).get("path") == MOUNT_PATH]
-        assert host_vols, f"mount DaemonSet must hostPath-mount {MOUNT_PATH}."
+        assert not [m for m in mounts if m.get("mountPath") == MOUNT_PATH], (
+            f"rclone must NOT mount {MOUNT_PATH} directly — a dead FUSE there wedges container creation."
+        )
+        host_vols = [v for v in mount_pod_spec.get("volumes", []) if v.get("hostPath", {}).get("path") == MOUNT_PARENT]
+        assert host_vols, f"mount DaemonSet must hostPath-mount the parent {MOUNT_PARENT}."
+        cmd = " ".join(mount_pod_spec["containers"][0].get("command", []))
+        assert MOUNT_PATH in cmd, f"rclone command must mount the FUSE at {MOUNT_PATH}."
 
     def test_liveness_probe(self, mount_pod_spec: dict) -> None:
         probe = mount_pod_spec["containers"][0].get("livenessProbe")


### PR DESCRIPTION
When rclone dies (e.g. OOM), the FUSE at `/mnt/hf_cache` goes stale ("transport endpoint is not connected") and containerd can't stat the volumeMount source, so the rclone container can't restart and every job pod on the node wedges in `CreateContainerError` until a manual unmount.

rclone now Bidirectional-mounts the stable parent `/mnt` instead of `/mnt/hf_cache`, so containerd always stats a live dir and the mount self-heals on restart. The init container also clears any dead FUSE on pod recreation.

**Updated 2026-07-17:**
- Rebased onto current main (was ~18 commits behind; now sits on top of the GPU tiering / GOMEMLIMIT / per-tier buffer changes and the smoke-test refactor).
- Switched all FUSE-clear calls from `fusermount` to **`fusermount3`**: the rclone image (rclone/rclone:1.69.1) and the AL2023 host both ship only the FUSE3 binary, so the previous `fusermount -uz` cleanups silently no-op'd (command not found) and never cleared a stale mount — which is exactly why mounts wedged. Verified in-cluster: `command -v fusermount` is empty, `/usr/bin/fusermount3` is present.

⚠️ Still changes mount propagation (now the parent `/mnt`) — needs a staging soak before prod.