### PR TITLE
osdc/monitoring: retain bin-pack-scheduler restart counter to make OOMs visible

### DIFF
--- a/osdc/modules/monitoring/helm/alloy-values.yaml
+++ b/osdc/modules/monitoring/helm/alloy-values.yaml
@@ -76,6 +76,21 @@ alloy:
           target_label  = "__keep_cp__"
           replacement   = "true"
         }
+        // Also keep restarts_total for the bin-pack-scheduler pods specifically.
+        // The secondary scheduler in kube-system OOMKills (exit 137) under memory
+        // pressure; retaining its restart counter lets us count OOM events over
+        // time (increase() over the counter) instead of only seeing the current
+        // pod's last-termination reason gauge, which resets on every redeploy.
+        // Scoped to the pod-name prefix so we do NOT retain restart series for
+        // every per-node kube-system DaemonSet pod (that would be a cardinality /
+        // billing blowup — the whole reason kube-system is excluded above).
+        rule {
+          action        = "replace"
+          source_labels = ["__name__", "namespace", "pod"]
+          regex         = "kube_pod_container_status_restarts_total;kube-system;bin-pack-scheduler-.*"
+          target_label  = "__keep_cp__"
+          replacement   = "true"
+        }
         rule {
           action        = "drop"
           source_labels = ["__name__", "__keep_cp__"]


### PR DESCRIPTION
The `bin-pack-scheduler` OOMKills under memory pressure (two of three replicas on `meta-prod-aws-ue1` show `OOMKilled / exit 137` right now, even after #930's bump to 6Gi), but we can't see how often: `kube_pod_container_status_restarts_total` is dropped for `kube-system` by the `cost_control` relabel, and the only surviving signal (`last_terminated_reason` gauge) resets on every redeploy.

Retain `restarts_total` for the `bin-pack-scheduler` pods only (scoped to the pod-name prefix so we don't retain a series per kube-system DaemonSet pod). OOM count then becomes:

```promql
sum(increase(kube_pod_container_status_restarts_total{namespace="kube-system", pod=~"bin-pack-scheduler.*"}[7d]))
```

Dashboard panel to follow once the series is flowing in Mimir.

Context: meta-pytorch/pytorch-gha-infra#1314
