### PR TITLE
Reduce memory on large 512Gi ARC runner defs to unblock Karpenter provisioning

### DIFF
--- a/osdc/modules/arc-runners-opt/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-arm64g3-61-463.yaml
@@ -1,12 +1,13 @@
 # ARC runner definition: l-arm64g3-61-463
 # Instance type: r7g.16xlarge — 64c/512Gi node
-# Actual K8s capacity ~473.7Gi. Max job memory after all overhead: 463Gi.
+# memory is sized below node capacity to leave headroom for Karpenter's
+# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
 runner:
   name: l-arm64g3-61-463
   instance_type: r7g.16xlarge
   disk_size: 600
   vcpu: 61
-  memory: 463Gi
+  memory: 448Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx512-125-463.yaml
@@ -1,12 +1,13 @@
 # ARC runner definition: l-x86aavx512-125-463
 # Instance type: m6i.32xlarge — 128c/512Gi node
-# Actual K8s capacity ~473.7Gi. Max job memory after all overhead: 463Gi.
+# memory is sized below node capacity to leave headroom for Karpenter's
+# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
 runner:
   name: l-x86aavx512-125-463
   instance_type: m6i.32xlarge
   disk_size: 200
   vcpu: 125
-  memory: 463Gi
+  memory: 448Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
@@ -1,12 +1,13 @@
 # ARC runner definition: l-arm64g3-61-463
 # Instance type: r7g.16xlarge — 64c/512Gi node
-# Actual K8s capacity ~473.7Gi. Max job memory after all overhead: 463Gi.
+# memory is sized below node capacity to leave headroom for Karpenter's
+# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
 runner:
   name: l-arm64g3-61-463
   instance_type: r7g.16xlarge
   disk_size: 600
   vcpu: 61
-  memory: 463Gi
+  memory: 448Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
@@ -1,12 +1,13 @@
 # ARC runner definition: l-x86aavx512-125-463
 # Instance type: m6i.32xlarge — 128c/512Gi node
-# Actual K8s capacity ~473.7Gi. Max job memory after all overhead: 463Gi.
+# memory is sized below node capacity to leave headroom for Karpenter's
+# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
 runner:
   name: l-x86aavx512-125-463
   instance_type: m6i.32xlarge
   disk_size: 200
   vcpu: 125
-  memory: 463Gi
+  memory: 448Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 15


### PR DESCRIPTION

**Impact:** CI only — the two large runner classes on 512Gi nodes
**Risk:** low

## What
Drops the per-job `memory` request on the two 512Gi "large" runner definitions from `463Gi` to `448Gi`, and rewrites the header comment to explain the headroom requirement.

## Why
At `463Gi` the request sits right up against node capacity. Karpenter's schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets) then computes the node as too small to hold the pod, so it provisions **zero** nodes and the runner never schedules. `448Gi` restores enough headroom for Karpenter to model the node as fitting while still giving jobs the bulk of a 512Gi box. Same class of "memory sized too close to allocatable" problem documented for the c7a fleet.