### PR TITLE
Don't restart multi-tenant runners that are processing a job

### DIFF
--- a/multi-tenant/playbooks/setup-host.yml
+++ b/multi-tenant/playbooks/setup-host.yml
@@ -377,11 +377,25 @@
       become: true
       become_user: "{{ item.name }}"
       ansible.builtin.shell: |
-        containers=$(docker ps -q)
-        if [ -n "$containers" ]; then
-          docker stop $containers
+        set -o pipefail
+        uid="$(id -u)"
+        # become_user has no ~/.bashrc, so set the rootless docker env ourselves.
+        export DOCKER_HOST="unix:///run/user/${uid}/docker.sock"
+        export XDG_RUNTIME_DIR="/run/user/${uid}"
+        export PATH="$HOME/bin:$PATH"
+        [ -S "/run/user/${uid}/docker.sock" ] || { echo "no docker socket"; exit 0; }
+        c=$(docker ps -q -f "name=ghad-main-shared-instance-container")
+        [ -n "$c" ] || { echo "no runner container"; exit 0; }
+        # Leave a running job alone (Runner.Worker present); ghad-manager respawns it after.
+        if docker top "$c" 2>/dev/null | grep -q "Runner.Worker"; then
+          echo "skip: job in progress"
+        else
+          echo "stopping idle runner"
+          docker stop "$c"
         fi
       loop: "{{ created_users.results }}"
+      loop_control:
+        label: "{{ item.name }}"
 
     - name: Create a HF cache directory
       ansible.builtin.file:

--- a/multi-tenant/playbooks/setup-host.yml
+++ b/multi-tenant/playbooks/setup-host.yml
@@ -377,21 +377,23 @@
       become: true
       become_user: "{{ item.name }}"
       ansible.builtin.shell: |
-        set -o pipefail
+        set -euo pipefail
         uid="$(id -u)"
+        NAME="ghad-main-shared-instance-container"
         # become_user has no ~/.bashrc, so set the rootless docker env ourselves.
         export DOCKER_HOST="unix:///run/user/${uid}/docker.sock"
         export XDG_RUNTIME_DIR="/run/user/${uid}"
         export PATH="$HOME/bin:$PATH"
         [ -S "/run/user/${uid}/docker.sock" ] || { echo "no docker socket"; exit 0; }
-        c=$(docker ps -q -f "name=ghad-main-shared-instance-container")
-        [ -n "$c" ] || { echo "no runner container"; exit 0; }
+        # Exact-name lookup via docker inspect (docker ps --filter name= is a substring match).
+        docker inspect -f '{% raw %}{{.State.Running}}{% endraw %}' "$NAME" 2>/dev/null | grep -qx true \
+          || { echo "no running runner container"; exit 0; }
         # Leave a running job alone (Runner.Worker present); ghad-manager respawns it after.
-        if docker top "$c" 2>/dev/null | grep -q "Runner.Worker"; then
+        if docker top "$NAME" 2>/dev/null | grep -q "Runner.Worker"; then
           echo "skip: job in progress"
         else
           echo "stopping idle runner"
-          docker stop "$c"
+          docker stop "$NAME"
         fi
       loop: "{{ created_users.results }}"
       loop_control:


### PR DESCRIPTION
## Problem

The `Restart runners` step in `setup-host.yml` ran `docker stop $(docker ps -q)` under `become_user`, with two issues:

1. **Wrong docker daemon.** `become_user` runs a non-login shell that never sources `~/.bashrc`, so `DOCKER_HOST` is unset and the CLI hits the (empty) root socket instead of the tenant's rootless dockerd — so it actually found and stopped nothing.
2. **Kills in-flight jobs.** It stopped runners unconditionally, so re-running the playbook could interrupt a job mid-execution.

## Fix

- Export `DOCKER_HOST`/`XDG_RUNTIME_DIR`/`PATH` for the per-tenant rootless daemon.
- Scope to the `ghad-main-shared-instance-container` and check `docker top` for a `Runner.Worker` child — that process exists only while a job is running. If present, leave it alone; `ghad-manager` respawns the runner (with current config) after the ephemeral runner finishes and exits.

Host-side signal only — no GitHub token or `docker exec` needed.