### PR TITLE
Adds "OSDC Service Status" dashboard in grafana

### DIFF
--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -439,95 +439,6 @@
         }
       }
     },
-    "panel-106": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "${datasource}"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "min(time() - git_cache_central_last_success_timestamp{cluster=~\"$cluster\"})",
-                      "legendFormat": ""
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Seconds since the git cache central StatefulSet last synced. Yellow at 30 min, red at 1 h. Affects runner clone speed.",
-        "id": 106,
-        "links": [],
-        "title": "Git Cache Central",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "max": 3600,
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "#EAB839",
-                      "value": 1800
-                    },
-                    {
-                      "color": "red",
-                      "value": 3600
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "background",
-              "graphMode": "area",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.2.0-30402795349"
-        }
-      }
-    },
     "panel-107": {
       "kind": "Panel",
       "spec": {
@@ -2575,6 +2486,951 @@
           "version": "13.2.0-30402795349"
         }
       }
+    },
+    "panel-134": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (sum(kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"hf-cache\", daemonset=~\"hf-cache-mount.*\"}) / clamp_min(sum(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"hf-cache\", daemonset=~\"hf-cache-mount.*\"}), 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the hf-cache rclone FUSE mount DaemonSets (all GPU tiers). Grey = not deployed on this cluster.",
+        "id": 134,
+        "links": [],
+        "title": "HF Cache Mount (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-135": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"keda\", deployment=\"keda-operator\"}) >= bool 1)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "KEDA operator Deployment readiness. Grey = KEDA not deployed on this cluster; DOWN = operator not ready.",
+        "id": 135,
+        "links": [],
+        "title": "KEDA Operator",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": null,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-136": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_max(sum(increase(keda_scaler_detail_errors_total{cluster=~\"$cluster\"}[10m])), 1)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Recent KEDA scaler errors (10m window). ERRORING = a build-node autoscaler trigger is failing / falling back to the fixed pool. Grey = no scalers on this cluster.",
+        "id": 136,
+        "links": [],
+        "title": "KEDA Scalers",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "text": "OK"
+                      },
+                      "1": {
+                        "color": "red",
+                        "text": "ERRORING"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": null,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-137": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"kube-system\", deployment=\"bin-pack-scheduler\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "bin-pack-scheduler Deployment readiness (secondary kube-scheduler). DOWN = not ready / crashlooping.",
+        "id": 137,
+        "links": [],
+        "title": "Bin-Pack Scheduler",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-138": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (sum(kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"monitoring\", daemonset=~\".*prometheus-node-exporter\"}) / clamp_min(sum(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"monitoring\", daemonset=~\".*prometheus-node-exporter\"}), 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the prometheus-node-exporter DaemonSet (source of node memory/conntrack metrics).",
+        "id": 138,
+        "links": [],
+        "title": "Node Exporter (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-139": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"monitoring\", deployment=\"prometheus-pushgateway\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "prometheus-pushgateway Deployment readiness (relays zombie-cleanup metrics).",
+        "id": 139,
+        "links": [],
+        "title": "Prometheus Pushgateway",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-140": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"ebs-csi-node\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"ebs-csi-node\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the ebs-csi-node DaemonSet (per-node EBS volume attach).",
+        "id": 140,
+        "links": [],
+        "title": "EBS CSI Node (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-141": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"algif-mitigation\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"algif-mitigation\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the algif-mitigation DaemonSet (kernel CVE mitigation).",
+        "id": 141,
+        "links": [],
+        "title": "Algif Mitigation (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-142": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"dirtyfrag-mitigation\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"dirtyfrag-mitigation\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the dirtyfrag-mitigation DaemonSet (kernel CVE mitigation).",
+        "id": 142,
+        "links": [],
+        "title": "DirtyFrag Mitigation (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-143": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"node-performance-tuning\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"node-performance-tuning\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready fraction of the node-performance-tuning DaemonSet.",
+        "id": 143,
+        "links": [],
+        "title": "Node Performance Tuning (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
     }
   },
   "layout": {
@@ -2672,11 +3528,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-106"
+                        "name": "panel-135"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 5,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-136"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
                       "y": 3
                     }
                   },
@@ -2689,19 +3558,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-105"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 3
                     }
@@ -2711,7 +3567,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-108"
+                        "name": "panel-105"
                       },
                       "height": 3,
                       "width": 4,
@@ -2724,11 +3580,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-107"
+                        "name": "panel-108"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-107"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 6
                     }
                   },
@@ -2741,7 +3610,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 6
                     }
                   },
@@ -2754,19 +3623,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 6
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-118"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 6
                     }
@@ -2776,7 +3632,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-109"
+                        "name": "panel-118"
                       },
                       "height": 3,
                       "width": 4,
