### PR TITLE
grafana/dgx_b200: add total B200 runner count panel

### DIFF
--- a/grafana/dgx_b200.json
+++ b/grafana/dgx_b200.json
@@ -579,7 +579,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  max(registered) AS registered\nFROM (\n  SELECT ts, series, sum(registered) AS registered\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) AS registered\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
+                      "rawSql": "SELECT\n  toStartOfDay(ts) AS time,\n  series,\n  max(runners) AS runners\nFROM (\n  SELECT ts, series, sum(runners) AS runners\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) AS runners\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
                     },
                     "version": "v0"
                   },
@@ -591,10 +591,10 @@
             "transformations": []
           }
         },
-        "description": "Self-hosted runners registered with the pytorch org carrying each B200 label, sampled every 30 min by test-infra's runner-fleet-metrics workflow. Fleet capacity, not utilisation.",
+        "description": "Registered self-hosted runners carrying each B200 label, from misc.runner_fleet_count (sampled every 30 min). Daily peak.",
         "id": 5,
         "links": [],
-        "title": "Registered runners [view]",
+        "title": "Total runners [view]",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -615,8 +615,8 @@
                   "axisPlacement": "auto",
                   "barAlignment": 0,
                   "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 10,
+                  "drawStyle": "bars",
+                  "fillOpacity": 70,
                   "gradientMode": "none",
                   "hideFrom": {
                     "legend": false,
@@ -633,7 +633,7 @@
                   "scaleDistribution": {
                     "type": "linear"
                   },
-                  "showPoints": "never",
+                  "showPoints": "auto",
                   "showValues": false,
                   "spanNulls": false,
                   "stacking": {
@@ -653,269 +653,6 @@
                     }
                   ]
                 }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.1.0-25668120414"
-        }
-      }
-    },
-    "panel-6": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "ceczcsck1b20wb"
-                    },
-                    "group": "grafana-clickhouse-datasource",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorType": "sql",
-                      "format": 0,
-                      "meta": {
-                        "builderOptions": {
-                          "columns": [],
-                          "database": "",
-                          "limit": 1000,
-                          "mode": "list",
-                          "queryType": "table",
-                          "table": ""
-                        }
-                      },
-                      "pluginVersion": "4.17.0",
-                      "queryType": "timeseries",
-                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  max(offline) AS offline\nFROM (\n  SELECT ts, series, sum(offline) AS offline\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) - max(online_count) AS offline\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Registered B200 runners not reporting status=online (total_count - online_count). Sustained non-zero means a DGX host or its ghad-manager sessions have dropped out.",
-        "id": 6,
-        "links": [],
-        "title": "Runners offline [view]",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic-by-name",
-                  "seriesBy": "max"
-                },
-                "min": 0,
-                "unit": "short",
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 10,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "never",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.1.0-25668120414"
-        }
-      }
-    },
-    "panel-7": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "ceczcsck1b20wb"
-                    },
-                    "group": "grafana-clickhouse-datasource",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorType": "sql",
-                      "format": 0,
-                      "meta": {
-                        "builderOptions": {
-                          "columns": [],
-                          "database": "",
-                          "limit": 1000,
-                          "mode": "list",
-                          "queryType": "table",
-                          "table": ""
-                        }
-                      },
-                      "pluginVersion": "4.17.0",
-                      "queryType": "timeseries",
-                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  round(100 * sum(busy) / nullIf(sum(online), 0), 1) AS busy_pct\nFROM (\n  SELECT ts, series, sum(busy) AS busy, sum(online) AS online\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(busy_count) AS busy, max(online_count) AS online\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Share of online B200 runners executing a job (busy_count / online_count), sample-weighted per bucket. Read alongside 'Queue time' — high utilisation with rising queue time means the fleet is capacity-bound.",
-        "id": 7,
-        "links": [],
-        "title": "Runner utilization [view]",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic-by-name",
-                  "seriesBy": "max"
-                },
-                "min": 0,
-                "unit": "percent",
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 10,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "never",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                },
-                "max": 100
               },
               "overrides": []
             },
