### PR TITLE
zombie-cleanup: protect busy ARC runners, reap only hung ones

### DIFF
--- a/osdc/.claude/skills/osdc-deployment/SKILL.md
+++ b/osdc/.claude/skills/osdc-deployment/SKILL.md
@@ -318,7 +318,7 @@ Per-arch override keys are separate (`amd64_*` and `arm64_*`) — there is no fl
 - `logging.grafana_cloud_loki_url` — Grafana Cloud Loki push endpoint.
 - `alloy_chart_version` — Alloy Helm chart version (shared by monitoring + logging Alloy DaemonSets).
 - `keda.chart_version` — KEDA operator Helm chart version (used by the `keda` module; consumed by buildkit autoscaling).
-- `zombie_cleanup.{enabled,pending_max_age_hours,running_max_age_hours,dry_run}` — orphan-pod GC tuning.
+- `zombie_cleanup.{enabled,pending_max_age_hours,running_max_age_hours,busy_max_age_hours,dry_run}` — orphan-pod GC tuning.
 - `pypi_cache.{instance_type,cuda_versions,python_versions,target_architectures,target_manylinux}` — PyPI wheel cache matrix (see `osdc-pypi-cache` for slug semantics; `cuda_versions` and `python_versions` are mandatory for this module).
 
 ### ARC Module — No Terraform

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -89,7 +89,8 @@ defaults:
   zombie_cleanup:
     enabled: true
     pending_max_age_hours: 24
-    running_max_age_hours: 12
+    running_max_age_hours: 24
+    busy_max_age_hours: 48
     dry_run: false
   pypi_cache:
     instance_type: r5d.12xlarge

--- a/osdc/docs/architecture.md
+++ b/osdc/docs/architecture.md
@@ -45,7 +45,7 @@ Current modules:
 | `buildkit` | Container build service — dual-arch BuildKit Deployments with HAProxy LB on dedicated nodes |
 | `pypi-cache` | Per-CUDA-slug nginx + pypiserver fanout backed by shared EFS wheelhouse, fed by an external wheel-build pipeline via S3 |
 | `cache-enforcer` | DaemonSet that installs iptables rules on runner nodes to block direct outbound access to external registries/PyPI, forcing traffic through internal caches |
-| `zombie-cleanup` | CronJob that reaps stuck/zombie ARC runner pods (configurable max age for pending/running) |
+| `zombie-cleanup` | CronJob that reaps stuck/zombie ARC runner pods (configurable max age for pending/running; runners actively running a job are protected until a longer busy hard-cap) |
 | `harbor-cache-recovery` | CronJob that detects ImagePullBackOff from Harbor proxy cache corruption and purges stale cache entries |
 | `logging` | Log collection pipeline — Grafana Alloy DaemonSet (pod logs + journal) + Events Deployment → Grafana Cloud Loki |
 | `monitoring` | Metrics pipeline — kube-prometheus-stack CRDs/exporters + Grafana Alloy → Grafana Cloud Mimir (see `docs/observability.md` for the three-Alloy architecture) |

--- a/osdc/modules/zombie-cleanup/deploy.sh
+++ b/osdc/modules/zombie-cleanup/deploy.sh
@@ -45,14 +45,15 @@ fi
 
 # --- Read cluster-specific config ---
 PENDING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.pending_max_age_hours "24")
-RUNNING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.running_max_age_hours "12")
+RUNNING_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.running_max_age_hours "24")
+BUSY_MAX_AGE=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.busy_max_age_hours "48")
 DRY_RUN=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.dry_run "false")
 PUSHGATEWAY_URL=$(uv run "$CFG" "$CLUSTER" zombie_cleanup.pushgateway_url "http://prometheus-pushgateway.monitoring.svc.cluster.local:9091")
 
 # --- Compute content-based image tag ---
 TAG=$(find "$MODULE_DIR/docker" "$MODULE_DIR/scripts/python" \
   \( -name '*.py' -o -name 'Dockerfile' -o -name 'pyproject.toml' \) \
-  ! -name 'test_*' -print0 | sort -z | xargs -0 cat | sha256sum | cut -c1-12)
+  ! -name 'test_*' ! -name 'conftest.py' -print0 | sort -z | xargs -0 cat | sha256sum | cut -c1-12)
 
 IMAGE="harbor:30002/osdc/zombie-cleanup"
 
@@ -107,8 +108,9 @@ else
   cp "$MODULE_DIR/docker/Dockerfile" "$BUILD_CONTEXT/"
   cp "$MODULE_DIR/docker/pyproject.toml" "$BUILD_CONTEXT/"
   cp "$MODULE_DIR/scripts/python/"*.py "$BUILD_CONTEXT/"
-  # Exclude test files from the build context
+  # Exclude test files and pytest fixtures from the build context
   rm -f "$BUILD_CONTEXT/test_"*.py
+  rm -f "$BUILD_CONTEXT/conftest.py"
 
   docker build --platform linux/amd64 \
     -t "zombie-cleanup:${TAG}" \
@@ -138,6 +140,7 @@ sed \
   -e "s|ZOMBIE_CLEANUP_IMAGE_PLACEHOLDER|${IMAGE}:${TAG}|" \
   -e "s|PENDING_MAX_AGE_PLACEHOLDER|${PENDING_MAX_AGE}|" \
   -e "s|RUNNING_MAX_AGE_PLACEHOLDER|${RUNNING_MAX_AGE}|" \
+  -e "s|BUSY_MAX_AGE_PLACEHOLDER|${BUSY_MAX_AGE}|" \
   -e "s|DRY_RUN_PLACEHOLDER|${DRY_RUN}|" \
   -e "s|PUSHGATEWAY_URL_PLACEHOLDER|${PUSHGATEWAY_URL}|" \
   "$MODULE_DIR/kubernetes/cronjob.yaml" | kubectl_apply_if_changed -f -

--- a/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/cronjob.yaml
@@ -47,6 +47,8 @@ spec:
                   value: "PENDING_MAX_AGE_PLACEHOLDER"
                 - name: RUNNING_MAX_AGE_HOURS
                   value: "RUNNING_MAX_AGE_PLACEHOLDER"
+                - name: BUSY_MAX_AGE_HOURS
+                  value: "BUSY_MAX_AGE_PLACEHOLDER"
                 - name: DRY_RUN
                   value: "DRY_RUN_PLACEHOLDER"
                 - name: PUSHGATEWAY_URL

