### PR TITLE
osdc: reset staging capacity_aware_fresh_multiplier to 1.0

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -168,7 +168,7 @@ clusters:
       runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
       runner_group: "meta-staging-aws-uw1"
       scheduler_name: bin-pack-scheduler
-      capacity_aware_fresh_multiplier: 0.8
+      capacity_aware_fresh_multiplier: 1.0
     buildkit:
       arm64_instance_type: m7gd.16xlarge
       arm64_pods_per_node: 4
@@ -243,7 +243,7 @@ clusters:
       runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
       runner_group: "meta-staging-aws-ue1"
       scheduler_name: bin-pack-scheduler
-      capacity_aware_fresh_multiplier: 0.25
+      capacity_aware_fresh_multiplier: 1.0
     buildkit:
       arm64_instance_type: m7gd.16xlarge
       arm64_pods_per_node: 4
@@ -320,7 +320,7 @@ clusters:
       runner_name_prefix: "c-mt-"          # staging/testing prefix — keeps labels distinct from prod's "mt-"
       runner_group: "meta-staging-aws-ue2"
       scheduler_name: bin-pack-scheduler
-      capacity_aware_fresh_multiplier: 0.8
+      capacity_aware_fresh_multiplier: 1.0
     buildkit:
       arm64_instance_type: m7gd.16xlarge
       arm64_pods_per_node: 4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #904
* #903
* #902
* __->__ #901

**Impact:** staging clusters only (meta-staging-aws-uw1/ue1/ue2, c-mt- runners)
**Risk:** low

## What
Set `capacity_aware_fresh_multiplier` back to `1.0` on all three staging
clusters' `arc-runners` blocks (uw1 0.8→1.0, ue1 0.25→1.0, ue2 0.8→1.0).

## Why
It was a mistake, the values for staging should be 1.0 as it runs every-now-and-then and 1.0 makes the integration/load tests faster.