### PR TITLE
Fix OSDC integration test build: use PEP 517 build instead of removed setup.py

### DIFF
--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1912,7 +1912,7 @@ jobs:
           cd /tmp/pytorch
           pip install --no-cache-dir -r requirements.txt
           export USE_CUDA=0 USE_ROCM=0 USE_XPU=0 BUILD_TEST=0 MAX_JOBS="$(nproc)"
-          python setup.py bdist_wheel
+          python -m build --wheel --no-isolation
           WHL=$(ls dist/torch-*.whl 2>/dev/null | head -1)
           if [ -z "$WHL" ]; then
             echo "FAIL: no torch wheel produced"
@@ -1946,7 +1946,7 @@ jobs:
           cd /tmp/pytorch
           pip install --no-cache-dir -r requirements.txt
           export USE_CUDA=0 USE_ROCM=0 USE_XPU=0 BUILD_TEST=0 MAX_JOBS="$(nproc)"
-          python setup.py bdist_wheel
+          python -m build --wheel --no-isolation
           WHL=$(ls dist/torch-*.whl 2>/dev/null | head -1)
           if [ -z "$WHL" ]; then
             echo "FAIL: no torch wheel produced"


### PR DESCRIPTION
## What

The OSDC integration test's "Build PyTorch CPU wheel from source" steps run `python setup.py bdist_wheel`. pytorch/pytorch has retired `setup.py` for the scikit-build-core / PEP 517 interface, so against current `pytorch` main this hard-fails before compiling — breaking `test-release-arm64` and `test-release-x86` (e.g. [this run](https://github.com/pytorch/pytorch-canary/actions/runs/30318804256/job/90150149730)).

## Change

Both build steps in `osdc/integration-tests/workflows/integration-test.yaml.tpl`:

```diff
-          python setup.py bdist_wheel
+          python -m build --wheel --no-isolation
```

`build` is already installed via PyTorch's requirements; the `USE_CUDA`/`MAX_JOBS` env knobs and the downstream `dist/torch-*.whl` check are unaffected.

## Test

`just lint` (13/13) and `just test` (98.78% coverage) both pass.