@@ -2789,11 +3645,37 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-122"
+                        "name": "panel-137"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-109"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-122"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
                       "y": 9
                     }
                   },
@@ -2806,8 +3688,47 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 15,
                       "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-141"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-142"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-143"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 12
                     }
                   },
                   {
@@ -2820,7 +3741,20 @@
                       "height": 3,
                       "width": 5,
                       "x": 10,
-                      "y": 9
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-140"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 12
                     }
                   },
                   {
@@ -2831,9 +3765,9 @@
                         "name": "panel-128"
                       },
                       "height": 3,
-                      "width": 5,
-                      "x": 15,
-                      "y": 9
+                      "width": 4,
+                      "x": 20,
+                      "y": 12
                     }
                   },
                   {
@@ -2844,9 +3778,22 @@
                         "name": "panel-129"
                       },
                       "height": 3,
-                      "width": 4,
-                      "x": 20,
-                      "y": 9
+                      "width": 5,
+                      "x": 0,
+                      "y": 15
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-134"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 15
                     }
                   },
                   {
@@ -2858,8 +3805,8 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 0,
-                      "y": 12
+                      "x": 10,
+                      "y": 15
                     }
                   },
                   {
@@ -2871,8 +3818,8 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
-                      "y": 12
+                      "x": 15,
+                      "y": 15
                     }
                   },
                   {
@@ -2883,9 +3830,9 @@
                         "name": "panel-131"
                       },
                       "height": 3,
-                      "width": 5,
-                      "x": 10,
-                      "y": 12
+                      "width": 4,
+                      "x": 20,
+                      "y": 15
                     }
                   },
                   {
@@ -2897,8 +3844,8 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 15,
-                      "y": 12
+                      "x": 0,
+                      "y": 18
                     }
                   },
                   {
@@ -2909,9 +3856,35 @@
                         "name": "panel-133"
                       },
                       "height": 3,
-                      "width": 4,
-                      "x": 20,
-                      "y": 12
+                      "width": 5,
+                      "x": 5,
+                      "y": 18
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-138"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 18
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-139"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 18
                     }
                   },
                   {
@@ -2922,9 +3895,9 @@
                         "name": "panel-127"
                       },
                       "height": 3,
-                      "width": 5,
-                      "x": 0,
-                      "y": 15
+                      "width": 4,
+                      "x": 20,
+                      "y": 18
                     }
                   },
                   {
@@ -2936,8 +3909,8 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
-                      "y": 15
+                      "x": 0,
+                      "y": 21
                     }
                   }
                 ]

--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -3431,6 +3431,222 @@
           "version": "13.2.0-30402795349"
         }
       }
+    },
+    "panel-144": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
+                      "instant": false,
+                      "legendFormat": "{{cluster}}",
+                      "queryType": "range",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-cluster count of hf-cache rclone mounts whose last container termination was OOMKilled. Sticky: includes already-recovered mounts until the pod is replaced (early-warning/upper-bound, not a live \"currently down\" count). The restart counter is not retained for the hf-cache namespace, so this last-terminated-reason gauge is the OOM signal.",
+        "id": 144,
+        "links": [],
+        "title": "hf-cache Mounts OOM-killed",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 0,
+                "color": {
+                  "mode": "palette-classic-by-name",
+                  "seriesBy": "max"
+                },
+                "custom": {
+                  "axisSoftMax": 5,
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.9,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineStyle": {
+                    "fill": "solid"
+                  },
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "line+area"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.1.0-25668120414"
+        }
+      }
+    },
+    "panel-145": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\"}[1h]))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Container restarts in the last hour (per cluster). NOTE: the metrics cost filter retains kube_pod_container_status_restarts_total only for namespaces arc-systems, karpenter, harbor-system, monitoring, logging, buildkit (plus bin-pack-scheduler) — restarts in kube-system, hf-cache, arc-runners, keda and others are NOT counted, so this is a core-services pulse, not a true cluster-wide total.",
+        "id": 145,
+        "links": [],
+        "title": "Container Restarts (1h)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": null,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "green"
+                    },
+                    {
+                      "value": 1,
+                      "color": "#EAB839"
+                    },
+                    {
+                      "value": 10,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
     }
   },
   "layout": {
@@ -3450,11 +3666,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-101"
+                        "name": "panel-145"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-101"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 0
                     }
                   },
@@ -3467,7 +3696,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 0
                     }
                   },
@@ -3480,19 +3709,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-102"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 0
                     }
@@ -3502,7 +3718,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-114"
+                        "name": "panel-102"
                       },
                       "height": 3,
                       "width": 4,
@@ -3515,11 +3731,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-104"
+                        "name": "panel-114"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-104"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 3
                     }
                   },
@@ -3532,7 +3761,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 3
                     }
                   },
@@ -3545,19 +3774,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-126"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 3
                     }
