### PR TITLE
Add OSDC cluster utilization Grafana dashboard

### DIFF
--- a/grafana/osdc_utilization.json
+++ b/grafana/osdc_utilization.json
@@ -1,0 +1,2400 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "grafana"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Crosshair",
+  "description": "Aggregate CPU and memory request utilization for nodes managed by node-compactor (Karpenter-managed OSDC runner nodes). Utilization = sum(pod requests) / sum(node allocatable).",
+  "editable": true,
+  "elements": {
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(rate(gha_started_jobs_total{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}[5m])) * 300",
+                      "legendFormat": "total jobs",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Number of GitHub Actions jobs started, in 5-minute buckets. Filter by $cluster and $runner to slice by runner scale set. Data source: gha_started_jobs_total counter.",
+        "id": 10,
+        "links": [],
+        "title": "Jobs started per 5min [cluster, runner]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max",
+                  "sum"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"})",
+                      "legendFormat": "running jobs",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Total GitHub Actions jobs currently running across all runners in the current $cluster/$fleet/$runner selection. Instant gauge from gha_running_jobs.",
+        "id": 11,
+        "links": [],
+        "title": "Currently running jobs [cluster, runner]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max",
+                  "sum"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-12": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 2,
+                      "meta": {
+                        "timezone": "browser"
+                      },
+                      "rawSql": "WITH\n  $__fromTime AS window_start,\n  $__toTime AS window_end,\n  base AS (\n    SELECT\n      toDateTime(ts) AS time_bucket,\n      floor(dateDiff('minute', started_at, toDateTime(ts)) / 5) * 5 AS age_bucket_minutes,\n      count() AS running_jobs\n    FROM workflow_job\n    ARRAY JOIN range(\n      toUInt32(toUnixTimestamp(greatest(window_start, toStartOfInterval(started_at, INTERVAL 5 MINUTE)))),\n      toUInt32(toUnixTimestamp(least(window_end, if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())))) + 1,\n      300\n    ) AS ts\n    WHERE runner_group_name IN (${cluster:sqlstring})\n      AND started_at BETWEEN window_start - INTERVAL 24 HOUR AND window_end\n      AND started_at > toDateTime64('2000-01-01', 9)\n      AND status IN ('in_progress', 'completed')\n      AND dateDiff('minute',\n                   started_at,\n                   if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())\n                  ) <= 360\n      AND toDateTime(ts) >= window_start\n      AND toDateTime(ts) <= window_end\n      AND (\n        '${runner:regex}' = '' OR\n        arrayExists(x -> match(x, '^mt-(${runner:regex})$'), labels)\n      )\n    GROUP BY time_bucket, age_bucket_minutes\n    HAVING age_bucket_minutes >= 0\n  )\nSELECT\n  time_bucket AS time,\n  sumIf(running_jobs, age_bucket_minutes = 0) AS `005m`,\n  sumIf(running_jobs, age_bucket_minutes = 5) AS `010m`,\n  sumIf(running_jobs, age_bucket_minutes = 10) AS `015m`,\n  sumIf(running_jobs, age_bucket_minutes = 15) AS `020m`,\n  sumIf(running_jobs, age_bucket_minutes = 20) AS `025m`,\n  sumIf(running_jobs, age_bucket_minutes = 25) AS `030m`,\n  sumIf(running_jobs, age_bucket_minutes >= 30 AND age_bucket_minutes < 45) AS `045m`,\n  sumIf(running_jobs, age_bucket_minutes >= 45 AND age_bucket_minutes < 60) AS `060m`,\n  sumIf(running_jobs, age_bucket_minutes >= 60 AND age_bucket_minutes < 90) AS `090m`,\n  sumIf(running_jobs, age_bucket_minutes >= 90 AND age_bucket_minutes < 120) AS `120m`,\n  sumIf(running_jobs, age_bucket_minutes >= 120 AND age_bucket_minutes < 150) AS `150m`,\n  sumIf(running_jobs, age_bucket_minutes >= 150 AND age_bucket_minutes < 180) AS `180m`,\n  sumIf(running_jobs, age_bucket_minutes >= 180 AND age_bucket_minutes < 210) AS `210m`,\n  sumIf(running_jobs, age_bucket_minutes >= 210 AND age_bucket_minutes < 240) AS `240m`,\n  sumIf(running_jobs, age_bucket_minutes >= 240 AND age_bucket_minutes < 300) AS `300m`,\n  sumIf(running_jobs, age_bucket_minutes >= 300 AND age_bucket_minutes < 360) AS `360m`,\n  sumIf(running_jobs, age_bucket_minutes >= 360 AND age_bucket_minutes < 420) AS `420m`,\n  sumIf(running_jobs, age_bucket_minutes >= 420) AS `999m`\nFROM base\nGROUP BY time\nORDER BY time"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Heatmap of currently-running GitHub Actions job ages across time. Y-axis rows = 5-minute age bands (a fresh job = 0, a job that's been running 20min = 20m). Cell opacity = number of jobs in that age band at that time. Data source: PyTorch HUD ClickHouse workflow_job table. Respects the $cluster and $runner filters; $fleet works transitively via $runner cascade.",
+        "id": 12,
+        "links": [],
+        "title": "Job running-time histogram over time [cluster, runner]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "calculate": false,
+              "cellGap": 1,
+              "color": {
+                "exponent": 0.5,
+                "fill": "#00FF00",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "scheme": "Oranges",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-09
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "tooltip": {
+                "mode": "single",
+                "showColorScale": false,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisPlacement": "left",
+                "reverse": false
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-13": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"cpu\"}))[$__range:1m] ) / sum_over_time( (sum(kube_node_status_allocatable{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )",
+                      "instant": true,
+                      "legendFormat": "CPU",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum(node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"memory\"}))[$__range:1m] ) / sum_over_time( (sum(kube_node_status_allocatable{resource=\"memory\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )",
+                      "instant": true,
+                      "legendFormat": "Memory",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Capacity- and time-weighted mean utilization over the selected range: sum_over_time(sum of pod requests) / sum_over_time(sum of node allocatable), sampled at 1m. Unlike the time-series legend's mean/max/median (which weight every timestamp equally regardless of fleet size), this weights each moment by allocatable capacity, giving the true fraction of provisioned node capacity that was requested over the window. Color uses a value-based red→yellow→green gradient (thresholds 0.5/0.8) rather than palette-classic-by-name because the color encodes utilization health, not series identity.",
+        "id": 13,
+        "links": [],
+        "title": "Weighted utilization (range) [cluster, fleet]",
+        "vizConfig": {
+          "group": "bargauge",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "continuous-GrYlRd"
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.8
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "overflow": "ellipsis",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "text": {
+                "titleSize": 20,
+                "valueSize": 15
+              },
+              "valueMode": "color"
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "CPU",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "Memory",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 2,
+        "links": [],
+        "title": "Total OSDC utilization over time [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max",
+                  "median"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": true,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-3": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (cluster) (node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"cpu\"}) / sum by (cluster) (kube_node_status_allocatable{resource=\"cpu\"} * on(cluster, node) group_left(nodepool) (node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} != bool -1))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 3,
+        "links": [],
+        "title": "Per-cluster CPU utilization [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false,
+                "sortBy": "Mean",
+                "sortDesc": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (cluster) (node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"memory\"}) / sum by (cluster) (kube_node_status_allocatable{resource=\"memory\"} * on(cluster, node) group_left(nodepool) (node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} != bool -1))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 4,
+        "links": [],
+        "title": "Per-cluster Memory utilization [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false,
+                "sortBy": "Mean",
+                "sortDesc": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (fleet) (label_replace(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}, \"fleet\", \"${1}${3}\", \"nodepool\", \"^(.+?)-([0-9]+xlarge|metal)(-.*)?$\") * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"cpu\"}) / sum by (fleet) (label_replace(kube_node_status_allocatable{resource=\"cpu\"} * on(cluster, node) group_left(nodepool) (node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} != bool -1), \"fleet\", \"${1}${3}\", \"nodepool\", \"^(.+?)-([0-9]+xlarge|metal)(-.*)?$\"))",
+                      "legendFormat": "{{fleet}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 5,
+        "links": [],
+        "title": "Per-fleet CPU utilization [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": true,
+                "sortBy": "Mean",
+                "sortDesc": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (fleet) (label_replace(node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}, \"fleet\", \"${1}${3}\", \"nodepool\", \"^(.+?)-([0-9]+xlarge|metal)(-.*)?$\") * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"memory\"}) / sum by (fleet) (label_replace(kube_node_status_allocatable{resource=\"memory\"} * on(cluster, node) group_left(nodepool) (node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} != bool -1), \"fleet\", \"${1}${3}\", \"nodepool\", \"^(.+?)-([0-9]+xlarge|metal)(-.*)?$\"))",
+                      "legendFormat": "{{fleet}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 6,
+        "links": [],
+        "title": "Per-fleet Memory utilization [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": true,
+                "sortBy": "Mean",
+                "sortDesc": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-7": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} < 0.10)",
+                      "legendFormat": "0-10%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.10 < 0.20)",
+                      "legendFormat": "10-20%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.20 < 0.30)",
+                      "legendFormat": "20-30%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "C"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.30 < 0.40)",
+                      "legendFormat": "30-40%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "D"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.40 < 0.50)",
+                      "legendFormat": "40-50%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "E"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.50 < 0.60)",
+                      "legendFormat": "50-60%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "F"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.60 < 0.70)",
+                      "legendFormat": "60-70%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "G"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.70 < 0.80)",
+                      "legendFormat": "70-80%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "H"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.80 < 0.90)",
+                      "legendFormat": "80-90%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "I"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.90)",
+                      "legendFormat": "90-100%",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "J"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Number of nodes in each CPU utilization tier over time. Y-axis rows = 10% util bands. Cell opacity = node count in that band (transparent=empty, solid green=many). Bimodal shape shows as opacity concentrated in the top and bottom rows.",
+        "id": 7,
+        "links": [],
+        "title": "Per-node CPU utilization histogram over time [cluster, fleet]",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "calculate": false,
+              "cellGap": 1,
+              "color": {
+                "exponent": 0.5,
+                "fill": "#00FF00",
+                "mode": "opacity",
+                "reverse": false,
+                "scale": "exponential",
+                "scheme": "Oranges",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-09
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "tooltip": {
+                "mode": "single",
+                "showColorScale": false,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisPlacement": "left",
+                "reverse": false
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-8": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} == 0)",
+                      "legendFormat": "empty (0%)",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} > 0 < 0.10)",
+                      "legendFormat": "mostly empty (0-10%)",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.10 < 0.50)",
+                      "legendFormat": "low (10-50%)",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "C"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.50 < 0.90)",
+                      "legendFormat": "partial (50-90%)",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "D"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "count(node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} >= 0.90)",
+                      "legendFormat": "well-packed (≥90%)",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "E"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "How many nodes sit in each utilization tier over time. The `empty` band shrinking is the direct signal that Karpenter+compactor are shedding idle nodes. Rising `well-packed` band = the bin-pack scheduler working.",
+        "id": 8,
+        "links": [],
+        "title": "Node count by utilization tier (CPU) [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 30,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-9": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "quantile(0.10, node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "p10",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "quantile(0.30, node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "p30",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "quantile(0.50, node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "p50",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "C"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "quantile(0.70, node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "p70",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "D"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "quantile(0.90, node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+                      "legendFormat": "p90",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "E"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Quantile spread across nodes. Wide gap between p10 and p90 = bimodal fleet with empty and packed nodes. Narrowing = more uniform packing. Rising p10 = tail of empty nodes catching up.",
+        "id": 9,
+        "links": [],
+        "title": "Per-node CPU utilization quantiles [cluster, fleet]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-14": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum by (cluster) (node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"cpu\"}))[$__range:1m] ) / sum_over_time( (sum by (cluster) (kube_node_status_allocatable{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )",
+                      "instant": true,
+                      "legendFormat": "{{cluster}}",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Capacity- and time-weighted mean utilization per cluster over the selected range: sum_over_time(sum of pod requests) / sum_over_time(sum of node allocatable), sampled at 1m. One bar per cluster. Weights each moment by allocatable capacity, giving the true fraction of provisioned node capacity requested over the window. Color uses a value-based red→yellow→green gradient (thresholds 0.5/0.8) rather than palette-classic-by-name because the color encodes utilization health, not series identity.",
+        "id": 14,
+        "links": [],
+        "title": "Weighted CPU (range) [cluster, fleet]",
+        "vizConfig": {
+          "group": "bargauge",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "continuous-GrYlRd"
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.8
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "overflow": "ellipsis",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "text": {
+                "titleSize": 10,
+                "valueSize": 15
+              },
+              "valueMode": "color"
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-15": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum by (cluster) (node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"} * on(cluster, node) group_left() kube_node_status_allocatable{resource=\"memory\"}))[$__range:1m] ) / sum_over_time( (sum by (cluster) (kube_node_status_allocatable{resource=\"memory\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"memory\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )",
+                      "instant": true,
+                      "legendFormat": "{{cluster}}",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Capacity- and time-weighted mean utilization per cluster over the selected range: sum_over_time(sum of pod requests) / sum_over_time(sum of node allocatable), sampled at 1m. One bar per cluster. Weights each moment by allocatable capacity, giving the true fraction of provisioned node capacity requested over the window. Color uses a value-based red→yellow→green gradient (thresholds 0.5/0.8) rather than palette-classic-by-name because the color encodes utilization health, not series identity.",
+        "id": 15,
+        "links": [],
+        "title": "Weighted memory (range) [cluster, fleet]",
+        "vizConfig": {
+          "group": "bargauge",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "continuous-GrYlRd"
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.8
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "overflow": "ellipsis",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "text": {
+                "titleSize": 10,
+                "valueSize": 15
+              },
+              "valueMode": "color"
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "GridLayout",
+    "spec": {
+      "items": [
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-2"
+            },
+            "height": 7,
+            "width": 20,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-13"
+            },
+            "height": 7,
+            "width": 4,
+            "x": 20,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-3"
+            },
+            "height": 9,
+            "width": 9,
+            "x": 0,
+            "y": 7
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-14"
+            },
+            "height": 9,
+            "width": 3,
+            "x": 9,
+            "y": 7
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-4"
+            },
+            "height": 9,
+            "width": 9,
+            "x": 12,
+            "y": 7
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-15"
+            },
+            "height": 9,
+            "width": 3,
+            "x": 21,
+            "y": 7
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-7"
+            },
+            "height": 9,
+            "width": 24,
+            "x": 0,
+            "y": 16
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-12"
+            },
+            "height": 9,
+            "width": 24,
+            "x": 0,
+            "y": 25
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-10"
+            },
+            "height": 9,
+            "width": 24,
+            "x": 0,
+            "y": 34
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-11"
+            },
+            "height": 9,
+            "width": 24,
+            "x": 0,
+            "y": 43
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-8"
+            },
+            "height": 9,
+            "width": 12,
+            "x": 0,
+            "y": 52
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-9"
+            },
+            "height": 9,
+            "width": 12,
+            "x": 12,
+            "y": 52
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-5"
+            },
+            "height": 11,
+            "width": 12,
+            "x": 0,
+            "y": 61
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-6"
+            },
+            "height": 11,
+            "width": 12,
+            "x": 12,
+            "y": 61
+          }
+        }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preload": false,
+  "tags": [
+    "osdc",
+    "utilization",
+    "capacity"
+  ],
+  "timeSettings": {
+    "autoRefresh": "1m",
+    "autoRefreshIntervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-12h",
+    "hideTimepicker": false,
+    "timezone": "browser",
+    "to": "now"
+  },
+  "title": "OSDC Cluster Utilization",
+  "variables": [
+    {
+      "kind": "DatasourceVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "grafanacloud-pytorchci-prom",
+          "value": "grafanacloud-prom"
+        },
+        "hide": "dontHide",
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "skipUrlSync": false
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allValue": ".+",
+        "allowCustomValue": true,
+        "current": {
+          "text": [
+            "lf-prod-aws-ue1",
+            "lf-prod-aws-ue2",
+            "meta-prod-aws-ue1",
+            "meta-prod-aws-ue2"
+          ],
+          "value": [
+            "lf-prod-aws-ue1",
+            "lf-prod-aws-ue2",
+            "meta-prod-aws-ue1",
+            "meta-prod-aws-ue2"
+          ]
+        },
+        "definition": "label_values(node_compactor_node_utilization_ratio, cluster)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "${datasource}"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(node_compactor_node_utilization_ratio, cluster)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allValue": ".+",
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "label_values(node_compactor_node_utilization_ratio{cluster=~\"$cluster\"}, nodepool)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Fleet",
+        "multi": true,
+        "name": "fleet",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "${datasource}"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(node_compactor_node_utilization_ratio{cluster=~\"$cluster\"}, nodepool)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "/^(.+?)-(?:[0-9]+xlarge|metal)(?:-.*)?$/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "query_result(kube_pod_info{cluster=~\"$cluster\", namespace=\"arc-runners\"} * on(cluster, node) group_left(nodepool) node_compactor_node_utilization_ratio{cluster=~\"$cluster\", resource=\"cpu\", nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Runner",
+        "multi": true,
+        "name": "runner",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "${datasource}"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 3,
+            "query": "query_result(kube_pod_info{cluster=~\"$cluster\", namespace=\"arc-runners\"} * on(cluster, node) group_left(nodepool) node_compactor_node_utilization_ratio{cluster=~\"$cluster\", resource=\"cpu\", nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"})",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "/pod=\"mt-(.+?)-[a-z0-9]+-runner-/",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new `osdc_utilization.json` Grafana dashboard that visualizes CPU and memory request utilization for the Karpenter-managed OSDC runner nodes (node-compactor). Utilization is defined as sum(pod requests) / sum(node allocatable).

https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc_utilization/osdc-cluster-utilization