@@ -964,7 +701,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-6"
+              "name": "panel-1"
             },
             "height": 8,
             "width": 24,
@@ -977,7 +714,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-7"
+              "name": "panel-2"
             },
             "height": 8,
             "width": 24,
@@ -990,7 +727,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-1"
+              "name": "panel-3"
             },
             "height": 8,
             "width": 24,
@@ -1003,38 +740,12 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-2"
-            },
-            "height": 8,
-            "width": 24,
-            "x": 0,
-            "y": 32
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-3"
-            },
-            "height": 8,
-            "width": 24,
-            "x": 0,
-            "y": 40
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
               "name": "panel-4"
             },
             "height": 8,
             "width": 24,
             "x": 0,
-            "y": 48
+            "y": 32
           }
         }
       ]

--- a/grafana/dgx_b200.json
+++ b/grafana/dgx_b200.json
@@ -951,7 +951,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-1"
+              "name": "panel-5"
             },
             "height": 8,
             "width": 24,
@@ -964,7 +964,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-2"
+              "name": "panel-6"
             },
             "height": 8,
             "width": 24,
@@ -977,7 +977,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-3"
+              "name": "panel-7"
             },
             "height": 8,
             "width": 24,
@@ -990,7 +990,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-4"
+              "name": "panel-1"
             },
             "height": 8,
             "width": 24,
@@ -1003,7 +1003,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-5"
+              "name": "panel-2"
             },
             "height": 8,
             "width": 24,
@@ -1016,7 +1016,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-6"
+              "name": "panel-3"
             },
             "height": 8,
             "width": 24,
@@ -1029,7 +1029,7 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-7"
+              "name": "panel-4"
             },
             "height": 8,
             "width": 24,

--- a/grafana/dgx_b200.json
+++ b/grafana/dgx_b200.json
@@ -546,6 +546,400 @@
           "version": "13.1.0-25668120414"
         }
       }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  max(registered) AS registered\nFROM (\n  SELECT ts, series, sum(registered) AS registered\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) AS registered\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Self-hosted runners registered with the pytorch org carrying each B200 label, sampled every 30 min by test-infra's runner-fleet-metrics workflow. Fleet capacity, not utilisation.",
+        "id": 5,
+        "links": [],
+        "title": "Registered runners [view]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "min": 0,
+                "unit": "short",
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  max(offline) AS offline\nFROM (\n  SELECT ts, series, sum(offline) AS offline\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) - max(online_count) AS offline\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Registered B200 runners not reporting status=online (total_count - online_count). Sustained non-zero means a DGX host or its ghad-manager sessions have dropped out.",
+        "id": 6,
+        "links": [],
+        "title": "Runners offline [view]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "min": 0,
+                "unit": "short",
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-7": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "ceczcsck1b20wb"
+                    },
+                    "group": "grafana-clickhouse-datasource",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorType": "sql",
+                      "format": 0,
+                      "meta": {
+                        "builderOptions": {
+                          "columns": [],
+                          "database": "",
+                          "limit": 1000,
+                          "mode": "list",
+                          "queryType": "table",
+                          "table": ""
+                        }
+                      },
+                      "pluginVersion": "4.17.0",
+                      "queryType": "timeseries",
+                      "rawSql": "SELECT\n  toStartOfInterval(ts, INTERVAL 30 MINUTE) AS time,\n  series,\n  round(100 * sum(busy) / nullIf(sum(online), 0), 1) AS busy_pct\nFROM (\n  SELECT ts, series, sum(busy) AS busy, sum(online) AS online\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(busy_count) AS busy, max(online_count) AS online\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Share of online B200 runners executing a job (busy_count / online_count), sample-weighted per bucket. Read alongside 'Queue time' — high utilisation with rising queue time means the fleet is capacity-bound.",
+        "id": 7,
+        "links": [],
+        "title": "Runner utilization [view]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "min": 0,
+                "unit": "percent",
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "max": 100
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
     }
   },
   "layout": {
@@ -602,6 +996,45 @@
             "width": 24,
             "x": 0,
             "y": 24
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-5"
+            },
+            "height": 8,
+            "width": 24,
+            "x": 0,
+            "y": 32
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-6"
+            },
+            "height": 8,
+            "width": 24,
+            "x": 0,
+            "y": 40
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-7"
+            },
+            "height": 8,
+            "width": 24,
+            "x": 0,
+            "y": 48
           }
         }
       ]