@@ -3567,7 +3783,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-105"
+                        "name": "panel-126"
                       },
                       "height": 3,
                       "width": 4,
@@ -3580,11 +3796,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-108"
+                        "name": "panel-105"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-108"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 6
                     }
                   },
@@ -3597,7 +3826,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 6
                     }
                   },
@@ -3610,19 +3839,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 6
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-117"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 6
                     }
@@ -3632,7 +3848,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-118"
+                        "name": "panel-117"
                       },
                       "height": 3,
                       "width": 4,
@@ -3645,11 +3861,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-137"
+                        "name": "panel-118"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-137"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 9
                     }
                   },
@@ -3662,7 +3891,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 9
                     }
                   },
@@ -3675,19 +3904,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 9
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-123"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 9
                     }
@@ -3697,7 +3913,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-141"
+                        "name": "panel-123"
                       },
                       "height": 3,
                       "width": 4,
@@ -3710,11 +3926,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-142"
+                        "name": "panel-141"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-142"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 12
                     }
                   },
@@ -3727,7 +3956,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 12
                     }
                   },
@@ -3740,19 +3969,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 12
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-140"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 12
                     }
@@ -3762,7 +3978,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-128"
+                        "name": "panel-140"
                       },
                       "height": 3,
                       "width": 4,
@@ -3775,11 +3991,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-129"
+                        "name": "panel-128"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 15
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-129"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 15
                     }
                   },
@@ -3792,7 +4021,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 15
                     }
                   },
@@ -3805,19 +4034,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 15
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-130"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 15
                     }
@@ -3827,7 +4043,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-131"
+                        "name": "panel-130"
                       },
                       "height": 3,
                       "width": 4,
@@ -3840,7 +4056,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-132"
+                        "name": "panel-131"
                       },
                       "height": 3,
                       "width": 5,
@@ -3853,7 +4069,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-133"
+                        "name": "panel-132"
                       },
                       "height": 3,
                       "width": 5,
@@ -3866,7 +4082,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-138"
+                        "name": "panel-133"
                       },
                       "height": 3,
                       "width": 5,
@@ -3879,7 +4095,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-139"
+                        "name": "panel-138"
                       },
                       "height": 3,
                       "width": 5,
@@ -3892,7 +4108,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-127"
+                        "name": "panel-139"
                       },
                       "height": 3,
                       "width": 4,
@@ -3905,12 +4121,38 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-112"
+                        "name": "panel-127"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
                       "y": 21
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-112"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 21
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-144"
+                      },
+                      "height": 8,
+                      "width": 24,
+                      "x": 0,
+                      "y": 24
                     }
                   }
                 ]

--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -3980,6 +3980,38 @@
           "version": "13.2.0-30402795349"
         }
       }
+    },
+    "panel-150": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 150,
+        "links": [],
+        "title": "",
+        "vizConfig": {
+          "group": "text",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {},
+              "overrides": []
+            },
+            "options": {
+              "content": "Matrix of diverging-signal counts by check-type (each row) and cluster (each tile). 0 = healthy; a higher number / red = something to investigate — expand that cluster's section below for detail.",
+              "mode": "markdown"
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
     }
   },
   "layout": {
@@ -4000,10 +4032,23 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-146"
+                        "name": "panel-150"
                       },
                       "x": 0,
                       "y": 0,
+                      "width": 24,
+                      "height": 2
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-146"
+                      },
+                      "x": 0,
+                      "y": 2,
                       "width": 24,
                       "height": 4
                     }
@@ -4016,7 +4061,7 @@
                         "name": "panel-147"
                       },
                       "x": 0,
-                      "y": 4,
+                      "y": 6,
                       "width": 24,
                       "height": 4
                     }
@@ -4029,7 +4074,7 @@
                         "name": "panel-148"
                       },
                       "x": 0,
-                      "y": 8,
+                      "y": 10,
                       "width": 24,
                       "height": 4
                     }
@@ -4042,7 +4087,7 @@
                         "name": "panel-149"
                       },
                       "x": 0,
-                      "y": 12,
+                      "y": 14,
                       "width": 24,
                       "height": 4
                     }

--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -4664,9 +4664,19 @@
       "spec": {
         "allowCustomValue": true,
         "current": {
-          "text": "All",
+          "text": [
+            "meta-prod-aws-ue1",
+            "meta-prod-aws-ue2",
+            "meta-prod-aws-uw1",
+            "lf-prod-aws-ue1",
+            "lf-prod-aws-ue2"
+          ],
           "value": [
-            "$__all"
+            "meta-prod-aws-ue1",
+            "meta-prod-aws-ue2",
+            "meta-prod-aws-uw1",
+            "lf-prod-aws-ue1",
+            "lf-prod-aws-ue2"
           ]
         },
         "definition": "label_values(up,cluster)",

--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -3450,9 +3450,9 @@
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "count by(cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
+                      "expr": "sum(kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or vector(0)",
                       "instant": false,
-                      "legendFormat": "{{cluster}}",
+                      "legendFormat": "",
                       "queryType": "range",
                       "range": true
                     },
