### PR TITLE
Add nodepools-agent-sandbox module: a gVisor node fleet

### DIFF
--- a/osdc/modules/nodepools-agent-sandbox/defs/ai-sandbox.yaml
+++ b/osdc/modules/nodepools-agent-sandbox/defs/ai-sandbox.yaml
@@ -1,0 +1,20 @@
+# Karpenter NodePool fleet: ai-sandbox — dedicated pool for the AI agent sandbox.
+#
+# These nodes run gVisor (runsc) as a containerd runtime handler, installed at
+# boot by scripts/install-gvisor.sh (embedded as a userData MIME part). Only the
+# agent sandbox pods (runtimeClassName: gvisor, pinned here via the RuntimeClass
+# scheduling block in modules/agent-sandbox) schedule onto this fleet.
+#
+# The node-fleet=ai-sandbox taint isolates the pool; agent pods tolerate it via
+# the gvisor RuntimeClass scheduling. Deliberately a single small CPU instance
+# type for the prototype — no NVMe, no GPU.
+fleet:
+  name: ai-sandbox
+  arch: amd64
+  gpu: false
+  instances:
+    - type: c7i.8xlarge
+      weight: 100
+      node_disk_size: 100
+      # gVisor (runsc) install runs as a userData MIME part on these nodes only.
+      user_data_script: scripts/install-gvisor.sh

--- a/osdc/modules/nodepools-agent-sandbox/deploy.sh
+++ b/osdc/modules/nodepools-agent-sandbox/deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# nodepools-agent-sandbox: thin shim that delegates to the base nodepools module
+# with this module's own defs/ + generated/ + module label. Mirrors the
+# nodepools-h100 / nodepools-b200 pattern so the AI-agent sandbox fleet
+# (gVisor-enabled) is generated and applied only on clusters that list this
+# module — it never lands on prod via the shared modules/nodepools defs.
+#
+# Called by: just deploy-module <cluster> nodepools-agent-sandbox
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$(cd "$MODULE_DIR/../.." && pwd)}"
+
+export NODEPOOLS_DEFS_DIR="$MODULE_DIR/defs"
+export NODEPOOLS_OUTPUT_DIR="$MODULE_DIR/generated"
+export NODEPOOLS_MODULE_NAME="nodepools-agent-sandbox"
+
+exec "$UPSTREAM_ROOT/modules/nodepools/deploy.sh" "$@"

--- a/osdc/modules/nodepools-agent-sandbox/scripts/install-gvisor.sh
+++ b/osdc/modules/nodepools-agent-sandbox/scripts/install-gvisor.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# gVisor (runsc) install for AI-agent sandbox nodes.
+#
+# Embedded as a text/x-shellscript userData MIME part by the nodepools generator
+# (referenced from defs/ai-sandbox.yaml via user_data_script). Runs once at node
+# boot, AFTER nodeadm has written the EKS containerd config and started kubelet.
+# The node still has full egress at boot (pod-level NetworkPolicy does not apply
+# to the host), so fetching the release binaries here is fine.
+#
+# Best-effort by design: this fleet is dedicated to sandbox pods only. If the
+# install fails, only runtimeClassName=gvisor pods fail to start (fail-closed) —
+# the rest of the cluster is unaffected. To iterate without gVisor, drop
+# runtimeClassName from the agent pod spec and pin it to this fleet manually.
+set -euxo pipefail
+
+ARCH="$(uname -m)"
+URL_BASE="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
+
+install_bin() {
+  local name="$1"
+  curl -fsSL "${URL_BASE}/${name}" -o "/usr/local/bin/${name}"
+  curl -fsSL "${URL_BASE}/${name}.sha512" -o "/tmp/${name}.sha512"
+  (cd /usr/local/bin && sha512sum -c "/tmp/${name}.sha512")
+  chmod 0755 "/usr/local/bin/${name}"
+}
+
+install_bin runsc
+install_bin containerd-shim-runsc-v1
+
+# Register runsc as a containerd runtime handler. EKS AL2023 ships containerd
+# v2.x with config `version = 3`, whose CRI plugin key is
+# `io.containerd.cri.v1.runtime` (NOT the containerd-1.x `io.containerd.grpc.v1.cri`
+# — a v1-style stanza is silently ignored, so runsc never registers). Appending a
+# runtime stanza under the v3 key is additive and leaves the default runc alone.
+CONFIG=/etc/containerd/config.toml
+if ! grep -q 'containerd.runtimes.runsc' "${CONFIG}"; then
+  cat >>"${CONFIG}" <<'EOF'
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+EOF
+fi
+
+systemctl restart containerd

