### PR TITLE
arc-runners: scope runner-name uniqueness smoke check to enabled modules

### DIFF
--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -60,10 +60,14 @@ class TestRunnerDefs:
             missing = REQUIRED_FIELDS - set(d.keys())
             assert not missing, f"Runner '{d.get('name', '?')}' missing fields: {missing}"
 
-    def test_names_are_unique(self, upstream_dir: Path) -> None:
-        """No duplicate runner names."""
-        defs = _load_all_defs(upstream_dir)
-        names = [d["name"] for d in defs]
+    def test_names_are_unique(self, upstream_dir: Path, enabled_modules: list[str]) -> None:
+        """No duplicate runner names among the arc-runners* modules enabled on this
+        cluster. arc-runners and arc-runners-opt are mutually-exclusive alternatives
+        (never co-enabled) that share names by design, so scope to what's enabled —
+        like test_configmaps_for_all_defs — instead of the union of all variants.
+        """
+        enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
+        names = [d["name"] for d in _load_all_defs(upstream_dir, enabled_arc)]
         dupes = [n for n in names if names.count(n) > 1]
         assert not dupes, f"Duplicate runner names: {set(dupes)}"
 


### PR DESCRIPTION
The `test_names_are_unique` smoke test loaded the **union** of every `arc-runners*/defs`, so it flags all 44 names as duplicates now that `arc-runners-opt` (#871) exists with names identical to `arc-runners`. Those two are **mutually exclusive** (only meta-prod-aws-ue1 uses `-opt`; no cluster enables both), so the shared names are by design.

Scope the check to the cluster's **enabled** arc-runners* modules — mirroring the existing `test_configmaps_for_all_defs`. Per cluster exactly one variant is enabled, so names are unique; a real collision (two name-overlapping variants enabled together) is still caught.

Not related to #883 (that was memory-only); this fixes a pre-existing collision introduced by #871.