### PR TITLE
Hard-spread base-node controllers to prevent CPU pile-up

### DIFF
--- a/osdc/base/helm/harbor/values.yaml
+++ b/osdc/base/helm/harbor/values.yaml
@@ -27,6 +27,17 @@ x-base-affinity: &base-affinity
               values:
                 - base-infrastructure
 
+# Hard-spread each component's replicas one-per-node. Without this, a
+# rolling base node replacement (nodes become Ready one at a time) can pile
+# every replica of core/registry/etc. onto whichever node comes up first,
+# starving other pods on that node of CPU — including harbor-database,
+# whose EBS volume pins it to one specific AZ/node. Component name is
+# templated in per-component below since each has a distinct label.
+x-spread-template: &spread-template
+  maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: DoNotSchedule
+
 # ============================================================================
 # Expose configuration (NodePort for containerd access)
 # ============================================================================
@@ -83,7 +94,15 @@ cache:
 core:
   tolerations: *base-tolerations
   affinity: *base-affinity
+  topologySpreadConstraints:
+    - <<: *spread-template
+      labelSelector:
+        matchLabels: {app: harbor, component: core}
 
+# registry and jobservice are NOT given topologySpreadConstraints: both use
+# an RWO PVC (see updateStrategy note below), so their replicas are already
+# constrained to land together on whatever node holds that volume — a hard
+# per-node spread would conflict with that and leave pods Pending.
 registry:
   tolerations: *base-tolerations
   affinity: *base-affinity
@@ -102,6 +121,10 @@ updateStrategy:
 portal:
   tolerations: *base-tolerations
   affinity: *base-affinity
+  topologySpreadConstraints:
+    - <<: *spread-template
+      labelSelector:
+        matchLabels: {app: harbor, component: portal}
 
 nginx:
   replicas: 3
@@ -114,6 +137,10 @@ nginx:
       memory: 1Gi
   tolerations: *base-tolerations
   affinity: *base-affinity
+  topologySpreadConstraints:
+    - <<: *spread-template
+      labelSelector:
+        matchLabels: {app: harbor, component: nginx}
 
 database:
   internal:

--- a/osdc/modules/arc/helm/arc/values.yaml
+++ b/osdc/modules/arc/helm/arc/values.yaml
@@ -54,3 +54,17 @@ tolerations:
 
 # Node selector (optional - can specify if base nodes have specific labels)
 nodeSelector: {}
+
+# Hard-spread controller replicas one-per-node. Without this, a rolling base
+# node replacement (nodes become Ready one at a time) can pile every replica
+# onto whichever node comes up first, starving other pods on that node of
+# CPU. maxUnavailable on the base node group never exceeds replicas-1 nodes,
+# so DoNotSchedule can't wedge this pending.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: gha-rs-controller
+        app.kubernetes.io/instance: arc

--- a/osdc/modules/bin-pack-scheduler/kubernetes/base/deployment.yaml
+++ b/osdc/modules/bin-pack-scheduler/kubernetes/base/deployment.yaml
@@ -30,16 +30,19 @@ spec:
           operator: Equal
           value: "true"
           effect: NoSchedule
-      # Spread replicas across nodes so a single node loss keeps a leader.
+      # Hard-spread replicas one-per-node. A "preferred" anti-affinity here
+      # let all replicas land on the same base node during a rolling node
+      # replacement (nodes become Ready one at a time, so early pods pile
+      # onto whichever node is up first) — that starved other pods on that
+      # node of CPU. maxUnavailable on the base node group never exceeds
+      # replicas-1 nodes, so a required constraint can't wedge this pending.
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchLabels:
-                    app: bin-pack-scheduler
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: bin-pack-scheduler
       containers:
         - name: kube-scheduler
           image: registry.k8s.io/kube-scheduler:v1.35.0


### PR DESCRIPTION
The ue2 base-node resize to m7i.4xlarge (COPS-418) exposed a latent scheduling gap: bin-pack-scheduler, the ARC controller, and Harbor's own multi-replica components had no hard per-node spread, so a rolling base node replacement could pile every replica of each onto whichever node came up first. On the smaller instance type this saturated one node's CPU requests, blocking harbor-database (which is AZ-pinned by its EBS volume) from scheduling and cascading into a full Harbor outage.

- bin-pack-scheduler: preferred pod anti-affinity was too weak to stop the pile-up; switch to required.
- ARC controller and Harbor's core/portal/nginx: add topologySpreadConstraints (maxSkew 1, DoNotSchedule).
- registry/jobservice deliberately excluded: their RWO PVCs already force same-node placement across replicas.