### PR TITLE
Bump ARC chart to 0.14.1-jeanschmidt.18 on staging + prod-ue1

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -150,6 +150,7 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
+      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -227,6 +228,7 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
+      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -306,6 +308,7 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
+      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -411,6 +414,8 @@ clusters:
         - osdc_gha_prod
     base:
       vpc_cidr: "10.4.0.0/16"
+    arc:
+      chart_version: "0.14.1-jeanschmidt.18"
     node_compactor:
       min_node_age_seconds: 300
     buildkit:

--- a/osdc/modules/arc/kubernetes/capacity-monitor-rbac.yaml
+++ b/osdc/modules/arc/kubernetes/capacity-monitor-rbac.yaml
@@ -1,15 +1,20 @@
-# RBAC for the capacity monitor running in listener pods.
-# Grants pod management permissions in the arc-runners namespace to listener
-# service accounts (in arc-systems) so they can create/delete placeholder pods.
+# RBAC for the capacity monitor running in listener pods. It needs two
+# permission scopes: a namespaced Role in arc-runners and a cluster-scoped
+# ClusterRole for nodes.
 #
-# Scope: namespaced (arc-runners) rather than cluster-wide. Listener SAs live
-# in arc-systems but the placeholder pods they manage are created in arc-runners,
-# so a Role in arc-runners with a RoleBinding to the arc-systems SA group is the
-# correct cross-namespace pattern.
+# Namespaced (arc-runners): grants pod and configmap management. The listener
+# service accounts live in arc-systems, but the placeholder pods and configmaps
+# the monitor manages are created in arc-runners. A Role in arc-runners with a
+# RoleBinding to the arc-systems SA group is the correct cross-namespace pattern.
 #
-# We bind to the system:serviceaccounts:arc-systems group rather than a specific
-# SA because there are multiple listener SAs (one per scale set), dynamically
-# created by the ARC controller.
+# Cluster-scoped (nodes): grants node read. The node-schedulability check lists
+# and watches nodes so it can discard placeholders on cordoned or disruption-
+# tainted nodes when counting usable capacity. Nodes are cluster-scoped, so a
+# namespaced Role cannot grant this.
+#
+# Both bind to the system:serviceaccounts:arc-systems group rather than a named
+# SA because listener SAs are created dynamically, one per scale set, by the ARC
+# controller.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -36,6 +41,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: arc-capacity-monitor
+subjects:
+  - kind: Group
+    name: system:serviceaccounts:arc-systems
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: arc-capacity-monitor-nodes
+  labels:
+    app.kubernetes.io/part-of: actions-runner-controller
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arc-capacity-monitor-nodes
+  labels:
+    app.kubernetes.io/part-of: actions-runner-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: arc-capacity-monitor-nodes
 subjects:
   - kind: Group
     name: system:serviceaccounts:arc-systems

