### PR TITLE
Add clear-stuck-runners playbook to remediate wedged runner slots

### DIFF
--- a/multi-tenant/justfile
+++ b/multi-tenant/justfile
@@ -21,6 +21,8 @@
 #   just setup-host dgxb200-03    # provision a single host / group
 #   just restart-services         # restart docker + ghad-manager
 #   just restart-ghad             # restart only the ghad-manager service
+#   just clear-stuck-runners dgxb200-04       # report orphaned runner containers
+#   just clear-stuck-runners dgxb200-04 true  # stop the orphaned ones
 
 set dotenv-load
 set dotenv-filename := "secrets.env"
@@ -72,6 +74,13 @@ restart-services limit=LIMIT: setup
 # Restart only the ghad-manager service on B200 host(s)
 restart-ghad limit=LIMIT: setup
     uv run ansible-playbook -i {{ INVENTORY }} --limit '{{ limit }}' -u {{ LOGIN_USER }} {{ CONNECT }} playbooks/restart-ghad-service.yml -vv
+
+# Find (apply=true also stops) orphaned runner containers not connected to GitHub.
+# Prompts for the GitHub token, then the SSH + sudo password. Dry-run unless apply=true.
+#   just clear-stuck-runners dgxb200-04           # report only
+#   just clear-stuck-runners dgxb200-04 true       # stop the stuck ones
+clear-stuck-runners limit=LIMIT apply="false": setup
+    uv run ansible-playbook -i {{ INVENTORY }} --limit '{{ limit }}' -u {{ LOGIN_USER }} {{ CONNECT }} playbooks/clear-stuck-runners.yml -e apply={{ apply }} -vv
 
 # Build and push the multi-tenant-gpu runner image to ECR
 docker-build:

--- a/multi-tenant/playbooks/clear-stuck-runners.yml
+++ b/multi-tenant/playbooks/clear-stuck-runners.yml
@@ -1,43 +1,15 @@
 ---
-# Clear orphaned / misregistered multi-tenant runner containers.
+# Stop runner containers that are Up but not healthily connected to GitHub, so
+# ghad-manager can respawn a correct one. Two cases: orphaned (expected
+# "<hostname>-<uid>" runner offline) or misregistered (connected under the hex
+# container hostname with wrong labels, so it never gets a job). Either way an
+# ephemeral runner never exits and the container wedges the GPU slot.
 #
-# Two failure modes this clears (both wedge the GPU slot because the container
-# is Up so ghad-manager won't respawn the correct runner):
-#   1. Orphaned    -> container Up but the expected runner "<hostname>-<uid>"
-#                     (e.g. dgxb200-04-1003) is not connected to GitHub.
-#   2. Misregistered -> container Up and connected, but registered under the
-#                     WRONG name (its hex container hostname) with default
-#                     labels, so it never matches a DGX job. This is the
-#                     config.sh-without-`--unattended` fallback bug; the fix is
-#                     in scripts/multi-tenant-gpu-main.sh, this just remediates.
+# Only stops a container that is NOT busy (under its expected or actual name)
+# AND up longer than min_uptime_hours (default 2h). Dry-run unless -e apply=true;
+# aborts before stopping anything if the GitHub API check fails.
 #
-# What it does per host:
-#   1. Asks GitHub which org runners are online/busy (needs your token).
-#   2. For each tenant, checks whether its container is Up, for how long, and
-#      what name it actually registered as (from the in-container ~/.runner).
-#   3. Classifies every slot:
-#        keep   -> Up AND connected as "<hostname>-<uid>" (idle OR busy)  => kept
-#        young  -> Up but for less than min_uptime_hours                  => kept
-#        STUCK  -> Up > min_uptime_hours AND (not connected OR name drift) => stop
-#        none   -> no running container (ghad-manager will spawn)
-#   4. Dry-run by default. With -e apply=true it stops ONLY the STUCK
-#      containers; ghad-manager respawns a fresh, connected runner within ~20s.
-#
-# Safeguard: a container is stopped ONLY when it is (a) NOT healthily connected
-# (either offline, or connected under the wrong name), (b) NOT busy under either
-# name, AND (c) has been running longer than min_uptime_hours (default 2h). The
-# 2h floor means transient/mid-registration containers are never touched.
-#
-# Safety:
-#   * Never stops a runner reporting busy=true under either its expected or its
-#     actual (drifted) name — a container running a job is always kept.
-#   * An already-running container cannot fix its own registration (ghad-manager
-#     only re-registers by respawning, which requires stopping it first) — so
-#     there is no race where a "stuck" slot silently becomes healthy.
-#   * If the GitHub API call fails (bad/unscoped token, network), the play
-#     aborts on the `uri` task BEFORE stopping anything.
-#
-# Run it via:  just clear-stuck-runners [host/group] [apply]   (see justfile)
+# Run via: just clear-stuck-runners [host/group] [apply]
 
 - name: Clear orphaned runner containers not connected to GitHub
   hosts: all

