### PR TITLE
Add provisioned vCPU-hours / CI-hours panels to OSDC utilization dashboard

### DIFF
--- a/grafana/osdc_utilization.json
+++ b/grafana/osdc_utilization.json
@@ -2038,6 +2038,224 @@
           "version": "13.2.0-28666480772"
         }
       }
+    },
+    "panel-16": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[1h:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}))[1h:1m] )",
+                      "interval": "1h",
+                      "legendFormat": "{{cluster}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Total provisioned vCPU-hours divided by CI-hours per cluster, in 1h buckets. Numerator (a): sum_over_time of total provisioned (node capacity) vCPU on OSDC nodes sampled at 1m over each 1h window; respects $cluster and $fleet. Denominator (b): sum_over_time of concurrently running jobs sampled at 1m over the same window; respects $cluster and $runner. Integrating instantaneous concurrency at 1m attributes each job to every hour bucket it overlaps, so a job spanning several hours contributes its true per-hour share to each bucket instead of being counted only in its start hour. The ratio is the average provisioned vCPU per concurrently running CI job; higher means more idle provisioned capacity per unit of CI work. The 1-minute sampling factor cancels between numerator and denominator.",
+        "id": 16,
+        "links": [],
+        "title": "Provisioned vCPU-hours / CI-hours per cluster [cluster, fleet, runner]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 5,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "suffix:vCPU·h/CI·h"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean"
+                ],
+                "displayMode": "table",
+                "enableFacetedFilter": false,
+                "overflow": "ellipsis",
+                "placement": "right",
+                "showLegend": false,
+                "sortBy": "Mean",
+                "sortDesc": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
+    },
+    "panel-17": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}))[$__range:1m] )",
+                      "instant": true,
+                      "legendFormat": "{{cluster}}",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Range-weighted mean of total provisioned vCPU-hours / CI-hours per cluster over the selected window: sum_over_time(total provisioned node-capacity vCPU) / sum_over_time(concurrently running jobs), both sampled at 1m. One bar per cluster. Respects $cluster, $fleet (capacity side) and $cluster, $runner (CI side). Companion to the time-series panel above, giving the at-a-glance mean per cluster.",
+        "id": 17,
+        "links": [],
+        "title": "Mean provisioned vCPU-hours / CI-hours (range) [cluster, fleet, runner]",
+        "vizConfig": {
+          "group": "bargauge",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name"
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "suffix:vCPU·h/CI·h"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "overflow": "ellipsis",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "text": {
+                "titleSize": 10,
+                "valueSize": 15
+              },
+              "valueMode": "color"
+            }
+          },
+          "version": "13.2.0-28666480772"
+        }
+      }
     }
   },
   "layout": {
@@ -2132,7 +2350,7 @@
             "height": 9,
             "width": 24,
             "x": 0,
-            "y": 16
+            "y": 25
           }
         },
         {
@@ -2145,7 +2363,7 @@
             "height": 9,
             "width": 24,
             "x": 0,
-            "y": 25
+            "y": 34
           }
         },
         {
@@ -2158,7 +2376,7 @@
             "height": 9,
             "width": 24,
             "x": 0,
-            "y": 34
+            "y": 43
           }
         },
         {
@@ -2171,7 +2389,7 @@
             "height": 9,
             "width": 24,
             "x": 0,
-            "y": 43
+            "y": 52
           }
         },
         {
@@ -2184,7 +2402,7 @@
             "height": 9,
             "width": 12,
             "x": 0,
-            "y": 52
+            "y": 61
           }
         },
         {
@@ -2197,7 +2415,7 @@
             "height": 9,
             "width": 12,
             "x": 12,
-            "y": 52
+            "y": 61
           }
         },
         {
@@ -2210,7 +2428,7 @@
             "height": 11,
             "width": 12,
             "x": 0,
-            "y": 61
+            "y": 70
           }
         },
         {
@@ -2223,7 +2441,33 @@
             "height": 11,
             "width": 12,
             "x": 12,
-            "y": 61
+            "y": 70
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-16"
+            },
+            "height": 9,
+            "width": 20,
+            "x": 0,
+            "y": 16
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-17"
+            },
+            "height": 9,
+            "width": 4,
+            "x": 20,
+            "y": 16
           }
         }
       ]

--- a/grafana/osdc_utilization.json
+++ b/grafana/osdc_utilization.json
@@ -43,7 +43,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "sum(rate(gha_started_jobs_total{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}[5m])) * 300",
+                      "expr": "sum(rate(gha_started_jobs_total{cluster=~\"$cluster\", pod=~\"((mt|lf)-)?($runner)-[a-z0-9]+-listener\"}[5m])) * 300",
                       "legendFormat": "total jobs",
                       "range": true
                     },
