### PR TITLE
Slow down fresh-job pickup on meta-staging-aws-ue1 to test peak smoothing

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -243,7 +243,7 @@ clusters:
       runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
       runner_group: "meta-staging-aws-ue1"
       scheduler_name: bin-pack-scheduler
-      capacity_aware_fresh_multiplier: 0.8
+      capacity_aware_fresh_multiplier: 0.25
     buildkit:
       arm64_instance_type: m7gd.16xlarge
       arm64_pods_per_node: 4


### PR DESCRIPTION
**Impact:** meta-staging-aws-ue1 staging cluster only (c-mt- runners); no prod impact
**Risk:** low

## What
Lower `capacity_aware_fresh_multiplier` from `0.8` to `0.25` for the `arc-runners` module on the `meta-staging-aws-ue1` staging cluster, so this peer claims a smaller slice of the fresh queued-job pool and starts new runner pairs more slowly.

## Why
Experiment: accepting fresh jobs more slowly should flatten burst peaks and let scheduling settle, which may improve bin-packing and node utilization. Staging-only knob change to observe the effect before considering it for prod.