--- a/osdc/modules/zombie-cleanup/kubernetes/rbac.yaml
+++ b/osdc/modules/zombie-cleanup/kubernetes/rbac.yaml
@@ -19,6 +19,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]
+  - apiGroups: ["actions.github.com"]
+    resources: ["ephemeralrunners"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/osdc/modules/zombie-cleanup/scripts/python/conftest.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/conftest.py
@@ -1,0 +1,101 @@
+"""Shared fixtures for the zombie-cleanup unit tests."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from lightkube.core.exceptions import ApiError
+from runner_busy import EphemeralRunner
+
+
+def api_error(code: int) -> ApiError:
+    """Build a lightkube ApiError carrying just a status code (no HTTP round-trip)."""
+    err = ApiError.__new__(ApiError)
+    err.status = MagicMock(code=code)
+    return err
+
+
+@pytest.fixture
+def make_pod():
+    """Factory for mock Pods with controllable metadata and status.
+
+    ``labels`` is set to a real dict (or None) rather than an auto-speccing
+    MagicMock so the busy gate's ``labels.get("runner-pod")`` behaves like a
+    real pod instead of returning a truthy mock.
+    """
+
+    def _make(name, phase="Running", age_hours=0.0, owner_kind=None, terminating=False, labels=None):
+        now = datetime.now(UTC)
+        pod = MagicMock()
+        pod.metadata.name = name
+        pod.metadata.creationTimestamp = now - timedelta(hours=age_hours)
+        pod.metadata.deletionTimestamp = now if terminating else None
+        if owner_kind:
+            ref = MagicMock()
+            ref.kind = owner_kind
+            pod.metadata.ownerReferences = [ref]
+        else:
+            pod.metadata.ownerReferences = None
+        pod.metadata.labels = labels
+        pod.status.phase = phase
+        return pod
+
+    return _make
+
+
+@pytest.fixture
+def make_er():
+    """Factory for EphemeralRunner custom resources keyed by runner pod name.
+
+    ``name`` MUST match the owning runner pod's name — that is the join key the
+    busy gate uses. ``with_status=False`` produces a runner whose status block is
+    absent (a freshly created EphemeralRunner).
+    """
+
+    def _make(name, job_id=None, with_status=True):
+        body = {"metadata": {"name": name}}
+        if with_status:
+            body["status"] = {"jobId": job_id} if job_id is not None else {}
+        return EphemeralRunner.from_dict(body)
+
+    return _make
+
+
+@pytest.fixture
+def set_list():
+    """Wire ``client.list`` and ``client.get`` for a full cleanup run.
+
+    The find phase lists Pods then EphemeralRunners; the pre-delete recheck GETs
+    one EphemeralRunner per candidate by name. ``client.list`` dispatches on the
+    resource TYPE; ``client.get`` resolves an EphemeralRunner from ``ers`` by name
+    and raises a 404 ApiError when absent (ER gone / anchor missing).
+
+    Pass ``er_error`` to make BOTH the ER listing and the ER GETs raise (the API
+    is down); pass ``get_error`` to fail only the recheck GETs.
+    """
+
+    def _set(client, pods=None, ers=None, er_error=None, get_error=None):
+        pod_list = list(pods or [])
+        er_list = list(ers or [])
+        er_by_name = {er.metadata.name: er for er in er_list}
+
+        def _dispatch(resource, *_args, **_kwargs):
+            if resource is EphemeralRunner:
+                if er_error is not None:
+                    raise er_error
+                return list(er_list)
+            return list(pod_list)
+
+        client.list.side_effect = _dispatch
+
+        def _get(resource, *_args, name=None, **_kwargs):
+            effective_error = get_error if get_error is not None else er_error
+            if effective_error is not None:
+                raise effective_error
+            if resource is EphemeralRunner and name in er_by_name:
+                return er_by_name[name]
+            raise api_error(404)
+
+        client.get.side_effect = _get
+
+    return _set

--- a/osdc/modules/zombie-cleanup/scripts/python/runner_busy.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/runner_busy.py
@@ -1,0 +1,254 @@
+"""GitHub Actions runner busy-state detection and protection classifier.
+
+Runner pods are owned by an EphemeralRunner custom resource and stay eligible for
+age-based cleanup, unlike controller-managed pods. This module distinguishes an
+idle runner (reapable) from one actively executing a job (protected): a runner is
+busy when its EphemeralRunner carries a status.jobId, or when a live workflow/step
+job pod pins it via the runner-pod label.
+
+classify_pod is the single decision function shared by the find pass and the
+pre-delete recheck, so the two paths cannot drift. The find pass feeds it liveness
+resolved from one batch listing; the recheck feeds it liveness resolved from a
+targeted per-pod GET.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.generic_resource import create_namespaced_resource
+from lightkube.resources.core_v1 import Pod
+
+log = logging.getLogger("zombie-cleanup")
+
+# GitHub Actions runner pods carry this ownerReference kind. Deliberately not a
+# controller-managed kind: idle runners stay reapable, busy ones are gated instead.
+EPHEMERAL_RUNNER_KIND = "EphemeralRunner"
+
+# Bare workflow/step job pods carry this label; its value is the owning runner
+# pod's name and is the join key back to the runner. Kubernetes label VALUES are
+# capped at 63 chars (pod names may reach 253), so this join holds only because
+# OSDC runner names stay well under 63 (the ~42-char runner-naming convention);
+# a longer runner name would be truncated in the label value and break the match.
+RUNNER_POD_LABEL = "runner-pod"
+
+# Terminal pod phases never count as busy and never pin a runner.
+TERMINAL_PHASES = frozenset({"Succeeded", "Failed"})
+
+EphemeralRunner = create_namespaced_resource("actions.github.com", "v1alpha1", "EphemeralRunner", "ephemeralrunners")
+
+
+class Decision(Enum):
+    """Outcome of the shared protection classifier for one pod.
+
+    The value doubles as a human-readable reason for log lines. is_delete marks
+    the two outcomes that lead to a deletion; every other outcome keeps the pod.
+    """
+
+    FAIL_SAFE_PROTECT = "fail-safe-protect"
+    BUSY_PROTECT = "busy-protect"
+    JOBPOD_PROTECT = "jobpod-protect"
+    HARD_CAP_DELETE = "hard-cap-delete"
+    NORMAL_AGE_DELETE = "normal-age-delete"
+    NOT_OVER_AGE_KEEP = "not-over-age-keep"
+
+    @property
+    def is_delete(self) -> bool:
+        return self in (Decision.HARD_CAP_DELETE, Decision.NORMAL_AGE_DELETE)
+
+
+@dataclass
+class RunnerLiveness:
+    """Per-pod inputs for classify_pod.
+
+    Resolved either from a batch snapshot (BusyState.liveness_for) or from a
+    targeted GET (recheck_liveness), so the classifier itself stays path-agnostic.
+    """
+
+    read_failed: bool = False
+    runner_busy: bool = False
+    anchor_present: bool = False
+
+
+@dataclass
+class BusyState:
+    """Runner busy-ness derived from one pod listing plus one EphemeralRunner listing."""
+
+    er_jobid: dict[str, str]
+    live_runner_names: set[str]
+    busy_by_workflow: set[str]
+    er_read_failed: bool
+
+    def is_runner_busy(self, pod_name: str) -> bool:
+        """True if the runner has an assigned jobId or a live job pod points at it."""
+        return self.er_jobid.get(pod_name, "") != "" or pod_name in self.busy_by_workflow
+
+    def liveness_for(self, pod: Pod) -> RunnerLiveness:
+        """Resolve classify_pod inputs for a pod from this batch snapshot."""
+        if is_ephemeralrunner_pod(pod):
+            return RunnerLiveness(read_failed=self.er_read_failed, runner_busy=self.is_runner_busy(pod.metadata.name))
+        label = get_runner_pod_label(pod)
+        if label is not None:
+            return RunnerLiveness(anchor_present=label in self.live_runner_names)
+        return RunnerLiveness()
+
+
+def is_ephemeralrunner_pod(pod: Pod) -> bool:
+    """Check if pod is a GitHub Actions runner pod (owned by an EphemeralRunner)."""
+    refs = pod.metadata.ownerReferences
+    if not refs:
+        return False
+    return any(ref.kind == EPHEMERAL_RUNNER_KIND for ref in refs)
+
+
+def get_runner_pod_label(pod: Pod) -> str | None:
+    """Return the runner-pod label value (owning runner name), or None if absent."""
+    labels = pod.metadata.labels
+    if not labels:
+        return None
+    return labels.get(RUNNER_POD_LABEL)
+
+
+def pod_phase(pod: Pod) -> str | None:
+    """Phase string from a pod's status, or None if unset."""
+    return pod.status.phase if pod.status else None
+
+
+def age_over_threshold(phase: str | None, age_hours: float, pending_max: int, running_max: int) -> int | None:
+    """Return the exceeded age threshold (hours) for a pod, or None if within limits."""
+    if phase == "Pending" and age_hours > pending_max:
+        return pending_max
+    if phase in ("Running", "Unknown") and age_hours > running_max:
+        return running_max
+    return None
+
+
+def classify_pod(
+    pod: Pod,
+    phase: str | None,
+    age_hours: float,
+    pending_max: int,
+    running_max: int,
+    busy_max: int,
+    liveness: RunnerLiveness,
+) -> Decision:
+    """Single protection classifier shared by the find and pre-delete-recheck paths.
+
+    Runner pods (EphemeralRunner-owned) and bare workflow/step pods (runner-pod
+    label) are protected while live, but both face an absolute busy hard cap: past
+    busy_max they are presumed hung and deleted even when still live. A failed
+    liveness read protects the pod (fail-safe). Everything else falls through to
+    the plain age thresholds.
+    """
+    if is_ephemeralrunner_pod(pod):
+        if liveness.read_failed:
+            return Decision.FAIL_SAFE_PROTECT
+        # A terminal (Succeeded/Failed) runner is finished and never busy; a stale
+        # workflow-pod pin must not resurrect it into the hard-cap path (ARC GC owns it).
+        if liveness.runner_busy and phase not in TERMINAL_PHASES:
+            return Decision.HARD_CAP_DELETE if age_hours > busy_max else Decision.BUSY_PROTECT
+        return _age_decision(phase, age_hours, pending_max, running_max)
+    if get_runner_pod_label(pod) is not None:
+        if liveness.read_failed:
+            return Decision.FAIL_SAFE_PROTECT
+        if liveness.anchor_present:
+            return Decision.HARD_CAP_DELETE if age_hours > busy_max else Decision.JOBPOD_PROTECT
+        return _age_decision(phase, age_hours, pending_max, running_max)
+    return _age_decision(phase, age_hours, pending_max, running_max)
+
+
+def _age_decision(phase: str | None, age_hours: float, pending_max: int, running_max: int) -> Decision:
+    if age_over_threshold(phase, age_hours, pending_max, running_max) is not None:
+        return Decision.NORMAL_AGE_DELETE
+    return Decision.NOT_OVER_AGE_KEEP
+
+
+def read_ephemeralrunner_jobids(client: Client, namespace: str) -> tuple[dict[str, str], bool]:
+    """List EphemeralRunners once and map runner name -> status.jobId ("" if none).
+
+    On ANY error returns ({}, True) so callers can treat every runner pod as
+    protected. status may be None on a freshly created EphemeralRunner.
+    """
+    er_jobid: dict[str, str] = {}
+    try:
+        for er in client.list(EphemeralRunner, namespace=namespace):
+            status = er.status or {}
+            er_jobid[er.metadata.name] = status.get("jobId") or ""
+    except Exception:
+        log.exception("Failed to list EphemeralRunners in %s; treating runner pods as protected", namespace)
+        return {}, True
+    return er_jobid, False
+
+
+def build_busy_sets(pods: list[Pod]) -> tuple[set[str], set[str]]:
+    """From an already-fetched pod list return (live_runner_names, busy_by_workflow).
+
+    Terminal (Succeeded/Failed) pods are ignored entirely: they neither pin a
+    runner nor count as a live runner. live_runner_names therefore holds ONLY
+    NON-TERMINAL EphemeralRunner-owned runner pod names, so a bare pod that
+    self-applies the runner-pod label cannot anchor its own protection, and a
+    lingering terminal runner pod cannot pin its orphaned workflow/step pods.
+    """
+    live_runner_names: set[str] = set()
+    busy_by_workflow: set[str] = set()
+    for pod in pods:
+        if pod_phase(pod) in TERMINAL_PHASES:
+            continue
+        if is_ephemeralrunner_pod(pod):
+            live_runner_names.add(pod.metadata.name)
+        label = get_runner_pod_label(pod)
+        if label:
+            busy_by_workflow.add(label)
+    return live_runner_names, busy_by_workflow
+
+
+def gather_busy_state(client: Client, namespace: str, pods: list[Pod]) -> BusyState:
+    """Build a BusyState from one pod listing plus a fresh EphemeralRunner listing."""
+    er_jobid, er_read_failed = read_ephemeralrunner_jobids(client, namespace)
+    live_runner_names, busy_by_workflow = build_busy_sets(pods)
+    return BusyState(er_jobid, live_runner_names, busy_by_workflow, er_read_failed)
+
+
+def get_ephemeralrunner(client: Client, name: str, namespace: str) -> tuple[bool, str, bool]:
+    """Targeted EphemeralRunner GET for the pre-delete recheck.
+
+    Returns (found, job_id, read_failed):
+      - (True, job_id, False)  -> ER exists (job_id "" when idle)
+      - (False, "", False)     -> 404: ER gone, i.e. the runner finished
+      - (False, "", True)      -> any other error; caller must fail safe
+    """
+    try:
+        er = client.get(EphemeralRunner, name=name, namespace=namespace)
+    except ApiError as e:
+        if e.status.code == 404:
+            return False, "", False
+        log.exception("Recheck: EphemeralRunner GET %s failed (HTTP %s)", name, e.status.code)
+        return False, "", True
+    except Exception:
+        log.exception("Recheck: EphemeralRunner GET %s failed", name)
+        return False, "", True
+    status = er.status or {}
+    return True, status.get("jobId") or "", False
+
+
+def recheck_liveness(client: Client, pod: Pod, namespace: str) -> RunnerLiveness:
+    """Fetch fresh per-pod liveness for one delete candidate via a targeted GET.
+
+    A runner pod GETs its own EphemeralRunner (busy = status.jobId set); a job pod
+    GETs its anchor runner (present = GET succeeds). Any non-404 error yields
+    read_failed so classify_pod protects the pod. Bare pods need no GET.
+    """
+    if is_ephemeralrunner_pod(pod):
+        found, job_id, read_failed = get_ephemeralrunner(client, pod.metadata.name, namespace)
+        if read_failed:
+            return RunnerLiveness(read_failed=True)
+        return RunnerLiveness(runner_busy=found and job_id != "")
+    label = get_runner_pod_label(pod)
+    if label is not None:
+        found, _job_id, read_failed = get_ephemeralrunner(client, label, namespace)
+        if read_failed:
+            return RunnerLiveness(read_failed=True)
+        return RunnerLiveness(anchor_present=found)
+    return RunnerLiveness()

--- a/osdc/modules/zombie-cleanup/scripts/python/test_runner_busy.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_runner_busy.py
@@ -1,0 +1,373 @@
+"""Tests for the runner_busy helper module."""
+
+from unittest.mock import MagicMock
+
+from lightkube.core.exceptions import ApiError
+from runner_busy import (
+    BusyState,
+    Decision,
+    RunnerLiveness,
+    age_over_threshold,
+    build_busy_sets,
+    classify_pod,
+    gather_busy_state,
+    get_ephemeralrunner,
+    get_runner_pod_label,
+    is_ephemeralrunner_pod,
+    pod_phase,
+    read_ephemeralrunner_jobids,
+    recheck_liveness,
+)
+
+# Mirror the production defaults so classifier tests read naturally.
+PENDING_MAX = 24
+RUNNING_MAX = 24
+BUSY_MAX = 48
+
+
+def _api_error(code: int) -> ApiError:
+    err = ApiError.__new__(ApiError)
+    err.status = MagicMock(code=code)
+    return err
+
+
+def _classify(pod, liveness, phase="Running", age_hours=0.0):
+    return classify_pod(pod, phase, age_hours, PENDING_MAX, RUNNING_MAX, BUSY_MAX, liveness)
+
+
+class TestBusyState:
+    def test_busy_by_jobid(self):
+        state = BusyState({"r1": "job-1"}, set(), set(), False)
+        assert state.is_runner_busy("r1")
+
+    def test_busy_by_workflow(self):
+        state = BusyState({"r1": ""}, set(), {"r1"}, False)
+        assert state.is_runner_busy("r1")
+
+    def test_not_busy_when_idle_and_unpinned(self):
+        state = BusyState({"r1": ""}, {"r1"}, set(), False)
+        assert not state.is_runner_busy("r1")
+
+    def test_unknown_runner_not_busy(self):
+        state = BusyState({}, set(), set(), False)
+        assert not state.is_runner_busy("ghost")
+
+
+class TestLivenessFor:
+    def test_runner_pod_reflects_read_failure_and_busy(self, make_pod):
+        state = BusyState({"r1": "job-1"}, {"r1"}, set(), False)
+        live = state.liveness_for(make_pod("r1", owner_kind="EphemeralRunner"))
+        assert live == RunnerLiveness(read_failed=False, runner_busy=True, anchor_present=False)
+
+    def test_runner_pod_read_failure_propagates(self, make_pod):
+        state = BusyState({}, set(), set(), True)
+        live = state.liveness_for(make_pod("r1", owner_kind="EphemeralRunner"))
+        assert live.read_failed is True
+
+    def test_job_pod_anchor_present(self, make_pod):
+        state = BusyState({}, {"runner-a"}, set(), False)
+        live = state.liveness_for(make_pod("step", labels={"runner-pod": "runner-a"}))
+        assert live == RunnerLiveness(anchor_present=True)
+
+    def test_job_pod_anchor_absent(self, make_pod):
+        state = BusyState({}, set(), set(), False)
+        live = state.liveness_for(make_pod("step", labels={"runner-pod": "gone"}))
+        assert live.anchor_present is False
+
+    def test_bare_pod_all_false(self, make_pod):
+        state = BusyState({}, {"anything"}, {"anything"}, True)
+        live = state.liveness_for(make_pod("bare"))
+        assert live == RunnerLiveness()
+
+
+class TestDecision:
+    def test_delete_decisions(self):
+        assert Decision.HARD_CAP_DELETE.is_delete
+        assert Decision.NORMAL_AGE_DELETE.is_delete
+
+    def test_keep_decisions(self):
+        for d in (
+            Decision.FAIL_SAFE_PROTECT,
+            Decision.BUSY_PROTECT,
+            Decision.JOBPOD_PROTECT,
+            Decision.NOT_OVER_AGE_KEEP,
+        ):
+            assert not d.is_delete
+
+
+class TestClassifyPodRunner:
+    def test_read_failure_protects(self, make_pod):
+        pod = make_pod("r", owner_kind="EphemeralRunner")
+        assert _classify(pod, RunnerLiveness(read_failed=True), age_hours=100) is Decision.FAIL_SAFE_PROTECT
+
+    def test_busy_under_hardcap_protected(self, make_pod):
+        pod = make_pod("r", owner_kind="EphemeralRunner")
+        assert _classify(pod, RunnerLiveness(runner_busy=True), age_hours=30) is Decision.BUSY_PROTECT
+
+    def test_busy_over_hardcap_deleted(self, make_pod):
+        pod = make_pod("r", owner_kind="EphemeralRunner")
+        assert _classify(pod, RunnerLiveness(runner_busy=True), age_hours=50) is Decision.HARD_CAP_DELETE
+
+    def test_idle_over_age_deleted(self, make_pod):
+        pod = make_pod("r", owner_kind="EphemeralRunner")
+        assert _classify(pod, RunnerLiveness(), age_hours=30) is Decision.NORMAL_AGE_DELETE
+
+    def test_idle_under_age_kept(self, make_pod):
+        pod = make_pod("r", owner_kind="EphemeralRunner")
+        assert _classify(pod, RunnerLiveness(), age_hours=5) is Decision.NOT_OVER_AGE_KEEP
+
+
+class TestClassifyPodJobPod:
+    def test_read_failure_protects(self, make_pod):
+        pod = make_pod("step", labels={"runner-pod": "r"})
+        assert _classify(pod, RunnerLiveness(read_failed=True), age_hours=100) is Decision.FAIL_SAFE_PROTECT
+
+    def test_anchor_present_under_hardcap_protected(self, make_pod):
+        pod = make_pod("step", labels={"runner-pod": "r"})
+        assert _classify(pod, RunnerLiveness(anchor_present=True), age_hours=30) is Decision.JOBPOD_PROTECT
+
+    def test_anchor_present_over_hardcap_deleted(self, make_pod):
+        pod = make_pod("step", labels={"runner-pod": "r"})
+        assert _classify(pod, RunnerLiveness(anchor_present=True), age_hours=50) is Decision.HARD_CAP_DELETE
+
+    def test_anchor_absent_over_age_deleted(self, make_pod):
+        pod = make_pod("step", labels={"runner-pod": "gone"})
+        assert _classify(pod, RunnerLiveness(), age_hours=30) is Decision.NORMAL_AGE_DELETE
+
+    def test_anchor_absent_under_age_kept(self, make_pod):
+        pod = make_pod("step", labels={"runner-pod": "gone"})
+        assert _classify(pod, RunnerLiveness(), age_hours=5) is Decision.NOT_OVER_AGE_KEEP
+
+
+class TestClassifyPodBare:
+    def test_pending_over_age_deleted(self, make_pod):
+        pod = make_pod("p")
+        assert _classify(pod, RunnerLiveness(), phase="Pending", age_hours=30) is Decision.NORMAL_AGE_DELETE
+
+    def test_running_over_age_deleted(self, make_pod):
+        pod = make_pod("p")
+        assert _classify(pod, RunnerLiveness(), phase="Running", age_hours=30) is Decision.NORMAL_AGE_DELETE
+
+    def test_under_age_kept(self, make_pod):
+        pod = make_pod("p")
+        assert _classify(pod, RunnerLiveness(), phase="Running", age_hours=5) is Decision.NOT_OVER_AGE_KEEP
+
+
+class TestAgeOverThreshold:
+    def test_pending_over(self):
+        assert age_over_threshold("Pending", 30, PENDING_MAX, RUNNING_MAX) == PENDING_MAX
+
+    def test_running_over(self):
+        assert age_over_threshold("Running", 30, PENDING_MAX, RUNNING_MAX) == RUNNING_MAX
+
+    def test_unknown_over(self):
+        assert age_over_threshold("Unknown", 30, PENDING_MAX, RUNNING_MAX) == RUNNING_MAX
+
+    def test_within_limits(self):
+        assert age_over_threshold("Running", 5, PENDING_MAX, RUNNING_MAX) is None
+
+    def test_none_phase(self):
+        assert age_over_threshold(None, 1000, PENDING_MAX, RUNNING_MAX) is None
+
+
+class TestIsEphemeralRunnerPod:
+    def test_no_owner_references(self, make_pod):
+        assert not is_ephemeralrunner_pod(make_pod("bare"))
+
+    def test_empty_owner_references(self, make_pod):
+        pod = make_pod("empty")
+        pod.metadata.ownerReferences = []
+        assert not is_ephemeralrunner_pod(pod)
+
+    def test_ephemeralrunner_owner(self, make_pod):
+        assert is_ephemeralrunner_pod(make_pod("runner", owner_kind="EphemeralRunner"))
+
+    def test_other_owner(self, make_pod):
+        assert not is_ephemeralrunner_pod(make_pod("rs-pod", owner_kind="ReplicaSet"))
+
+
+class TestGetRunnerPodLabel:
+    def test_no_labels(self, make_pod):
+        assert get_runner_pod_label(make_pod("p")) is None
+
+    def test_empty_labels(self, make_pod):
+        assert get_runner_pod_label(make_pod("p", labels={})) is None
+
+    def test_label_absent(self, make_pod):
+        assert get_runner_pod_label(make_pod("p", labels={"other": "x"})) is None
+
+    def test_label_present(self, make_pod):
+        assert get_runner_pod_label(make_pod("p", labels={"runner-pod": "r1"})) == "r1"
+
+
+class TestPodPhase:
+    def test_phase_set(self, make_pod):
+        assert pod_phase(make_pod("p", phase="Running")) == "Running"
+
+    def test_no_status(self, make_pod):
+        pod = make_pod("p")
+        pod.status = None
+        assert pod_phase(pod) is None
+
+
+class TestReadEphemeralRunnerJobids:
+    def test_maps_jobids(self, make_er):
+        client = MagicMock()
+        client.list.return_value = [
+            make_er("r1", job_id="job-1"),
+            make_er("r2", job_id=""),
+            make_er("r3", with_status=False),
+        ]
+        jobids, failed = read_ephemeralrunner_jobids(client, "arc-runners")
+        assert failed is False
+        assert jobids == {"r1": "job-1", "r2": "", "r3": ""}
+
+    def test_failure_returns_all_protected(self):
+        client = MagicMock()
+        client.list.side_effect = Exception("api down")
+        jobids, failed = read_ephemeralrunner_jobids(client, "arc-runners")
+        assert failed is True
+        assert jobids == {}
+
+
+class TestBuildBusySets:
+    def test_only_ephemeralrunner_pods_are_live_names(self, make_pod):
+        pods = [
+            make_pod("runner-a", age_hours=1, owner_kind="EphemeralRunner"),
+            make_pod("step-1", labels={"runner-pod": "runner-a"}),
+            make_pod("done-step", phase="Succeeded", labels={"runner-pod": "runner-b"}),
+            make_pod("failed-step", phase="Failed", labels={"runner-pod": "runner-c"}),
+        ]
+        live, busy = build_busy_sets(pods)
+        # Only the ER-owned runner is a live runner name; bare job pods are not.
+        assert live == {"runner-a"}
+        # Only the non-terminal step pins its runner; terminal step pods don't.
+        assert busy == {"runner-a"}
+
+    def test_self_labeled_bare_pod_is_not_a_live_name(self, make_pod):
+        # A bare pod self-applying runner-pod=<own name> must not anchor itself.
+        pods = [make_pod("evil", labels={"runner-pod": "evil"})]
+        live, busy = build_busy_sets(pods)
+        assert live == set()
+        assert busy == {"evil"}
+
+    def test_terminal_ephemeralrunner_pod_excluded_from_live_names(self, make_pod):
+        # A terminal (Succeeded) runner pod must not count as a live runner name,
+        # or a lingering terminal runner would pin its orphaned workflow pods.
+        pods = [
+            make_pod("dead-runner", phase="Succeeded", owner_kind="EphemeralRunner"),
+            make_pod("live-runner", phase="Running", owner_kind="EphemeralRunner"),
+        ]
+        live, _busy = build_busy_sets(pods)
+        assert live == {"live-runner"}
+
+    def test_empty(self):
+        live, busy = build_busy_sets([])
+        assert live == set()
+        assert busy == set()
+
+
+class TestGatherBusyState:
+    def test_combines_pod_and_er_listings(self, make_pod, make_er):
+        client = MagicMock()
+        client.list.return_value = [make_er("runner-a", job_id="job-9")]
+        pods = [
+            make_pod("runner-a", age_hours=1, owner_kind="EphemeralRunner"),
+            make_pod("step-1", labels={"runner-pod": "runner-a"}),
+        ]
+        state = gather_busy_state(client, "arc-runners", pods)
+        assert state.er_read_failed is False
+        assert state.er_jobid == {"runner-a": "job-9"}
+        assert state.live_runner_names == {"runner-a"}
+        assert state.busy_by_workflow == {"runner-a"}
+        assert state.is_runner_busy("runner-a")
+
+    def test_er_read_failure_propagates(self, make_pod):
+        client = MagicMock()
+        client.list.side_effect = Exception("api down")
+        state = gather_busy_state(client, "arc-runners", [make_pod("runner-a", owner_kind="EphemeralRunner")])
+        assert state.er_read_failed is True
+        assert state.er_jobid == {}
+        assert state.live_runner_names == {"runner-a"}
+
+
+class TestGetEphemeralRunner:
+    def test_found_returns_jobid(self, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("r1", job_id="job-7")
+        assert get_ephemeralrunner(client, "r1", "arc-runners") == (True, "job-7", False)
+
+    def test_found_idle_returns_empty_jobid(self, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("r1", job_id="")
+        assert get_ephemeralrunner(client, "r1", "arc-runners") == (True, "", False)
+
+    def test_found_without_status(self, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("r1", with_status=False)
+        assert get_ephemeralrunner(client, "r1", "arc-runners") == (True, "", False)
+
+    def test_not_found_is_not_read_failure(self):
+        client = MagicMock()
+        client.get.side_effect = _api_error(404)
+        assert get_ephemeralrunner(client, "gone", "arc-runners") == (False, "", False)
+
+    def test_other_api_error_is_read_failure(self):
+        client = MagicMock()
+        client.get.side_effect = _api_error(403)
+        assert get_ephemeralrunner(client, "r1", "arc-runners") == (False, "", True)
+
+    def test_generic_error_is_read_failure(self):
+        client = MagicMock()
+        client.get.side_effect = Exception("boom")
+        assert get_ephemeralrunner(client, "r1", "arc-runners") == (False, "", True)
+
+
+class TestRecheckLiveness:
+    def test_runner_busy(self, make_pod, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("r1", job_id="job-1")
+        live = recheck_liveness(client, make_pod("r1", owner_kind="EphemeralRunner"), "arc-runners")
+        assert live == RunnerLiveness(runner_busy=True)
+
+    def test_runner_idle(self, make_pod, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("r1", job_id="")
+        live = recheck_liveness(client, make_pod("r1", owner_kind="EphemeralRunner"), "arc-runners")
+        assert live == RunnerLiveness(runner_busy=False)
+
+    def test_runner_er_gone_not_busy(self, make_pod):
+        client = MagicMock()
+        client.get.side_effect = _api_error(404)
+        live = recheck_liveness(client, make_pod("r1", owner_kind="EphemeralRunner"), "arc-runners")
+        assert live == RunnerLiveness(runner_busy=False, read_failed=False)
+
+    def test_runner_read_failure(self, make_pod):
+        client = MagicMock()
+        client.get.side_effect = _api_error(500)
+        live = recheck_liveness(client, make_pod("r1", owner_kind="EphemeralRunner"), "arc-runners")
+        assert live == RunnerLiveness(read_failed=True)
+
+    def test_job_pod_anchor_present(self, make_pod, make_er):
+        client = MagicMock()
+        client.get.return_value = make_er("runner-a", job_id="")
+        live = recheck_liveness(client, make_pod("step", labels={"runner-pod": "runner-a"}), "arc-runners")
+        assert live == RunnerLiveness(anchor_present=True)
+
+    def test_job_pod_anchor_gone(self, make_pod):
+        client = MagicMock()
+        client.get.side_effect = _api_error(404)
+        live = recheck_liveness(client, make_pod("step", labels={"runner-pod": "gone"}), "arc-runners")
+        assert live == RunnerLiveness(anchor_present=False)
+
+    def test_job_pod_read_failure(self, make_pod):
+        client = MagicMock()
+        client.get.side_effect = _api_error(500)
+        live = recheck_liveness(client, make_pod("step", labels={"runner-pod": "runner-a"}), "arc-runners")
+        assert live == RunnerLiveness(read_failed=True)
+
+    def test_bare_pod_no_get(self, make_pod):
+        client = MagicMock()
+        live = recheck_liveness(client, make_pod("bare"), "arc-runners")
+        assert live == RunnerLiveness()
+        client.get.assert_not_called()

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
@@ -33,6 +33,7 @@ def _reset_metrics():
         m.oldest_zombie_age_hours,
         m.runner_pods_busy_skipped,
         m.job_pods_protected,
+        m.failsafe_protected,
         m.ephemeralrunner_read_errors,
         m.recheck_skipped,
     ):
@@ -337,6 +338,36 @@ class TestFindZombiePods:
         zombies = find_zombie_pods(client, _config())
         assert [z.metadata.name for z in zombies] == ["bare-zombie"]
         assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_failsafe_protected") == 1
+
+    def test_failsafe_protected_counts_every_runner_pod(self, make_pod, set_list):
+        """On ER-read failure, failsafe_protected equals the number of over-age runner pods protected."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[
+                make_pod("arc-runner-a", age_hours=100, owner_kind="EphemeralRunner"),
+                make_pod("arc-runner-b", age_hours=100, owner_kind="EphemeralRunner"),
+                make_pod("bare-zombie", age_hours=100),
+            ],
+            er_error=Exception("api down"),
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["bare-zombie"]
+        assert m.registry.get_sample_value("zombie_cleanup_failsafe_protected") == 2
+        assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 1
+
+    def test_failsafe_protected_zero_without_read_failure(self, make_pod, make_er, set_list):
+        """A healthy run with no ER-read failure leaves failsafe_protected at 0."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[make_pod("idle-old-runner", age_hours=30, owner_kind="EphemeralRunner")],
+            ers=[make_er("idle-old-runner", job_id="")],
+        )
+        find_zombie_pods(client, _config())
+        assert m.registry.get_sample_value("zombie_cleanup_failsafe_protected") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 0
 
     def test_job_pod_protected_when_runner_live(self, make_pod, make_er, set_list):
         """A bare workflow/step pod under the hard cap is protected while its owning runner pod exists."""
@@ -434,6 +465,7 @@ class TestFindZombiePods:
         assert [z.metadata.name for z in zombies] == ["idle-old-runner"]
         assert m.registry.get_sample_value("zombie_cleanup_runner_pods_busy_skipped") == 1
         assert m.registry.get_sample_value("zombie_cleanup_job_pods_protected") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_failsafe_protected") == 0
         assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 0
         assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 0
 

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_cleanup.py
@@ -1,10 +1,11 @@
-"""Tests for zombie_cleanup module."""
+"""Tests for the zombie_cleanup module."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 import zombie_metrics as m
+from lightkube.core.exceptions import ApiError
 from zombie_cleanup import (
     MANAGED_OWNER_KINDS,
     delete_zombies,
@@ -13,68 +14,60 @@ from zombie_cleanup import (
     get_pod_age_hours,
     is_managed_pod,
     is_terminating,
+    main,
+    validate_config,
 )
 
 
 @pytest.fixture(autouse=True)
 def _reset_metrics():
-    """Reset all gauge metrics before each test to avoid state leakage."""
-    m.pods_total.set(0)
-    m.zombies_found.set(0)
-    m.pods_deleted.set(0)
-    m.pods_failed.set(0)
-    m.pods_skipped.set(0)
-    m.duration_seconds.set(0)
-    m.pods_managed_skipped.set(0)
-    m.oldest_zombie_age_hours.set(0)
+    """Reset metrics before each test to avoid state leakage across tests."""
+    for gauge in (
+        m.pods_total,
+        m.zombies_found,
+        m.pods_deleted,
+        m.pods_failed,
+        m.pods_skipped,
+        m.duration_seconds,
+        m.pods_managed_skipped,
+        m.oldest_zombie_age_hours,
+        m.runner_pods_busy_skipped,
+        m.job_pods_protected,
+        m.ephemeralrunner_read_errors,
+        m.recheck_skipped,
+    ):
+        gauge.set(0)
+    # Counters have no .set(); reset the underlying value directly.
+    m.busy_hardcap_deletions_total._value.set(0)
 
 
-def _make_pod(
-    name: str,
-    phase: str = "Running",
-    age_hours: float = 0,
-    owner_kind: str | None = None,
-    terminating: bool = False,
-):
-    """Create a mock Pod with the given properties."""
-    now = datetime.now(UTC)
-    created = now - timedelta(hours=age_hours)
-
-    pod = MagicMock()
-    pod.metadata.name = name
-    pod.metadata.creationTimestamp = created
-    pod.metadata.deletionTimestamp = datetime.now(UTC) if terminating else None
-
-    if owner_kind:
-        ref = MagicMock()
-        ref.kind = owner_kind
-        pod.metadata.ownerReferences = [ref]
-    else:
-        pod.metadata.ownerReferences = None
-
-    pod.status.phase = phase
-    return pod
+def _config(pending_max=24, running_max=24, busy_max=48, dry_run=False, namespace="arc-runners"):
+    """Config dict with every key find_zombie_pods and delete_zombies read."""
+    return {
+        "namespace": namespace,
+        "pending_max_hours": pending_max,
+        "running_max_hours": running_max,
+        "busy_max_hours": busy_max,
+        "dry_run": dry_run,
+    }
 
 
 # --- is_managed_pod ---
 
 
 class TestIsManagedPod:
-    def test_no_owner_references(self):
-        pod = _make_pod("bare-pod")
-        assert not is_managed_pod(pod)
+    def test_no_owner_references(self, make_pod):
+        assert not is_managed_pod(make_pod("bare-pod"))
 
     @pytest.mark.parametrize("kind", sorted(MANAGED_OWNER_KINDS))
-    def test_managed_owner_kinds(self, kind):
-        pod = _make_pod("managed-pod", owner_kind=kind)
-        assert is_managed_pod(pod)
+    def test_managed_owner_kinds(self, make_pod, kind):
+        assert is_managed_pod(make_pod("managed-pod", owner_kind=kind))
 
-    def test_unmanaged_owner_kind(self):
-        pod = _make_pod("arc-pod", owner_kind="EphemeralRunner")
-        assert not is_managed_pod(pod)
+    def test_unmanaged_owner_kind(self, make_pod):
+        assert not is_managed_pod(make_pod("arc-pod", owner_kind="EphemeralRunner"))
 
-    def test_empty_owner_references(self):
-        pod = _make_pod("empty-refs")
+    def test_empty_owner_references(self, make_pod):
+        pod = make_pod("empty-refs")
         pod.metadata.ownerReferences = []
         assert not is_managed_pod(pod)
 
@@ -83,17 +76,14 @@ class TestIsManagedPod:
 
 
 class TestIsTerminating:
-    def test_not_terminating(self):
-        pod = _make_pod("normal-pod")
-        assert not is_terminating(pod)
+    def test_not_terminating(self, make_pod):
+        assert not is_terminating(make_pod("normal-pod"))
 
-    def test_terminating(self):
-        pod = _make_pod("dying-pod", terminating=True)
-        assert is_terminating(pod)
+    def test_terminating(self, make_pod):
+        assert is_terminating(make_pod("dying-pod", terminating=True))
 
-    def test_no_deletion_timestamp_attr(self):
-        """Pods without deletionTimestamp attr should not be terminating."""
-        pod = _make_pod("no-attr-pod")
+    def test_no_deletion_timestamp_attr(self, make_pod):
+        pod = make_pod("no-attr-pod")
         del pod.metadata.deletionTimestamp
         assert not is_terminating(pod)
 
@@ -102,282 +92,492 @@ class TestIsTerminating:
 
 
 class TestGetPodAgeHours:
-    def test_recent_pod(self):
-        now = datetime.now(UTC)
-        pod = _make_pod("new-pod", age_hours=0.5)
-        age = get_pod_age_hours(pod, now)
+    def test_recent_pod(self, make_pod):
+        age = get_pod_age_hours(make_pod("new-pod", age_hours=0.5), datetime.now(UTC))
         assert 0.4 < age < 0.6
 
-    def test_old_pod(self):
-        now = datetime.now(UTC)
-        pod = _make_pod("old-pod", age_hours=25)
-        age = get_pod_age_hours(pod, now)
+    def test_old_pod(self, make_pod):
+        age = get_pod_age_hours(make_pod("old-pod", age_hours=25), datetime.now(UTC))
         assert 24.9 < age < 25.1
 
-    def test_no_timestamp(self):
-        pod = _make_pod("no-ts")
+    def test_no_timestamp(self, make_pod):
+        pod = make_pod("no-ts")
         pod.metadata.creationTimestamp = None
         assert get_pod_age_hours(pod, datetime.now(UTC)) == -1.0
 
-    def test_naive_timestamp_treated_as_utc(self):
+    def test_naive_timestamp_treated_as_utc(self, make_pod):
         now = datetime.now(UTC)
-        pod = _make_pod("naive-ts", age_hours=5)
-        # Strip timezone to simulate naive datetime from lightkube
+        pod = make_pod("naive-ts", age_hours=5)
         pod.metadata.creationTimestamp = pod.metadata.creationTimestamp.replace(tzinfo=None)
         age = get_pod_age_hours(pod, now)
         assert 4.9 < age < 5.1
+
+
+# --- validate_config ---
+
+
+class TestValidateConfig:
+    def test_defaults_are_valid(self):
+        assert validate_config(_config()) is None
+
+    def test_busy_below_running_is_invalid(self):
+        err = validate_config(_config(running_max=24, busy_max=10))
+        assert err is not None
+        assert "busy_max_age_hours" in err
+
+    def test_busy_equal_running_is_valid(self):
+        assert validate_config(_config(running_max=24, busy_max=24)) is None
+
+    def test_running_max_zero_is_invalid(self):
+        err = validate_config(_config(running_max=0))
+        assert err is not None
+        assert "running_max_age_hours" in err
+
+    def test_pending_max_zero_is_invalid(self):
+        err = validate_config(_config(pending_max=0))
+        assert err is not None
+        assert "pending_max_age_hours" in err
 
 
 # --- find_zombie_pods ---
 
 
 class TestFindZombiePods:
-    def _make_config(self, pending_max=24, running_max=12):
-        return {
-            "namespace": "arc-runners",
-            "pending_max_hours": pending_max,
-            "running_max_hours": running_max,
-            "dry_run": False,
-        }
-
-    def test_no_pods(self):
+    def test_no_pods(self, set_list):
         client = MagicMock()
-        client.list.return_value = []
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(client)
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_skips_managed_pods(self):
+    def test_skips_managed_pods(self, make_pod, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
-            _make_pod("hooks-warmer", phase="Running", age_hours=100, owner_kind="DaemonSet"),
-            _make_pod("cron-pod", phase="Running", age_hours=100, owner_kind="Job"),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[
+                make_pod("listener", age_hours=100, owner_kind="ReplicaSet"),
+                make_pod("hooks-warmer", age_hours=100, owner_kind="DaemonSet"),
+                make_pod("cron-pod", age_hours=100, owner_kind="Job"),
+            ],
+        )
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_detects_pending_zombie(self):
+    def test_detects_pending_zombie(self, make_pod, set_list):
         client = MagicMock()
-        old_pending = _make_pod("stuck-pending", phase="Pending", age_hours=25)
-        client.list.return_value = [old_pending]
-        zombies = find_zombie_pods(client, self._make_config())
-        assert len(zombies) == 1
-        assert zombies[0].metadata.name == "stuck-pending"
+        set_list(client, pods=[make_pod("stuck-pending", phase="Pending", age_hours=25)])
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["stuck-pending"]
 
-    def test_detects_running_zombie(self):
+    def test_detects_running_zombie(self, make_pod, set_list):
         client = MagicMock()
-        old_running = _make_pod("stuck-running", phase="Running", age_hours=13)
-        client.list.return_value = [old_running]
-        zombies = find_zombie_pods(client, self._make_config())
-        assert len(zombies) == 1
-        assert zombies[0].metadata.name == "stuck-running"
+        set_list(client, pods=[make_pod("stuck-running", phase="Running", age_hours=30)])
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["stuck-running"]
 
-    def test_ignores_young_pods(self):
+    def test_ignores_young_pods(self, make_pod, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("new-pending", phase="Pending", age_hours=1),
-            _make_pod("new-running", phase="Running", age_hours=2),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[
+                make_pod("new-pending", phase="Pending", age_hours=1),
+                make_pod("new-running", phase="Running", age_hours=2),
+            ],
+        )
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_ignores_succeeded_failed(self):
+    def test_ignores_succeeded_failed(self, make_pod, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("done", phase="Succeeded", age_hours=100),
-            _make_pod("err", phase="Failed", age_hours=100),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[
+                make_pod("done", phase="Succeeded", age_hours=100),
+                make_pod("err", phase="Failed", age_hours=100),
+            ],
+        )
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_mixed_pods(self):
+    def test_mixed_pods(self, make_pod, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
-            _make_pod("young-runner", phase="Running", age_hours=1),
-            _make_pod("zombie-runner", phase="Running", age_hours=15),
-            _make_pod("zombie-pending", phase="Pending", age_hours=30),
-            _make_pod("done", phase="Succeeded", age_hours=100),
-        ]
-        zombies = find_zombie_pods(client, self._make_config())
-        names = {z.metadata.name for z in zombies}
-        assert names == {"zombie-runner", "zombie-pending"}
+        set_list(
+            client,
+            pods=[
+                make_pod("listener", age_hours=100, owner_kind="ReplicaSet"),
+                make_pod("young-runner", age_hours=1),
+                make_pod("zombie-runner", age_hours=30),
+                make_pod("zombie-pending", phase="Pending", age_hours=30),
+                make_pod("done", phase="Succeeded", age_hours=100),
+            ],
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert {z.metadata.name for z in zombies} == {"zombie-runner", "zombie-pending"}
 
-    def test_arc_owned_pods_not_skipped(self):
-        """Runner pods owned by EphemeralRunner CRD should be checked."""
+    def test_idle_over_age_runner_reaped(self, make_pod, make_er, set_list):
+        """An idle EphemeralRunner pod past the running threshold is still reaped."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod(
-                "arc-runner",
-                phase="Running",
-                age_hours=15,
-                owner_kind="EphemeralRunner",
-            ),
-        ]
-        zombies = find_zombie_pods(client, self._make_config())
-        assert len(zombies) == 1
+        set_list(
+            client,
+            pods=[make_pod("arc-runner", age_hours=30, owner_kind="EphemeralRunner")],
+            ers=[make_er("arc-runner", job_id="")],
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["arc-runner"]
 
-    def test_pending_under_boundary(self):
+    def test_idle_under_age_runner_kept(self, make_pod, make_er, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("under-boundary", phase="Pending", age_hours=23.5),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[make_pod("arc-runner", age_hours=5, owner_kind="EphemeralRunner")],
+            ers=[make_er("arc-runner", job_id="")],
+        )
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_running_under_boundary(self):
+    def test_busy_by_jobid_skipped(self, make_pod, make_er, set_list):
+        """A runner with an assigned status.jobId is protected from age-based reaping."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("under-boundary", phase="Running", age_hours=11.5),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[make_pod("busy-runner", age_hours=30, owner_kind="EphemeralRunner")],
+            ers=[make_er("busy-runner", job_id="job-42")],
+        )
+        assert find_zombie_pods(client, _config()) == []
+        assert m.registry.get_sample_value("zombie_cleanup_runner_pods_busy_skipped") == 1
 
-    def test_detects_unknown_phase_zombie(self):
-        """Pods in Unknown phase (e.g. node failure) use running threshold."""
+    def test_busy_by_workflow_label_skipped(self, make_pod, make_er, set_list):
+        """A live job pod pinning a runner via the runner-pod label makes it busy."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("unknown-pod", phase="Unknown", age_hours=15),
-        ]
-        zombies = find_zombie_pods(client, self._make_config())
-        assert len(zombies) == 1
-        assert zombies[0].metadata.name == "unknown-pod"
+        set_list(
+            client,
+            pods=[
+                make_pod("wf-runner", age_hours=30, owner_kind="EphemeralRunner"),
+                make_pod("job-pod", age_hours=1, labels={"runner-pod": "wf-runner"}),
+            ],
+            ers=[make_er("wf-runner", job_id="")],
+        )
+        assert find_zombie_pods(client, _config()) == []
+        assert m.registry.get_sample_value("zombie_cleanup_runner_pods_busy_skipped") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_job_pods_protected") == 1
 
-    def test_unknown_phase_under_threshold(self):
+    def test_busy_over_hardcap_selected_but_counter_not_incremented(self, make_pod, make_er, set_list):
+        """A busy runner older than the busy hard cap is selected, but find must NOT count it."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("unknown-young", phase="Unknown", age_hours=5),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(
+            client,
+            pods=[make_pod("hung-runner", age_hours=50, owner_kind="EphemeralRunner")],
+            ers=[make_er("hung-runner", job_id="job-1")],
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["hung-runner"]
+        # F5: the hard-cap counter is incremented only on an actual delete, never at selection.
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_runner_pods_busy_skipped") == 0
 
-    def test_skips_terminating_pods(self):
-        """Pods already being terminated should not be re-deleted."""
+    def test_self_labeled_bare_pod_not_protected(self, make_pod, set_list):
+        """A bare pod self-labeling runner-pod=<own name> cannot anchor its own protection (F1)."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("dying-pod", phase="Running", age_hours=15, terminating=True),
-        ]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(client, pods=[make_pod("evil", age_hours=100, labels={"runner-pod": "evil"})])
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["evil"]
 
-    def test_skips_pod_without_timestamp(self):
-        """Pods with no creationTimestamp should be skipped."""
+    def test_job_pod_over_hardcap_reaped_despite_runner(self, make_pod, make_er, set_list):
+        """A workflow/step pod past the busy hard cap is presumed hung even with its runner live (F1)."""
         client = MagicMock()
-        pod = _make_pod("no-ts-pod", phase="Running", age_hours=15)
+        set_list(
+            client,
+            pods=[
+                make_pod("runner-x", age_hours=1, owner_kind="EphemeralRunner"),
+                make_pod("step-pod", age_hours=50, labels={"runner-pod": "runner-x"}),
+            ],
+            ers=[make_er("runner-x", job_id="job-9")],
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["step-pod"]
+        # Selection must not touch the hard-cap counter.
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 0
+
+    def test_terminal_runner_does_not_protect_its_workflow_pod(self, make_pod, make_er, set_list):
+        """A lingering terminal (Succeeded) runner pod must not anchor its orphaned workflow pod (F1)."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[
+                make_pod("dead-runner", phase="Succeeded", age_hours=100, owner_kind="EphemeralRunner"),
+                make_pod("step-pod", age_hours=100, labels={"runner-pod": "dead-runner"}),
+            ],
+            ers=[make_er("dead-runner", job_id="")],
+        )
+        zombies = find_zombie_pods(client, _config())
+        # The workflow pod is reaped, not protected by the terminal runner; the
+        # terminal runner itself is left for ARC GC (never hard-capped).
+        assert [z.metadata.name for z in zombies] == ["step-pod"]
+        assert m.registry.get_sample_value("zombie_cleanup_job_pods_protected") == 0
+
+    def test_terminal_runner_pinned_by_workflow_not_selected(self, make_pod, make_er, set_list):
+        """A terminal (Succeeded) runner pinned by a live workflow pod is NOT hard-capped at find."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[
+                make_pod("dead-runner", phase="Succeeded", age_hours=100, owner_kind="EphemeralRunner"),
+                make_pod("live-step", age_hours=1, labels={"runner-pod": "dead-runner"}),
+            ],
+            ers=[make_er("dead-runner", job_id="")],
+        )
+        assert find_zombie_pods(client, _config()) == []
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 0
+
+    def test_er_read_failure_protects_runner_pods(self, make_pod, set_list):
+        """When the EphemeralRunner listing fails, runner pods are protected but bare pods still clean."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[
+                make_pod("arc-runner", age_hours=100, owner_kind="EphemeralRunner"),
+                make_pod("bare-zombie", age_hours=100),
+            ],
+            er_error=Exception("api down"),
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["bare-zombie"]
+        assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 1
+
+    def test_job_pod_protected_when_runner_live(self, make_pod, make_er, set_list):
+        """A bare workflow/step pod under the hard cap is protected while its owning runner pod exists."""
+        client = MagicMock()
+        set_list(
+            client,
+            pods=[
+                make_pod("runner-x", age_hours=1, owner_kind="EphemeralRunner"),
+                make_pod("step-pod", age_hours=10, labels={"runner-pod": "runner-x"}),
+            ],
+            ers=[make_er("runner-x", job_id="job-9")],
+        )
+        assert find_zombie_pods(client, _config()) == []
+        assert m.registry.get_sample_value("zombie_cleanup_job_pods_protected") == 1
+
+    def test_orphaned_job_pod_reaped(self, make_pod, set_list):
+        """A job pod whose owning runner no longer exists is reaped when over age."""
+        client = MagicMock()
+        set_list(client, pods=[make_pod("orphan-step", age_hours=100, labels={"runner-pod": "gone-runner"})])
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["orphan-step"]
+
+    def test_orphaned_job_pod_under_age_kept(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("orphan-young", age_hours=1, labels={"runner-pod": "gone"})])
+        assert find_zombie_pods(client, _config()) == []
+
+    def test_pending_under_boundary(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("under-boundary", phase="Pending", age_hours=23.5)])
+        assert find_zombie_pods(client, _config()) == []
+
+    def test_running_under_boundary(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("under-boundary", phase="Running", age_hours=23.5)])
+        assert find_zombie_pods(client, _config()) == []
+
+    def test_detects_unknown_phase_zombie(self, make_pod, set_list):
+        """Pods in Unknown phase (e.g. node failure) use the running threshold."""
+        client = MagicMock()
+        set_list(client, pods=[make_pod("unknown-pod", phase="Unknown", age_hours=30)])
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["unknown-pod"]
+
+    def test_unknown_phase_under_threshold(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("unknown-young", phase="Unknown", age_hours=5)])
+        assert find_zombie_pods(client, _config()) == []
+
+    def test_skips_terminating_pods(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("dying-pod", age_hours=30, terminating=True)])
+        assert find_zombie_pods(client, _config()) == []
+
+    def test_skips_pod_without_timestamp(self, make_pod, set_list):
+        client = MagicMock()
+        pod = make_pod("no-ts-pod", age_hours=30)
         pod.metadata.creationTimestamp = None
-        client.list.return_value = [pod]
-        assert find_zombie_pods(client, self._make_config()) == []
+        set_list(client, pods=[pod])
+        assert find_zombie_pods(client, _config()) == []
 
-    def test_sets_metrics_for_mixed_pods(self):
-        """Metrics reflect total, managed, zombie counts, and oldest age."""
+    def test_sets_metrics_for_mixed_pods(self, make_pod, set_list):
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("listener", phase="Running", age_hours=100, owner_kind="ReplicaSet"),
-            _make_pod("ds-pod", phase="Running", age_hours=50, owner_kind="DaemonSet"),
-            _make_pod("young-runner", phase="Running", age_hours=1),
-            _make_pod("zombie-old", phase="Running", age_hours=20),
-            _make_pod("zombie-new", phase="Running", age_hours=13),
-        ]
-        find_zombie_pods(client, self._make_config())
-
+        set_list(
+            client,
+            pods=[
+                make_pod("listener", age_hours=100, owner_kind="ReplicaSet"),
+                make_pod("ds-pod", age_hours=50, owner_kind="DaemonSet"),
+                make_pod("young-runner", age_hours=1),
+                make_pod("zombie-old", age_hours=30),
+                make_pod("zombie-new", age_hours=25),
+            ],
+        )
+        find_zombie_pods(client, _config())
         assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 5
         assert m.registry.get_sample_value("zombie_cleanup_pods_managed_skipped") == 2
         assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 2
         age = m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours")
         assert age is not None
-        assert age > 19
+        assert age > 29
 
-    def test_metrics_no_zombies(self):
-        """When no zombies found, zombie count and oldest age are zero."""
+    def test_sets_busy_state_metrics(self, make_pod, make_er, set_list):
+        """busy-skip, job-protect, hardcap and read-error gauges are all populated."""
         client = MagicMock()
-        client.list.return_value = [
-            _make_pod("young-runner", phase="Running", age_hours=1),
-        ]
-        find_zombie_pods(client, self._make_config())
+        set_list(
+            client,
+            pods=[
+                make_pod("busy-runner", age_hours=10, owner_kind="EphemeralRunner"),
+                make_pod("idle-old-runner", age_hours=30, owner_kind="EphemeralRunner"),
+                make_pod("step-pod", age_hours=5, labels={"runner-pod": "busy-runner"}),
+            ],
+            ers=[make_er("busy-runner", job_id="j1"), make_er("idle-old-runner", job_id="")],
+        )
+        zombies = find_zombie_pods(client, _config())
+        assert [z.metadata.name for z in zombies] == ["idle-old-runner"]
+        assert m.registry.get_sample_value("zombie_cleanup_runner_pods_busy_skipped") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_job_pods_protected") == 1
+        assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 0
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 0
 
+    def test_metrics_no_zombies(self, make_pod, set_list):
+        client = MagicMock()
+        set_list(client, pods=[make_pod("young-runner", age_hours=1)])
+        find_zombie_pods(client, _config())
         assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 0
         assert m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours") == 0
         assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 1
         assert m.registry.get_sample_value("zombie_cleanup_pods_managed_skipped") == 0
 
-    def test_metrics_empty_namespace(self):
-        """Empty namespace sets all counts to zero."""
+    def test_metrics_empty_namespace(self, set_list):
         client = MagicMock()
-        client.list.return_value = []
-        find_zombie_pods(client, self._make_config())
-
+        set_list(client)
+        find_zombie_pods(client, _config())
         assert m.registry.get_sample_value("zombie_cleanup_pods_total") == 0
         assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 0
         assert m.registry.get_sample_value("zombie_cleanup_oldest_zombie_age_hours") == 0
 
 
-# --- delete_zombies ---
+# --- delete_zombies (returns a 3-tuple: deleted, failed, recheck_skipped) ---
 
 
 class TestDeleteZombies:
-    def _make_config(self, dry_run=False):
-        return {
-            "namespace": "arc-runners",
-            "pending_max_hours": 24,
-            "running_max_hours": 12,
-            "dry_run": dry_run,
-        }
-
-    def test_deletes_pods(self):
+    def test_deletes_pods(self, make_pod, set_list):
         client = MagicMock()
         zombies = [
-            _make_pod("z1", phase="Running", age_hours=15),
-            _make_pod("z2", phase="Pending", age_hours=30),
+            make_pod("z1", phase="Running", age_hours=30),
+            make_pod("z2", phase="Pending", age_hours=30),
         ]
-        deleted, failed = delete_zombies(client, zombies, self._make_config())
-        assert deleted == 2
-        assert failed == 0
+        set_list(client, pods=zombies)
+        assert delete_zombies(client, zombies, _config()) == (2, 0, 0)
         assert client.delete.call_count == 2
 
-    def test_dry_run_skips_delete(self):
+    def test_dry_run_skips_delete(self, make_pod, set_list):
         client = MagicMock()
-        zombies = [_make_pod("z1", phase="Running", age_hours=15)]
-        deleted, failed = delete_zombies(client, zombies, self._make_config(dry_run=True))
-        assert deleted == 1
-        assert failed == 0
+        zombies = [make_pod("z1", phase="Running", age_hours=30)]
+        set_list(client, pods=zombies)
+        assert delete_zombies(client, zombies, _config(dry_run=True)) == (1, 0, 0)
         client.delete.assert_not_called()
 
-    def test_continues_on_delete_failure(self):
+    def test_continues_on_delete_failure(self, make_pod, set_list):
         client = MagicMock()
+        zombies = [
+            make_pod("z1", phase="Running", age_hours=30),
+            make_pod("z2", phase="Running", age_hours=31),
+        ]
+        set_list(client, pods=zombies)
         client.delete.side_effect = [Exception("API error"), None]
-        zombies = [
-            _make_pod("z1", phase="Running", age_hours=15),
-            _make_pod("z2", phase="Running", age_hours=16),
-        ]
-        deleted, failed = delete_zombies(client, zombies, self._make_config())
-        assert deleted == 1
-        assert failed == 1
+        assert delete_zombies(client, zombies, _config()) == (1, 1, 0)
         assert client.delete.call_count == 2
 
-    def test_empty_list(self):
+    def test_empty_list(self, set_list):
         client = MagicMock()
-        deleted, failed = delete_zombies(client, [], self._make_config())
-        assert deleted == 0
-        assert failed == 0
+        set_list(client)
+        assert delete_zombies(client, [], _config()) == (0, 0, 0)
         client.delete.assert_not_called()
 
-    def test_404_counted_as_success(self):
-        """Pod deleted between list and delete should count as success."""
-        from lightkube.core.exceptions import ApiError
-
+    def test_404_counted_as_success(self, make_pod, set_list):
+        """A pod deleted between list and delete should count as success."""
         client = MagicMock()
+        set_list(client)
         not_found = ApiError.__new__(ApiError)
         not_found.status = MagicMock(code=404)
         client.delete.side_effect = not_found
-        zombies = [_make_pod("gone-pod", phase="Running", age_hours=15)]
-        deleted, failed = delete_zombies(client, zombies, self._make_config())
-        assert deleted == 1
-        assert failed == 0
+        zombies = [make_pod("gone-pod", phase="Running", age_hours=30)]
+        assert delete_zombies(client, zombies, _config()) == (1, 0, 0)
 
-    def test_api_error_non_404_counted_as_failure(self):
-        """Non-404 ApiErrors should count as failures."""
-        from lightkube.core.exceptions import ApiError
-
+    def test_api_error_non_404_counted_as_failure(self, make_pod, set_list):
         client = MagicMock()
+        set_list(client)
         forbidden = ApiError.__new__(ApiError)
         forbidden.status = MagicMock(code=403)
         client.delete.side_effect = forbidden
-        zombies = [_make_pod("forbidden-pod", phase="Running", age_hours=15)]
-        deleted, failed = delete_zombies(client, zombies, self._make_config())
-        assert deleted == 0
-        assert failed == 1
+        zombies = [make_pod("forbidden-pod", phase="Running", age_hours=30)]
+        assert delete_zombies(client, zombies, _config()) == (0, 1, 0)
+
+    def test_toctou_now_busy_skips_delete(self, make_pod, make_er, set_list):
+        """A runner idle at find time but busy at the recheck is not deleted."""
+        client = MagicMock()
+        runner = make_pod("flip-runner", age_hours=15, owner_kind="EphemeralRunner")
+        set_list(client, ers=[make_er("flip-runner", job_id="late-job")])
+        assert delete_zombies(client, [runner], _config()) == (0, 0, 1)
+        client.delete.assert_not_called()
+
+    def test_toctou_er_read_failure_skips_delete(self, make_pod, set_list):
+        """If the per-pod EphemeralRunner GET fails, runner pods are fail-safe skipped."""
+        client = MagicMock()
+        runner = make_pod("safe-runner", age_hours=30, owner_kind="EphemeralRunner")
+        set_list(client, er_error=Exception("api down"))
+        assert delete_zombies(client, [runner], _config()) == (0, 0, 1)
+        client.delete.assert_not_called()
+        assert m.registry.get_sample_value("zombie_cleanup_ephemeralrunner_read_errors") == 1
+
+    def test_idle_runner_deleted_at_recheck(self, make_pod, make_er, set_list):
+        """A runner still idle at recheck is deleted."""
+        client = MagicMock()
+        runner = make_pod("idle-runner", age_hours=30, owner_kind="EphemeralRunner")
+        set_list(client, ers=[make_er("idle-runner", job_id="")])
+        assert delete_zombies(client, [runner], _config()) == (1, 0, 0)
+        client.delete.assert_called_once()
+
+    def test_recheck_er_gone_deletes_runner(self, make_pod, set_list):
+        """A runner whose EphemeralRunner is gone (404) at recheck is treated as not-busy and deleted."""
+        client = MagicMock()
+        runner = make_pod("done-runner", age_hours=30, owner_kind="EphemeralRunner")
+        set_list(client, ers=[])
+        assert delete_zombies(client, [runner], _config()) == (1, 0, 0)
+        client.delete.assert_called_once()
+
+    def test_hardcap_runner_deleted_at_recheck(self, make_pod, make_er, set_list):
+        """A busy runner past the hard cap is deleted even though busy, and counts as a hard-cap delete."""
+        client = MagicMock()
+        runner = make_pod("hung-runner", age_hours=50, owner_kind="EphemeralRunner")
+        set_list(client, ers=[make_er("hung-runner", job_id="stuck")])
+        assert delete_zombies(client, [runner], _config()) == (1, 0, 0)
+        client.delete.assert_called_once()
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 1
+
+    def test_job_pod_protected_at_recheck(self, make_pod, make_er, set_list):
+        """A job pod under the hard cap whose owning runner is live at recheck is not deleted."""
+        client = MagicMock()
+        step = make_pod("step-pod", age_hours=10, labels={"runner-pod": "runner-live"})
+        set_list(client, ers=[make_er("runner-live", job_id="j")])
+        assert delete_zombies(client, [step], _config()) == (0, 0, 1)
+        client.delete.assert_not_called()
+
+    def test_job_pod_over_hardcap_deleted_at_recheck(self, make_pod, make_er, set_list):
+        """A job pod past the hard cap is deleted at recheck despite its runner being live (F1/F5)."""
+        client = MagicMock()
+        step = make_pod("step-pod", age_hours=50, labels={"runner-pod": "runner-live"})
+        set_list(client, ers=[make_er("runner-live", job_id="j")])
+        assert delete_zombies(client, [step], _config()) == (1, 0, 0)
+        client.delete.assert_called_once()
+        assert m.registry.get_sample_value("zombie_cleanup_busy_hardcap_deletions_total") == 1
+
+    def test_orphan_job_pod_deleted_at_recheck(self, make_pod, set_list):
+        """A job pod whose owning runner is gone (404) at recheck is deleted."""
+        client = MagicMock()
+        step = make_pod("orphan-step", age_hours=100, labels={"runner-pod": "gone"})
+        set_list(client, ers=[])
+        assert delete_zombies(client, [step], _config()) == (1, 0, 0)
+        client.delete.assert_called_once()
 
 
 # --- get_config ---
@@ -389,13 +589,13 @@ class TestGetConfig:
             config = get_config()
         assert config["namespace"] == "arc-runners"
         assert config["pending_max_hours"] == 24
-        assert config["running_max_hours"] == 12
+        assert config["running_max_hours"] == 24
+        assert config["busy_max_hours"] == 48
         assert config["dry_run"] is False
         assert config["pushgateway_url"] == ""
 
     def test_pushgateway_url_from_env(self):
-        env = {"PUSHGATEWAY_URL": "http://pushgw:9091"}
-        with patch.dict("os.environ", env, clear=True):
+        with patch.dict("os.environ", {"PUSHGATEWAY_URL": "http://pushgw:9091"}, clear=True):
             config = get_config()
         assert config["pushgateway_url"] == "http://pushgw:9091"
 
@@ -404,6 +604,7 @@ class TestGetConfig:
             "TARGET_NAMESPACE": "custom-ns",
             "PENDING_MAX_AGE_HOURS": "48",
             "RUNNING_MAX_AGE_HOURS": "6",
+            "BUSY_MAX_AGE_HOURS": "72",
             "DRY_RUN": "true",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -411,205 +612,179 @@ class TestGetConfig:
         assert config["namespace"] == "custom-ns"
         assert config["pending_max_hours"] == 48
         assert config["running_max_hours"] == 6
+        assert config["busy_max_hours"] == 72
         assert config["dry_run"] is True
 
     @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes"])
     def test_dry_run_truthy(self, value):
         with patch.dict("os.environ", {"DRY_RUN": value}, clear=True):
-            config = get_config()
-        assert config["dry_run"] is True
+            assert get_config()["dry_run"] is True
 
     @pytest.mark.parametrize("value", ["false", "0", "no", ""])
     def test_dry_run_falsy(self, value):
         with patch.dict("os.environ", {"DRY_RUN": value}, clear=True):
-            config = get_config()
-        assert config["dry_run"] is False
+            assert get_config()["dry_run"] is False
 
 
 # --- main ---
 
 
 class TestMain:
-    def test_no_zombies(self):
+    def test_no_zombies(self, set_list):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = []
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client)
+            mock_client_cls.return_value = client
             assert main() == 0
 
-    def test_deletes_zombies(self):
-        zombie = _make_pod("old-runner", phase="Running", age_hours=15)
+    def test_deletes_zombies(self, make_pod, set_list):
+        zombie = make_pod("old-runner", phase="Running", age_hours=30)
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = [zombie]
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client, pods=[zombie])
+            mock_client_cls.return_value = client
             assert main() == 0
-            mock_client.delete.assert_called_once()
+            client.delete.assert_called_once()
+
+    def test_invalid_config_fails_closed(self):
+        """busy_max < running_max exits 1 before any client is created or pod deleted."""
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch.dict(
+                "os.environ",
+                {"BUSY_MAX_AGE_HOURS": "1", "RUNNING_MAX_AGE_HOURS": "24"},
+                clear=True,
+            ),
+        ):
+            assert main() == 1
+            mock_client_cls.assert_not_called()
 
     def test_client_creation_failure(self):
-        """Client() failure propagates (it's outside the try block)."""
+        """Client() failure propagates (it is created outside the try block)."""
         with (
             patch("zombie_cleanup.Client", side_effect=Exception("no cluster")),
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
+            pytest.raises(Exception, match="no cluster"),
         ):
-            from zombie_cleanup import main
-
-            with pytest.raises(Exception, match="no cluster"):
-                main()
+            main()
 
     def test_list_failure(self):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.side_effect = Exception("API error")
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            client.list.side_effect = Exception("API error")
+            mock_client_cls.return_value = client
             assert main() == 1
 
-    def test_partial_failure_returns_1(self):
-        """main() returns 1 when some deletes fail."""
-        zombie1 = _make_pod("z1", phase="Running", age_hours=15)
-        zombie2 = _make_pod("z2", phase="Running", age_hours=16)
+    def test_partial_failure_returns_1(self, make_pod, set_list):
+        z1 = make_pod("z1", phase="Running", age_hours=30)
+        z2 = make_pod("z2", phase="Running", age_hours=31)
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = [zombie1, zombie2]
-            mock_client.delete.side_effect = [Exception("API error"), None]
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client, pods=[z1, z2])
+            client.delete.side_effect = [Exception("API error"), None]
+            mock_client_cls.return_value = client
             assert main() == 1
 