--- a/multi-tenant/playbooks/clear-stuck-runners.yml
+++ b/multi-tenant/playbooks/clear-stuck-runners.yml
@@ -1,0 +1,264 @@
+---
+# Clear orphaned / misregistered multi-tenant runner containers.
+#
+# Two failure modes this clears (both wedge the GPU slot because the container
+# is Up so ghad-manager won't respawn the correct runner):
+#   1. Orphaned    -> container Up but the expected runner "<hostname>-<uid>"
+#                     (e.g. dgxb200-04-1003) is not connected to GitHub.
+#   2. Misregistered -> container Up and connected, but registered under the
+#                     WRONG name (its hex container hostname) with default
+#                     labels, so it never matches a DGX job. This is the
+#                     config.sh-without-`--unattended` fallback bug; the fix is
+#                     in scripts/multi-tenant-gpu-main.sh, this just remediates.
+#
+# What it does per host:
+#   1. Asks GitHub which org runners are online/busy (needs your token).
+#   2. For each tenant, checks whether its container is Up, for how long, and
+#      what name it actually registered as (from the in-container ~/.runner).
+#   3. Classifies every slot:
+#        keep   -> Up AND connected as "<hostname>-<uid>" (idle OR busy)  => kept
+#        young  -> Up but for less than min_uptime_hours                  => kept
+#        STUCK  -> Up > min_uptime_hours AND (not connected OR name drift) => stop
+#        none   -> no running container (ghad-manager will spawn)
+#   4. Dry-run by default. With -e apply=true it stops ONLY the STUCK
+#      containers; ghad-manager respawns a fresh, connected runner within ~20s.
+#
+# Safeguard: a container is stopped ONLY when it is (a) NOT healthily connected
+# (either offline, or connected under the wrong name), (b) NOT busy under either
+# name, AND (c) has been running longer than min_uptime_hours (default 2h). The
+# 2h floor means transient/mid-registration containers are never touched.
+#
+# Safety:
+#   * Never stops a runner reporting busy=true under either its expected or its
+#     actual (drifted) name — a container running a job is always kept.
+#   * An already-running container cannot fix its own registration (ghad-manager
+#     only re-registers by respawning, which requires stopping it first) — so
+#     there is no race where a "stuck" slot silently becomes healthy.
+#   * If the GitHub API call fails (bad/unscoped token, network), the play
+#     aborts on the `uri` task BEFORE stopping anything.
+#
+# Run it via:  just clear-stuck-runners [host/group] [apply]   (see justfile)
+
+- name: Clear orphaned runner containers not connected to GitHub
+  hosts: all
+  become: yes
+  gather_facts: yes
+  vars:
+    # Fixed tenant-user ordering; sliced to the group's num_users (inventory var).
+    user_names:
+      - alice
+      - bob
+      - charlie
+      - david
+      - eve
+      - frank
+      - grace
+      - henry
+      - isaac
+      - julia
+      - kevin
+      - lisa
+    ansible_host_key_checking: false
+    org: pytorch
+    container_name: ghad-main-shared-instance-container
+    min_uptime_hours: 2        # safeguard: never stop a container younger than this
+    apply: false               # override with -e apply=true to actually stop
+  vars_prompt:
+    - name: github_token
+      prompt: "GitHub token (org admin / manage_runners:org) — used to check runner status"
+      private: yes
+  module_defaults:
+    shell:
+      executable: /bin/bash
+
+  tasks:
+    - name: Require a GitHub token
+      ansible.builtin.assert:
+        that: github_token | length > 0
+        fail_msg: "A GitHub token is required to verify runner connectivity."
+
+    - name: Announce mode
+      ansible.builtin.debug:
+        msg: >-
+          Host {{ ansible_hostname }} — {{ 'APPLY (will stop stuck containers)'
+          if apply | bool else 'DRY-RUN (report only)' }},
+          min_uptime={{ min_uptime_hours }}h, num_users={{ num_users }}
+
+    - name: Resolve tenant uids
+      ansible.builtin.getent:
+        database: passwd
+
+    - name: Build tenant (name + uid) list
+      ansible.builtin.set_fact:
+        tenants: "{{ tenants | default([]) + [ {'name': item, 'uid': getent_passwd[item][1]} ] }}"
+      loop: "{{ user_names[:(num_users | int)] }}"
+
+    # -- Ask GitHub which of this org's self-hosted runners are online/busy -----
+    - name: List org runners (first page, for total_count)
+      ansible.builtin.uri:
+        url: "https://api.github.com/orgs/{{ org }}/actions/runners?per_page=100&page=1"
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        return_content: yes
+        status_code: 200
+      register: gh_first
+      no_log: true
+
+    - name: Compute number of runner pages
+      ansible.builtin.set_fact:
+        gh_pages: "{{ ((gh_first.json.total_count | int) / 100) | round(0, 'ceil') | int }}"
+
+    - name: List org runners (remaining pages)
+      ansible.builtin.uri:
+        url: "https://api.github.com/orgs/{{ org }}/actions/runners?per_page=100&page={{ item }}"
+        headers:
+          Authorization: "Bearer {{ github_token }}"
+          Accept: "application/vnd.github+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        return_content: yes
+        status_code: 200
+      register: gh_rest
+      no_log: true
+      loop: "{{ range(2, (gh_pages | int) + 1) | list }}"
+      when: (gh_pages | int) > 1
+
+    - name: Assemble the org runner list
+      ansible.builtin.set_fact:
+        all_runners: >-
+          {{ gh_first.json.runners
+             + (gh_rest.results | default([]) | map(attribute='json.runners') | flatten) }}
+
+    - name: Report GitHub visibility for this host
+      ansible.builtin.debug:
+        msg: >-
+          GitHub: {{ all_runners | length }} org runners total;
+          {{ all_runners | selectattr('name', 'match', '^' ~ ansible_hostname ~ '-')
+             | list | length }} match this host prefix
+
+    # -- Inspect each tenant's runner container ---------------------------------
+    # Emits "running;up_seconds;agentName". agentName is what the runner actually
+    # registered with GitHub as (read from the in-container ~/.runner). A healthy
+    # runner registers as "<hostname>-<uid>"; a broken one falls back to the
+    # container's hex hostname with default labels (see config.sh --unattended
+    # fix). Comparing the two is the direct signal that a slot is misregistered.
+    - name: Inspect the runner container for each tenant
+      become: true
+      become_user: "{{ item.name }}"
+      ansible.builtin.shell: |
+        set -o pipefail
+        NAME="{{ container_name }}"
+        uid="{{ item.uid }}"
+        # become_user runs a non-login shell that never sources ~/.bashrc, so we
+        # must point the CLI at the per-tenant rootless dockerd ourselves.
+        export DOCKER_HOST="unix:///run/user/${uid}/docker.sock"
+        export XDG_RUNTIME_DIR="/run/user/${uid}"
+        export PATH="$HOME/bin:$PATH"
+        [ -S "/run/user/${uid}/docker.sock" ] || { echo "NOSOCK"; exit 0; }
+        RUNNER_CFG="/home/{{ item.name }}/.runner"
+        info=$(docker inspect -f '{% raw %}{{.State.Running}};{{.State.StartedAt}}{% endraw %}' "$NAME" 2>/dev/null) \
+          || { echo "ABSENT"; exit 0; }
+        running="${info%%;*}"; started="${info#*;}"
+        up=$(( $(date +%s) - $(date -d "$started" +%s) ))
+        agent=$(docker exec "$NAME" cat "$RUNNER_CFG" 2>/dev/null \
+          | sed -n 's/.*"agentName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+        echo "${running};${up};${agent}"
+      register: inspected
+      changed_when: false
+      loop: "{{ tenants }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Classify each tenant slot
+      ansible.builtin.set_fact:
+        slots: "{{ slots | default([]) + [ slot ] }}"
+      vars:
+        rname: "{{ ansible_hostname }}-{{ item.item.uid }}"
+        out: "{{ item.stdout | trim }}"
+        fields: "{{ out.split(';') if (out not in ['ABSENT', 'NOSOCK']) else [] }}"
+        running: "{{ (fields | length > 0) and ((fields[0] | lower) == 'true') }}"
+        up_sec: "{{ (fields[1] | int) if (fields | length > 1) else 0 }}"
+        # What the runner actually registered as (empty if we couldn't read it).
+        agent: "{{ fields[2] if (fields | length > 2) else '' }}"
+        # Expected-name entry in the org list (the healthy identity).
+        ghmatch: "{{ all_runners | selectattr('name', 'equalto', rname) | list }}"
+        online: "{{ (ghmatch | length > 0) and (ghmatch[0].status == 'online') }}"
+        # The actual registered runner's entry (by its real agentName), if any.
+        agentmatch: "{{ (all_runners | selectattr('name', 'equalto', agent) | list) if agent else [] }}"
+        # Never stop a runner that is actually running a job, under either name.
+        busy: >-
+          {{ ((ghmatch | length > 0) and (ghmatch[0].busy | default(false)))
+             or ((agentmatch | length > 0) and (agentmatch[0].busy | default(false))) }}
+        # Registered under the wrong name => misregistered (wrong labels, jobless).
+        name_drift: "{{ (running | bool) and (agent | length > 0) and (agent != rname) }}"
+        # Healthy = connected under the expected name and not drifted.
+        healthy: "{{ (online | bool) and (not (name_drift | bool)) }}"
+        old_enough: "{{ (up_sec | int) >= (min_uptime_hours | float) * 3600 }}"
+        stuck: "{{ (running | bool) and (not (busy | bool)) and (not (healthy | bool)) and (old_enough | bool) }}"
+        status: >-
+          {{ 'rootless docker not running — run: just restart-services' if (out == 'NOSOCK')
+             else 'no container (ghad-manager will spawn)' if not (running | bool)
+             else 'keep: CONNECTED, busy (job running)' if (busy | bool)
+             else 'keep: CONNECTED, idle (listening)' if (healthy | bool)
+             else ('STUCK: misregistered as ' ~ agent ~ ' (wrong name/labels, jobless), up > ' ~ min_uptime_hours ~ 'h'
+                   if (name_drift | bool) else 'STUCK: not connected, up > ' ~ min_uptime_hours ~ 'h') if (stuck | bool)
+             else ('misregistered as ' ~ agent ~ ' but up < ' if (name_drift | bool) else 'not connected but up < ')
+                   ~ min_uptime_hours ~ 'h — SKIP (safeguard)' }}
+        slot:
+          user: "{{ item.item.name }}"
+          uid: "{{ item.item.uid }}"
+          runner: "{{ rname }}"
+          agent: "{{ agent }}"
+          up_min: "{{ (up_sec | int) // 60 }}"
+          stuck: "{{ stuck }}"
+          status: "{{ status | trim }}"
+      loop: "{{ inspected.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+    - name: Classification report
+      ansible.builtin.debug:
+        msg: >-
+          {{ '%-8s' | format(item.user) }} uid={{ item.uid }}
+          {{ '%-16s' | format(item.runner) }}
+          as={{ '%-16s' | format(item.agent | default('?') if item.agent else '(none)') }}
+          up={{ (item.up_min | int) // 60 }}h{{ '%02d' | format((item.up_min | int) % 60) }}m
+          -> {{ item.status }}
+      loop: "{{ slots }}"
+      loop_control:
+        label: "{{ item.user }}"
+
+    - name: Summary
+      ansible.builtin.debug:
+        msg: >-
+          {{ (slots | selectattr('stuck', 'equalto', true) | list | length) }} stuck container(s):
+          {{ slots | selectattr('stuck', 'equalto', true) | map(attribute='runner') | list | default([]) }}.
+          {{ 'Stopping them now.' if apply | bool
+             else 'DRY-RUN: re-run with apply=true (or -e apply=true) to stop them.' }}
+
+    # -- Stop only the orphaned containers, only when apply=true -----------------
+    - name: Stop orphaned containers
+      become: true
+      become_user: "{{ item.user }}"
+      ansible.builtin.shell: |
+        NAME="{{ container_name }}"
+        uid="{{ item.uid }}"
+        export DOCKER_HOST="unix:///run/user/${uid}/docker.sock"
+        export XDG_RUNTIME_DIR="/run/user/${uid}"
+        export PATH="$HOME/bin:$PATH"
+        docker stop "$NAME"
+      loop: "{{ slots }}"
+      loop_control:
+        label: "{{ item.user }} ({{ item.runner }})"
+      when:
+        - apply | bool
+        - item.stuck | bool
+
+    - name: Done
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'Stopped stuck containers; ghad-manager will respawn & reconnect within ~20s.
+              Verify with: journalctl -u ghad-manager -f'
+             if apply | bool
+             else 'No changes made (dry-run).' }}


### PR DESCRIPTION
## What

Adds `playbooks/clear-stuck-runners.yml` + a `just clear-stuck-runners` recipe to find and (with `apply=true`) stop runner containers that are Up but **not healthily connected to GitHub** — either orphaned (expected `<host>-<uid>` runner offline) or misregistered under the container hostname with wrong labels. Such an ephemeral runner never gets a job, so it never exits, and the running container blocks `ghad-manager` from respawning the correct one.

## Safeguards

- Never stops a runner `busy` under its expected or actual name.
- Only stops containers up longer than `min_uptime_hours` (default 2h).
- Aborts before stopping anything if the GitHub API check fails.
- Dry-run by default; `apply=true` to stop.

## Usage

```
just clear-stuck-runners dgxb200-05        # report only
just clear-stuck-runners dgxb200-05 true   # stop the stuck ones
```