### PR TITLE
Scope hard-spread constraints to current ReplicaSet generation

### DIFF
--- a/osdc/base/helm/harbor/values.yaml
+++ b/osdc/base/helm/harbor/values.yaml
@@ -33,10 +33,21 @@ x-base-affinity: &base-affinity
 # starving other pods on that node of CPU — including harbor-database,
 # whose EBS volume pins it to one specific AZ/node. Component name is
 # templated in per-component below since each has a distinct label.
+#
+# matchLabelKeys: [pod-template-hash] scopes the skew calculation to the
+# current ReplicaSet generation only. Without it, a Deployment rollout
+# deadlocks whenever replicas > node count: the constraint counts old- and
+# new-generation pods together (both share the same component label), so
+# leftover old pods on a node block new pods from ever satisfying maxSkew,
+# and whenUnsatisfiable: DoNotSchedule refuses to place them — the rollout
+# can't finish because new pods never go Ready, and old pods can't be
+# removed until new ones do.
 x-spread-template: &spread-template
   maxSkew: 1
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: DoNotSchedule
+  matchLabelKeys:
+    - pod-template-hash
 
 # ============================================================================
 # Expose configuration (NodePort for containerd access)

--- a/osdc/modules/arc/helm/arc/values.yaml
+++ b/osdc/modules/arc/helm/arc/values.yaml
@@ -60,6 +60,13 @@ nodeSelector: {}
 # onto whichever node comes up first, starving other pods on that node of
 # CPU. maxUnavailable on the base node group never exceeds replicas-1 nodes,
 # so DoNotSchedule can't wedge this pending.
+#
+# matchLabelKeys: [pod-template-hash] scopes the skew calculation to the
+# current ReplicaSet generation only, so a Deployment rollout doesn't count
+# old-generation pods still awaiting termination against new pods'
+# placement — replicaCount currently sits under node count so this hasn't
+# deadlocked yet, but see base/helm/harbor/values.yaml for the rollout
+# deadlock this avoids once that margin disappears.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname
@@ -68,3 +75,5 @@ topologySpreadConstraints:
       matchLabels:
         app.kubernetes.io/name: gha-rs-controller
         app.kubernetes.io/instance: arc
+    matchLabelKeys:
+      - pod-template-hash

--- a/osdc/modules/bin-pack-scheduler/kubernetes/base/deployment.yaml
+++ b/osdc/modules/bin-pack-scheduler/kubernetes/base/deployment.yaml
@@ -36,6 +36,13 @@ spec:
       # onto whichever node is up first) — that starved other pods on that
       # node of CPU. maxUnavailable on the base node group never exceeds
       # replicas-1 nodes, so a required constraint can't wedge this pending.
+      #
+      # matchLabelKeys: [pod-template-hash] scopes the anti-affinity to the
+      # current ReplicaSet generation only, so a Deployment rollout doesn't
+      # count old-generation pods still awaiting termination against new
+      # pods' placement — replicas currently sit under node count so this
+      # hasn't deadlocked yet, but see base/helm/harbor/values.yaml for the
+      # rollout deadlock this avoids once that margin disappears.
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -43,6 +50,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: bin-pack-scheduler
+              matchLabelKeys:
+                - pod-template-hash
       containers:
         - name: kube-scheduler
           image: registry.k8s.io/kube-scheduler:v1.35.0


### PR DESCRIPTION
matchLabelKeys: [pod-template-hash] limits each hard spread/ anti-affinity constraint's skew calculation to pods from the current rollout generation. Without it, old- and new-generation pods share the same selector label and count together, so a Deployment with replicas > node count deadlocks mid-rollout: leftover old pods occupy nodes, new pods can never satisfy maxSkew, and whenUnsatisfiable: DoNotSchedule (or the equivalent required anti-affinity) refuses to place them.

Applied to all three components #946 touched:
- harbor core/portal/nginx (base/helm/harbor/values.yaml) — the one that actually deadlocked
- ARC gha-rs-controller and bin-pack-scheduler — same exposure, just not triggered yet since their replica counts (2 and 3) still sit under the 4-node base floor; that margin disappears the moment either grows or the base node count shrinks