### PR TITLE
osdc/hf-cache: cut rclone RSS with --buffer-size 4M --use-mmap

### DIFF
--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -18,6 +18,12 @@ rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 `deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
 1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
 
+To keep RSS inside those reserves the mount runs with `--buffer-size 0` (no
+per-open-file in-RAM read-ahead — redundant under `--vfs-cache-mode full`, which
+serves from the on-disk cache) and `--use-mmap` (frees buffers back to the OS).
+Without them, concurrent large-model (safetensors) reads OOM-kill rclone, and the
+dead FUSE mount surfaces as a spurious `LocalEntryNotFoundError` in the job.
+
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the
 pytorch/pytorch workflow assumes a GitHub-OIDC role

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -18,11 +18,13 @@ rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 `deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
 1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
 
-To keep RSS inside those reserves the mount runs with `--buffer-size 0` (no
-per-open-file in-RAM read-ahead — redundant under `--vfs-cache-mode full`, which
-serves from the on-disk cache) and `--use-mmap` (frees buffers back to the OS).
-Without them, concurrent large-model (safetensors) reads OOM-kill rclone, and the
-dead FUSE mount surfaces as a spurious `LocalEntryNotFoundError` in the job.
+To keep RSS inside those reserves the mount runs with `--buffer-size 4M` (a 4x cut
+from rclone's 16Mi-per-open-file default read-ahead — the dominant RSS driver when
+a model opens many shards; kept non-zero so cold reads retain some prefetch, with
+`--vfs-cache-mode full` serving the rest from the on-disk cache) and `--use-mmap`
+(frees buffers back to the OS). Without them, concurrent large-model (safetensors)
+reads OOM-kill rclone, and the dead FUSE mount surfaces as a spurious
+`LocalEntryNotFoundError` in the job.
 
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -122,10 +122,12 @@ spec:
               #
               # RSS control (keeps rclone under the per-tier reserve; large
               # safetensors reads OOM-killed the mount on the small 1-GPU tier):
-              #   --buffer-size 0  drops the per-open-file in-RAM read-ahead —
-              #     redundant under vfs-cache-mode full, which serves from the
-              #     on-disk cache — the dominant RSS driver when many shards open.
-              #   --use-mmap       returns freed buffers to the OS instead of Go
+              #   --buffer-size 4M  shrinks the per-open-file in-RAM read-ahead
+              #     4x from rclone's 16Mi default — the dominant RSS driver when a
+              #     model opens many shards at once. Kept non-zero so cold reads
+              #     retain some prefetch (vfs-cache-mode full serves the rest from
+              #     the on-disk cache).
+              #   --use-mmap        returns freed buffers to the OS instead of Go
               #     retaining them as process RSS.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
@@ -139,7 +141,7 @@ spec:
                 --vfs-cache-max-size "$VFS_MAX" \
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
-                --buffer-size 0 \
+                --buffer-size 4M \
                 --use-mmap \
                 --cache-dir "$CACHE" \
                 --no-modtime \

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -119,6 +119,14 @@ spec:
               # Background rclone so we can drop a sentinel once mounted — the
               # taint-remover waits on that rather than inspecting the host, which
               # keeps it unprivileged. Creds via IRSA (env_auth).
+              #
+              # RSS control (keeps rclone under the per-tier reserve; large
+              # safetensors reads OOM-killed the mount on the small 1-GPU tier):
+              #   --buffer-size 0  drops the per-open-file in-RAM read-ahead —
+              #     redundant under vfs-cache-mode full, which serves from the
+              #     on-disk cache — the dominant RSS driver when many shards open.
+              #   --use-mmap       returns freed buffers to the OS instead of Go
+              #     retaining them as process RSS.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
@@ -131,6 +139,8 @@ spec:
                 --vfs-cache-max-size "$VFS_MAX" \
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
+                --buffer-size 0 \
+                --use-mmap \
                 --cache-dir "$CACHE" \
                 --no-modtime \
                 --umask 022 \


### PR DESCRIPTION
## Problem
On the 1-GPU mount tier (512Mi), concurrent large-model (safetensors) reads OOM-kill rclone → the node-wide `/mnt/hf_cache` FUSE mount dies → the job's mmap'd read faults with **SIGBUS**, surfacing as a misleading `LocalEntryNotFoundError` ("missing weights").

Example — failing `inductor_huggingface` a10g job:
```
Loading weights: 25%|██▍| 36/146 … Run failed with return code: -7   # SIGBUS
huggingface_hub.errors.LocalEntryNotFoundError: Cannot find the requested files in the disk cache ...
```
Stats — live rclone `OOMKilled` mounts, **gpu1 tier only** (cpu/gpu4/gpu8 = 0): ue2 **17/59**, ue1 **9/80**.

## Fix
rclone RSS under `--vfs-cache-mode full` is dominated by per-open-file read-ahead buffers, not GPU count:
- `--buffer-size 4M` — 4x cut from rclone's 16Mi-per-open-file default read-ahead (the RSS driver when a model opens many shards); kept non-zero so cold reads retain some prefetch, with the on-disk cache serving the rest.
- `--use-mmap` — return freed buffers to the OS instead of Go retaining them as RSS.

Keeps rclone inside the reserve without raising the limit. Complements #890 (512Mi→1Gi headroom).
