### PR TITLE
Right-size lf-prod base nodes to m7i.4xlarge

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -525,7 +525,7 @@ clusters:
         - lf_osdc_admin
     base:
       base_node_count: 4
-      base_node_instance_type: m7i.8xlarge
+      base_node_instance_type: m7i.4xlarge
       vpc_cidr: "10.12.0.0/16"
     node_compactor:
       min_node_age_seconds: 300
@@ -557,7 +557,7 @@ clusters:
         - lf_osdc_admin
     base:
       base_node_count: 4
-      base_node_instance_type: m7i.8xlarge
+      base_node_instance_type: m7i.4xlarge
       vpc_cidr: "10.16.0.0/16"
     node_compactor:
       min_node_age_seconds: 300


### PR DESCRIPTION
lf-prod-aws-ue1/ue2 base nodes on m7i.8xlarge sit well under capacity: 14-day peak CPU was 37% and real memory usage measured via kubelet stats/summary topped out at 10.1% of 128GiB. Real memory drivers (git-cache-central, karpenter) and CPU peaks both fit comfortably within m7i.4xlarge, freeing up cost without affecting workload scheduling.