### PR TITLE
Lower Karpenter VM memory overhead to 0.06 and restore 512Gi runner memory

### DIFF
--- a/osdc/modules/arc-runners-opt/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-arm64g3-61-463.yaml
@@ -1,13 +1,15 @@
 # ARC runner definition: l-arm64g3-61-463
 # Instance type: r7g.16xlarge — 64c/512Gi node
-# memory is sized below node capacity to leave headroom for Karpenter's
-# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
+# memory is sized ~11Gi below Karpenter's modeled node allocatable (advertised
+# 512Gi x (1 - vmMemoryOverheadPercent) - kube-reserved - counted DaemonSets) so
+# the schedule-time simulation still models the pod as fitting; sizing it up to
+# the modeled ceiling makes Karpenter provision zero nodes.
 runner:
   name: l-arm64g3-61-463
   instance_type: r7g.16xlarge
   disk_size: 600
   vcpu: 61
-  memory: 448Gi
+  memory: 460Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners-opt/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners-opt/defs/l-x86aavx512-125-463.yaml
@@ -1,13 +1,15 @@
 # ARC runner definition: l-x86aavx512-125-463
 # Instance type: m6i.32xlarge — 128c/512Gi node
-# memory is sized below node capacity to leave headroom for Karpenter's
-# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
+# memory is sized ~11Gi below Karpenter's modeled node allocatable (advertised
+# 512Gi x (1 - vmMemoryOverheadPercent) - kube-reserved - counted DaemonSets) so
+# the schedule-time simulation still models the pod as fitting; sizing it up to
+# the modeled ceiling makes Karpenter provision zero nodes.
 runner:
   name: l-x86aavx512-125-463
   instance_type: m6i.32xlarge
   disk_size: 200
   vcpu: 125
-  memory: 448Gi
+  memory: 460Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-arm64g3-61-463.yaml
@@ -1,13 +1,15 @@
 # ARC runner definition: l-arm64g3-61-463
 # Instance type: r7g.16xlarge — 64c/512Gi node
-# memory is sized below node capacity to leave headroom for Karpenter's
-# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
+# memory is sized ~11Gi below Karpenter's modeled node allocatable (advertised
+# 512Gi x (1 - vmMemoryOverheadPercent) - kube-reserved - counted DaemonSets) so
+# the schedule-time simulation still models the pod as fitting; sizing it up to
+# the modeled ceiling makes Karpenter provision zero nodes.
 runner:
   name: l-arm64g3-61-463
   instance_type: r7g.16xlarge
   disk_size: 600
   vcpu: 61
-  memory: 448Gi
+  memory: 460Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx512-125-463.yaml
@@ -1,13 +1,15 @@
 # ARC runner definition: l-x86aavx512-125-463
 # Instance type: m6i.32xlarge — 128c/512Gi node
-# memory is sized below node capacity to leave headroom for Karpenter's
-# schedule-time overhead model (VM reserve + kube-reserved + counted DaemonSets); raising it toward node capacity makes Karpenter model the node as too small and provision zero nodes.
+# memory is sized ~11Gi below Karpenter's modeled node allocatable (advertised
+# 512Gi x (1 - vmMemoryOverheadPercent) - kube-reserved - counted DaemonSets) so
+# the schedule-time simulation still models the pod as fitting; sizing it up to
+# the modeled ceiling makes Karpenter provision zero nodes.
 runner:
   name: l-x86aavx512-125-463
   instance_type: m6i.32xlarge
   disk_size: 200
   vcpu: 125
-  memory: 448Gi
+  memory: 460Gi
   gpu: 0
   proactive_capacity: 0
   hud_failure_base_capacity: 15

--- a/osdc/modules/karpenter/helm/values.yaml
+++ b/osdc/modules/karpenter/helm/values.yaml
@@ -33,6 +33,13 @@ settings:
   # env entries that break `helm upgrade` strategic-merge patches.
   batchMaxDuration: 45s
   batchIdleDuration: 45s
+  # Memory overhead subtracted from each instance type's advertised RAM during
+  # scheduling simulation. The chart default (0.075) overshoots the real overhead
+  # measured across this fleet (1.7-5.3%, worst case g6/L4 at 5.3%), modeling
+  # large-memory nodes (g5/r7a .48xlarge) as too small for full-node runners and
+  # provisioning zero capacity for them. 0.06 stays above the g6 worst case (never
+  # overcommits) while leaving modeled headroom for full-node runners to fit.
+  vmMemoryOverheadPercent: 0.06
   # Feature gates
   featureGates:
     spotToSpotConsolidation: true


### PR DESCRIPTION
**Impact:** Karpenter provisioning and pod fitting
**Risk:** medium

## What
Drops the global `vmMemoryOverheadPercent` from the chart default 0.075 to 0.06, and raises per-job memory on the two 512Gi runner defs from 448Gi to 460Gi.

## Why
Karpenter subtracts a flat 7.5% VM memory overhead from every instance type's advertised RAM during scheduling simulation. Measured across the live fleet the real overhead is only 1.7–5.3%, so large-memory nodes get modeled 20–37 GiB smaller than they are. Full-node runners then look too big to fit and Karpenter provisions zero capacity — the 8-GPU A10G runner (`mt-l-x86aavx2-189-704-a10g-8`) was stuck at 2 nodes with a deep queue, and #897 had to shrink the 512Gi runners to 448Gi as a workaround. Correcting the global overhead to 6% (still above the worst real overhead, so nodes are never overcommitted) fixes the root cause and lets the 448Gi workaround be partly reverted.

## Notes

### Headroom per contender (at the new 0.06 overhead)

| Runner | Instance | Actual headroom | Karpenter-modeled headroom | Difference | |---|---|--:|--:|--:|
| `l-x86aavx2-189-704-a10g-8` | g5.48xlarge (768Gi) | 34.6 Gi | 8.6 Gi | 26.0 Gi | | `l-arm64g3-61-463` | r7g.16xlarge (512Gi) | 24.8 Gi | 11.3 Gi | 13.5 Gi | | `l-x86aavx512-125-463` | m6i.32xlarge (512Gi) | 24.8 Gi | 11.3 Gi | 13.5 Gi † |

† No live m6i.32xlarge node in any accessible cluster; capacity taken from the r7g.16xlarge measurement (same 512Gi advertised, same maxPods class, identical kube-reserved).

- Actual headroom = real_allocatable − counted_overhead − runner_memory
- Karpenter-modeled headroom = advertised × (1 − 0.06) − kube_reserved − counted_overhead − runner_memory (must stay positive or Karpenter provisions zero nodes)
- Difference = real_capacity − advertised × (1 − 0.06) — pure Karpenter VM-overhead pessimism