### PR TITLE
integration-tests: drop B200 GPU verification job

### DIFF
--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -41,7 +41,6 @@ TAG_REQUIREMENTS: dict[str, list[str]] = {
     "HF_CACHE_OIDC": ["arc-runners", "hf-cache"],
     "GPU_T4": ["arc-runners", "nodepools"],
     "BUILDKIT": ["arc-runners", "buildkit"],
-    "B200": ["arc-runners-b200", "nodepools-b200"],
     "CACHE_ENFORCER": ["arc-runners", "cache-enforcer"],
     "RELEASE": ["arc-runners"],
 }

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -128,12 +128,6 @@ def workflow_template(tmp_path):
         "  buildkit-job:\n"
         "    uses: ./.github/workflows/build-image.yaml\n"
         "  # END_BUILDKIT\n"
-        "  # BEGIN_B200\n"
-        "  b200-job:\n"
-        '    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}b200-runner"] }\n'
-        "    steps:\n"
-        "      - run: echo B200\n"
-        "  # END_B200\n"
         "  # BEGIN_CACHE_ENFORCER\n"
         "  cache-enforcer-job:\n"
         '    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}enforcer-runner"] }\n'
@@ -347,7 +341,6 @@ class TestGenerateWorkflow:
             "pypi-job",
             "gpu-t4-job",
             "buildkit-job",
-            "b200-job",
             "cache-enforcer-job",
             "release-job",
         ):
@@ -374,7 +367,6 @@ class TestGenerateWorkflow:
         assert "BEGIN_BUILDKIT" not in result
         assert "END_BUILDKIT" not in result
         assert "arc-job" in result
-        assert "b200-job" in result
         assert "cache-enforcer-job" in result
 
     def test_cache_enforcer_stripped(self, workflow_template):
@@ -421,8 +413,7 @@ class TestGenerateWorkflow:
     def test_opt_variants_keep_arc_runner_jobs(self, workflow_template):
         # meta-prod-aws-ue1 runs the -opt shim modules. arc-runners-opt / nodepools-opt
         # must satisfy the base arc-runners / nodepools gates so the runner jobs survive
-        # instead of degrading to a no-op. B200 stays stripped: no -b200 module is present
-        # and removesuffix("-opt") never produces one. RELEASE is stripped too — this is
+        # instead of degrading to a no-op. RELEASE is stripped too — this is
         # a prod cluster, and prod never runs the release-runner builds.
         result = generate_workflow(
             workflow_template,
@@ -439,8 +430,6 @@ class TestGenerateWorkflow:
         assert "BEGIN_GPU_T4" not in result
         assert "BEGIN_BUILDKIT" not in result
         assert "BEGIN_RELEASE" not in result
-        assert "b200-job" not in result
-        assert "BEGIN_B200" not in result
         assert "pypi-job" not in result
         assert "  cache-enforcer-job:" not in result
 
@@ -456,18 +445,6 @@ class TestGenerateWorkflow:
         assert "BEGIN_NO_CACHE_ENFORCER" not in result
         assert "END_NO_CACHE_ENFORCER" not in result
         assert "cache-enforcer-job" in result
-
-    def test_b200_requires_both_modules(self, workflow_template):
-        result = generate_workflow(
-            workflow_template,
-            "cbr",
-            "meta-prod-aws-ue2",
-            "meta-prod-aws-ue2",
-            cluster_modules=["arc-runners", "arc-runners-b200"],
-        )
-        assert "b200-job" not in result
-        assert "BEGIN_B200" not in result
-        assert "arc-job" in result
 
     def test_gpu_t4_requires_arc_runners_and_nodepools(self, workflow_template):
         result = generate_workflow(
@@ -739,9 +716,10 @@ class TestGenerateWorkflowNoopFallback:
         )
         assert "no-op:" in result
         assert "arc-job" not in result
-        assert "b200-job" not in result
 
-    def test_noop_when_only_arc_runners_b200_without_nodepools_b200(self, workflow_template):
+    def test_noop_when_only_arc_runners_b200_without_base_arc_runners(self, workflow_template):
+        # arc-runners-b200 does not alias to the base arc-runners module, so a cluster
+        # running only the B200 runner fleet still degrades to a no-op integration test.
         result = generate_workflow(
             workflow_template,
             "cbr",
@@ -750,7 +728,6 @@ class TestGenerateWorkflowNoopFallback:
             cluster_modules=["arc-runners-b200", "cache-enforcer"],
         )
         assert "no-op:" in result
-        assert "b200-job" not in result
         assert "arc-job" not in result
 
     def test_noop_preserves_top_level_keys(self, workflow_template):

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1723,40 +1723,6 @@ jobs:
           echo "PASS: TORCH_CI_MAX_MEMORY is correct"
   # END_GPU_T4
 
-  # BEGIN_B200
-  test-gpu-b200-2:
-    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-44-450-b200-2"] }
-    container:
-      image: ghcr.io/actions/actions-runner:latest
-    steps:
-      - name: Verify B200 multi-GPU
-        run: |
-          echo "=== nvidia-smi ==="
-          nvidia-smi
-          echo ""
-          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
-          if [ "$GPU_COUNT" -ne {{GPU__L_X86IAMX_44_450_B200_2}} ]; then
-            echo "FAIL: Expected 2 GPUs, found $GPU_COUNT"
-            exit 1
-          fi
-          echo "PASS: Found $GPU_COUNT B200 GPUs"
-      - name: Verify TORCH_CI_MAX_MEMORY
-        run: |
-          echo "=== TORCH_CI_MAX_MEMORY ==="
-          EXPECTED={{TORCHMEM__L_X86IAMX_44_450_B200_2}}
-          ACTUAL="${TORCH_CI_MAX_MEMORY:-}"
-          echo "TORCH_CI_MAX_MEMORY=$ACTUAL (expected: $EXPECTED)"
-          if [ -z "$ACTUAL" ]; then
-            echo "FAIL: TORCH_CI_MAX_MEMORY is not set"
-            exit 1
-          fi
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "FAIL: TORCH_CI_MAX_MEMORY mismatch"
-            exit 1
-          fi
-          echo "PASS: TORCH_CI_MAX_MEMORY is correct"
-  # END_B200
-
   # BEGIN_BUILDKIT
   # ── BuildKit Tests ────────────────────────────────────────────────────
   # Each call runs a buildctl connectivity build + an 8-wide docker buildx burst


### PR DESCRIPTION
Removes the `test-gpu-b200-2` integration job so the deployment workflow stops consuming scarce, heavily-used B200 GPU capacity just for a integration test.