@@ -3466,94 +3466,59 @@
             "transformations": []
           }
         },
-        "description": "Per-cluster count of hf-cache rclone mounts whose last container termination was OOMKilled. Sticky: includes already-recovered mounts until the pod is replaced (early-warning/upper-bound, not a live \"currently down\" count). The restart counter is not retained for the hf-cache namespace, so this last-terminated-reason gauge is the OOM signal.",
+        "description": "hf-cache rclone mounts whose last termination was OOMKilled, reduced as MAX over the selected time window — RED if any OOM occurred in the window, green if none. Sticky signal (a mount stays flagged until its pod is replaced), so it includes already-recovered mounts; the restart counter isn’t retained for the hf-cache namespace, so this reason gauge is used.",
         "id": 144,
         "links": [],
         "title": "hf-cache Mounts OOM-killed",
         "vizConfig": {
-          "group": "timeseries",
+          "group": "stat",
           "kind": "VizConfig",
           "spec": {
             "fieldConfig": {
               "defaults": {
-                "decimals": 0,
                 "color": {
-                  "mode": "palette-classic-by-name",
-                  "seriesBy": "max"
+                  "mode": "thresholds"
                 },
-                "custom": {
-                  "axisSoftMax": 5,
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.9,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 2,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "line+area"
-                  }
-                },
+                "max": null,
+                "min": 0,
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green",
-                      "value": 0
+                      "value": null,
+                      "color": "green"
                     },
                     {
-                      "color": "red",
-                      "value": 1
+                      "value": 1,
+                      "color": "red"
                     }
                   ]
-                }
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
               },
               "overrides": []
             },
             "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "max"
+                ],
+                "fields": "",
+                "values": false
               },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
             }
           },
-          "version": "13.1.0-25668120414"
+          "version": "13.2.0-30402795349"
         }
       }
     },
@@ -3647,6 +3612,374 @@
           "version": "13.2.0-30402795349"
         }
       }