@@ -165,7 +165,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "sum(gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"})",
+                      "expr": "sum(gha_running_jobs{cluster=~\"$cluster\", pod=~\"((mt|lf)-)?($runner)-[a-z0-9]+-listener\"})",
                       "legendFormat": "running jobs",
                       "range": true
                     },
@@ -288,7 +288,7 @@
                       "meta": {
                         "timezone": "browser"
                       },
-                      "rawSql": "WITH\n  $__fromTime AS window_start,\n  $__toTime AS window_end,\n  base AS (\n    SELECT\n      toDateTime(ts) AS time_bucket,\n      floor(dateDiff('minute', started_at, toDateTime(ts)) / 5) * 5 AS age_bucket_minutes,\n      count() AS running_jobs\n    FROM workflow_job\n    ARRAY JOIN range(\n      toUInt32(toUnixTimestamp(greatest(window_start, toStartOfInterval(started_at, INTERVAL 5 MINUTE)))),\n      toUInt32(toUnixTimestamp(least(window_end, if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())))) + 1,\n      300\n    ) AS ts\n    WHERE runner_group_name IN (${cluster:sqlstring})\n      AND started_at BETWEEN window_start - INTERVAL 24 HOUR AND window_end\n      AND started_at > toDateTime64('2000-01-01', 9)\n      AND status IN ('in_progress', 'completed')\n      AND dateDiff('minute',\n                   started_at,\n                   if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())\n                  ) <= 360\n      AND toDateTime(ts) >= window_start\n      AND toDateTime(ts) <= window_end\n      AND (\n        '${runner:regex}' = '' OR\n        arrayExists(x -> match(x, '^mt-(${runner:regex})$'), labels)\n      )\n    GROUP BY time_bucket, age_bucket_minutes\n    HAVING age_bucket_minutes >= 0\n  )\nSELECT\n  time_bucket AS time,\n  sumIf(running_jobs, age_bucket_minutes = 0) AS `005m`,\n  sumIf(running_jobs, age_bucket_minutes = 5) AS `010m`,\n  sumIf(running_jobs, age_bucket_minutes = 10) AS `015m`,\n  sumIf(running_jobs, age_bucket_minutes = 15) AS `020m`,\n  sumIf(running_jobs, age_bucket_minutes = 20) AS `025m`,\n  sumIf(running_jobs, age_bucket_minutes = 25) AS `030m`,\n  sumIf(running_jobs, age_bucket_minutes >= 30 AND age_bucket_minutes < 45) AS `045m`,\n  sumIf(running_jobs, age_bucket_minutes >= 45 AND age_bucket_minutes < 60) AS `060m`,\n  sumIf(running_jobs, age_bucket_minutes >= 60 AND age_bucket_minutes < 90) AS `090m`,\n  sumIf(running_jobs, age_bucket_minutes >= 90 AND age_bucket_minutes < 120) AS `120m`,\n  sumIf(running_jobs, age_bucket_minutes >= 120 AND age_bucket_minutes < 150) AS `150m`,\n  sumIf(running_jobs, age_bucket_minutes >= 150 AND age_bucket_minutes < 180) AS `180m`,\n  sumIf(running_jobs, age_bucket_minutes >= 180 AND age_bucket_minutes < 210) AS `210m`,\n  sumIf(running_jobs, age_bucket_minutes >= 210 AND age_bucket_minutes < 240) AS `240m`,\n  sumIf(running_jobs, age_bucket_minutes >= 240 AND age_bucket_minutes < 300) AS `300m`,\n  sumIf(running_jobs, age_bucket_minutes >= 300 AND age_bucket_minutes < 360) AS `360m`,\n  sumIf(running_jobs, age_bucket_minutes >= 360 AND age_bucket_minutes < 420) AS `420m`,\n  sumIf(running_jobs, age_bucket_minutes >= 420) AS `999m`\nFROM base\nGROUP BY time\nORDER BY time"
+                      "rawSql": "WITH\n  $__fromTime AS window_start,\n  $__toTime AS window_end,\n  base AS (\n    SELECT\n      toDateTime(ts) AS time_bucket,\n      floor(dateDiff('minute', started_at, toDateTime(ts)) / 5) * 5 AS age_bucket_minutes,\n      count() AS running_jobs\n    FROM workflow_job\n    ARRAY JOIN range(\n      toUInt32(toUnixTimestamp(greatest(window_start, toStartOfInterval(started_at, INTERVAL 5 MINUTE)))),\n      toUInt32(toUnixTimestamp(least(window_end, if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())))) + 1,\n      300\n    ) AS ts\n    WHERE runner_group_name IN (${cluster:sqlstring})\n      AND started_at BETWEEN window_start - INTERVAL 24 HOUR AND window_end\n      AND started_at > toDateTime64('2000-01-01', 9)\n      AND status IN ('in_progress', 'completed')\n      AND dateDiff('minute',\n                   started_at,\n                   if(completed_at > toDateTime64('2000-01-01', 9), completed_at, now())\n                  ) <= 360\n      AND toDateTime(ts) >= window_start\n      AND toDateTime(ts) <= window_end\n      AND (\n        '${runner:regex}' = '' OR\n        arrayExists(x -> match(x, '^(mt|lf)-(${runner:regex})$'), labels)\n      )\n    GROUP BY time_bucket, age_bucket_minutes\n    HAVING age_bucket_minutes >= 0\n  )\nSELECT\n  time_bucket AS time,\n  sumIf(running_jobs, age_bucket_minutes = 0) AS `005m`,\n  sumIf(running_jobs, age_bucket_minutes = 5) AS `010m`,\n  sumIf(running_jobs, age_bucket_minutes = 10) AS `015m`,\n  sumIf(running_jobs, age_bucket_minutes = 15) AS `020m`,\n  sumIf(running_jobs, age_bucket_minutes = 20) AS `025m`,\n  sumIf(running_jobs, age_bucket_minutes = 25) AS `030m`,\n  sumIf(running_jobs, age_bucket_minutes >= 30 AND age_bucket_minutes < 45) AS `045m`,\n  sumIf(running_jobs, age_bucket_minutes >= 45 AND age_bucket_minutes < 60) AS `060m`,\n  sumIf(running_jobs, age_bucket_minutes >= 60 AND age_bucket_minutes < 90) AS `090m`,\n  sumIf(running_jobs, age_bucket_minutes >= 90 AND age_bucket_minutes < 120) AS `120m`,\n  sumIf(running_jobs, age_bucket_minutes >= 120 AND age_bucket_minutes < 150) AS `150m`,\n  sumIf(running_jobs, age_bucket_minutes >= 150 AND age_bucket_minutes < 180) AS `180m`,\n  sumIf(running_jobs, age_bucket_minutes >= 180 AND age_bucket_minutes < 210) AS `210m`,\n  sumIf(running_jobs, age_bucket_minutes >= 210 AND age_bucket_minutes < 240) AS `240m`,\n  sumIf(running_jobs, age_bucket_minutes >= 240 AND age_bucket_minutes < 300) AS `300m`,\n  sumIf(running_jobs, age_bucket_minutes >= 300 AND age_bucket_minutes < 360) AS `360m`,\n  sumIf(running_jobs, age_bucket_minutes >= 360 AND age_bucket_minutes < 420) AS `420m`,\n  sumIf(running_jobs, age_bucket_minutes >= 420) AS `999m`\nFROM base\nGROUP BY time\nORDER BY time"
                     },
                     "version": "v0"
                   },