--- a/osdc/modules/arc/tests/smoke/test_capacity_monitor_rbac.py
+++ b/osdc/modules/arc/tests/smoke/test_capacity_monitor_rbac.py
@@ -1,0 +1,90 @@
+"""Smoke tests for the ARC capacity-monitor RBAC.
+
+The capacity monitor runs inside each AutoscalingListener pod (namespace
+arc-systems, one dynamically-created ServiceAccount per scale set, all covered
+by the group system:serviceaccounts:arc-systems). It requires namespaced
+pod/configmap management in arc-runners to create and reap placeholder pods,
+and cluster-scoped node read for the schedulability check that drops
+placeholders on cordoned or disruption-tainted nodes. A missing grant degrades
+capacity accounting silently instead of crashing, so these tests fail loudly if
+any of the four RBAC objects is dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+from helpers import run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+NS_RUNNERS = "arc-runners"
+SA_GROUP = "system:serviceaccounts:arc-systems"
+
+ROLE_NAME = "arc-capacity-monitor"
+NODES_CLUSTERROLE_NAME = "arc-capacity-monitor-nodes"
+
+NODE_VERBS = {"get", "list", "watch"}
+NAMESPACED_VERBS = {"create", "delete", "deletecollection", "get", "list", "watch"}
+
+
+def _verbs_for_resource(rules: list[dict], resource: str) -> set[str]:
+    return {verb for rule in rules if resource in rule.get("resources", []) for verb in rule.get("verbs", [])}
+
+
+def _binds_group(binding: dict, group: str) -> bool:
+    return any(
+        subject.get("kind") == "Group" and subject.get("name") == group for subject in binding.get("subjects", [])
+    )
+
+
+class TestCapacityMonitorNodesRBAC:
+    """Cluster-scoped node read for the listener schedulability check."""
+
+    def test_clusterrole_grants_node_read(self) -> None:
+        role = run_kubectl(["get", "clusterrole", NODES_CLUSTERROLE_NAME])
+        verbs = _verbs_for_resource(role.get("rules", []), "nodes")
+        assert verbs >= NODE_VERBS, (
+            f"ClusterRole {NODES_CLUSTERROLE_NAME} must grant {sorted(NODE_VERBS)} on "
+            f"nodes for the listener node-schedulability check; got {sorted(verbs)}"
+        )
+
+    def test_clusterrolebinding_targets_listener_group(self) -> None:
+        binding = run_kubectl(["get", "clusterrolebinding", NODES_CLUSTERROLE_NAME])
+        role_ref = binding.get("roleRef", {})
+        assert role_ref.get("name") == NODES_CLUSTERROLE_NAME, (
+            f"ClusterRoleBinding {NODES_CLUSTERROLE_NAME} roleRef must point at "
+            f"ClusterRole {NODES_CLUSTERROLE_NAME}; got {role_ref}"
+        )
+        assert role_ref.get("kind") == "ClusterRole", (
+            f"ClusterRoleBinding {NODES_CLUSTERROLE_NAME} roleRef.kind must be ClusterRole; got {role_ref.get('kind')}"
+        )
+        assert _binds_group(binding, SA_GROUP), (
+            f"ClusterRoleBinding {NODES_CLUSTERROLE_NAME} must bind group {SA_GROUP}; got {binding.get('subjects')}"
+        )
+
+
+class TestCapacityMonitorPlaceholderRBAC:
+    """Namespaced pod/configmap management for placeholder pods in arc-runners."""
+
+    def test_role_grants_pod_and_configmap_management(self) -> None:
+        role = run_kubectl(["get", "role", ROLE_NAME], namespace=NS_RUNNERS)
+        rules = role.get("rules", [])
+        for resource in ("pods", "configmaps"):
+            verbs = _verbs_for_resource(rules, resource)
+            assert verbs >= NAMESPACED_VERBS, (
+                f"Role {ROLE_NAME} in {NS_RUNNERS} must grant "
+                f"{sorted(NAMESPACED_VERBS)} on {resource}; got {sorted(verbs)}"
+            )
+
+    def test_rolebinding_targets_listener_group(self) -> None:
+        binding = run_kubectl(["get", "rolebinding", ROLE_NAME], namespace=NS_RUNNERS)
+        role_ref = binding.get("roleRef", {})
+        assert role_ref.get("name") == ROLE_NAME, (
+            f"RoleBinding {ROLE_NAME} roleRef must point at Role {ROLE_NAME}; got {role_ref}"
+        )
+        assert role_ref.get("kind") == "Role", (
+            f"RoleBinding {ROLE_NAME} roleRef.kind must be Role; got {role_ref.get('kind')}"
+        )
+        assert _binds_group(binding, SA_GROUP), (
+            f"RoleBinding {ROLE_NAME} in {NS_RUNNERS} must bind group {SA_GROUP}; got {binding.get('subjects')}"
+        )


### PR DESCRIPTION
*Impact:** ARC runner autoscaling on the three staging clusters and prod-ue1
**Risk:** high

## What
Pins the ARC fork chart to `0.14.1-jeanschmidt.18` on `meta-staging-aws-{uw1,ue1,ue2}` and `meta-prod-aws-ue1`, overriding the `defaults.arc.chart_version` of `.17`. The new chart ships the capacity-accounting rework from jeanschmidt/actions-runner-controller#13.

## Why
The current chart over-advertises capacity, so GitHub dispatches more jobs than the cluster can actually run, over-provisioning runners relative to real capacity. This was causing failure to start workflow pod that stayed on pending state. The fork PR fixes two failure modes behind this:

- **Count bug:** capacity was computed as `runningRunners + runningPairs` and double-counted workflow pods. A job needs both a runner pod *and* a separately-created workflow pod, so runners with no free workflow slot were still counted. The new logic reports `min(runnerSide, workflowSide)` and credits real workflow pods once per runner (matched by the `-workflow` suffix) instead of letting container/Docker-action step pods inflate the count.
- **Placeholders on tainted nodes:** placeholder pods sitting on cordoned or disruption-tainted nodes were counted as usable capacity even though no replacement real pod could schedule there. A node-schedulability check now drops those placeholders, and the `karpenter.sh/do-not-disrupt` annotation is removed so Karpenter can reclaim their nodes.

Rolling to staging + one prod region first to validate before promoting the default.

# Notes
- Upstream PR: https://github.com/jeanschmidt/actions-runner-controller/pull/13 (author-flagged **high** risk).
- The new node-schedulability check (`CAPACITY_AWARE_ENABLE_NODE_SCHEDULABILITY_CHECK`, default **true**) needs node get/list/watch RBAC; without it the reporter self-degrades to core counting rather than wedging. Confirm the runner chart grants that RBAC on these clusters.
- Controller and runner charts must stay on the same minor version — a mismatch triggers ARS deletion.