### PR TITLE
osdc/hf-cache: raise 1-GPU rclone reserve to 1Gi

### DIFF
--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx2-29-113-a10g.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-a10g
 # Instance type: g5.8xlarge — 1-GPU A10G, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Job 112Gi after overhead incl. hf-cache 1Gi reserve; label keeps -113-.
 runner:
   name: l-x86aavx2-29-113-a10g
   instance_type: g5.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx2-29-113-l4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-l4
 # Instance type: g6.8xlarge — 1-GPU L4, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Job 112Gi after overhead incl. hf-cache 1Gi reserve; label keeps -113-.
 runner:
   name: l-x86aavx2-29-113-l4
   instance_type: g6.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners-opt/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86iavx512-29-115-t4.yaml
@@ -1,14 +1,14 @@
 # ARC runner definition: l-x86iavx512-29-115-t4
 # Instance type: g4dn.8xlarge — 1-GPU T4, 32c/128Gi node
 # Actual K8s capacity ~118.4Gi after VM overhead. With kubelet reserved,
-# DaemonSets, sidecar (750m/512Mi), and hooks overhead (320m/522Mi),
-# max job memory is 115Gi.
+# DaemonSets (incl. hf-cache 1Gi GPU reserve), sidecar (750m/512Mi), and hooks
+# overhead (320m/522Mi), job memory is 114Gi; label keeps -115-.
 runner:
   name: l-x86iavx512-29-115-t4
   instance_type: g4dn.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 115Gi
+  memory: 114Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-a10g
 # Instance type: g5.8xlarge — 1-GPU A10G, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Job 112Gi after overhead incl. hf-cache 1Gi reserve; label keeps -113-.
 runner:
   name: l-x86aavx2-29-113-a10g
   instance_type: g5.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-l4
 # Instance type: g6.8xlarge — 1-GPU L4, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Job 112Gi after overhead incl. hf-cache 1Gi reserve; label keeps -113-.
 runner:
   name: l-x86aavx2-29-113-l4
   instance_type: g6.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -1,14 +1,14 @@
 # ARC runner definition: l-x86iavx512-29-115-t4
 # Instance type: g4dn.8xlarge — 1-GPU T4, 32c/128Gi node
 # Actual K8s capacity ~118.4Gi after VM overhead. With kubelet reserved,
-# DaemonSets, sidecar (750m/512Mi), and hooks overhead (320m/522Mi),
-# max job memory is 115Gi.
+# DaemonSets (incl. hf-cache 1Gi GPU reserve), sidecar (750m/512Mi), and hooks
+# overhead (320m/522Mi), job memory is 114Gi; label keeps -115-.
 runner:
   name: l-x86iavx512-29-115-t4
   instance_type: g4dn.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 115Gi
+  memory: 114Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -15,8 +15,10 @@ get the path bind-mounted read-only via the gated `# BEGIN_HF_CACHE` block in
 
 rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 (`karpenter.k8s.aws/instance-gpu-count`), since RSS scales with job concurrency:
