### PR TITLE
Register multi-tenant runners with --unattended --replace

### DIFF
--- a/multi-tenant/scripts/multi-tenant-gpu-main.sh
+++ b/multi-tenant/scripts/multi-tenant-gpu-main.sh
@@ -28,4 +28,4 @@ mkdir -p ~/.docker
 sudo cat /docker/config.json | jq 'del(.currentContext)' > ~/.docker/config.json
 sudo chown -R 1000:1000 ~/.docker
 
-sudo su - $RUNNER_USER -c "/bin/bash -c './config.sh --url $RUNNER_URL --token $GH_TOKEN --name ${INSTANCE_ID}-${RUNNER_UID} --labels $INSTANCE_LABEL --ephemeral && ./run.sh'"
+sudo su - $RUNNER_USER -c "/bin/bash -c './config.sh --url $RUNNER_URL --token $GH_TOKEN --name ${INSTANCE_ID}-${RUNNER_UID} --labels $INSTANCE_LABEL --unattended --replace --ephemeral && ./run.sh'"


### PR DESCRIPTION
## Problem

Runners on the DGX B200 boxes intermittently fail to connect under their expected name (`<host>-<uid>`, e.g. `dgxb200-05-1002`) and never pick up jobs, wedging a GPU slot.

Root cause: `config.sh` is invoked **without `--unattended`**. Without it, the runner config tool runs interactively and treats `--name`/`--labels` as mere prompt defaults. Because we launch it via `su -c` with no TTY, the prompts hit EOF and it silently falls back to the container hostname with only the default `self-hosted/Linux/X64` labels — yet still exits 0, so `run.sh` starts and the runner reports "Listening for Jobs".

Evidence from a wedged container (correct args passed in, wrong registration out):
- `docker inspect` args: `--name dgxb200-05-1002 --labels linux.dgx.b200`
- `~/.runner` `agentName`: `edc57a424bad` (the container hostname)
- `Running job` count in logs: **0** (missing `linux.dgx.b200` ⇒ no DGX job ever targets it)

Since the runner is `--ephemeral`, it only exits after a job — so it never exits, the container stays Up, and `ghad-manager` never respawns the correct runner.

## Fix

Add `--unattended` (honor the provided `--name`/`--labels`, never prompt) and `--replace` (reclaim a lingering same-name registration instead of falling back to the hostname).

## Deploy

The script is mounted into the container from `/home/<user>/multi-tenant-gpu-main.sh`, so no image rebuild — `just setup-host <host>` redeploys it, then clear the wedged containers so they respawn against the fixed script.