-    def test_cleanup_cap_limits_deletions(self):
-        """When zombies exceed the cap, only cap-many are deleted."""
-        # 20 total pods → cap = max(20*0.1, 10) = 10
-        # 15 zombies → clean 10, skip 5
-        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(5)] + [
-            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(15)
+    def test_cleanup_cap_limits_deletions(self, make_pod, set_list):
+        # 20 total pods -> cap = max(20*0.1, 10) = 10; 15 zombies -> clean 10, skip 5
+        pods = [make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(5)] + [
+            make_pod(f"zombie-{i}", phase="Running", age_hours=30) for i in range(15)
         ]
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = pods
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client, pods=pods)
+            mock_client_cls.return_value = client
             main()
-            assert mock_client.delete.call_count == 10
+            assert client.delete.call_count == 10
             assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 5
             assert m.registry.get_sample_value("zombie_cleanup_zombies_found") == 15
 
-    def test_cleanup_cap_no_truncation_when_under_cap(self):
-        """When zombies are under the cap, all are deleted and skipped=0."""
-        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(95)] + [
-            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(5)
+    def test_cleanup_cap_no_truncation_when_under_cap(self, make_pod, set_list):
+        pods = [make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(95)] + [
+            make_pod(f"zombie-{i}", phase="Running", age_hours=30) for i in range(5)
         ]
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = pods
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client, pods=pods)
+            mock_client_cls.return_value = client
             main()
