### PR TITLE
grafana/osdc: add hf-cache OOM-killed-mounts panel

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1436,6 +1436,125 @@
           }
         }
       }
+    },
+    "panel-12": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1)",
+                      "instant": false,
+                      "legendFormat": "{{cluster}}",
+                      "queryType": "range",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Count of hf-cache rclone mounts whose container's LAST termination was OOMKilled (kube_pod_container_status_last_terminated_reason). This is a sticky signal: it stays set after the pod recovers and only clears when the pod is replaced (node recycle / rollout) — so it counts mounts that OOM'd recently, INCLUDING ones already back to Running. It is an upper bound / early-warning indicator, NOT a live 'currently broken' count (that would need a per-pod not-ready or waiting-reason metric, which is not currently shipped to Mimir for the hf-cache namespace). A sustained rise still means the small-tier OOM is active and jobs on those nodes can fail to start.",
+        "id": 12,
+        "links": [],
+        "title": "hf-cache Mounts OOM-killed — recent, incl. recovered [cluster]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.9,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
     }
   },
   "layout": {
@@ -1583,6 +1702,19 @@
             "width": 12,
             "x": 12,
             "y": 40
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-12"
+            },
+            "height": 8,
+            "width": 24,
+            "x": 0,
+            "y": 48
           }
         }
       ]

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1455,7 +1455,7 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1)",
+                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
                       "instant": false,
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
@@ -1481,11 +1481,13 @@
           "spec": {
             "fieldConfig": {
               "defaults": {
+                "decimals": 0,
                 "color": {
                   "mode": "palette-classic-by-name",
                   "seriesBy": "max"
                 },
                 "custom": {
+                  "axisSoftMax": 5,
                   "axisBorderShow": false,
                   "axisCenteredZero": false,
                   "axisColorMode": "text",
@@ -1519,7 +1521,7 @@
                     "mode": "none"
                   },
                   "thresholdsStyle": {
-                    "mode": "off"
+                    "mode": "line+area"
                   }
                 },
                 "thresholds": {
@@ -1528,6 +1530,10 @@
                     {
                       "color": "green",
                       "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
                     }
                   ]
                 }

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -22,8 +22,8 @@ GPU_COUNT_LABEL = "karpenter.k8s.aws/instance-gpu-count"
 # (request == limit). ds name -> (affinity op, gpu-count values, memory). Must match
 # deploy.sh MOUNT_TIERS.
 MOUNT_TIERS = {
-    "hf-cache-mount": ("NotIn", {"1", "2", "4", "8"}, "256Mi"),
-    "hf-cache-mount-gpu1": ("In", {"1"}, "512Mi"),
+    "hf-cache-mount": ("NotIn", {"1", "2", "4", "8"}, "640Mi"),
+    "hf-cache-mount-gpu1": ("In", {"1"}, "640Mi"),
     "hf-cache-mount-gpu2": ("In", {"2"}, "1Gi"),
     "hf-cache-mount-gpu4": ("In", {"4"}, "2Gi"),
     "hf-cache-mount-gpu8": ("In", {"8"}, "4Gi"),


### PR DESCRIPTION
Adds a timeseries panel **hf-cache Mounts Broken by rclone OOM [cluster]** to the OSDC dashboard.

```
count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~"$cluster", namespace="hf-cache", container="rclone", reason="OOMKilled"} == 1)
```

hf-cache runs one rclone DaemonSet pod per node serving /mnt/hf_cache, so an OOMKilled rclone container = a broken node-wide FUSE mount (usually wedged in CreateContainerError until the node is recycled). This surfaces, per cluster, the small-tier OOM count that until now needed manual kubectl queries.

### Preview

[Dashboard](https://pytorchci.grafana.net/d/hu2zptv/osdc?orgId=1&from=2026-07-17T15:23:51.578Z&to=2026-07-17T18:26:38.245Z&timezone=browser&var-cluster=$__all&var-runner_name_prefix=$__all&var-scale_set=$__all&var-repository=$__all)