### PR TITLE
osdc/hf-cache: per-tier rclone --buffer-size (CPU 0, gpu1 2M)

### DIFF
--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -16,15 +16,18 @@ get the path bind-mounted read-only via the gated `# BEGIN_HF_CACHE` block in
 rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 (`karpenter.k8s.aws/instance-gpu-count`), since RSS scales with job concurrency:
 `deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
-1-GPU → 512Mi, and the CPU catch-all → 256Mi. See `MOUNT_TIERS` in `deploy.sh`.
+1-GPU → 640Mi, and the CPU catch-all → 640Mi. See `MOUNT_TIERS` in `deploy.sh`.
 
-To keep RSS inside those reserves the mount runs with `--buffer-size 4M` (a 4x cut
-from rclone's 16Mi-per-open-file default read-ahead — the dominant RSS driver when
-a model opens many shards; kept non-zero so cold reads retain some prefetch, with
-`--vfs-cache-mode full` serving the rest from the on-disk cache). Together with the
-per-tier `GOMEMLIMIT` (see `deploy.sh`), this keeps concurrent large-model
-(safetensors) reads from OOM-killing rclone; a dead FUSE mount otherwise surfaces as
-a spurious `LocalEntryNotFoundError` in the job.
+To keep RSS inside those reserves, `--buffer-size` (rclone's per-open-file read-ahead
+— the dominant RSS driver when a model opens many shards) is set **per tier** in
+`deploy.sh`, because peak concurrent opens scale with a node's pod density, not its GPU
+count: the packed CPU catch-all (big 48xl/metal nodes, many runner pods sharing one
+mount) runs `--buffer-size 0` (read-ahead off; reads served from the `--vfs-cache-mode
+full` on-disk cache), the tight 640Mi 1-GPU tier also uses `0`, and the roomier multi-GPU
+tiers keep `4M`.
+Together with the per-tier `GOMEMLIMIT`, this keeps concurrent large-model (safetensors)
+reads from OOM-killing rclone; a dead FUSE mount otherwise surfaces as a spurious
+`LocalEntryNotFoundError` in the job.
 
 **Writes are gated by GitHub OIDC, not by the mount.** Job pods can't write the
 cache (read-only mount, read-only IRSA). On `ci-refresh-hf-cache` runs, the

--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -32,17 +32,25 @@ TAINT_REMOVER_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.taint_remover_image \
 VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
 # rclone RSS scales with job concurrency ~ GPU count, so memory is tiered by
 # instance-gpu-count and reserved (request == limit). One DaemonSet per tier; the
-# affinity keeps them exclusive. Fields: <ds-name> <affinity-op> <gpu-count-csv> <memory>.
+# affinity keeps them exclusive. Fields:
+#   <ds-name> <affinity-op> <gpu-count-csv> <memory> <buffer-size>
 # The "hf-cache-mount" NotIn catch-all covers CPU + any unclassified count, so every
 # node gets a mount to clear the startup taint.
+# <buffer-size> is rclone's per-open-file read-ahead; rclone RAM ~= buffer-size x
+# concurrent open files. The two tight tiers run 0 (read-ahead off; reads served from
+# the vfs-cache-mode full on-disk cache): the packed CPU catch-all (48xl/metal, many
+# runner pods on one mount) and the 640Mi 1-GPU tier, where even 1M x ~146 shards
+# (~146MB) eats headroom rclone's heap/metadata needs. (1-GPU is 640Mi not 1Gi: 1Gi
+# strands the a10g/l4/t4 runners on the 8xl 1-GPU nodes; 640Mi still fits per
+# analyze_node_utilization.) The roomier multi-GPU tiers (1-4Gi) keep 4M for prefetch.
 # FOLLOW-UP: the GPU-only PR drops CPU (nvidia.com/gpu nodeSelector); then collapse the
-# first two rows into "hf-cache-mount NotIn 2,4,8 512Mi" (1-GPU + rest).
+# first two rows into "hf-cache-mount NotIn 2,4,8 640Mi" (1-GPU + rest, both 640Mi).
 MOUNT_TIERS=(
-  "hf-cache-mount NotIn 1,2,4,8 256Mi"
-  "hf-cache-mount-gpu1 In 1 512Mi"
-  "hf-cache-mount-gpu2 In 2 1Gi"
-  "hf-cache-mount-gpu4 In 4 2Gi"
-  "hf-cache-mount-gpu8 In 8 4Gi"
+  "hf-cache-mount NotIn 1,2,4,8 640Mi 0"
+  "hf-cache-mount-gpu1 In 1 640Mi 0"
+  "hf-cache-mount-gpu2 In 2 1Gi 4M"
+  "hf-cache-mount-gpu4 In 4 2Gi 4M"
+  "hf-cache-mount-gpu8 In 8 4Gi 4M"
 )
 BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
 # Bucket is in the cluster's region, so rclone's S3 region is the cluster region.
@@ -85,7 +93,8 @@ kubectl create configmap node-taint-remover-lib \
 # --- Render + apply the mount DaemonSets (one per GPU-count tier) ---
 render_mount_ds() {
   # $1 = DaemonSet name, $2 = affinity operator, $3 = gpu-count CSV,
-  # $4 = rclone memory (rendered as both request and limit → reserved)
+  # $4 = rclone memory (rendered as both request and limit → reserved),
+  # $5 = rclone --buffer-size (per-open-file read-ahead; 0 = off)
   local values="[\"${3//,/\",\"}\"]"
   # GOMEMLIMIT ~= 90% of the reserved limit, in Go's byte-suffix format (MiB/GiB — Go
   # rejects k8s's Mi/Gi). rclone is a Go binary that OOMs from lazy GC, not real need;
@@ -109,6 +118,7 @@ render_mount_ds() {
     -e "s|__MULTI_GPU_COUNTS__|${values}|g" \
     -e "s|__RCLONE_MEMORY_LIMIT__|${4}|g" \
     -e "s|__GOMEMLIMIT__|${gomemlimit}|g" \
+    -e "s|__BUFFER_SIZE__|${5}|g" \
     "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl"
 }
 
@@ -120,10 +130,10 @@ echo "[hf-cache] Applying mount DaemonSets (per GPU-count tier)..."
 {
   first=1
   for tier in "${MOUNT_TIERS[@]}"; do
-    read -r _name _op _counts _mem <<<"$tier"
+    read -r _name _op _counts _mem _buf <<<"$tier"
     [ "$first" = 1 ] || echo "---"
     first=0
-    render_mount_ds "$_name" "$_op" "$_counts" "$_mem"
+    render_mount_ds "$_name" "$_op" "$_counts" "$_mem" "$_buf"
   done
 } | kubectl_apply_if_changed -f -
 

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -9,7 +9,7 @@
 #
 # Placeholders (deploy.sh): __NAMESPACE__ __BUCKET__ __REGION__ __RCLONE_IMAGE__
 # __VFS_CACHE_MAX_SIZE__ __TAINT_REMOVER_IMAGE__ __RCLONE_MEMORY_LIMIT__ __GOMEMLIMIT__
-# __DS_NAME__ __GPU_OP__ __MULTI_GPU_COUNTS__
+# __DS_NAME__ __GPU_OP__ __MULTI_GPU_COUNTS__ __BUFFER_SIZE__
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -120,13 +120,18 @@ spec:
               # taint-remover waits on that rather than inspecting the host, which
               # keeps it unprivileged. Creds via IRSA (env_auth).
               #
-              # RSS control (keeps rclone under the per-tier reserve; large
-              # safetensors reads OOM-killed the mount on the small 1-GPU tier):
-              #   --buffer-size 4M  shrinks the per-open-file in-RAM read-ahead
-              #     4x from rclone's 16Mi default — the dominant RSS driver when a
-              #     model opens many shards at once. Kept non-zero so cold reads
-              #     retain some prefetch (vfs-cache-mode full serves the rest from
-              #     the on-disk cache).
+              # RSS control (keeps rclone under the per-tier reserve). Per-open-file
+              # in-RAM read-ahead is the dominant RSS driver when a model opens many
+              # shards at once, and peak concurrent opens scale with node pod-density,
+              # so --buffer-size is set per tier by deploy.sh (__BUFFER_SIZE__):
+              #   CPU catch-all (640Mi, packed 48xl/metal nodes) → 0: read-ahead off,
+              #     served from the vfs-cache-mode full on-disk cache. High pod density
+              #     means many concurrent readers on one mount, so any non-zero buffer
+              #     OOMs the small reserve.
+              #   1-GPU tier (640Mi) → 0: like CPU. rclone RAM ~= buffer-size x concurrent
+              #     open files, so even 1M x ~146 shards (~146MB) eats headroom the rclone
+              #     heap/metadata needs at 512Mi; read-ahead off, served from the disk cache.
+              #   multi-GPU tiers (1-4Gi) → 4M: roomier reserve, so keep more prefetch.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \
                 "$MOUNT" \
@@ -139,7 +144,7 @@ spec:
                 --vfs-cache-max-size "$VFS_MAX" \
                 --vfs-cache-max-age 24h \
                 --vfs-read-chunk-size 128M \
-                --buffer-size 4M \
+                --buffer-size __BUFFER_SIZE__ \
                 --cache-dir "$CACHE" \
                 --no-modtime \
                 --umask 022 \

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -57,13 +57,13 @@ EKS_ADDON_DAEMONSETS: list[DaemonSetOverhead] = [
 # .tpl-rendered DaemonSets the raw-YAML scan can't see (unresolved __PLACEHOLDER__s).
 # hf-cache's memory is tiered by GPU count (deploy.sh MOUNT_TIERS); this base is the
 # CPU/catch-all tier counted on every node, and GPU nodes add hf_cache_gpu_topup_mib().
-HF_CACHE_BASE_MIB = 256
+HF_CACHE_BASE_MIB = 640
 TEMPLATED_DAEMONSETS: list[DaemonSetOverhead] = [
     DaemonSetOverhead("hf-cache-mount", 100, HF_CACHE_BASE_MIB, False, "constant:tpl:modules/hf-cache"),
 ]
 
 # Reserved hf-cache memory (MiB) by GPU count (MOUNT_TIERS); other counts + CPU get the base.
-HF_CACHE_TIER_MIB = {1: 512, 2: 1024, 4: 2048, 8: 4096}
+HF_CACHE_TIER_MIB = {1: 640, 2: 1024, 4: 2048, 8: 4096}
 
 
 def hf_cache_gpu_topup_mib(gpu_count: int) -> int:

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -507,16 +507,16 @@ class TestRealManifests:
         assert by_name["runner-hooks-warmer"].memory_mib == 32
 
     def test_hf_cache_templated_overhead(self, upstream_dir):
-        """hf-cache is a .tpl DaemonSet (invisible to the YAML scan), added as a 256Mi
+        """hf-cache is a .tpl DaemonSet (invisible to the YAML scan), added as a 640Mi
         base on all nodes; GPU nodes reserve more per GPU count via the top-up helper."""
         by_name = {ds.name: ds for ds in discover_daemonsets(upstream_dir)}
 
         base = by_name["hf-cache-mount"]
         assert base.gpu_only is False
-        assert base.memory_mib == 256  # CPU / catch-all tier
+        assert base.memory_mib == 640  # CPU / catch-all tier
 
         # base + top-up == the reserved memory tier for each GPU count (MOUNT_TIERS)
-        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 512
+        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 640
         assert base.memory_mib + hf_cache_gpu_topup_mib(2) == 1024
         assert base.memory_mib + hf_cache_gpu_topup_mib(4) == 2048
         assert base.memory_mib + hf_cache_gpu_topup_mib(8) == 4096


### PR DESCRIPTION
Makes rclone `--buffer-size` a **per-tier** value in `deploy.sh` instead of one global flag. Read-ahead RAM scales as (concurrent open shards) × buffer-size, and peak concurrency scales with a node's **pod density**, so the tight small tiers need less read-ahead:

- **CPU catch-all (256Mi)** — densely packed (many runner pods per node share one mount) → `--buffer-size 0` (read-ahead off; served from the `--vfs-cache-mode full` on-disk cache).
- **1-GPU tier (512Mi)** → `--buffer-size 2M` (a single HF model opening ~100+ shards at 4M overruns the 512Mi reserve; observed OOMs on g5.16xlarge gpu1 nodes).
- **multi-GPU tiers (1–4Gi)** → `--buffer-size 4M` (roomier reserve, keep more prefetch).

Addresses the OOM driver on both small tiers via buffer sizing. Note this is buffer-size only; the deeper fix (mount reserve sized to pod density) can follow, and #876 adds self-heal so any residual OOM recovers instead of wedging.