-            assert mock_client.delete.call_count == 5
+            assert client.delete.call_count == 5
             assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 0
 
-    def test_cleanup_cap_uses_ten_percent_when_larger(self):
-        """When 10% of total pods > 10, that higher cap is used."""
-        # 200 total pods → cap = max(200*0.1, 10) = 20
-        # 25 zombies → clean 20, skip 5
-        pods = [_make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(175)] + [
-            _make_pod(f"zombie-{i}", phase="Running", age_hours=15) for i in range(25)
+    def test_cleanup_cap_uses_ten_percent_when_larger(self, make_pod, set_list):
+        # 200 total pods -> cap = max(200*0.1, 10) = 20; 25 zombies -> clean 20, skip 5
+        pods = [make_pod(f"normal-{i}", phase="Running", age_hours=1) for i in range(175)] + [
+            make_pod(f"zombie-{i}", phase="Running", age_hours=30) for i in range(25)
         ]
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = pods
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client, pods=pods)
+            mock_client_cls.return_value = client
             main()
-            assert mock_client.delete.call_count == 20
+            assert client.delete.call_count == 20
             assert m.registry.get_sample_value("zombie_cleanup_pods_skipped") == 5
 
-    def test_sets_duration_metric(self):
-        """main() records a positive duration."""
+    def test_sets_duration_metric(self, set_list):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = []
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client)
+            mock_client_cls.return_value = client
             main()
             duration = m.registry.get_sample_value("zombie_cleanup_duration_seconds")
             assert duration is not None
