### PR TITLE
integration-tests: derive resource assertions from runner defs instead of hardcoding

### DIFF
--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -16,8 +16,10 @@ from pathlib import Path
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "python"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "modules" / "arc-runners" / "scripts" / "python"))
 
 from conditional_blocks import strip_conditional_block
+from generate_runners import parse_memory_bytes
 from nodepool_defs import is_excluded_for_region
 from run import (
     CANARY_REPO,
@@ -279,6 +281,42 @@ def _replace_jobs_with_noop(content: str) -> str:
     return "\n".join(out) + suffix
 
 
+def resource_placeholders(upstream_dir: Path, cluster_modules: list[str]) -> dict[str, str]:
+    """Build resource-assertion placeholders from the cluster's arc-runners defs.
+
+    For every runner def in each enabled arc-runners* module's defs/ dir, emit
+    four placeholders keyed by the def name uppercased with hyphens as underscores
+    (VCPU__/MEMGI__/TORCHMEM__/GPU__<KEY>). These feed the integration-test
+    template's hardcoded CPU/memory/GPU assertions so they track the deployed
+    runner spec instead of drifting.
+
+    Base module defs are processed first, then specialized variants (-opt/-b200/
+    -h100), so a variant that redefines a shared label wins.
+    """
+    base = [m for m in cluster_modules if m == "arc-runners"]
+    specialized = sorted(m for m in cluster_modules if m.startswith("arc-runners") and m != "arc-runners")
+    placeholders: dict[str, str] = {}
+    for module in base + specialized:
+        defs_dir = upstream_dir / "modules" / module / "defs"
+        if not defs_dir.is_dir():
+            continue
+        for def_path in sorted(defs_dir.glob("*.yaml")):
+            data = yaml.safe_load(def_path.read_text()) or {}
+            runner = data.get("runner")
+            if not runner:
+                continue
+            name = runner.get("name")
+            if not name:
+                continue
+            key = name.upper().replace("-", "_")
+            memory_bytes = parse_memory_bytes(runner["memory"])
+            placeholders[f"{{{{VCPU__{key}}}}}"] = str(runner["vcpu"])
+            placeholders[f"{{{{MEMGI__{key}}}}}"] = str(memory_bytes // (1024**3))
+            placeholders[f"{{{{TORCHMEM__{key}}}}}"] = str(memory_bytes)
+            placeholders[f"{{{{GPU__{key}}}}}"] = str(runner.get("gpu", 0))
+    return placeholders
+
+
 def generate_workflow(
     upstream_dir: Path,
     prefix: str,
@@ -307,6 +345,9 @@ def generate_workflow(
     content = content.replace("{{ECR_PULL_RESOLVED_TAG}}", ecr_pull_resolved_tag)
     content = content.replace("{{ECR_PULL_SHA}}", ecr_pull_sha)
 
+    for placeholder, value in resource_placeholders(upstream_dir, cluster_modules).items():
+        content = content.replace(placeholder, value)
+
     # Guard: any "{{...}}" left after substitution is a template/code drift bug.
     leftover = re.findall(r"\{\{[A-Z_]+\}\}", content)
     if leftover:
@@ -327,6 +368,13 @@ def generate_workflow(
     excluded_blocks = region_excluded_blocks(upstream_dir, region)
     for tag in REGION_GATED_BLOCKS:
         content = strip_conditional_block(content, tag, keep=tag not in excluded_blocks)
+
+    # Resource-assertion guard (after stripping, so placeholders inside a removed
+    # job — e.g. b200 on a non-b200 cluster — are already gone). A surviving
+    # resource placeholder means a running job's runner def wasn't found: a real bug.
+    leftover_res = re.findall(r"\{\{(?:VCPU|MEMGI|TORCHMEM|GPU)__[A-Z0-9_]+\}\}", content)
+    if leftover_res:
+        raise RuntimeError(f"Unresolved resource placeholders: {sorted(set(leftover_res))}")
 
     if not _has_any_job(content):
         content = _replace_jobs_with_noop(content)

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -39,7 +39,7 @@ jobs:
           fi
       - name: Verify CPU count
         run: |
-          EXPECTED=8
+          EXPECTED={{VCPU__L_X86IAMX_8_32}}
           ACTUAL=$(nproc)
           echo "CPUs: $ACTUAL (expected: $EXPECTED)"
           if [ "$ACTUAL" -ne "$EXPECTED" ]; then
@@ -49,7 +49,7 @@ jobs:
           echo "PASS: CPU count matches"
       - name: Verify memory
         run: |
-          EXPECTED_GI=32
+          EXPECTED_GI={{MEMGI__L_X86IAMX_8_32}}
           if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
             BYTES=$(cat /sys/fs/cgroup/memory.max)
           elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
@@ -68,7 +68,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=34359738368
+          EXPECTED={{TORCHMEM__L_X86IAMX_8_32}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -110,7 +110,7 @@ jobs:
           fi
       - name: Verify CPU count
         run: |
-          EXPECTED=8
+          EXPECTED={{VCPU__L_X86IAMX_8_32}}
           ACTUAL=$(nproc)
           echo "CPUs: $ACTUAL (expected: $EXPECTED)"
           if [ "$ACTUAL" -ne "$EXPECTED" ]; then
@@ -120,7 +120,7 @@ jobs:
           echo "PASS: CPU count matches"
       - name: Verify memory
         run: |
-          EXPECTED_GI=32
+          EXPECTED_GI={{MEMGI__L_X86IAMX_8_32}}
           if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
             BYTES=$(cat /sys/fs/cgroup/memory.max)
           elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
@@ -139,7 +139,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=34359738368
+          EXPECTED={{TORCHMEM__L_X86IAMX_8_32}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -169,7 +169,7 @@ jobs:
           echo "PASS: Architecture is $ARCH"
       - name: Verify CPU count
         run: |
-          EXPECTED=16
+          EXPECTED={{VCPU__L_ARM64G3_16_62}}
           ACTUAL=$(nproc)
           echo "CPUs: $ACTUAL (expected: >= $EXPECTED)"
           if [ "$ACTUAL" -lt "$EXPECTED" ]; then
@@ -179,7 +179,7 @@ jobs:
           echo "PASS: CPU count within expected range"
       - name: Verify memory
         run: |
-          EXPECTED_GI=62
+          EXPECTED_GI={{MEMGI__L_ARM64G3_16_62}}
           if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
             BYTES=$(cat /sys/fs/cgroup/memory.max)
           elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
@@ -198,7 +198,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=66571993088
+          EXPECTED={{TORCHMEM__L_ARM64G3_16_62}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: >= $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -1650,7 +1650,7 @@ jobs:
           nvidia-smi
           echo ""
           GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
-          if [ "$GPU_COUNT" -lt 1 ]; then
+          if [ "$GPU_COUNT" -lt {{GPU__L_X86IAVX512_29_115_T4}} ]; then
             echo "FAIL: Expected at least 1 GPU, found $GPU_COUNT"
             exit 1
           fi
@@ -1673,7 +1673,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=123480309760
+          EXPECTED={{TORCHMEM__L_X86IAVX512_29_115_T4}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -1697,7 +1697,7 @@ jobs:
           nvidia-smi
           echo ""
           GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
-          if [ "$GPU_COUNT" -ne 4 ]; then
+          if [ "$GPU_COUNT" -ne {{GPU__L_X86IAVX512_45_172_T4_4}} ]; then
             echo "FAIL: Expected 4 GPUs, found $GPU_COUNT"
             exit 1
           fi
@@ -1709,7 +1709,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=182536110080  # 170Gi = l-x86iavx512-45-172-t4-4 memory; keep in sync with the runner def
+          EXPECTED={{TORCHMEM__L_X86IAVX512_45_172_T4_4}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -1735,7 +1735,7 @@ jobs:
           nvidia-smi
           echo ""
           GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
-          if [ "$GPU_COUNT" -ne 2 ]; then
+          if [ "$GPU_COUNT" -ne {{GPU__L_X86IAMX_44_450_B200_2}} ]; then
             echo "FAIL: Expected 2 GPUs, found $GPU_COUNT"
             exit 1
           fi
@@ -1743,7 +1743,7 @@ jobs:
       - name: Verify TORCH_CI_MAX_MEMORY
         run: |
           echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED=483183820800
+          EXPECTED={{TORCHMEM__L_X86IAMX_44_450_B200_2}}
           ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
           echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
           if [ -z "$ACTUAL" ]; then
@@ -1920,7 +1920,7 @@ jobs:
     steps:
       - name: Verify CPU count
         run: |
-          EXPECTED=16
+          EXPECTED={{VCPU__REL_L_ARM64G4_16_62}}
           ACTUAL=$(nproc)
           echo "CPUs: $ACTUAL (expected: $EXPECTED)"
           if [ "$ACTUAL" -ne "$EXPECTED" ]; then


### PR DESCRIPTION
**Impact:** integration-test workflow generation (CI only)
**Risk:** low

## What
The generated integration-test workflow now pulls its CPU/memory/GPU assertion values straight from the enabled arc-runners `defs/` at generation time, via `{{VCPU__...}}`/`{{MEMGI__...}}`/`{{TORCHMEM__...}}`/`{{GPU__...}}` placeholders, replacing the hardcoded `EXPECTED=...` literals in `integration-test.yaml.tpl`.

## Why
Every time a runner's vcpu/memory/gpu spec changed, the integration-test template's hardcoded expectations drifted and had to be updated by hand (see the recent `-opt` runner right-sizing and the t4-multi memory fixup). Deriving the values from the same runner defs the cluster actually deploys keeps the tests in sync automatically.

# Notes
- `resource_placeholders()` processes the base `arc-runners` module first, then specialized variants (`-opt`/`-b200`/`-h100`) sorted, so a variant that redefines a shared runner name wins — this is what lets the ue1 `-opt` sizes flow through.
- Substitution runs before conditional-block stripping; a dedicated guard after stripping fails generation if a resource placeholder survives inside a live job (unresolved runner def = real bug), while placeholders in removed jobs are cleaned up harmlessly.
- Adds an import path to `modules/arc-runners/scripts/python` to reuse `parse_memory_bytes` rather than reimplement memory parsing.