--- a/osdc/modules/nodepools-agent-sandbox/tests/smoke/conftest.py
+++ b/osdc/modules/nodepools-agent-sandbox/tests/smoke/conftest.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from smoke_conftest import *  # noqa: F403

--- a/osdc/modules/nodepools-agent-sandbox/tests/smoke/test_nodepools_agent_sandbox.py
+++ b/osdc/modules/nodepools-agent-sandbox/tests/smoke/test_nodepools_agent_sandbox.py
@@ -1,0 +1,49 @@
+"""Smoke tests for the nodepools-agent-sandbox module.
+
+Validates the dedicated gVisor fleet: the NodePool exists with the isolating
+node-fleet=ai-sandbox taint, and its EC2NodeClass userData carries the runsc
+install script (without which runtimeClassName=gvisor pods can never start).
+"""
+
+from __future__ import annotations
+
+import pytest
+from helpers import run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+NODEPOOL = "ai-sandbox-8xlarge"
+MODULE_LABEL = "nodepools-agent-sandbox"
+
+
+class TestAgentSandboxNodePool:
+    def test_nodepool_exists(self, all_nodepools: dict) -> None:
+        names = {np["metadata"]["name"] for np in all_nodepools.get("items", [])}
+        assert NODEPOOL in names, f"NodePool '{NODEPOOL}' not found. Existing: {sorted(names)}"
+
+    def test_nodepool_has_fleet_taint(self, all_nodepools: dict) -> None:
+        np = next(n for n in all_nodepools["items"] if n["metadata"]["name"] == NODEPOOL)
+        taints = np["spec"]["template"]["spec"].get("taints", [])
+        fleet_taints = [(t["key"], t.get("value")) for t in taints if t["key"] == "node-fleet"]
+        assert ("node-fleet", "ai-sandbox") in fleet_taints, (
+            f"NodePool '{NODEPOOL}' must carry the node-fleet=ai-sandbox NoSchedule taint; got {taints}."
+        )
+
+    def test_module_label(self, all_nodepools: dict) -> None:
+        np = next(n for n in all_nodepools["items"] if n["metadata"]["name"] == NODEPOOL)
+        labels = np["metadata"].get("labels", {})
+        assert labels.get("osdc.io/module") == MODULE_LABEL, (
+            f"NodePool '{NODEPOOL}' must be labeled osdc.io/module={MODULE_LABEL}; got {labels}."
+        )
+
+
+class TestAgentSandboxNodeClass:
+    def test_userdata_installs_gvisor(self) -> None:
+        """The EC2NodeClass userData must embed the runsc install so nodes register
+        the gvisor containerd runtime handler at boot."""
+        ec2nc = run_kubectl(["get", "ec2nodeclasses.karpenter.k8s.aws", NODEPOOL])
+        user_data = ec2nc["spec"].get("userData", "")
+        assert "runsc" in user_data, f"EC2NodeClass '{NODEPOOL}' userData must install runsc (gVisor)."
+        assert "containerd.runtimes.runsc" in user_data, (
+            f"EC2NodeClass '{NODEPOOL}' userData must register the runsc containerd runtime handler."
+        )


### PR DESCRIPTION
Thin shim over `modules/nodepools` (mirrors `nodepools-h100`/`-b200`) generating a dedicated `ai-sandbox` Karpenter fleet whose nodes install gVisor (runsc) as a containerd runtime handler via userData. Being its own module with its own `defs/`, the fleet only exists on clusters that list it — it can't land on prod through the shared nodepools defs.

Nothing schedules here until `agent-sandbox` adds the `gvisor` RuntimeClass (PR 2 of this stack), and the gVisor install is fail-closed: if it fails, only `runtimeClassName: gvisor` pods fail to start. No cluster enables this module yet.

**Stack** (review bottom-up, 1/5 — this PR):
1. **nodepools-agent-sandbox: gVisor fleet** ← this PR
2. agent-sandbox module
3. canary integration test
4. enable on ue1 staging
5. build the agent image in deploy.sh

`just lint` 12/13 (the one failure, hadolint on `runner-base`, is pre-existing on main), `just test` green.