### PR TITLE
integration-tests: fix t4-multi TORCH_CI_MAX_MEMORY after #883 runner trim

### DIFF
--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1709,7 +1709,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=184683593728
+          EXPECTED=182536110080  # 170Gi = l-x86iavx512-45-172-t4-4 memory; keep in sync with the runner def
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then


### PR DESCRIPTION
#883 trimmed the `l-x86iavx512-45-172-t4-4` runner 172→170Gi (room for hf-cache's 4-GPU reserve) but left the integration test's hardcoded `EXPECTED` at 172Gi. `TORCH_CI_MAX_MEMORY` = the runner's memory in bytes, so `test-gpu-t4-multi` now fails (172 ≠ 170). Update `EXPECTED` to 170Gi (`182536110080`).

(The separate "Duplicate runner names" smoke failure is **not** from #883 — it's the `arc-runners-opt` module from #871 sharing names with `arc-runners`; needs its own fix.)