### PR TITLE
Revert #907 + #913: restore pre-#907 hf-cache rclone config

### DIFF
--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -18,14 +18,6 @@ rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 `deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
 1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
 
-To keep RSS inside those reserves the mount runs with `--buffer-size 4M` (a 4x cut
-from rclone's 16Mi-per-open-file default read-ahead — the dominant RSS driver when
-a model opens many shards; kept non-zero so cold reads retain some prefetch, with
-`--vfs-cache-mode full` serving the rest from the on-disk cache) and `--use-mmap`
-(frees buffers back to the OS). Without them, concurrent large-model (safetensors)
-reads OOM-kill rclone, and the dead FUSE mount surfaces as a spurious
-`LocalEntryNotFoundError` in the job.
-
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the
 pytorch/pytorch workflow assumes a GitHub-OIDC role

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -21,10 +21,10 @@ rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 To keep RSS inside those reserves the mount runs with `--buffer-size 4M` (a 4x cut
 from rclone's 16Mi-per-open-file default read-ahead — the dominant RSS driver when
 a model opens many shards; kept non-zero so cold reads retain some prefetch, with
-`--vfs-cache-mode full` serving the rest from the on-disk cache). Together with the
-per-tier `GOMEMLIMIT` (see `deploy.sh`), this keeps concurrent large-model
-(safetensors) reads from OOM-killing rclone; a dead FUSE mount otherwise surfaces as
-a spurious `LocalEntryNotFoundError` in the job.
+`--vfs-cache-mode full` serving the rest from the on-disk cache) and `--use-mmap`
+(frees buffers back to the OS). Without them, concurrent large-model (safetensors)
+reads OOM-kill rclone, and the dead FUSE mount surfaces as a spurious
+`LocalEntryNotFoundError` in the job.
 
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -127,6 +127,8 @@ spec:
               #     model opens many shards at once. Kept non-zero so cold reads
               #     retain some prefetch (vfs-cache-mode full serves the rest from
               #     the on-disk cache).
+              #   --use-mmap        returns freed buffers to the OS instead of Go
+              #     retaining them as process RSS.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
@@ -140,6 +142,7 @@ spec:
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
                 --buffer-size 4M \
+                --use-mmap \
                 --cache-dir "$CACHE" \
                 --no-modtime \
                 --umask 022 \

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -119,16 +119,6 @@ spec:
               # Background rclone so we can drop a sentinel once mounted — the
               # taint-remover waits on that rather than inspecting the host, which
               # keeps it unprivileged. Creds via IRSA (env_auth).
-              #
-              # RSS control (keeps rclone under the per-tier reserve; large
-              # safetensors reads OOM-killed the mount on the small 1-GPU tier):
-              #   --buffer-size 4M  shrinks the per-open-file in-RAM read-ahead
-              #     4x from rclone's 16Mi default — the dominant RSS driver when a
-              #     model opens many shards at once. Kept non-zero so cold reads
-              #     retain some prefetch (vfs-cache-mode full serves the rest from
-              #     the on-disk cache).
-              #   --use-mmap        returns freed buffers to the OS instead of Go
-              #     retaining them as process RSS.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
@@ -141,8 +131,6 @@ spec:
                 --vfs-cache-max-size "$VFS_MAX" \
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
-                --buffer-size 4M \
-                --use-mmap \
                 --cache-dir "$CACHE" \
                 --no-modtime \
                 --umask 022 \


### PR DESCRIPTION
Reverts #913 and #907, returning the hf-cache rclone mount to its pre-#907 config (no `--use-mmap`, no `--buffer-size 4M` — rclone defaults + the per-tier `GOMEMLIMIT`). This is the same config `meta-prod-aws-ue1` runs today with zero small-tier OOMs.

#907 added `--buffer-size 4M --use-mmap` and #913 later dropped only `--use-mmap`; post-deploy verification on ue2 showed small-tier (256Mi CPU / 512Mi gpu1) OOMs continued regardless, so neither flag was the driver. The real cause is that rclone mount memory is tiered by GPU count while per-node RSS scales with pod density — ue2 packs runners onto 48xl/metal nodes, overwhelming the single 256Mi per-node mount. Reverting to the known-good baseline while the tiering fix is developed separately.