### PR TITLE
osdc/hf-cache: tier rclone memory by GPU count

### DIFF
--- a/osdc/modules/arc-runners-opt/defs/l-bx86iavx512-94-344-t4-8.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-bx86iavx512-94-344-t4-8.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-bx86iavx512-94-344-t4-8
 # Instance type: g4dn.metal — 8-GPU T4, 96c/384Gi node
-# Actual K8s capacity ~355.2Gi. Max job memory after all overhead: 344Gi.
+# Actual K8s capacity ~355.2Gi. Job 340Gi after overhead incl. hf-cache 4Gi reserve; label keeps -344-.
 runner:
   name: l-bx86iavx512-94-344-t4-8
   instance_type: g4dn.metal
   node_fleet: g4dn-metal
   disk_size: 150
   vcpu: 94
-  memory: 344Gi
+  memory: 340Gi
   gpu: 8
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-x86aavx2-189-704-a10g-8
 # Instance type: g5.48xlarge — 8-GPU A10G, 192c/768Gi node
-# Actual K8s capacity ~710.4Gi. Max job: 189c/704Gi after all overhead.
+# Actual K8s capacity ~710.4Gi. Job 700Gi after overhead incl. hf-cache 4Gi reserve; label keeps -704-.
 runner:
   name: l-x86aavx2-189-704-a10g-8
   instance_type: g5.48xlarge
   node_fleet: g5-large
   disk_size: 150
   vcpu: 189
-  memory: 704Gi
+  memory: 700Gi
   gpu: 8
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx2-45-167-a10g-4.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx2-45-167-a10g-4.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-x86aavx2-45-167-a10g-4
 # Instance type: g5.12xlarge — 4-GPU A10G, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 167Gi.
+# Actual K8s capacity ~177.6Gi. Job 165Gi after overhead incl. hf-cache 2Gi reserve; label keeps -167-.
 runner:
   name: l-x86aavx2-45-167-a10g-4
   instance_type: g5.12xlarge
   node_fleet: g5-12xl
   disk_size: 150
   vcpu: 47
-  memory: 167Gi
+  memory: 165Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx2-45-172-l4-4.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx2-45-172-l4-4.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-x86aavx2-45-172-l4-4
 # Instance type: g6.12xlarge — 4-GPU L4, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 173Gi.
+# Actual K8s capacity ~177.6Gi. Job 171Gi after overhead incl. hf-cache 2Gi reserve; label keeps -172-.
 runner:
   name: l-x86aavx2-45-172-l4-4
   instance_type: g6.12xlarge
   node_fleet: g6-12xl
   disk_size: 150
   vcpu: 47
-  memory: 173Gi
+  memory: 171Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners-opt/defs/l-x86iavx512-45-172-t4-4.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86iavx512-45-172-t4-4.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-x86iavx512-45-172-t4-4
 # Instance type: g4dn.12xlarge — 4-GPU T4, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 173Gi.
+# Actual K8s capacity ~177.6Gi. Job 171Gi after overhead incl. hf-cache 2Gi reserve; label keeps -172-.
 runner:
   name: l-x86iavx512-45-172-t4-4
   instance_type: g4dn.12xlarge
   node_fleet: g4dn-12xl
   disk_size: 150
   vcpu: 47
-  memory: 173Gi
+  memory: 171Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-bx86iavx512-94-344-t4-8.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-bx86iavx512-94-344-t4-8
 # Instance type: g4dn.metal — 8-GPU T4, 96c/384Gi node
-# Actual K8s capacity ~355.2Gi. Max job memory after all overhead: 344Gi.
+# Actual K8s capacity ~355.2Gi. Job 340Gi after overhead incl. hf-cache 4Gi reserve; label keeps -344-.
 runner:
   name: l-bx86iavx512-94-344-t4-8
   instance_type: g4dn.metal
   node_fleet: g4dn-metal
   disk_size: 150
   vcpu: 94
-  memory: 344Gi
+  memory: 340Gi
   gpu: 8
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-189-704-a10g-8.yaml
@@ -1,13 +1,13 @@
 # ARC runner definition: l-x86aavx2-189-704-a10g-8
 # Instance type: g5.48xlarge — 8-GPU A10G, 192c/768Gi node
