### PR TITLE
integration-tests: skip release-runner tests on prod clusters

### DIFF
--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -24,6 +24,7 @@ from nodepool_defs import is_excluded_for_region
 from run import (
     CANARY_REPO,
     PR_TITLE_PREFIX,
+    is_prod_cluster,
     normalize_modules,
     run_cmd,
     safe_json_loads,
@@ -48,6 +49,11 @@ TAG_REQUIREMENTS: dict[str, list[str]] = {
 INVERSE_TAG_EXCLUSIONS: dict[str, list[str]] = {
     "NO_CACHE_ENFORCER": ["cache-enforcer"],
 }
+
+# Blocks stripped on prod clusters. Prod release runner groups are restricted to
+# selected pytorch workflows, so the canary integration-test PR can't schedule on
+# them — the release tests run on staging only.
+PROD_EXCLUDED_BLOCKS: set[str] = {"RELEASE"}
 
 # Conditional blocks whose job targets a runner backed by a region-restricted
 # GPU fleet. Module gating can't catch this — the fleet exists as a module but is
@@ -352,6 +358,12 @@ def generate_workflow(
     leftover = re.findall(r"\{\{[A-Z_]+\}\}", content)
     if leftover:
         raise RuntimeError(f"Unsubstituted template placeholders remain: {sorted(set(leftover))}")
+
+    # Before module gating: these tags also live in TAG_REQUIREMENTS, whose loop
+    # consumes their markers. On non-prod, leave them for module/region gating.
+    if is_prod_cluster(cluster_id):
+        for tag in PROD_EXCLUDED_BLOCKS:
+            content = strip_conditional_block(content, tag, keep=False)
 
     modules_set = normalize_modules(cluster_modules)
     for tag, required in TAG_REQUIREMENTS.items():

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -99,6 +99,13 @@ def has_module(cfg: dict, module_name: str) -> bool:
     return module_name in modules
 
 
+def is_prod_cluster(cluster_id: str) -> bool:
+    """True for prod clusters, keyed off the env segment of the
+    `<org>-<env>-<cloud>-<region>` id (meta-prod-aws-uw1, lf-prod-aws-ue1)."""
+    parts = cluster_id.split("-")
+    return len(parts) >= 2 and parts[1] == "prod"
+
+
 # ── Subprocess helpers ──────────────────────────────────────────────────
 
 

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -20,6 +20,7 @@ from run import (
     format_duration,
     gh_api,
     has_module,
+    is_prod_cluster,
     load_cluster_config,
     normalize_modules,
     parse_args,
@@ -283,6 +284,32 @@ class TestHasModule:
         assert has_module(cfg, "arc-runners") is False
 
 
+# ── is_prod_cluster ───────────────────────────────────────────────────────
+
+
+class TestIsProdCluster:
+    @pytest.mark.parametrize(
+        "cluster_id",
+        ["meta-prod-aws-uw1", "meta-prod-aws-ue1", "meta-prod-aws-ue2", "lf-prod-aws-ue1", "lf-prod-aws-ue2"],
+    )
+    def test_prod_clusters(self, cluster_id):
+        assert is_prod_cluster(cluster_id) is True
+
+    @pytest.mark.parametrize(
+        "cluster_id",
+        ["meta-staging-aws-uw1", "meta-staging-aws-ue1", "meta-staging-aws-ue2"],
+    )
+    def test_staging_clusters(self, cluster_id):
+        assert is_prod_cluster(cluster_id) is False
+
+    def test_env_segment_not_substring(self):
+        # "prod" must be the environment segment, not merely present elsewhere.
+        assert is_prod_cluster("meta-staging-prodlike-uw1") is False
+
+    def test_single_segment_id(self):
+        assert is_prod_cluster("x") is False
+
+
 # ── generate_workflow ─────────────────────────────────────────────────────
 
 
@@ -306,11 +333,13 @@ class TestGenerateWorkflow:
         assert "{{CLUSTER_NAME}}" not in result
 
     def test_all_tags_kept_with_full_modules(self, workflow_template):
+        # Staging cluster: the RELEASE block is only kept off prod (see
+        # PROD_EXCLUDED_BLOCKS), so "all tags kept" is a non-prod assertion.
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "meta-prod-aws-ue2",
-            "meta-prod-aws-ue2",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             cluster_modules=ALL_MODULES,
         )
         for job in (
@@ -393,7 +422,8 @@ class TestGenerateWorkflow:
         # meta-prod-aws-ue1 runs the -opt shim modules. arc-runners-opt / nodepools-opt
         # must satisfy the base arc-runners / nodepools gates so the runner jobs survive
         # instead of degrading to a no-op. B200 stays stripped: no -b200 module is present
-        # and removesuffix("-opt") never produces one.
+        # and removesuffix("-opt") never produces one. RELEASE is stripped too — this is
+        # a prod cluster, and prod never runs the release-runner builds.
         result = generate_workflow(
             workflow_template,
             "mt",
@@ -404,7 +434,7 @@ class TestGenerateWorkflow:
         assert "arc-job" in result
         assert "gpu-t4-job" in result
         assert "buildkit-job" in result
-        assert "release-job" in result
+        assert "release-job" not in result
         assert "BEGIN_ARC_RUNNERS" not in result
         assert "BEGIN_GPU_T4" not in result
         assert "BEGIN_BUILDKIT" not in result
@@ -450,7 +480,8 @@ class TestGenerateWorkflow:
         assert "gpu-t4-job" not in result
         assert "BEGIN_GPU_T4" not in result
         assert "arc-job" in result
-        assert "release-job" in result
+        # meta-prod-aws-ue2 is prod → release-runner tests stripped.
+        assert "release-job" not in result
 
     def test_pypi_cache_requires_pypi_cache_module(self, workflow_template):
         result = generate_workflow(
@@ -465,11 +496,12 @@ class TestGenerateWorkflow:
         assert "arc-job" in result
 
     def test_release_kept_with_arc_runners(self, workflow_template):
+        # Non-prod cluster with arc-runners keeps the release-runner tests.
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "meta-prod-aws-ue2",
-            "meta-prod-aws-ue2",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             cluster_modules=["arc-runners"],
         )
         assert "release-job" in result
@@ -480,11 +512,38 @@ class TestGenerateWorkflow:
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "meta-prod-aws-ue2",
-            "meta-prod-aws-ue2",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             cluster_modules=["nodepools"],
         )
         assert "release-job" not in result
+        assert "BEGIN_RELEASE" not in result
+
+    def test_release_stripped_on_prod_cluster(self, workflow_template):
+        # Prod cluster with arc-runners: module gating would keep RELEASE, but the
+        # prod environment gate strips it so long release builds stay off prod.
+        result = generate_workflow(
+            workflow_template,
+            "mt",
+            "meta-prod-aws-ue2",
+            "meta-prod-aws-ue2",
+            cluster_modules=["arc-runners"],
+        )
+        assert "release-job" not in result
+        assert "BEGIN_RELEASE" not in result
+        assert "END_RELEASE" not in result
+        # Other arc-runners jobs are unaffected by the prod gate.
+        assert "arc-job" in result
+
+    def test_release_kept_on_staging_cluster(self, workflow_template):
+        result = generate_workflow(
+            workflow_template,
+            "c-mt",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
+            cluster_modules=["arc-runners"],
+        )
+        assert "release-job" in result
         assert "BEGIN_RELEASE" not in result
 
     def test_pypi_slugs_substituted(self, workflow_template):
@@ -555,11 +614,13 @@ class TestGenerateWorkflow:
         assert "{{RUNNER_GROUP}}" not in result
 
     def test_release_runner_group_substituted(self, workflow_template):
+        # Staging cluster: the release-runner job (which carries RELEASE_RUNNER_GROUP)
+        # is only kept off prod.
         result = generate_workflow(
             workflow_template,
             "cbr",
-            "meta-prod-aws-ue2",
-            "meta-prod-aws-ue2",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
             cluster_modules=ALL_MODULES,
             runner_group="default",
             release_runner_group="rel-rg",

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1917,6 +1917,8 @@ jobs:
   # real from-scratch PyTorch CPU wheel build (USE_CUDA=0) from source. This is
   # the release lane's actual job — it exercises the full toolchain, all cores,
   # disk, and egress. (Long-running: ~30-50 min per arch; see timeout-minutes.)
+  # Skipped on prod: prod release runner groups are restricted to selected
+  # pytorch workflows, so the canary PR can't schedule on them (see phases.py).
   test-release-arm64:
     runs-on: { group: "{{RELEASE_RUNNER_GROUP}}", labels: ["{{PREFIX}}rel-l-arm64g3-44-340"] }
     timeout-minutes: 180


### PR DESCRIPTION
Skip the release-runner integration tests (`test-release-arm64` / `test-release-x86`) on prod clusters.

Prod release runner groups are only available to selected workflows from pytorch, so the canary integration-test PR can't schedule on them — the jobs would queue forever. Validate the release lane on staging instead.

`is_prod_cluster()` keys off the env segment of the `<org>-<env>-<cloud>-<region>` cluster id; the `PROD_EXCLUDED_BLOCKS` gate in `generate_workflow` strips the RELEASE block on prod (net keep condition: `arc-runners present AND not prod`).

`just lint` and `just test` pass.