--- a/grafana/dgx_b200.json
+++ b/grafana/dgx_b200.json
@@ -591,7 +591,7 @@
             "transformations": []
           }
         },
-        "description": "Registered self-hosted runners carrying each B200 label, from misc.runner_fleet_count (sampled every 30 min). Daily peak.",
+        "description": "Registered self-hosted runners carrying each B200 label, from misc.runner_fleet_count (sampled every 30 min). Daily peak. The dashed line is the expected count from multi-tenant/inventory/manual_inventory: 24 for linux.dgx.b200 (3 hosts x num_users=8) and 3 for linux.dgx.b200.8 (3 hosts x num_users=1).",
         "id": 5,
         "links": [],
         "title": "Total runners [view]",
@@ -641,20 +641,96 @@
                     "mode": "none"
                   },
                   "thresholdsStyle": {
-                    "mode": "off"
+                    "mode": "dashed"
                   }
                 },
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green",
+                      "color": "rgba(255, 255, 255, 0)",
                       "value": 0
                     }
                   ]
                 }
               },
-              "overrides": []
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "linux.dgx.b200",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "rgba(255, 255, 255, 0)",
+                            "value": 0
+                          },
+                          {
+                            "color": "#EAB839",
+                            "value": 24
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "linux.dgx.b200.8",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "rgba(255, 255, 255, 0)",
+                            "value": 0
+                          },
+                          {
+                            "color": "#EAB839",
+                            "value": 3
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "b200 (aggregated)",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "rgba(255, 255, 255, 0)",
+                            "value": 0
+                          },
+                          {
+                            "color": "#EAB839",
+                            "value": 27
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             "options": {
               "annotations": {

--- a/grafana/dgx_b200.json
+++ b/grafana/dgx_b200.json
@@ -579,7 +579,7 @@
                       },
                       "pluginVersion": "4.17.0",
                       "queryType": "timeseries",
-                      "rawSql": "SELECT\n  toStartOfDay(ts) AS time,\n  series,\n  max(runners) AS runners\nFROM (\n  SELECT ts, series, sum(runners) AS runners\n  FROM (\n    SELECT\n      time_stamp AS ts,\n      label,\n      if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n      max(total_count) AS runners\n    FROM misc.runner_fleet_count\n    WHERE $__timeFilter(time_stamp)\n      AND org = 'pytorch'\n      AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n      AND ('$view' IN ('aggregated','all') OR label = '$view')\n    GROUP BY ts, label, series\n  )\n  GROUP BY ts, series\n)\nGROUP BY time, series\nORDER BY time, series"
+                      "rawSql": "WITH samples AS (\n  SELECT\n    time_stamp AS ts,\n    label,\n    if('$view' = 'aggregated', 'b200 (aggregated)', label) AS series,\n    max(total_count) AS runners,\n    multiIf(label = 'linux.dgx.b200', 24, label = 'linux.dgx.b200.8', 3, 0) AS expected\n  FROM misc.runner_fleet_count\n  WHERE $__timeFilter(time_stamp)\n    AND org = 'pytorch'\n    AND label IN ('linux.dgx.b200','linux.dgx.b200.8')\n    AND ('$view' IN ('aggregated','all') OR label = '$view')\n  GROUP BY ts, label, series, expected\n),\nper_sample AS (\n  SELECT ts, series, sum(runners) AS runners, sum(expected) AS expected\n  FROM samples\n  GROUP BY ts, series\n)\nSELECT * FROM (\n  SELECT toStartOfDay(ts) AS time, series, max(runners) AS runners\n  FROM per_sample\n  GROUP BY time, series\n  UNION ALL\n  SELECT toStartOfDay(ts) AS time, concat(series, ' expected') AS series, max(expected) AS runners\n  FROM per_sample\n  GROUP BY time, series\n)\nORDER BY time, series"
                     },
                     "version": "v0"
                   },