-            assert duration > 0
+            assert duration >= 0
 
-    def test_increments_runs_total_success(self):
-        """Successful run increments runs_total with status=success."""
+    def test_increments_runs_total_success(self, set_list):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = []
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client)
+            mock_client_cls.return_value = client
             main()
-            val = m.registry.get_sample_value(
-                "zombie_cleanup_runs_total",
-                {"status": "success"},
-            )
+            val = m.registry.get_sample_value("zombie_cleanup_runs_total", {"status": "success"})
             assert val is not None
             assert val >= 1
 
     def test_increments_runs_total_failure(self):
-        """Failed run increments runs_total with status=failure."""
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.side_effect = Exception("boom")
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            client.list.side_effect = Exception("boom")
+            mock_client_cls.return_value = client
             main()
-            val = m.registry.get_sample_value(
-                "zombie_cleanup_runs_total",
-                {"status": "failure"},
-            )
+            val = m.registry.get_sample_value("zombie_cleanup_runs_total", {"status": "failure"})
             assert val is not None
             assert val >= 1
 
-    def test_pushes_metrics_when_url_set(self):
-        """main() calls push_metrics when PUSHGATEWAY_URL is set."""
+    def test_pushes_metrics_no_zombies(self, set_list):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch("zombie_cleanup.m.push_metrics") as mock_push,
@@ -619,25 +794,53 @@ class TestMain:
                 clear=True,
             ),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = []
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client)
+            mock_client_cls.return_value = client
             main()
             mock_push.assert_called_once_with("http://pushgw:9091")
 