@@ -2058,7 +2058,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[1h:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}))[1h:1m] )",
+                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[1h:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"((mt|lf)-)?($runner)-[a-z0-9]+-listener\"}))[1h:1m] )",
                       "interval": "1h",
                       "legendFormat": "{{cluster}}",
                       "range": true
@@ -2181,7 +2181,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"(mt-)?($runner)-[a-z0-9]+-listener\"}))[$__range:1m] )",
+                      "expr": "sum_over_time( (sum by (cluster) (kube_node_status_capacity{resource=\"cpu\"} and on(cluster, node) node_compactor_node_utilization_ratio{resource=\"cpu\",cluster=~\"$cluster\",nodepool=~\"($fleet)(-[0-9]+xlarge|-metal)?\"}))[$__range:1m] )\n/\nsum_over_time( (sum by (cluster) (gha_running_jobs{cluster=~\"$cluster\", pod=~\"((mt|lf)-)?($runner)-[a-z0-9]+-listener\"}))[$__range:1m] )",
                       "instant": true,
                       "legendFormat": "{{cluster}}",
                       "range": false
@@ -2634,7 +2634,7 @@
           "version": "v0"
         },
         "refresh": "onTimeRangeChanged",
-        "regex": "/pod=\"mt-(.+?)-[a-z0-9]+-runner-/",
+        "regex": "/pod=\"(?:mt|lf)-(.+?)-[a-z0-9]+-runner-/",
         "regexApplyTo": "value",
         "skipUrlSync": false,
         "sort": "alphabeticalAsc"


### PR DESCRIPTION
**Impact:** Grafana dashboard viewers (OSDC utilization) only — no runtime/service impact
**Risk:** low

Link: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc_utilization/osdc-cluster-utilization

## What
Adds two panels to `osdc_utilization.json`: a time-series and a companion range bar gauge showing total provisioned vCPU-hours divided by concurrently-running CI-hours per cluster, honoring the existing `$cluster`, `$fleet`, and `$runner` variables. Existing panels are shifted down to make room at the top.

# Notes
* Only layout coordinates changed for the pre-existing panels — no query or config edits to them. Both new panels use `palette-classic-by-name` per the repo's shared-series color rule.
* Fixes filtering on other graphs that was excluding `lf-` fleet by accident