+    },
+    "panel-146": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (cluster) (kube_deployment_status_replicas_unavailable{cluster=~\"$cluster\"} or clamp_min(kube_statefulset_replicas{cluster=~\"$cluster\"} - kube_statefulset_status_replicas_ready{cluster=~\"$cluster\"}, 0)) + (count by (cluster) ((kube_daemonset_status_number_unavailable{cluster=~\"$cluster\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\"}, 1)) > 0.1) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true,
+                      "instant": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-cluster workload health: count of unavailable Deployment/StatefulSet replicas, plus DaemonSets that are >10% unavailable (churn-tolerant, so routine node scale-up/down does not trip it). Green=0, yellow=1, red>=2.",
+        "id": 146,
+        "links": [],
+        "title": "Workloads",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": null,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "green"
+                    },
+                    {
+                      "value": 1,
+                      "color": "#EAB839"
+                    },
+                    {
+                      "value": 2,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "values": false,
+                "calcs": [
+                  "lastNotNull"
+                ]
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-147": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(count by (cluster) (up{cluster=~\"$cluster\", job=~\"monitoring/coredns|monitoring/nodelocaldns|monitoring/arc-listeners|dcgm-exporter\"} == 0) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) (harbor_health{cluster=~\"$cluster\"} == 0) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) (group by (cluster, proxy)(haproxy_server_status{cluster=~\"$cluster\", proxy=~\"bk_.*\"}) unless group by (cluster, proxy)(haproxy_server_status{cluster=~\"$cluster\", proxy=~\"bk_.*\", state=\"UP\"} == 1)) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) ((100 * sum by (cluster)(rate(apiserver_request_total{cluster=~\"$cluster\", code=~\"5..\"}[5m])) / clamp_min(sum by (cluster)(rate(apiserver_request_total{cluster=~\"$cluster\"}[5m])), 1)) >= 2) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) ((100 * max by (cluster)(node_nf_conntrack_entries{cluster=~\"$cluster\"} / node_nf_conntrack_entries_limit{cluster=~\"$cluster\"})) >= 60) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true,
+                      "instant": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-cluster count of unreachable/unhealthy services: scrape targets down (CoreDNS, NodeLocal DNS, ARC Listeners, DCGM), Harbor unhealthy, BuildKit LB backends down, API Server 5xx>=2%, conntrack>=60%. Green=0, yellow=1, red>=2. Fires on ANY down scrape target, so it can be slightly more eager than the per-service %-healthy panels (never falsely green).",
+        "id": 147,
+        "links": [],
+        "title": "Liveness",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": null,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "green"
+                    },
+                    {
+                      "value": 1,
+                      "color": "#EAB839"
+                    },
+                    {
+                      "value": 2,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "values": false,
+                "calcs": [
+                  "lastNotNull"
+                ]
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-148": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(count by (cluster) ((time() - max by (cluster)(kube_job_status_completion_time{cluster=~\"$cluster\", namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\"})) >= 600) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) ((time() - max by (cluster)(gha_capacity_reconcile_last_success_timestamp_seconds{cluster=~\"$cluster\"})) >= 600) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) ((time() - max by (cluster)(kube_job_status_completion_time{cluster=~\"$cluster\", namespace=\"arc-runners\", job_name=~\"zombie-cleanup-.*\"})) >= 7200) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) (sum by (cluster)(rate(node_compactor_reconcile_cycles_total{cluster=~\"$cluster\", status=\"success\"}[5m])) == 0) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true,
+                      "instant": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-cluster count of stale scheduled jobs / reconcile loops: Harbor Cache Recovery (>10m), ARC Capacity reconcile (>10m), Zombie Cleanup (>2h), Node Compactor (no successful cycle in 5m). Green=0, yellow=1, red>=2.",
+        "id": 148,
+        "links": [],
+        "title": "Freshness",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": null,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "green"
+                    },
+                    {
+                      "value": 1,
+                      "color": "#EAB839"
+                    },
+                    {
+                      "value": 2,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "values": false,
+                "calcs": [
+                  "lastNotNull"
+                ]
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-149": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(count by (cluster) (kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=\"hf-cache\", container=\"rclone\", reason=\"OOMKilled\"} == 1) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0)) + (count by (cluster) (sum by (cluster)(increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\"}[1h])) >= 20) or (group by (cluster)(up{cluster=~\"$cluster\"}) * 0))",
+                      "legendFormat": "{{cluster}}",
+                      "range": true,
+                      "instant": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Per-cluster: hf-cache rclone OOM-kills (any in window) + a restart storm (>=20 container restarts in 1h; the baseline is ~10/h so this flags genuine storms, not routine churn). Green=0, yellow=1, red>=2. Restart coverage limited to namespaces where the restart counter is retained (see Container Restarts tile).",
+        "id": 149,
+        "links": [],
+        "title": "OOM / Restarts",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": null,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "green"
+                    },
+                    {
+                      "value": 1,
+                      "color": "#EAB839"
+                    },
+                    {
+                      "value": 2,
+                      "color": "red"
+                    }
+                  ]
+                },
+                "unit": "short",
+                "decimals": 0,
+                "noValue": null
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "values": false,
+                "calcs": [
+                  "lastNotNull"
+                ]
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
     }
   },
   "layout": {
@@ -3656,7 +3989,73 @@
         {
           "kind": "RowsLayoutRow",
           "spec": {
+            "title": "Summary",
             "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-146"
+                      },
+                      "x": 0,
+                      "y": 0,
+                      "width": 24,
+                      "height": 4
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-147"
+                      },
+                      "x": 0,
+                      "y": 4,
+                      "width": 24,
+                      "height": 4
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-148"
+                      },
+                      "x": 0,
+                      "y": 8,
+                      "width": 24,
+                      "height": 4
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-149"
+                      },
+                      "x": 0,
+                      "y": 12,
+                      "width": 24,
+                      "height": 4
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": true,
             "layout": {
               "kind": "GridLayout",
               "spec": {
@@ -4030,7 +4429,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-119"
+                        "name": "panel-144"
                       },
                       "height": 3,
                       "width": 5,
@@ -4043,7 +4442,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-130"
+                        "name": "panel-119"
                       },
                       "height": 3,
                       "width": 4,
@@ -4056,11 +4455,24 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-131"
+                        "name": "panel-130"
                       },
                       "height": 3,
                       "width": 5,
                       "x": 0,
+                      "y": 18
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-131"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
                       "y": 18
                     }
                   },
@@ -4073,7 +4485,7 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 5,
+                      "x": 10,
                       "y": 18
                     }
                   },
@@ -4086,19 +4498,6 @@
                       },
                       "height": 3,
                       "width": 5,
-                      "x": 10,
-                      "y": 18
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-138"
-                      },
-                      "height": 3,
-                      "width": 5,
                       "x": 15,
                       "y": 18
                     }
@@ -4108,7 +4507,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-139"
+                        "name": "panel-138"
                       },
                       "height": 3,
                       "width": 4,
@@ -4121,7 +4520,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-127"
+                        "name": "panel-139"
                       },
                       "height": 3,
                       "width": 5,
@@ -4134,7 +4533,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-112"
+                        "name": "panel-127"
                       },
                       "height": 3,
                       "width": 5,
@@ -4147,12 +4546,12 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-144"
+                        "name": "panel-112"
                       },