-    def test_skips_push_when_url_empty(self):
-        """main() does not push metrics when PUSHGATEWAY_URL is empty."""
+    def test_pushes_metrics_after_delete(self, make_pod, set_list):
+        zombie = make_pod("old-runner", phase="Running", age_hours=30)
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch("zombie_cleanup.m.push_metrics") as mock_push,
+            patch.dict(
+                "os.environ",
+                {"TARGET_NAMESPACE": "arc-runners", "PUSHGATEWAY_URL": "http://pushgw:9091"},
+                clear=True,
+            ),
+        ):
+            client = MagicMock()
+            set_list(client, pods=[zombie])
+            mock_client_cls.return_value = client
+            main()
+            mock_push.assert_called_once_with("http://pushgw:9091")
+
+    def test_pushes_metrics_on_exception(self):
+        with (
+            patch("zombie_cleanup.Client") as mock_client_cls,
+            patch("zombie_cleanup.m.push_metrics") as mock_push,
+            patch.dict(
+                "os.environ",
+                {"TARGET_NAMESPACE": "arc-runners", "PUSHGATEWAY_URL": "http://pushgw:9091"},
+                clear=True,
+            ),
+        ):
+            client = MagicMock()
+            client.list.side_effect = Exception("boom")
+            mock_client_cls.return_value = client
+            main()
+            mock_push.assert_called_once_with("http://pushgw:9091")
+
+    def test_skips_push_when_url_empty(self, set_list):
         with (
             patch("zombie_cleanup.Client") as mock_client_cls,
             patch("zombie_cleanup.m.push_metrics") as mock_push,
             patch.dict("os.environ", {"TARGET_NAMESPACE": "arc-runners"}, clear=True),
         ):
