### PR TITLE
Raise ARC listener memory to fit the capacity-aware informer

### DIFF
--- a/osdc/modules/arc-runners/templates/runner.yaml.tpl
+++ b/osdc/modules/arc-runners/templates/runner.yaml.tpl
@@ -151,12 +151,14 @@ listenerTemplate:
       - name: listener
         resources:
           limits:
-            cpu: "200m"
-            memory: "256Mi"
+            cpu: "250m"
+            memory: "1331Mi"
           requests:
-            cpu: "100m"
-            memory: "128Mi"
+            cpu: "250m"
+            memory: "1331Mi"
         env:
+          - name: GOMEMLIMIT
+            value: "1198MiB"
           - name: CAPACITY_AWARE_ENABLED
             value: "true"
           - name: CAPACITY_AWARE_PROACTIVE_CAPACITY
@@ -169,6 +171,8 @@ listenerTemplate:
             value: "{{HUD_FAILURE_BASE_CAPACITY}}"
           - name: CAPACITY_AWARE_RECALCULATE_INTERVAL
             value: "30s"
+          - name: CAPACITY_AWARE_REPORT_INTERVAL
+            value: "10s"
           - name: CAPACITY_AWARE_PLACEHOLDER_TIMEOUT
             value: "20m"
           - name: CAPACITY_AWARE_WORKFLOW_CPU


### PR DESCRIPTION
**Impact:** ARC GHA runner listeners
**Risk:** medium

## What
Bumps the listener container memory limit/request from 256Mi to 1331Mi, pins `GOMEMLIMIT` to 1198MiB, and doubles the `CAPACITY_AWARE_REPORT_INTERVAL` to 10s.

## Why
The capacity-aware listener shipped in #963 (chart `0.14.1-jeanschmidt.18`) runs a per-listener all-nodes informer whose working set exceeds randomly the old 256Mi limit at prod node scale (I blame GC). Activating `.18` on prod-ue1 OOM-crashlooped all 44 listeners; Staging survived multiple rounds of load test, likely due to some randomness of the GC behavior. Sizing memory to the informer's real footprint (with `GOMEMLIMIT` giving the Go runtime headroom below the cgroup limit) stops the crashloop.