@@ -641,14 +641,14 @@
                     "mode": "none"
                   },
                   "thresholdsStyle": {
-                    "mode": "dashed"
+                    "mode": "off"
                   }
                 },
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "rgba(255, 255, 255, 0)",
+                      "color": "green",
                       "value": 0
                     }
                   ]
@@ -658,24 +658,41 @@
                 {
                   "matcher": {
                     "id": "byName",
-                    "options": "linux.dgx.b200",
+                    "options": "linux.dgx.b200 expected",
                     "scope": "series"
                   },
                   "properties": [
                     {
-                      "id": "thresholds",
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineStyle",
                       "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "rgba(255, 255, 255, 0)",
-                            "value": 0
-                          },
-                          {
-                            "color": "#EAB839",
-                            "value": 24
-                          }
+                        "fill": "dash",
+                        "dash": [
+                          10,
+                          10
                         ]
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "#EAB839",
+                        "mode": "fixed"
                       }
                     }
                   ]
@@ -683,24 +700,41 @@
                 {
                   "matcher": {
                     "id": "byName",
-                    "options": "linux.dgx.b200.8",
+                    "options": "linux.dgx.b200.8 expected",
                     "scope": "series"
                   },
                   "properties": [
                     {
-                      "id": "thresholds",
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineStyle",
                       "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "rgba(255, 255, 255, 0)",
-                            "value": 0
-                          },
-                          {
-                            "color": "#EAB839",
-                            "value": 3
-                          }
+                        "fill": "dash",
+                        "dash": [
+                          10,
+                          10
                         ]
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "#EAB839",
+                        "mode": "fixed"
                       }
                     }
                   ]
@@ -708,24 +742,41 @@
                 {
                   "matcher": {
                     "id": "byName",
-                    "options": "b200 (aggregated)",
+                    "options": "b200 (aggregated) expected",
                     "scope": "series"
                   },
                   "properties": [
                     {
-                      "id": "thresholds",
+                      "id": "custom.drawStyle",
+                      "value": "line"
+                    },
+                    {
+                      "id": "custom.lineStyle",
                       "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "rgba(255, 255, 255, 0)",
-                            "value": 0
-                          },
-                          {
-                            "color": "#EAB839",
-                            "value": 27
-                          }
+                        "fill": "dash",
+                        "dash": [
+                          10,
+                          10
                         ]
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 2
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 0
+                    },
+                    {
+                      "id": "custom.showPoints",
+                      "value": "never"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "#EAB839",
+                        "mode": "fixed"
                       }
                     }
                   ]


### PR DESCRIPTION
Adds a `Total runners [view]` panel to the DGX B200 dashboard showing registered runner counts for `linux.dgx.b200` and `linux.dgx.b200.8`, from the new `misc.runner_fleet_count` table (pytorch/test-infra#8403).

The dashboard could only infer capacity from job events before; this is the fleet's own count. Note the table only has data from 2026-07-30 22:00 UTC, when the test-infra collector first ran.

### Preview

https://pytorchci.grafana.net/d/hurzv7z/dgx-b200-runners?orgId=1&from=now-3M&to=now&timezone=browser&var-view=all&var-percentile=0.9