-            mock_client = MagicMock()
-            mock_client.list.return_value = []
-            mock_client_cls.return_value = mock_client
-            from zombie_cleanup import main
-
+            client = MagicMock()
+            set_list(client)
+            mock_client_cls.return_value = client
             main()
             mock_push.assert_not_called()

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
@@ -27,6 +27,7 @@ class TestMetricRegistration:
         "zombie_cleanup_oldest_zombie_age_hours",
         "zombie_cleanup_runner_pods_busy_skipped",
         "zombie_cleanup_job_pods_protected",
+        "zombie_cleanup_failsafe_protected",
         "zombie_cleanup_ephemeralrunner_read_errors",
         "zombie_cleanup_recheck_skipped",
         "zombie_cleanup_busy_hardcap_deletions",

--- a/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/test_zombie_metrics.py
@@ -25,6 +25,11 @@ class TestMetricRegistration:
         "zombie_cleanup_duration_seconds",
         "zombie_cleanup_pods_managed_skipped",
         "zombie_cleanup_oldest_zombie_age_hours",
+        "zombie_cleanup_runner_pods_busy_skipped",
+        "zombie_cleanup_job_pods_protected",
+        "zombie_cleanup_ephemeralrunner_read_errors",
+        "zombie_cleanup_recheck_skipped",
+        "zombie_cleanup_busy_hardcap_deletions",
     }
 
     def _registered_names(self) -> set[str]:

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -6,6 +6,13 @@ or Running too long (stuck execution). Skips pods managed by controllers
 (ReplicaSets, DaemonSets, StatefulSets, Jobs) to avoid interfering with
 long-lived infrastructure components like listener pods or hooks-warmer
 DaemonSets.