-# Actual K8s capacity ~710.4Gi. Max job: 189c/704Gi after all overhead.
+# Actual K8s capacity ~710.4Gi. Job 700Gi after overhead incl. hf-cache 4Gi reserve; label keeps -704-.
 runner:
   name: l-x86aavx2-189-704-a10g-8
   instance_type: g5.48xlarge
   node_fleet: g5-large
   disk_size: 150
   vcpu: 189
-  memory: 704Gi
+  memory: 700Gi
   gpu: 8
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-167-a10g-4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-45-167-a10g-4
 # Instance type: g5.12xlarge — 4-GPU A10G, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 167Gi.
+# Actual K8s capacity ~177.6Gi. Job 165Gi after overhead incl. hf-cache 2Gi reserve; label keeps -167-.
 runner:
   name: l-x86aavx2-45-167-a10g-4
   instance_type: g5.12xlarge
   disk_size: 150
   vcpu: 45
-  memory: 167Gi
+  memory: 165Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-45-172-l4-4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-45-172-l4-4
 # Instance type: g6.12xlarge — 4-GPU L4, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 172Gi.
+# Actual K8s capacity ~177.6Gi. Job 170Gi after overhead incl. hf-cache 2Gi reserve; label keeps -172-.
 runner:
   name: l-x86aavx2-45-172-l4-4
   instance_type: g6.12xlarge
   disk_size: 150
   vcpu: 45
-  memory: 172Gi
+  memory: 170Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-45-172-t4-4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86iavx512-45-172-t4-4
 # Instance type: g4dn.12xlarge — 4-GPU T4, 48c/192Gi node
-# Actual K8s capacity ~177.6Gi. Max job memory after all overhead: 172Gi.
+# Actual K8s capacity ~177.6Gi. Job 170Gi after overhead incl. hf-cache 2Gi reserve; label keeps -172-.
 runner:
   name: l-x86iavx512-45-172-t4-4
   instance_type: g4dn.12xlarge
   disk_size: 150
   vcpu: 45
-  memory: 172Gi
+  memory: 170Gi
   gpu: 4
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -13,6 +13,11 @@ cold node only pulls the models its jobs touch. Job pods (ARC kubernetes mode)
 get the path bind-mounted read-only via the gated `# BEGIN_HF_CACHE` block in
 `modules/arc-runners/templates/runner.yaml.tpl`.
 
+rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
+(`karpenter.k8s.aws/instance-gpu-count`), since RSS scales with job concurrency:
+`deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
+1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
+
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the
 pytorch/pytorch workflow assumes a GitHub-OIDC role
@@ -30,7 +35,7 @@ follows symlinks, so the S3 layout is symlink-free and portable.
 |-----------|--------------|
 | `terraform/` | Per-cluster private bucket + read-only IRSA role (`hf-cache-mount` SA) |
 | `kubernetes/mount-daemonset.yaml.tpl` | rclone read-only FUSE mount → `/mnt/hf_cache` on every runner/workflow node |
-| `deploy.sh` | Annotates the SA with the role and rolls out the DaemonSet |
+| `deploy.sh` | Annotates the SA with the role and rolls out the per-GPU-count mount DaemonSets (`MOUNT_TIERS`) |
 | (pytorch-gha-infra) | `gha_workflow_hf-cache-write` OIDC role — the only writer |
 
 ## Runner consumption

--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -30,14 +30,20 @@ RCLONE_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_image "rclone/rclone:1.6
 TAINT_REMOVER_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.taint_remover_image \
   "public.ecr.aws/amazonlinux/amazonlinux:2023")
 VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
-# Only large-GPU nodes pull multi-GB models and OOM rclone, so only the -largegpu
-# DaemonSet gets the raised limit; standard nodes keep the modest default. Which GPUs
-# count as "large" is the instance-gpu-name set below (comma-separated in config).
-RCLONE_MEMORY_LIMIT=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_memory_limit "1Gi")
-RCLONE_MEMORY_LIMIT_LARGEGPU=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_memory_limit_largegpu "4Gi")
-# h100,b200 -> ["h100","b200"] for the node-affinity values list.
-LARGE_GPU_NAMES=$(uv run "$CFG" "$CLUSTER" hf_cache.large_gpu_names "h100,b200")
-LARGE_GPU_VALUES="[\"${LARGE_GPU_NAMES//,/\",\"}\"]"
+# rclone RSS scales with job concurrency ~ GPU count, so memory is tiered by
+# instance-gpu-count and reserved (request == limit). One DaemonSet per tier; the
+# affinity keeps them exclusive. Fields: <ds-name> <affinity-op> <gpu-count-csv> <memory>.
+# The "hf-cache-mount" NotIn catch-all covers CPU + any unclassified count, so every
+# node gets a mount to clear the startup taint.
+# FOLLOW-UP: the GPU-only PR drops CPU (nvidia.com/gpu nodeSelector); then collapse the
+# first two rows into "hf-cache-mount NotIn 2,4,8 512Mi" (1-GPU + rest).
+MOUNT_TIERS=(
+  "hf-cache-mount NotIn 1,2,4,8 256Mi"
+  "hf-cache-mount-gpu1 In 1 512Mi"
+  "hf-cache-mount-gpu2 In 2 1Gi"
+  "hf-cache-mount-gpu4 In 4 2Gi"
+  "hf-cache-mount-gpu8 In 8 4Gi"
+)
 BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
 # Bucket is in the cluster's region, so rclone's S3 region is the cluster region.
 BUCKET_REGION="$REGION"
@@ -76,11 +82,11 @@ kubectl create configmap node-taint-remover-lib \
   -n "$NAMESPACE" --dry-run=client -o yaml \
   | kubectl_apply_if_changed -f -
 
-# --- Render + apply the mount DaemonSet(s) ---
-# One template, two DaemonSets (standard + -largegpu); the __GPU_OP__ affinity keeps
-# them mutually exclusive so exactly one rclone mount runs per node.
+# --- Render + apply the mount DaemonSets (one per GPU-count tier) ---
 render_mount_ds() {
-  # $1 = DaemonSet name, $2 = gpu affinity operator, $3 = rclone memory limit
+  # $1 = DaemonSet name, $2 = affinity operator, $3 = gpu-count CSV,
+  # $4 = rclone memory (rendered as both request and limit → reserved)
+  local values="[\"${3//,/\",\"}\"]"
   sed -e "s|__NAMESPACE__|${NAMESPACE}|g" \
     -e "s|__BUCKET__|${BUCKET}|g" \
     -e "s|__REGION__|${BUCKET_REGION}|g" \
@@ -89,24 +95,33 @@ render_mount_ds() {
     -e "s|__TAINT_REMOVER_IMAGE__|${TAINT_REMOVER_IMAGE}|g" \
     -e "s|__DS_NAME__|${1}|g" \
     -e "s|__GPU_OP__|${2}|g" \
-    -e "s|__RCLONE_MEMORY_LIMIT__|${3}|g" \
-    -e "s|__LARGE_GPU_NAMES__|${LARGE_GPU_VALUES}|g" \
+    -e "s|__MULTI_GPU_COUNTS__|${values}|g" \
+    -e "s|__RCLONE_MEMORY_LIMIT__|${4}|g" \
     "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl"
 }
 
-echo "[hf-cache] Applying mount DaemonSets (standard + large-GPU)..."
+# Retire the pre-tier -largegpu DaemonSet first: the gpu8 tier supersedes it and
+# both would otherwise select 8-GPU nodes and double-mount /mnt/hf_cache.
+kubectl delete daemonset hf-cache-mount-largegpu -n "$NAMESPACE" --ignore-not-found
+
+echo "[hf-cache] Applying mount DaemonSets (per GPU-count tier)..."
 {
-  render_mount_ds "hf-cache-mount" "NotIn" "${RCLONE_MEMORY_LIMIT}"
-  echo "---"
-  render_mount_ds "hf-cache-mount-largegpu" "In" "${RCLONE_MEMORY_LIMIT_LARGEGPU}"
+  first=1
+  for tier in "${MOUNT_TIERS[@]}"; do
+    read -r _name _op _counts _mem <<<"$tier"
+    [ "$first" = 1 ] || echo "---"
+    first=0
+    render_mount_ds "$_name" "$_op" "$_counts" "$_mem"
+  done
 } | kubectl_apply_if_changed -f -
 
 echo "[hf-cache] Waiting for mount DaemonSet rollouts..."
-for DS in hf-cache-mount hf-cache-mount-largegpu; do
-  kubectl rollout status daemonset "$DS" \
+for tier in "${MOUNT_TIERS[@]}"; do
+  read -r _name _rest <<<"$tier"
+  kubectl rollout status daemonset "$_name" \
     -n "$NAMESPACE" --timeout=300s || {
-    echo "[hf-cache] WARNING: $DS rollout did not complete within timeout"
-    echo "[hf-cache] Check: kubectl get pods -n $NAMESPACE -l app=$DS"
+    echo "[hf-cache] WARNING: $_name rollout did not complete within timeout"
+    echo "[hf-cache] Check: kubectl get pods -n $NAMESPACE -l app=$_name"
   }
 done
 

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -3,13 +3,13 @@
 # in modules/arc-runners/templates/runner.yaml.tpl. Reads are lazy and cached on
 # NVMe (LRU). Writes go via the GitHub-OIDC refresh path, not this mount.
 #
-# deploy.sh renders this twice: a standard DaemonSet and a "-largegpu" one (via
-# __GPU_OP__) scoped to H100/B200, which gets a larger rclone memory limit. The
-# instance-gpu-name affinity keeps them mutually exclusive (one mount per node).
+# deploy.sh renders this once per GPU-count tier (via __GPU_OP__/__MULTI_GPU_COUNTS__),
+# each with a memory limit scaled to that tier. The instance-gpu-count affinity keeps
+# the tiers mutually exclusive (exactly one mount per node).
 #
 # Placeholders (deploy.sh): __NAMESPACE__ __BUCKET__ __REGION__ __RCLONE_IMAGE__
 # __VFS_CACHE_MAX_SIZE__ __TAINT_REMOVER_IMAGE__ __RCLONE_MEMORY_LIMIT__
-# __DS_NAME__ __GPU_OP__ __LARGE_GPU_NAMES__
+# __DS_NAME__ __GPU_OP__ __MULTI_GPU_COUNTS__
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -44,17 +44,16 @@ spec:
       nodeSelector:
         workload-type: github-runner
 
-      # instance-gpu-name is absent on non-GPU nodes; NotIn matches those too, so the
-      # standard DaemonSet still covers CPU + small-GPU nodes while -largegpu takes the
-      # large-GPU names from hf_cache.large_gpu_names.
+      # Per-tier selector (deploy.sh renders one DaemonSet per gpu-count). instance-gpu-count
+      # is absent on non-GPU nodes, so the NotIn "rest" tier also covers CPU.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: karpenter.k8s.aws/instance-gpu-name
+                  - key: karpenter.k8s.aws/instance-gpu-count
                     operator: __GPU_OP__
-                    values: __LARGE_GPU_NAMES__
+                    values: __MULTI_GPU_COUNTS__
 
       # Schedule before the node-init.osdc.io/* taints clear, so the mount precedes
       # runner pods. operator:Exists avoids a deadlock from missing one (cf. cache-enforcer).
@@ -157,13 +156,12 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
-          # An rclone OOM drops the mount node-wide, so -largegpu (H100/B200) renders a
-          # raised limit; multi-GB model pulls under --vfs-cache-mode full blow past a
-          # tight cap. Configurable via hf_cache.rclone_memory_limit{,_largegpu}.
+          # An rclone OOM drops the mount node-wide. Memory is tiered by GPU count and
+          # reserved (request == limit) — see deploy.sh MOUNT_TIERS.
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: __RCLONE_MEMORY_LIMIT__
             limits:
               cpu: "1"
               memory: __RCLONE_MEMORY_LIMIT__

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -13,13 +13,21 @@ from helpers import assert_daemonset_healthy, filter_daemonsets, run_kubectl
 pytestmark = [pytest.mark.live]
 
 NAMESPACE = "hf-cache"
-MOUNT_DS = "hf-cache-mount"
-MOUNT_DS_LARGEGPU = "hf-cache-mount-largegpu"
+MOUNT_DS = "hf-cache-mount"  # the CPU/catch-all tier; also the pod-spec fixture DS
 MOUNT_SA = "hf-cache-mount"
 IRSA_KEY = "eks.amazonaws.com/role-arn"
 MOUNT_PATH = "/mnt/hf_cache"
-GPU_NAME_LABEL = "karpenter.k8s.aws/instance-gpu-name"
-LARGE_GPU_VALUES = {"h100", "b200"}
+GPU_COUNT_LABEL = "karpenter.k8s.aws/instance-gpu-count"
+# rclone memory is tiered by GPU count; each tier is its own DaemonSet and reserves
+# (request == limit). ds name -> (affinity op, gpu-count values, memory). Must match
+# deploy.sh MOUNT_TIERS.
+MOUNT_TIERS = {
+    "hf-cache-mount": ("NotIn", {"1", "2", "4", "8"}, "256Mi"),
+    "hf-cache-mount-gpu1": ("In", {"1"}, "512Mi"),
+    "hf-cache-mount-gpu2": ("In", {"2"}, "1Gi"),
+    "hf-cache-mount-gpu4": ("In", {"4"}, "2Gi"),
+    "hf-cache-mount-gpu8": ("In", {"8"}, "4Gi"),
+}
 RUNNER_NODE_SELECTOR = {"workload-type": ["github-runner"]}
 
 
@@ -136,7 +144,7 @@ class TestHfCacheMountDaemonSet:
 
 
 def _gpu_affinity_op(pod_spec: dict) -> tuple[str, set]:
-    """Return (operator, values) of the instance-gpu-name node-affinity requirement."""
+    """Return (operator, values) of the instance-gpu-count node-affinity requirement."""
     terms = (
         pod_spec.get("affinity", {})
         .get("nodeAffinity", {})
@@ -145,15 +153,15 @@ def _gpu_affinity_op(pod_spec: dict) -> tuple[str, set]:
     )
     for term in terms:
         for expr in term.get("matchExpressions", []):
-            if expr.get("key") == GPU_NAME_LABEL:
+            if expr.get("key") == GPU_COUNT_LABEL:
                 return expr.get("operator", ""), set(expr.get("values", []))
     return "", set()
 
 
-class TestHfCacheLargeGpuSplit:
-    """The mount runs as two DaemonSets: standard (CPU + small GPU) and -largegpu
-    (H100/B200, raised rclone memory). They must be mutually exclusive so exactly
-    one rclone mount runs per node, and only the large-GPU one carries the big limit.
+class TestHfCacheGpuTiers:
+    """The mount is rendered as one DaemonSet per gpu-count tier, memory scaled to
+    concurrency and reserved (request == limit). Tiers are mutually exclusive (via the
+    instance-gpu-count affinity) so exactly one rclone mount runs per node.
     """
 
     def _pod_spec(self, all_daemonsets: dict, name: str) -> dict:
@@ -161,32 +169,25 @@ class TestHfCacheLargeGpuSplit:
         assert ds, f"DaemonSet '{name}' not found in {NAMESPACE}."
         return ds[0]["spec"]["template"]["spec"]
 
-    def _rclone_mem(self, pod_spec: dict) -> str:
+    def _rclone_res(self, pod_spec: dict) -> tuple[str, str]:
         rclone = next(c for c in pod_spec["containers"] if c.get("name") == "rclone")
-        return rclone.get("resources", {}).get("limits", {}).get("memory", "")
+        res = rclone.get("resources", {})
+        return res.get("requests", {}).get("memory", ""), res.get("limits", {}).get("memory", "")
 
-    def test_largegpu_daemonset_targets_h100_b200(self, all_daemonsets: dict) -> None:
-        op, values = _gpu_affinity_op(self._pod_spec(all_daemonsets, MOUNT_DS_LARGEGPU))
-        assert values == LARGE_GPU_VALUES, f"{MOUNT_DS_LARGEGPU} must target {LARGE_GPU_VALUES}; got {values}."
-        assert op == "In", f"{MOUNT_DS_LARGEGPU} must use In affinity to select large-GPU nodes; got op={op}."
-
-    def test_standard_daemonset_excludes_h100_b200(self, all_daemonsets: dict) -> None:
-        op, values = _gpu_affinity_op(self._pod_spec(all_daemonsets, MOUNT_DS))
-        assert values == LARGE_GPU_VALUES, f"{MOUNT_DS} affinity must reference {LARGE_GPU_VALUES}; got {values}."
-        assert op == "NotIn", (
-            f"{MOUNT_DS} must use NotIn affinity so it doesn't double-mount large-GPU nodes; got op={op}."
-        )
-
-    def test_largegpu_has_more_memory(self, all_daemonsets: dict) -> None:
-        std = self._rclone_mem(self._pod_spec(all_daemonsets, MOUNT_DS))
-        big = self._rclone_mem(self._pod_spec(all_daemonsets, MOUNT_DS_LARGEGPU))
-
-        def gib(v: str) -> float:
-            return float(v[:-2]) if v.endswith("Gi") else float(v[:-2]) / 1024 if v.endswith("Mi") else float(v)
-
-        assert gib(big) > gib(std), (
-            f"{MOUNT_DS_LARGEGPU} rclone memory limit ({big}) must exceed the standard one ({std})."
-        )
+    @pytest.mark.parametrize(
+        ("ds_name", "op", "values", "mem"),
+        [(name, *spec) for name, spec in MOUNT_TIERS.items()],
+    )
+    def test_tier_affinity_and_reserved_memory(
+        self, all_daemonsets: dict, ds_name: str, op: str, values: set, mem: str
+    ) -> None:
+        pod_spec = self._pod_spec(all_daemonsets, ds_name)
+        aff_op, aff_values = _gpu_affinity_op(pod_spec)
+        assert aff_op == op, f"{ds_name}: expected affinity op {op!r}, got {aff_op!r}."
+        assert aff_values == values, f"{ds_name}: expected gpu-count values {values}, got {aff_values}."
+        req, lim = self._rclone_res(pod_spec)
+        assert lim == mem, f"{ds_name}: expected rclone memory limit {mem}, got {lim}."
+        assert req == lim, f"{ds_name}: request must == limit to reserve memory; got {req} vs {lim}."
 
 
 class TestHfCacheTaintGate:

--- a/osdc/scripts/python/analyze_node_utilization.py
+++ b/osdc/scripts/python/analyze_node_utilization.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import yaml
 from cli_colors import BOLD, CYAN, DIM, GREEN, NC, RED, YELLOW
-from daemonset_overhead import DaemonSetOverhead, discover_daemonsets
+from daemonset_overhead import DaemonSetOverhead, discover_daemonsets, hf_cache_gpu_topup_mib
 from instance_specs import ENI_MAX_PODS, INSTANCE_SPECS
 
 # ARC container-hooks overhead: injected containers added to the workflow
@@ -158,6 +158,7 @@ def compute_allocatable(
     max_pods = ENI_MAX_PODS.get(instance_type, spec["vcpu"])  # fallback to vcpu if unknown
     kube_cpu, kube_mem = kubelet_reserved(spec["vcpu"], spec["memory_gib"], max_pods)
     ds_cpu, ds_mem = compute_daemonset_overhead(daemonsets, is_gpu)
+    ds_mem += hf_cache_gpu_topup_mib(spec["gpu"])  # per-GPU-count hf-cache reserve
 
     total_cpu_m = spec["vcpu"] * 1000
     total_mem_mi = spec["memory_mi"]

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -54,6 +54,22 @@ EKS_ADDON_DAEMONSETS: list[DaemonSetOverhead] = [
     DaemonSetOverhead("ebs-csi-node", 10, 50, False, "constant:eks-addon"),
 ]
 
+# .tpl-rendered DaemonSets the raw-YAML scan can't see (unresolved __PLACEHOLDER__s).
+# hf-cache's memory is tiered by GPU count (deploy.sh MOUNT_TIERS); this base is the
+# CPU/catch-all tier counted on every node, and GPU nodes add hf_cache_gpu_topup_mib().
+HF_CACHE_BASE_MIB = 256
+TEMPLATED_DAEMONSETS: list[DaemonSetOverhead] = [
+    DaemonSetOverhead("hf-cache-mount", 100, HF_CACHE_BASE_MIB, False, "constant:tpl:modules/hf-cache"),
+]
+
+# Reserved hf-cache memory (MiB) by GPU count (MOUNT_TIERS); other counts + CPU get the base.
+HF_CACHE_TIER_MIB = {1: 512, 2: 1024, 4: 2048, 8: 4096}
+
+
+def hf_cache_gpu_topup_mib(gpu_count: int) -> int:
+    """hf-cache memory (MiB) a GPU node reserves beyond the base tier."""
+    return HF_CACHE_TIER_MIB.get(gpu_count, HF_CACHE_BASE_MIB) - HF_CACHE_BASE_MIB
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
@@ -209,6 +225,9 @@ def discover_daemonsets(
 
     # Discover from YAML manifests
     discovered = _discover_from_yaml(search_dirs)
+
+    # .tpl-rendered DaemonSets the YAML scan can't see (always part of the project)
+    discovered.extend(TEMPLATED_DAEMONSETS)
 
     # Add constants
     if include_helm:

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -12,6 +12,7 @@ from daemonset_overhead import (
     _extract_container_resources,
     _is_gpu_only,
     discover_daemonsets,
+    hf_cache_gpu_topup_mib,
     main,
     parse_cpu_millicores,
     parse_memory_mib,
@@ -504,6 +505,24 @@ class TestRealManifests:
         # hooks-warmer: 10m CPU, 32Mi
         assert by_name["runner-hooks-warmer"].cpu_millicores == 10
         assert by_name["runner-hooks-warmer"].memory_mib == 32
+
+    def test_hf_cache_templated_overhead(self, upstream_dir):
+        """hf-cache is a .tpl DaemonSet (invisible to the YAML scan), added as a 256Mi
+        base on all nodes; GPU nodes reserve more per GPU count via the top-up helper."""
+        by_name = {ds.name: ds for ds in discover_daemonsets(upstream_dir)}
+
+        base = by_name["hf-cache-mount"]
+        assert base.gpu_only is False
+        assert base.memory_mib == 256  # CPU / catch-all tier
+
+        # base + top-up == the reserved memory tier for each GPU count (MOUNT_TIERS)
+        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 512
+        assert base.memory_mib + hf_cache_gpu_topup_mib(2) == 1024
+        assert base.memory_mib + hf_cache_gpu_topup_mib(4) == 2048
+        assert base.memory_mib + hf_cache_gpu_topup_mib(8) == 4096
+        # CPU and unclassified GPU counts stay at the 256Mi base (no top-up)
+        assert hf_cache_gpu_topup_mib(0) == 0
+        assert hf_cache_gpu_topup_mib(16) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
rclone OOMs on high-concurrency GPU nodes regardless of GPU model — observed on an a10g `g5.48xlarge`, not just H100/B200. #874 keyed the 4Gi split on `instance-gpu-name In [h100,b200]`, leaving a10g at 1Gi.

Example failure (a10g): https://github.com/pytorch/pytorch/actions/runs/28908017258/job/85761532112 — node `ip-10-4-176-7` (`g5.48xlarge`, 8× a10g) on meta-prod-aws-ue2, rclone OOMKilled → `/mnt/hf_cache` dead FUSE → job pod `CreateContainerError`.

Render one mount DaemonSet per GPU-count tier (`karpenter.k8s.aws/instance-gpu-count`), reserved (`request == limit`) memory scaled to concurrency:

| tier | affinity | DaemonSet | memory |
|---|---|---|---|
| 8-GPU | `In [8]` | hf-cache-mount-gpu8 | 4Gi |
| 4-GPU | `In [4]` | hf-cache-mount-gpu4 | 2Gi |
| 2-GPU | `In [2]` | hf-cache-mount-gpu2 | 1Gi |
| 1-GPU | `In [1]` | hf-cache-mount-gpu1 | 512Mi |
| CPU / rest | `NotIn [1,2,4,8]` | hf-cache-mount | 256Mi |

Affinity keeps tiers mutually exclusive (the `NotIn` catch-all also matches non-GPU nodes, so CPU is covered and every node still gets a mount to clear the startup taint). Retires the pre-tier `-largegpu` DaemonSet.

Also counts hf-cache in the packing analysis (it's a `.tpl` the YAML scan skipped): `daemonset_overhead` adds a 256Mi base on all nodes, and `analyze_node_utilization` adds the per-GPU-count top-up (`hf_cache_gpu_topup_mib`) — a flat constant can't express the tiers.

### Packing impact (`just analyze-utilization`)

Large-RAM GPU nodes (p5/p6-b200/p4d, 2TB / 1TB) have 50–86Gi of slack — the reservation is negligible there. The small-RAM GPU nodes run a single runner sized to ~full node memory, so reserving there needs a matching trim. Job memory dropped by the tier reservation (labels keep their `-NNN-`, names stable):

| runner | node | trim |
|---|---|---|
| a10g-8 / t4-8 | g5.48xlarge / g4dn.metal | −4Gi (704→700, 344→340) |
| a10g-4 / t4-4 / l4-4 | g5.12xlarge / g4dn.12xlarge / g6.12xlarge | −2Gi (167→165, 172→170) |

After the trims every GPU runner fits on memory. The 1-GPU runners already fit; the remaining ~30–70m CPU gap on the small-GPU runners is hf-cache's **pre-existing 100m CPU request** (since #874), now merely visible in the overhead — it's <0.15% of node CPU and within the tool's kubelet estimate, not a new failure.

Deploy: redeploy `hf-cache` **and** `arc-runners` (+`arc-runners-opt`) to uw1 + ue2 (the runner-memory trims ship with the reservation).
