### PR TITLE
Add retrying OSDC setup composite action and use it across CI workflows

### DIFF
--- a/.github/actions/osdc-setup/action.yml
+++ b/.github/actions/osdc-setup/action.yml
@@ -1,0 +1,42 @@
+name: OSDC setup
+description: Install just, the mise toolchain, and Python dependencies for OSDC workflows, retrying transient failures.
+runs:
+  using: composite
+  steps:
+    # GitHub Actions has no native per-step retry, so each step below is retried
+    # by duplication: continue-on-error on the first attempt plus a copy gated on
+    # its failure. Preferred over a retry action so that no unpinnable
+    # third-party code runs on the deploy / merge-queue paths.
+    - name: Install just
+      id: install-just
+      continue-on-error: true
+      uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+    - name: Install just (retry)
+      if: ${{ steps.install-just.outcome == 'failure' }}
+      uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+    - name: Install mise
+      id: install-mise
+      continue-on-error: true
+      uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      with:
+        version: "2026.5.11"
+        install: true
+        working_directory: osdc
+    - name: Install mise (retry)
+      if: ${{ steps.install-mise.outcome == 'failure' }}
+      uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      with:
+        version: "2026.5.11"
+        install: true
+        working_directory: osdc
+
+    - name: Install Python dependencies
+      id: install-python
+      continue-on-error: true
+      shell: bash
+      run: cd osdc && uv sync
+    - name: Install Python dependencies (retry)
+      if: ${{ steps.install-python.outcome == 'failure' }}
+      shell: bash
+      run: cd osdc && uv sync

--- a/.github/workflows/_osdc-deploy.yml
+++ b/.github/workflows/_osdc-deploy.yml
@@ -65,18 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-        with:
-          version: "2026.5.11"
-          install: true
-          working_directory: osdc
-
-      - name: Install Python dependencies
-        run: uv sync
+      - name: Set up OSDC toolchain
+        uses: ./.github/actions/osdc-setup
 
       - name: Lint
         if: ${{ !inputs.skip_lint_test }}
@@ -98,7 +88,13 @@ jobs:
       # (and node-compactor) for both archs; whenever the content-addressed
       # tag changes (Dockerfile edit, etc.) the build branch runs and needs
       # cross-arch emulation.
+      # GitHub Actions has no native step retry; retried by duplication.
       - name: Set up QEMU for cross-arch builds
+        id: setup-qemu
+        continue-on-error: true
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up QEMU for cross-arch builds (retry)
+        if: ${{ steps.setup-qemu.outcome == 'failure' }}
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Deploy ${{ inputs.cluster }}
@@ -123,18 +119,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-        with:
-          version: "2026.5.11"
-          install: true
-          working_directory: osdc
-
-      - name: Install Python dependencies
-        run: uv sync
+      - name: Set up OSDC toolchain
+        uses: ./.github/actions/osdc-setup
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -159,18 +145,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-        with:
-          version: "2026.5.11"
-          install: true
-          working_directory: osdc
-
-      - name: Install Python dependencies
-        run: uv sync
+      - name: Set up OSDC toolchain
+        uses: ./.github/actions/osdc-setup
 
       - name: Verify gh CLI
         run: gh --version

--- a/.github/workflows/osdc-drain.yml
+++ b/.github/workflows/osdc-drain.yml
@@ -68,18 +68,8 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-        with:
-          version: "2026.5.11"
-          install: true
-          working_directory: osdc
-
-      - name: Install Python dependencies
-        run: uv sync
+      - name: Set up OSDC toolchain
+        uses: ./.github/actions/osdc-setup
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/.github/workflows/osdc-undrain.yml
+++ b/.github/workflows/osdc-undrain.yml
@@ -69,18 +69,8 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-
-      - name: Install mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
-        with:
-          version: "2026.5.11"
-          install: true
-          working_directory: osdc
-
-      - name: Install Python dependencies
-        run: uv sync
+      - name: Set up OSDC toolchain
+        uses: ./.github/actions/osdc-setup
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/osdc/.claude/skills/osdc-deployment/SKILL.md
+++ b/osdc/.claude/skills/osdc-deployment/SKILL.md
@@ -349,9 +349,11 @@ Key workflows (all callable as reusable workflows via `workflow_call` from the o
 | `osdc-pre-merge.yml` | Lint + test on PR |
 | `osdc-plan-prod.yml` | `just plan <cluster>` (read-only tofu plan; CI-safe) |
 | `osdc-deploy-prod.yml` | Per-cluster prod deploy. Calls `_osdc-deploy.yml` |
-| `_osdc-deploy.yml` | Reusable: `just lint && just test` → `just deploy <cluster>` → `just smoke <cluster>` → `just integration-test <cluster> --skip-drain --skip-smoke --skip-compactor`. Pre-flight checks can be skipped with the `skip-checks` input (firefighting only). |
+| `_osdc-deploy.yml` | Reusable: `just lint && just test` → `just deploy <cluster>` → `just smoke <cluster>` → `just integration-test <cluster> --skip-drain --skip-smoke --skip-compactor`. Pre-flight checks can be skipped with the `skip_lint_test` input (firefighting only). |
 | `_osdc-plan.yml` | Reusable: `just plan <cluster>` and tee to `plan.txt` |
 | `_osdc-slow-tests.yml` | Reusable: `just load-test`, `just test-compactor`, `just test-janitor` |
 | `osdc-capacity-report.yml` | `just simulate-cluster` + `just analyze-utilization`, periodic |
 
 When adding a new `just` recipe that CI should run, plumb it through the corresponding reusable workflow.
+
+The OSDC-rooted CI jobs — the `deploy`/`smoke`/`integration` jobs in `_osdc-deploy.yml`, plus `osdc-drain.yml` and `osdc-undrain.yml` — set up their toolchain via the local composite action `./.github/actions/osdc-setup` (installs just + mise + `uv sync`). Its setup steps are retried on transient failures by **retry-by-duplication** (`continue-on-error` on the first attempt plus a copy gated on `steps.<id>.outcome == 'failure'`), chosen over a retry action deliberately: GitHub Actions has no native step retry, and a retry action would run unpinnable third-party code on the deploy / merge-queue path. `actions/checkout` and `aws-actions/configure-aws-credentials` are intentionally NOT wrapped because they already retry internally.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #933
* __->__ #932

**Impact:** CI only — OSDC deploy, drain, undrain, and pre-merge workflows
**Risk:** low

## What
Extracts the repeated "install just + mise + `uv sync`" setup into a new local composite action (`.github/actions/osdc-setup`) and swaps the four OSDC workflows over to it. Each setup step (plus the QEMU setup in `_osdc-deploy.yml`) is now retried on transient failure via retry-by-duplication.

## Why
The toolchain install steps were copy-pasted across `_osdc-deploy.yml`, `osdc-drain.yml`, and `osdc-undrain.yml`, and occasionally failed on transient network hiccups — flaking deploy and merge-queue runs. Consolidating into one action removes the duplication and adds retries in a single place.

The retry is done by duplicating each step (`continue-on-error` on the first attempt + a copy gated on its failure) rather than pulling in a third-party retry action, so no unpinnable code runs on the deploy / merge-queue path. `actions/checkout` and `configure-aws-credentials` are left alone since they retry internally.

# Notes
The SKILL.md doc update also corrects a stale reference: the `_osdc-deploy.yml` skip input is `skip_lint_test`, not `skip-checks`.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>