+
+GitHub Actions runner pods are owned by an EphemeralRunner custom resource, not
+by a kind in MANAGED_OWNER_KINDS, so they remain eligible for cleanup. A runner
+actively executing a job (see runner_busy) is protected from age-based reaping
+until it exceeds a much larger busy hard-cap, at which point it is presumed hung.
+Every delete candidate is re-checked against fresh per-pod state immediately
+before deletion, so a runner that picks up a job mid-run is never reaped.
 """
 
 import logging
@@ -18,6 +25,13 @@ import zombie_metrics as m
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Pod
+from runner_busy import (
+    Decision,
+    classify_pod,
+    gather_busy_state,
+    pod_phase,
+    recheck_liveness,
+)
 
 log = logging.getLogger("zombie-cleanup")
 
@@ -32,10 +46,35 @@ def get_config() -> dict:
     return {
         "namespace": os.environ.get("TARGET_NAMESPACE", "arc-runners"),
         "pending_max_hours": int(os.environ.get("PENDING_MAX_AGE_HOURS", "24")),
-        "running_max_hours": int(os.environ.get("RUNNING_MAX_AGE_HOURS", "12")),
+        "running_max_hours": int(os.environ.get("RUNNING_MAX_AGE_HOURS", "24")),
+        # Hard cap on a busy runner's lifetime before it is presumed hung. Pod age is
+        # a valid job-runtime proxy only because every scale set runs minRunners:0 —
+        # the pod is created at job assignment, so its age tracks job runtime — and 48h
+        # sits far above any legit job (GHA 6h max + prepare timeout). A warm pool
+        # (minRunners>0) would break this proxy.
+        "busy_max_hours": int(os.environ.get("BUSY_MAX_AGE_HOURS", "48")),
         "dry_run": os.environ.get("DRY_RUN", "false").lower() in ("true", "1", "yes"),
         "pushgateway_url": os.environ.get("PUSHGATEWAY_URL", ""),
     }
+
+
+def validate_config(config: dict) -> str | None:
+    """Return an error message if the age thresholds are unsafe, else None.
+
+    All thresholds must be positive so cleanup can never run with a zero/negative
+    age gate that would sweep every pod. busy_max must be >= running_max so a busy
+    runner is never reaped sooner than an idle one.
+    """
+    pending_max = config["pending_max_hours"]
+    running_max = config["running_max_hours"]
+    busy_max = config["busy_max_hours"]
+    if running_max <= 0:
+        return f"running_max_age_hours must be > 0 (got {running_max})"
+    if pending_max <= 0:
+        return f"pending_max_age_hours must be > 0 (got {pending_max})"
+    if busy_max < running_max:
+        return f"busy_max_age_hours ({busy_max}) must be >= running_max_age_hours ({running_max})"
+    return None
 
 
 def is_managed_pod(pod: Pod) -> bool:
@@ -67,17 +106,24 @@ def get_pod_age_hours(pod: Pod, now: datetime) -> float:
 
 
 def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
-    """Find pods that qualify as zombies based on age thresholds."""
+    """Find pods that qualify as zombies based on age thresholds and runner busy state."""
     namespace = config["namespace"]
     pending_max = config["pending_max_hours"]
     running_max = config["running_max_hours"]
+    busy_max = config["busy_max_hours"]
     now = datetime.now(UTC)
-    zombies = []
+
+    pods = list(client.list(Pod, namespace=namespace))
+    state = gather_busy_state(client, namespace, pods)
+
+    zombies: list[Pod] = []
     total_count = 0
     managed_count = 0
+    busy_skipped = 0
+    job_protected = 0
     max_age = 0.0
 
-    for pod in client.list(Pod, namespace=namespace):
+    for pod in pods:
         total_count += 1
         if is_managed_pod(pod):
             managed_count += 1
@@ -85,71 +131,106 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
         if is_terminating(pod):
             continue
 
-        phase = pod.status.phase if pod.status else None
+        phase = pod_phase(pod)
         age_hours = get_pod_age_hours(pod, now)
         if age_hours < 0:
             continue
 
         name = pod.metadata.name
-        threshold = None
+        decision = classify_pod(pod, phase, age_hours, pending_max, running_max, busy_max, state.liveness_for(pod))
 
-        if phase == "Pending" and age_hours > pending_max:
-            threshold = pending_max
-        elif phase in ("Running", "Unknown") and age_hours > running_max:
-            threshold = running_max
-
-        if threshold is not None:
-            log.info(
-                "Zombie found: %s phase=%s age=%.1fh (threshold=%dh)",
-                name,
-                phase,
-                age_hours,
-                threshold,
-            )
+        if decision.is_delete:
+            if decision is Decision.HARD_CAP_DELETE:
+                log.warning(
+                    "%s presumed hung: age=%.1fh over busy hard cap %dh; selecting for deletion",
+                    name,
+                    age_hours,
+                    busy_max,
+                )
+            else:
+                log.info("Zombie found: %s phase=%s age=%.1fh", name, phase, age_hours)
             zombies.append(pod)
-            if age_hours > max_age:
-                max_age = age_hours
+            max_age = max(max_age, age_hours)
+        elif decision is Decision.BUSY_PROTECT:
+            busy_skipped += 1
+        elif decision is Decision.JOBPOD_PROTECT:
+            job_protected += 1
 
     m.pods_total.set(total_count)
     m.pods_managed_skipped.set(managed_count)
     m.zombies_found.set(len(zombies))
     m.oldest_zombie_age_hours.set(max_age)
+    m.runner_pods_busy_skipped.set(busy_skipped)
+    m.job_pods_protected.set(job_protected)
+    m.ephemeralrunner_read_errors.set(1 if state.er_read_failed else 0)
 
     return zombies
 
 
-def delete_zombies(client: Client, zombies: list[Pod], config: dict) -> tuple[int, int]:
-    """Delete zombie pods. Returns (deleted_count, failed_count)."""
+def delete_zombies(client: Client, zombies: list[Pod], config: dict) -> tuple[int, int, int]:
+    """Delete zombie pods after a fresh, per-pod busy/liveness recheck.
+
+    Each candidate is re-classified against state fetched for THAT pod immediately
+    before its delete, so a runner that became busy — or a job pod whose runner is
+    still live — between selection and deletion is skipped. Returns
+    (deleted, failed, recheck_skipped).
+    """
     namespace = config["namespace"]
+    pending_max = config["pending_max_hours"]
+    running_max = config["running_max_hours"]
+    busy_max = config["busy_max_hours"]
     dry_run = config["dry_run"]
+    now = datetime.now(UTC)
+
     deleted = 0
     failed = 0
+    recheck_skipped = 0
+    er_read_failed = False
 
     for pod in zombies:
         name = pod.metadata.name
-        phase = pod.status.phase if pod.status else "Unknown"
+        phase = pod_phase(pod) or "Unknown"
+        age_hours = get_pod_age_hours(pod, now)
+
+        liveness = recheck_liveness(client, pod, namespace)
+        er_read_failed = er_read_failed or liveness.read_failed
+        decision = classify_pod(pod, phase, age_hours, pending_max, running_max, busy_max, liveness)
+
+        if not decision.is_delete:
+            log.info("Recheck: skipping %s — %s", name, decision.value)
+            recheck_skipped += 1
+            continue
 
         if dry_run:
-            log.info("DRY RUN: would delete %s (phase=%s)", name, phase)
+            log.info("DRY RUN: would delete %s (phase=%s, %s)", name, phase, decision.value)
             deleted += 1
             continue
 
+        succeeded = False
         try:
             client.delete(Pod, name=name, namespace=namespace)
             log.info("Deleted zombie pod: %s (phase=%s)", name, phase)
-            deleted += 1
+            succeeded = True
         except ApiError as e:
             if e.status.code == 404:
                 log.info("Pod %s already gone (404), counting as success", name)
-                deleted += 1
+                succeeded = True
             else:
                 log.exception("Failed to delete pod %s (HTTP %s)", name, e.status.code)
                 failed += 1
-        except Exception as e:
-            log.exception("Failed to delete pod %s: %s", name, e)
+        except Exception:
+            log.exception("Failed to delete pod %s", name)
             failed += 1
 
-    return deleted, failed
+        if succeeded:
+            deleted += 1
+            if decision is Decision.HARD_CAP_DELETE:
+                m.busy_hardcap_deletions_total.inc()
+
+    if er_read_failed:
+        m.ephemeralrunner_read_errors.set(1)
+
+    return deleted, failed, recheck_skipped
 
 
 def main() -> int:
@@ -162,12 +243,18 @@ def main() -> int:
 
     config = get_config()
     log.info(
-        "Starting zombie cleanup: namespace=%s pending_max=%dh running_max=%dh dry_run=%s",
+        "Starting zombie cleanup: namespace=%s pending_max=%dh running_max=%dh busy_max=%dh dry_run=%s",
         config["namespace"],
         config["pending_max_hours"],
         config["running_max_hours"],
+        config["busy_max_hours"],
         config["dry_run"],
     )
+
+    config_error = validate_config(config)
+    if config_error:
+        log.error("Invalid configuration, refusing to run: %s", config_error)
+        return 1
 
     client = Client()
     start_time = time.monotonic()
@@ -179,6 +266,7 @@ def main() -> int:
             m.pods_deleted.set(0)
             m.pods_failed.set(0)
             m.pods_skipped.set(0)
+            m.recheck_skipped.set(0)
             m.duration_seconds.set(time.monotonic() - start_time)
             m.runs_total.labels(status="success").inc()
             if config["pushgateway_url"]:
@@ -198,11 +286,18 @@ def main() -> int:
             zombies = zombies[:cleanup_cap]
 
         log.info("Found %d zombie pod(s) to clean", len(zombies))
-        deleted, failed = delete_zombies(client, zombies, config)
-        log.info("Cleanup complete: %d deleted, %d failed, %d deferred", deleted, failed, skipped_count)
+        deleted, failed, recheck_skipped = delete_zombies(client, zombies, config)
+        log.info(
+            "Cleanup complete: %d deleted, %d failed, %d deferred, %d recheck-skipped",
+            deleted,
+            failed,
+            skipped_count,
+            recheck_skipped,
+        )
         m.pods_deleted.set(deleted)
         m.pods_failed.set(failed)
         m.pods_skipped.set(skipped_count)
+        m.recheck_skipped.set(recheck_skipped)
         m.duration_seconds.set(time.monotonic() - start_time)
         m.runs_total.labels(status="success" if failed == 0 else "failure").inc()
         if config["pushgateway_url"]:
@@ -213,6 +308,7 @@ def main() -> int:
         m.pods_deleted.set(0)
         m.pods_failed.set(0)
         m.pods_skipped.set(0)
+        m.recheck_skipped.set(0)
         m.duration_seconds.set(time.monotonic() - start_time)
         m.runs_total.labels(status="failure").inc()
         if config["pushgateway_url"]:

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_cleanup.py
@@ -121,6 +121,7 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
     managed_count = 0
     busy_skipped = 0
     job_protected = 0
+    failsafe_protected = 0
     max_age = 0.0
 
     for pod in pods:
@@ -155,6 +156,8 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
             busy_skipped += 1
         elif decision is Decision.JOBPOD_PROTECT:
             job_protected += 1
+        elif decision is Decision.FAIL_SAFE_PROTECT:
+            failsafe_protected += 1
 
     m.pods_total.set(total_count)
     m.pods_managed_skipped.set(managed_count)
@@ -162,6 +165,7 @@ def find_zombie_pods(client: Client, config: dict) -> list[Pod]:
     m.oldest_zombie_age_hours.set(max_age)
     m.runner_pods_busy_skipped.set(busy_skipped)
     m.job_pods_protected.set(job_protected)
+    m.failsafe_protected.set(failsafe_protected)
     m.ephemeralrunner_read_errors.set(1 if state.er_read_failed else 0)
 
     return zombies

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
@@ -40,6 +40,11 @@ job_pods_protected = Gauge(
     "Workflow/step job pods skipped because their owning runner is still live",
     registry=registry,
 )
+failsafe_protected = Gauge(
+    "zombie_cleanup_failsafe_protected",
+    "Runner pods protected this run because the EphemeralRunner read failed (fail-safe)",
+    registry=registry,
+)
 ephemeralrunner_read_errors = Gauge(
     "zombie_cleanup_ephemeralrunner_read_errors",
     "1 if listing EphemeralRunners failed this run (fail-safe engaged), else 0",

--- a/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
+++ b/osdc/modules/zombie-cleanup/scripts/python/zombie_metrics.py
@@ -30,6 +30,31 @@ oldest_zombie_age_hours = Gauge(
     "Age of oldest zombie in hours",
     registry=registry,
 )
+runner_pods_busy_skipped = Gauge(
+    "zombie_cleanup_runner_pods_busy_skipped",
+    "Runner pods skipped because they are actively running a job",
+    registry=registry,
+)
+job_pods_protected = Gauge(
+    "zombie_cleanup_job_pods_protected",
+    "Workflow/step job pods skipped because their owning runner is still live",
+    registry=registry,
+)
+ephemeralrunner_read_errors = Gauge(
+    "zombie_cleanup_ephemeralrunner_read_errors",
+    "1 if listing EphemeralRunners failed this run (fail-safe engaged), else 0",
+    registry=registry,
+)
+recheck_skipped = Gauge(
+    "zombie_cleanup_recheck_skipped",
+    "Delete candidates skipped at the pre-delete recheck (became busy or protected)",
+    registry=registry,
+)
+busy_hardcap_deletions_total = Counter(
+    "zombie_cleanup_busy_hardcap_deletions_total",
+    "Live runner or workflow/step pods deleted after exceeding the busy hard-cap age (presumed hung)",
+    registry=registry,
+)
 
 
 def push_metrics(pushgateway_url: str) -> None:


### PR DESCRIPTION
**Impact:** zombie-cleanup
**Risk:** high

## What
Teaches the zombie-cleanup CronJob to tell an idle runner apart from one actively running a job. Runners executing a workflow are now protected from age-based reaping until they cross a much larger busy hard cap (48h, presumed hung), and every delete candidate is re-checked against fresh per-pod state immediately before deletion so a runner that picks up a job mid-run is never killed. Also bumps `running_max_age_hours` 12h→24h and adds the `busy_max_age_hours` knob.

## Why
The previous logic reaped any runner pod once it had been `Running` past the age threshold, with no notion of whether it was doing work. A long-running-but-legitimate job (up to GHA's 6h max plus prepare time) sitting past the threshold would get its pod deleted out from under it, failing the job. This keeps the GC's value — cleaning up genuinely stuck/orphaned pods — while no longer disrupting live jobs. Busy state is derived from the owning `EphemeralRunner` (`status.jobId`) and from live workflow/step pods that pin a runner via the `runner-pod` label.
