### PR TITLE
Promote ARC chart 0.14.1-jeanschmidt.18 to fleet-wide default

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -53,7 +53,7 @@ defaults:
     pdb_enabled: true
     pdb_min_available: 1
   arc:
-    chart_version: "0.14.1-jeanschmidt.17"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
+    chart_version: "0.14.1-jeanschmidt.18"  # MUST match for controller + runner charts (minor version mismatch = ARS deletion). Fork chart published from jeanschmidt/actions-runner-controller.
     replica_count: 4
     log_level: info
     controller_cpu_request: "1"
@@ -151,7 +151,6 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
-      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -229,7 +228,6 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
-      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -309,7 +307,6 @@ clusters:
       pdb_enabled: false
       pdb_min_available: 0
     arc:
-      chart_version: "0.14.1-jeanschmidt.18"
       replica_count: 1
       log_level: debug
       controller_cpu_request: "500m"
@@ -415,8 +412,6 @@ clusters:
         - osdc_gha_prod
     base:
       vpc_cidr: "10.4.0.0/16"
-    arc:
-      chart_version: "0.14.1-jeanschmidt.18"
     node_compactor:
       min_node_age_seconds: 300
     buildkit:


### PR DESCRIPTION
**Impact:** all ARC clusters 
**Risk:** medium

## What
Bumps the default ARC controller/runner chart version to `0.14.1-jeanschmidt.18` and drops the now-redundant per-cluster `.18` overrides, so every cluster inherits `.18` from `defaults`.

## Why
`.18` has already been soaking on all three staging clusters and prod-ue1. This finishes the rollout by moving the remaining prod clusters — prod-uw1, prod-ue2, lf-prod-ue1, lf-prod-ue2 — off `.17` and onto `.18`, and collapses the four scattered overrides back into a single source of truth in `defaults`.

# Notes
- A chart-version bump alone does **not** roll the ghalistener pods (the capacity code lives in the listener). To actually activate `.18` on the newly-bumped prod clusters, the deploy must run with `restart_listeners` enabled so the AutoscalingListener CRs are recreated. Verify listeners come up healthy on each cluster after deploy.