-                      "height": 8,
-                      "width": 24,
-                      "x": 0,
-                      "y": 24
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 21
                     }
                   }
                 ]
@@ -4175,7 +4574,7 @@
     "osdc"
   ],
   "timeSettings": {
-    "autoRefresh": "1m",
+    "autoRefresh": "30s",
     "autoRefreshIntervals": [
       "5s",
       "10s",

--- a/grafana/osdc_services_status.json
+++ b/grafana/osdc_services_status.json
@@ -1,0 +1,3041 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Crosshair",
+  "editable": true,
+  "elements": {
+    "panel-101": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(sum(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"arc-systems\", deployment=~\"arc-gha-rs-controller\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready replicas of the ARC controller (`arc-gha-rs-controller`) Deployment. Down when none ready — operator is offline, runner-scale-set CRs stop reconciling.",
+        "id": 101,
+        "links": [],
+        "title": "ARC Controller",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-102": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(count(karpenter_nodepools_usage{cluster=~\"$cluster\"}) > bool 0) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Karpenter is reporting nodepool usage metrics (proxy for `controller running`). Down = no node autoscaling.",
+        "id": 102,
+        "links": [],
+        "title": "Karpenter",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-104": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(count by (proxy) (haproxy_server_status{cluster=~\"$cluster\", proxy=~\"bk_.*\", state=\"UP\"} == 1)) > bool 0) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "HAProxy has at least one backend marked UP for each `bk_*` proxy. Down = builds can't be dispatched.",
+        "id": 104,
+        "links": [],
+        "title": "BuildKit LB",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-105": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(sum(rate(node_compactor_reconcile_cycles_total{cluster=~\"$cluster\", status=\"success\"}[5m])) > bool 0) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Compactor reconcile loop has produced successful cycles in the last 5 min. Down = no node consolidation, EKS spend rises.",
+        "id": 105,
+        "links": [],
+        "title": "Node Compactor",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-106": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "min(time() - git_cache_central_last_success_timestamp{cluster=~\"$cluster\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Seconds since the git cache central StatefulSet last synced. Yellow at 30 min, red at 1 h. Affects runner clone speed.",
+        "id": 106,
+        "links": [],
+        "title": "Git Cache Central",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 3600,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 1800
+                    },
+                    {
+                      "color": "red",
+                      "value": 3600
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-107": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * (count(up{cluster=~\"$cluster\", job=\"monitoring/coredns\"} == 1) / clamp_min(count(up{cluster=~\"$cluster\", job=\"monitoring/coredns\"}), 1))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of in-cluster CoreDNS scrape targets up. Yellow below 80%, red below 50%. Cluster DNS resolution at risk.",
+        "id": 107,
+        "links": [],
+        "title": "CoreDNS (in-cluster)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 50
+                    },
+                    {
+                      "color": "green",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-108": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * sum(rate(apiserver_request_total{cluster=~\"$cluster\", code=~\"5..\"}[5m])) / clamp_min(sum(rate(apiserver_request_total{cluster=~\"$cluster\"}[5m])), 1)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "5xx error rate on the EKS Kubernetes API server, last 5 min. Yellow at >=2%, red at >=5%. High values mean control-plane instability — kubectl, operators, and webhooks will be flaky.",
+        "id": 108,
+        "links": [],
+        "title": "API Server",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 10,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 2
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-109": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "harbor_health{cluster=~\"$cluster\"} or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Aggregate `harbor_health` gauge from harbor-exporter. UP = all components healthy; DOWN = any Harbor component failing (Trivy/registry/core/portal).",
+        "id": 109,
+        "links": [],
+        "title": "Harbor Health",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-112": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "time() - max(kube_job_status_completion_time{cluster=~\"$cluster\", namespace=\"harbor-system\", job_name=~\"harbor-cache-recovery-.*\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Seconds since the last harbor-cache-recovery cron job completed. Yellow at 10 min, red at 20 min (job schedule is every 5 min).",
+        "id": 112,
+        "links": [],
+        "title": "Harbor Cache Recovery",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 1200,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 600
+                    },
+                    {
+                      "color": "red",
+                      "value": 1200
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-113": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * (count(up{cluster=~\"$cluster\", job=\"monitoring/nodelocaldns\"} == 1) / clamp_min(count(up{cluster=~\"$cluster\", job=\"monitoring/nodelocaldns\"}), 1))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of NodeLocal DNS DaemonSet pods up. Yellow below 95%, red below 90%. Per-node DNS cache; degradation hurts runner DNS latency.",
+        "id": 113,
+        "links": [],
+        "title": "NodeLocal DNS",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 90
+                    },
+                    {
+                      "color": "green",
+                      "value": 95
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-114": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"buildkit\", deployment=~\"buildkitd-(amd64|arm64)\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Min ready replicas across `buildkitd-amd64` and `buildkitd-arm64` Deployments. Down = builds stall on one or both architectures.",
+        "id": 114,
+        "links": [],
+        "title": "BuildKit Workers",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-115": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * (count(up{cluster=~\"$cluster\", job=\"monitoring/arc-listeners\"} == 1) / clamp_min(count(up{cluster=~\"$cluster\", job=\"monitoring/arc-listeners\"}), 1))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of ARC listener pods (`monitoring/arc-listeners`) up. Yellow below 95%, red below 90%. Each listener handles one scale set; individual failures silently break that scale set's dispatch.",
+        "id": 115,
+        "links": [],
+        "title": "ARC Listeners",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 90
+                    },
+                    {
+                      "color": "green",
+                      "value": 95
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-116": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "time() - max(gha_capacity_reconcile_last_success_timestamp_seconds{cluster=~\"$cluster\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Seconds since the ARC capacity monitor last completed a reconcile loop. Yellow at 10 min, red at 20 min. If stale, capacity dashboards and the `ARCListenerStall` alert go blind.",
+        "id": 116,
+        "links": [],
+        "title": "ARC Capacity Monitor",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 1200,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 600
+                    },
+                    {
+                      "color": "red",
+                      "value": 1200
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-117": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"aws-node\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"aws-node\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of `aws-node` DaemonSet pods healthy (1 per node). Yellow below 93%, red below 85%. Pods on affected nodes can't get IPs.",
+        "id": 117,
+        "links": [],
+        "title": "VPC CNI (aws-node) (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-118": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"kube-proxy\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"kube-proxy\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of `kube-proxy` DaemonSet pods healthy. Yellow below 93%, red below 85%. Affected nodes lose Service VIP routing.",
+        "id": 118,
+        "links": [],
+        "title": "kube-proxy (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-119": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * max(node_nf_conntrack_entries{cluster=~\"$cluster\"} / node_nf_conntrack_entries_limit{cluster=~\"$cluster\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Max conntrack table utilization across all nodes. Yellow at >=60%, red at >=80%. Saturation drops new connections (IPv6 SNAT side effect).",
+        "id": 119,
+        "links": [],
+        "title": "Conntrack Pressure",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-121": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"kube-system\", deployment=\"ebs-csi-controller\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready replicas of the EBS CSI controller Deployment. Down = new EBS volumes can't be provisioned (slow-burn; existing PVs keep working).",
+        "id": 121,
+        "links": [],
+        "title": "EBS CSI Driver",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-122": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(kube_deployment_status_replicas_unavailable{cluster=~\"$cluster\", namespace=\"harbor-system\"}) + sum(kube_statefulset_replicas{cluster=~\"$cluster\", namespace=\"harbor-system\"} - kube_statefulset_status_replicas_ready{cluster=~\"$cluster\", namespace=\"harbor-system\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Sum of unhealthy Harbor Deployments + StatefulSets (replicas - ready). Green at 0, yellow >=1, red >=2.",
+        "id": 122,
+        "links": [],
+        "title": "Harbor Components",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 5,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-123": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"image-cache-janitor\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"image-cache-janitor\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of image-cache-janitor DaemonSet pods healthy. Yellow below 93%, red below 85%. Stops node disk eviction.",
+        "id": 123,
+        "links": [],
+        "title": "Image Cache Janitor (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-126": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"arc-runners\", daemonset=\"runner-hooks-warmer\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"arc-runners\", daemonset=\"runner-hooks-warmer\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of runner-hooks-warmer DaemonSet pods healthy. Yellow below 93%, red below 85%. Down = runner pods can't mount patched container hooks and fail to start.",
+        "id": 126,
+        "links": [],
+        "title": "Runner Hooks Warmer (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-127": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "time() - max(kube_job_status_completion_time{cluster=~\"$cluster\", namespace=\"arc-runners\", job_name=~\"zombie-cleanup-.*\"})",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Seconds since the zombie-cleanup CronJob last completed. Yellow at 2 h, red at 4 h. Stale = zombie runner pods can pile up and squat capacity.",
+        "id": 127,
+        "links": [],
+        "title": "Zombie Cleanup",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 14400,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 7200
+                    },
+                    {
+                      "color": "red",
+                      "value": 14400
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-128": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"nvidia-device-plugin-daemonset\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"kube-system\", daemonset=\"nvidia-device-plugin-daemonset\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of NVIDIA device plugin DaemonSet pods healthy on GPU nodes. Yellow below 93%, red below 85%. Down = `nvidia.com/gpu` resource zeroes out, GPU runners can't schedule.",
+        "id": 128,
+        "links": [],
+        "title": "NVIDIA Device Plugin (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-129": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "100 * (count(up{cluster=~\"$cluster\", job=\"dcgm-exporter\"} == 1) / clamp_min(count(up{cluster=~\"$cluster\", job=\"dcgm-exporter\"}), 1))",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of DCGM exporter scrape targets up on GPU nodes. Yellow below 95%, red below 90%. Powers all GPU alerts (ECC, XID, temp, row-remap).",
+        "id": 129,
+        "links": [],
+        "title": "DCGM Exporter",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 90
+                    },
+                    {
+                      "color": "green",
+                      "value": 95
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-130": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"monitoring\", deployment=\"alloy\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready replicas of the Alloy metrics pipeline Deployment. Down = no metrics flow to Grafana Cloud Mimir, this dashboard goes blank.",
+        "id": 130,
+        "links": [],
+        "title": "Alloy Metrics",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-131": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "clamp_min(100 * (1 - (kube_daemonset_status_number_unavailable{cluster=~\"$cluster\", namespace=\"logging\", daemonset=\"alloy-logging\"} / clamp_min(kube_daemonset_status_desired_number_scheduled{cluster=~\"$cluster\", namespace=\"logging\", daemonset=\"alloy-logging\"}, 1))), 0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Percent of alloy-logging DaemonSet pods healthy. Yellow below 93%, red below 85%. Affected nodes stop shipping logs to Grafana Cloud Loki.",
+        "id": 131,
+        "links": [],
+        "title": "Alloy Logging (% healthy)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "max": 100,
+                "min": 80,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 85
+                    },
+                    {
+                      "color": "green",
+                      "value": 93
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-132": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"monitoring\", deployment=~\".*kube-state-metrics\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready replicas of kube-state-metrics. Down = roughly half of this dashboard's cards (any using `kube_*` metrics) go red.",
+        "id": 132,
+        "links": [],
+        "title": "kube-state-metrics",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    },
+    "panel-133": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "${datasource}"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "(min(kube_deployment_status_replicas_ready{cluster=~\"$cluster\", namespace=\"monitoring\", deployment=\"kube-prometheus-stack-operator\"}) >= bool 1) or on() vector(0)",
+                      "legendFormat": ""
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Ready replicas of `kube-prometheus-stack-operator`. Down = new ServiceMonitors/PodMonitors stop being reconciled (slow-burn; existing scrapes keep working).",
+        "id": 133,
+        "links": [],
+        "title": "Prometheus Operator",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "noValue": "DOWN",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.2.0-30402795349"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "RowsLayout",
+    "spec": {
+      "rows": [
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-101"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-115"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-116"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-102"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-114"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-104"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-106"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-126"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-105"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-108"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 3
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-107"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-113"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-117"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-118"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-109"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 6
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-122"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-123"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-121"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-128"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-129"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 9
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-119"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-130"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-131"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 10,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-132"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 15,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-133"
+                      },
+                      "height": 3,
+                      "width": 4,
+                      "x": 20,
+                      "y": 12
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-127"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 0,
+                      "y": 15
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-112"
+                      },
+                      "height": 3,
+                      "width": 5,
+                      "x": 5,
+                      "y": 15
+                    }
+                  }
+                ]
+              }
+            },
+            "repeat": {
+              "mode": "variable",
+              "value": "cluster"
+            },
+            "title": "${cluster}"
+          }
+        }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preload": false,
+  "tags": [
+    "osdc"
+  ],
+  "timeSettings": {
+    "autoRefresh": "1m",
+    "autoRefreshIntervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-1h",
+    "hideTimepicker": false,
+    "timezone": "browser",
+    "to": "now"
+  },
+  "title": "OSDC Services Status",
+  "variables": [
+    {
+      "kind": "DatasourceVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "grafanacloud-pytorchci-prom",
+          "value": "grafanacloud-prom"
+        },
+        "hide": "hideVariable",
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "skipUrlSync": false
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(up,cluster)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "${datasource}"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(up,cluster)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "version": "v0"
+        },
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds to our dashboard a "OSDC Service Status" dashboard. Designed to be a quick and fast glance to answer the question "Is everything all right with the OSDC cluster and services?".

It is designed in such a way:

- On top there is a quick matrix, of signal *types* (row) and cluster (column) with a count of the number of yellow/red services in that cluster;
- Collapsed, there is a detail of each cluster service and how each service is performing right now;
- By clicking with right button and choosing "Explore" it is possible to investigate this signal;

Honesty part:
I noticed that for a few clusters, a few of the signals are very flaky, going between green -> (yellow and red) by the minute. Honestly, I don't know if this is a healthy behavior or something to investigate. My personal take: ship as-is and investigate signal-by-signal to parse what is noise and we need to adjust the thresholds and what is a legitimate instability that is just self-recovering. My goal is to do this as a follow up as this should take time.

Link: https://pytorchci.grafana.net/d/ci-infra-f4vfmq-osdc_services_status/osdc-services-status