-`deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
-1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
+`deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU / 1-GPU → 1Gi,
+and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`. The 1-GPU floor is 1Gi,
+not smaller: rclone RSS is driven by model-file reads (not GPU count), and 512Mi OOM'd a
+single-GPU node (dead FUSE → job-pod `CreateContainerError`).
 
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the

--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -35,11 +35,15 @@ VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
 # affinity keeps them exclusive. Fields: <ds-name> <affinity-op> <gpu-count-csv> <memory>.
 # The "hf-cache-mount" NotIn catch-all covers CPU + any unclassified count, so every
 # node gets a mount to clear the startup taint.
+# The 1-GPU tier is floored at 1Gi, not 512Mi: rclone RSS is driven by model-file reads
+# (not GPU count), so a single-GPU inductor job OOM'd rclone at 512Mi, dropping the mount
+# node-wide (dead FUSE → job-pod CreateContainerError). Observed on a g5.8xlarge a10g:
+# https://github.com/pytorch/pytorch/actions/runs/29042231396/job/86206746830
 # FOLLOW-UP: the GPU-only PR drops CPU (nvidia.com/gpu nodeSelector); then collapse the
-# first two rows into "hf-cache-mount NotIn 2,4,8 512Mi" (1-GPU + rest).
+# first two rows into "hf-cache-mount NotIn 2,4,8 1Gi" (1-GPU + rest).
 MOUNT_TIERS=(
   "hf-cache-mount NotIn 1,2,4,8 256Mi"
-  "hf-cache-mount-gpu1 In 1 512Mi"
+  "hf-cache-mount-gpu1 In 1 1Gi"
   "hf-cache-mount-gpu2 In 2 1Gi"
   "hf-cache-mount-gpu4 In 4 2Gi"
   "hf-cache-mount-gpu8 In 8 4Gi"

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -23,7 +23,7 @@ GPU_COUNT_LABEL = "karpenter.k8s.aws/instance-gpu-count"
 # deploy.sh MOUNT_TIERS.
 MOUNT_TIERS = {
     "hf-cache-mount": ("NotIn", {"1", "2", "4", "8"}, "256Mi"),
-    "hf-cache-mount-gpu1": ("In", {"1"}, "512Mi"),
+    "hf-cache-mount-gpu1": ("In", {"1"}, "1Gi"),
     "hf-cache-mount-gpu2": ("In", {"2"}, "1Gi"),
     "hf-cache-mount-gpu4": ("In", {"4"}, "2Gi"),
     "hf-cache-mount-gpu8": ("In", {"8"}, "4Gi"),

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -63,7 +63,9 @@ TEMPLATED_DAEMONSETS: list[DaemonSetOverhead] = [
 ]
 
 # Reserved hf-cache memory (MiB) by GPU count (MOUNT_TIERS); other counts + CPU get the base.
-HF_CACHE_TIER_MIB = {1: 512, 2: 1024, 4: 2048, 8: 4096}
+# 1-GPU is floored at 1Gi (not 512Mi): rclone RSS tracks model-file reads, not GPU count,
+# and 512Mi OOM'd a single-GPU node (dead FUSE → job-pod CreateContainerError).
+HF_CACHE_TIER_MIB = {1: 1024, 2: 1024, 4: 2048, 8: 4096}
 
 
 def hf_cache_gpu_topup_mib(gpu_count: int) -> int:

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -516,7 +516,7 @@ class TestRealManifests:
         assert base.memory_mib == 256  # CPU / catch-all tier
 
         # base + top-up == the reserved memory tier for each GPU count (MOUNT_TIERS)
-        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 512
+        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 1024  # 1-GPU floored at 1Gi
         assert base.memory_mib + hf_cache_gpu_topup_mib(2) == 1024
         assert base.memory_mib + hf_cache_gpu_topup_mib(4) == 2048
         assert base.memory_mib + hf_cache_gpu_topup_mib(8) == 4096


### PR DESCRIPTION
## What
Raise the `hf-cache-mount-gpu1` rclone memory tier **512Mi → 1Gi**, and trim the three single-GPU runner defs (`arc-runners` + `arc-runners-opt`) to fit under the larger `request == limit` reserve.

## Why
#883 tiered rclone memory by GPU count and gave the 1-GPU tier 512Mi. But under `--vfs-cache-mode full`, rclone RSS tracks the **model files a job reads, not GPU count** — and 1-GPU a10g nodes run the `inductor_huggingface` suite, which loads the largest models. rclone crosses 512Mi → **OOMKilled** → the node-wide `/mnt/hf_cache` FUSE mount dies → the job's mmap'd safetensors read faults with **SIGBUS (`Run failed with return code: -7`)**, which surfaces as a *misleading* `LocalEntryNotFoundError` ("missing weights"). 1Gi restores the floor these nodes ran at before #883.

### Evidence
Live rclone OOMs, both prod clusters, **gpu1 tier only** (cpu/gpu4/gpu8 = 0):
- meta-prod-aws-ue2: **17/59** mounts `OOMKilled`
- meta-prod-aws-ue1: **9/80** `OOMKilled`

Flaky because the OOM only trips when rclone crosses 512Mi mid-load — same job, same ue1 bucket:
- fail: pytorch/pytorch runs/29433922962/job/87421947313 (`Loading weights: 25%|…| 36/146 … return code: -7`)
- pass: pytorch/pytorch runs/29436575323/job/87456375877

The file isn't missing (the load reached 25% of 146 shards); the `LocalEntryNotFoundError` is a retry cascade after the SIGBUS.

## Runner trims (label keeps `-NNN-`)
- a10g `g5.8xlarge` / l4 `g6.8xlarge`: 113 → 112Gi
- t4 `g4dn.8xlarge`: 115 → 114Gi

## Deploy
Redeploy `hf-cache` + `arc-runners` (+`arc-runners-opt`) to the clusters running these 1-GPU classes.
