### PR TITLE
grafana/osdc: dashboard quality-of-life tweaks

### DIFF
--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -1436,6 +1436,131 @@
           }
         }
       }
+    },
+    "panel-12": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
+                      "instant": false,
+                      "legendFormat": "{{cluster}}",
+                      "queryType": "range",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Count of hf-cache rclone mounts whose container's LAST termination was OOMKilled (kube_pod_container_status_last_terminated_reason). This is a sticky signal: it stays set after the pod recovers and only clears when the pod is replaced (node recycle / rollout) — so it counts mounts that OOM'd recently, INCLUDING ones already back to Running. It is an upper bound / early-warning indicator, NOT a live 'currently broken' count (that would need a per-pod not-ready or waiting-reason metric, which is not currently shipped to Mimir for the hf-cache namespace). A sustained rise still means the small-tier OOM is active and jobs on those nodes can fail to start.",
+        "id": 12,
+        "links": [],
+        "title": "hf-cache Mounts OOM-killed — recent, incl. recovered [cluster]",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 0,
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "custom": {
+                  "axisSoftMax": 5,
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.9,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "line+area"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
     }
   },
   "layout": {
@@ -1583,6 +1708,19 @@
             "width": 12,
             "x": 12,
             "y": 40
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-12"
+            },
+            "height": 8,
+            "width": 24,
+            "x": 0,
+            "y": 48
           }
         }
       ]

--- a/grafana/osdc.json
+++ b/grafana/osdc.json
@@ -540,7 +540,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "app": "grafana-assistant-app",
-                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0)",
+                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_running_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0) unless on(cluster) (label_replace(vector(1), \"cluster\", \"meta-prod-aws-uw1\", \"\", \"\") and on() (count(count by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\"})) == count(count by(cluster) (gha_assigned_jobs{cluster=~\".*arc.*production.*|meta-prod-aws-.*|lf-prod-aws-.*\"}))))",
                       "instant": false,
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
@@ -556,7 +556,7 @@
             "transformations": []
           }
         },
-        "description": "Week-over-week percentage change in the 3-hour rolling average of running jobs.",
+        "description": "Week-over-week percentage change in the 3-hour rolling average of running jobs. meta-prod-aws-uw1 is hidden when all clusters are selected (its low traffic makes the week-over-week percentage too spiky to be useful) and reappears when an explicit cluster subset that includes it is selected.",
         "id": 4,
         "links": [],
         "title": "Running Jobs Week-over-Week % Change, 3h Avg [cluster, scale_set]",
@@ -678,7 +678,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "app": "grafana-assistant-app",
-                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0)",
+                      "expr": "(100 * (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"}))[3h:]) - avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) / avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:])) and on(cluster) (avg_over_time((sum by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\", name=~\"$scale_set\"} offset 1w))[3h:]) > 0) unless on(cluster) (label_replace(vector(1), \"cluster\", \"meta-prod-aws-uw1\", \"\", \"\") and on() (count(count by(cluster) (gha_assigned_jobs{cluster=~\"$cluster\"})) == count(count by(cluster) (gha_assigned_jobs{cluster=~\".*arc.*production.*|meta-prod-aws-.*|lf-prod-aws-.*\"}))))",
                       "instant": false,
                       "legendFormat": "{{cluster}}",
                       "queryType": "range",
@@ -694,7 +694,7 @@
             "transformations": []
           }
         },
-        "description": "Week-over-week percentage change in the 3-hour rolling average of assigned jobs.",
+        "description": "Week-over-week percentage change in the 3-hour rolling average of assigned jobs. meta-prod-aws-uw1 is hidden when all clusters are selected (its low traffic makes the week-over-week percentage too spiky to be useful) and reappears when an explicit cluster subset that includes it is selected.",
         "id": 5,
         "links": [],
         "title": "Assigned Jobs Week-over-Week % Change, 3h Avg [cluster, scale_set]",
@@ -1436,131 +1436,6 @@
           }
         }
       }
-    },
-    "panel-12": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "grafanacloud-prom"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
-                      "instant": false,
-                      "legendFormat": "{{cluster}}",
-                      "queryType": "range",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Count of hf-cache rclone mounts whose container's LAST termination was OOMKilled (kube_pod_container_status_last_terminated_reason). This is a sticky signal: it stays set after the pod recovers and only clears when the pod is replaced (node recycle / rollout) — so it counts mounts that OOM'd recently, INCLUDING ones already back to Running. It is an upper bound / early-warning indicator, NOT a live 'currently broken' count (that would need a per-pod not-ready or waiting-reason metric, which is not currently shipped to Mimir for the hf-cache namespace). A sustained rise still means the small-tier OOM is active and jobs on those nodes can fail to start.",
-        "id": 12,
-        "links": [],
-        "title": "hf-cache Mounts OOM-killed — recent, incl. recovered [cluster]",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "decimals": 0,
-                "color": {
-                  "mode": "palette-classic-by-name",
-                  "seriesBy": "max"
-                },
-                "custom": {
-                  "axisSoftMax": 5,
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.9,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 2,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "line+area"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.1.0-25668120414"
-        }
-      }
     }
   },
   "layout": {
@@ -1709,19 +1584,6 @@
             "x": 12,
             "y": 40
           }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-12"
-            },
-            "height": 8,
-            "width": 24,
-            "x": 0,
-            "y": 48
-          }
         }
       ]
     }
@@ -1739,7 +1601,7 @@
   "preload": false,
   "tags": [],
   "timeSettings": {
-    "autoRefresh": "",
+    "autoRefresh": "1m",
     "autoRefreshIntervals": [
       "5s",
       "10s",
@@ -1753,7 +1615,7 @@
       "1d"
     ],
     "fiscalYearStartMonth": 0,
-    "from": "now-6h",
+    "from": "now-24h",
     "hideTimepicker": false,
     "timezone": "browser",
     "to": "now"


### PR DESCRIPTION
- Hide meta-prod-aws-uw1 from both Week-over-Week % Change panels when all clusters are selected; it reappears for explicit subsets
- Set default time range to now-24h (was now-6h)
- Enable 1m auto-refresh (was disabled)

uw1's low traffic makes its week-over-week percentage too spiky to be useful in the aggregate view, so the queries add an `unless on(cluster)` guard that drops it only when the current selection equals the full cluster set. Descriptions updated to document the behavior.

dashboard: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc/osdc