### PR TITLE
osdc/hf-cache: drop --use-mmap, keep buffer-size reduction

### DIFF
--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -21,10 +21,10 @@ rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 To keep RSS inside those reserves the mount runs with `--buffer-size 4M` (a 4x cut
 from rclone's 16Mi-per-open-file default read-ahead — the dominant RSS driver when
 a model opens many shards; kept non-zero so cold reads retain some prefetch, with
-`--vfs-cache-mode full` serving the rest from the on-disk cache) and `--use-mmap`
-(frees buffers back to the OS). Without them, concurrent large-model (safetensors)
-reads OOM-kill rclone, and the dead FUSE mount surfaces as a spurious
-`LocalEntryNotFoundError` in the job.
+`--vfs-cache-mode full` serving the rest from the on-disk cache). Together with the
+per-tier `GOMEMLIMIT` (see `deploy.sh`), this keeps concurrent large-model
+(safetensors) reads from OOM-killing rclone; a dead FUSE mount otherwise surfaces as
+a spurious `LocalEntryNotFoundError` in the job.
 
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -127,8 +127,6 @@ spec:
               #     model opens many shards at once. Kept non-zero so cold reads
               #     retain some prefetch (vfs-cache-mode full serves the rest from
               #     the on-disk cache).
-              #   --use-mmap        returns freed buffers to the OS instead of Go
-              #     retaining them as process RSS.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
@@ -142,7 +140,6 @@ spec:
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
                 --buffer-size 4M \
-                --use-mmap \
                 --cache-dir "$CACHE" \
                 --no-modtime \
                 --umask 022 \


### PR DESCRIPTION
Remove `--use-mmap` from the rclone mount, keeping the `--buffer-size 4M` read-ahead cut. Both were added together in #907; we're rolling out one lever at a time, starting with the buffer-size reduction.

I want to make one change at a time for this tricky part to make sure that the cause and effect can be seen clearly