### PR TITLE
Add agent-sandbox module: an AI agent sandbox callable like BuildKit

### DIFF
--- a/osdc/modules/agent-sandbox/README.md
+++ b/osdc/modules/agent-sandbox/README.md
@@ -1,0 +1,141 @@
+# agent-sandbox (PROTOTYPE)
+
+A sandbox for running an untrusted AI agent in OSDC CI. The agent clones a
+**public** repo, calls **Bedrock**, and returns a result — isolated under gVisor,
+holding exactly one credential (a **read-only Bedrock IRSA role**) and nothing else.
+
+It is **callable over the network like BuildKit**: a runner does
+`curl sandbox-agent.ai-sandbox.svc:8080/run …`, gated by a NetworkPolicy that
+allows the `arc-runners` namespace — **no RBAC on the caller**.
+
+This is a **Phase-1 PoC**. There are **no credential proxies** and **no operator
+secrets**: the agent clones public GitHub anonymously and calls Bedrock directly
+with its scoped IRSA role.
+
+## Architecture
+
+```
+[arc-runners] runner job ── curl ──► sandbox-agent.ai-sandbox.svc:8080/run
+   (no RBAC; NetworkPolicy allow)              │
+   ai-sandbox namespace                        ▼
+   ┌───────────────────────────────────────────────────────────────────────┐
+   │ [UNTRUSTED] sandbox-agent   Deployment, runtimeClassName: gvisor        │
+   │   • holds ONE credential: a read-only Bedrock IRSA role (nothing else)  │
+   │   • git clone (public repo, anonymous — no token)                       │
+   │   • Bedrock InvokeModel via boto3 (signed with the pod's IRSA creds)    │
+   │   • egress: OPEN internet (prototype; lockdown deferred)                │
+   │        pinned to the ai-sandbox gVisor fleet                            │
+   └───────────────────────────────────────────────────────────────────────┘
+```
+
+- **Isolation:** `nodepools-agent-sandbox` fleet installs gVisor (runsc); the
+  `gvisor` RuntimeClass pins the worker there. IMDS hop-limit 1 keeps the node
+  role out of reach — the agent gets only its own scoped IRSA role.
+- **Credential:** a read-only Bedrock IRSA role (terraform) on the `sandbox-agent`
+  SA. GitHub public repos are cloned anonymously (no token).
+- **Invocation:** `sandbox-agent` Service (`:8080`), reachable from `arc-runners`
+  via `sandbox-agent-ingress` NetworkPolicy — BuildKit parity.
+
+## Endpoints
+
+- `GET /healthz` → `{"status":"ok"}`
+- `POST /run` body `{"repo","ref","task","model"?}` →
+  `{"cloned":bool,"file_count":int,"report":str,"errors":{…}}`
+
+## One-time prerequisite: build + push the agent image
+
+Push to the in-cluster Harbor `osdc` project (nodes pull anonymously via the
+`harbor:30002` mirror; `clusters.yaml` already points `agent_sandbox.agent_image`
+at `harbor:30002/osdc/ci-agent-sandbox:prototype`):
+
+```bash
+docker buildx build --platform linux/amd64 -t ci-agent-sandbox:prototype \
+  -o type=docker,dest=/tmp/agent.tar modules/agent-sandbox/agent
+
+HARBOR_PASS=$(kubectl get secret harbor-admin-password -n harbor-system -o jsonpath='{.data.password}' | base64 -d)
+kubectl port-forward --address 127.0.0.1 svc/harbor -n harbor-system 8081:80 >/dev/null 2>&1 &
+crane auth login 127.0.0.1:8081 -u admin -p "$HARBOR_PASS"
+crane push /tmp/agent.tar 127.0.0.1:8081/osdc/ci-agent-sandbox:prototype
+```
+
+(No secrets to create — the previous mitmproxy CA / GitHub token are gone.)
+
+## Deploy
+
+```bash
+just deploy-module meta-staging-aws-ue1 nodepools-agent-sandbox   # gVisor fleet
+just deploy-module meta-staging-aws-ue1 agent-sandbox             # IRSA role + worker
+```
+`agent-sandbox` runs terraform (Bedrock IRSA role) → applies the namespace,
+RuntimeClass, SA, worker + Service, NetworkPolicies → annotates the `sandbox-agent`
+SA with the role.
+
+## Use it (from anywhere with cluster network access, e.g. a runner)
+
+```bash
+curl -fsS -X POST http://sandbox-agent.ai-sandbox.svc.cluster.local:8080/run \
+  -H 'Content-Type: application/json' \
+  -d '{"repo":"pytorch/pytorch","ref":"main","task":"Summarize the build layout",
+       "model":"<enabled-bedrock-model-or-inference-profile-id>"}'
+```
+Omitting `model` uses `BEDROCK_MODEL_ID`, set at deploy time from
+`clusters.yaml` → `agent_sandbox.model_id`.
+
+## Choosing the Bedrock model
+
+**It must be a cross-region inference profile ID (`us.` / `global.` prefix), not
+a bare foundation-model ID.** In `us-east-1` every Anthropic model on Bedrock is
+`INFERENCE_PROFILE`-only; the one still advertising `ON_DEMAND`
+(`anthropic.claude-3-haiku-20240307-v1:0`) is refused by the provider:
+
+```
+ResourceNotFoundException: Access denied. This Model is marked by provider as
+Legacy and you have not been actively using the model in the last 30 days.
+```
+
+So "just use an old cheap model" is not an option — the current default is
+`us.anthropic.claude-haiku-4-5-20251001-v1:0` (cheapest active model). To list
+what this account can actually invoke:
+
+```bash
+aws bedrock list-foundation-models --region us-east-1 --by-provider anthropic \
+  --query 'modelSummaries[].[modelId,inferenceTypesSupported,modelLifecycle.status]' --output table
+aws bedrock list-inference-profiles --region us-east-1 \
+  --query 'inferenceProfileSummaries[?contains(inferenceProfileId, `anthropic`)].inferenceProfileId' --output table
+```
+
+Because a `us.` profile routes the request to any US region, the IRSA policy
+grants `bedrock:InvokeModel` on `arn:aws:bedrock:*::foundation-model/*` in
+addition to this region's inference profiles — with the region pinned, invokes
+fail `AccessDenied` whenever routing leaves the cluster's region.
+
+## Integration test
+
+Runs in the standard canary flow, gated by the `AGENT_SANDBOX` tag:
+```
+just integration-test meta-staging-aws-ue1
+```
+
+## Limitations (prototype)
+
+- **Egress is OPEN** — the agent has internet access; egress lockdown
+  (egress-restricted subnet / Security-Groups-for-Pods) is deferred, so network
+  exfiltration is not yet mitigated.
+- **The agent holds a credential** — a read-only Bedrock IRSA role. A prompt-injected
+  agent could misuse it (bounded to Bedrock invoke cost/quota).
+- **gVisor install is best-effort** node userData (fail-closed if runsc doesn't register).
+- **Warm worker, not per-task-ephemeral** (like buildkitd) — no per-task isolation reset yet.
+- **Output is trusted as-is** — the propose/dispose validation gate is Phase 2.
+- **Prompt is coarse** — the task prompt carries only the repo/ref and a file
+  count, so the model's "report" is largely ungrounded. Feeding real repo context
+  is the next step; today the Bedrock call proves the credential path, not agent
+  quality.
+
+## Future direction: vetted MCP services
+
+Secret-backed data sources (GitHub private, ClickHouse, Grafana, CloudWatch)
+should be exposed to the agent as **vetted MCP servers** that hold the secrets and
+expose only specific tools — the agent calls tools, never sees the secret. That
+restores "the agent holds no data-source secrets" at a finer grain than a
+credential proxy. Bedrock (the model backend) stays a direct call; MCP is for the
+tools the model *uses*.

--- a/osdc/modules/agent-sandbox/agent/Dockerfile
+++ b/osdc/modules/agent-sandbox/agent/Dockerfile
@@ -1,0 +1,29 @@
+# Credential-free (except its Bedrock IRSA role) agent worker image.
+#
+# A long-running HTTP worker (server.py) callable over the network like buildkitd.
+# It clones PUBLIC repos anonymously (no token) and calls Bedrock directly via
+# boto3 (which picks up the pod's IRSA web-identity credentials). No proxies.
+#
+# Build + push once to the in-cluster Harbor osdc project (see README):
+#   docker buildx build --platform linux/amd64 -t ci-agent-sandbox:prototype \
+#     -o type=docker,dest=/tmp/agent.tar modules/agent-sandbox/agent
+#   crane push /tmp/agent.tar <harbor>/osdc/ci-agent-sandbox:prototype
+FROM public.ecr.aws/docker/library/debian:12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        python3 \
+        python3-pip \
+    && pip3 install --no-cache-dir --break-system-packages boto3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY server.py /usr/local/bin/server.py
+RUN chmod 0755 /usr/local/bin/server.py
+
+# UID 1000, non-root. The pod securityContext enforces this too.
+USER 1000
+
+EXPOSE 8080
+ENTRYPOINT ["python3", "/usr/local/bin/server.py"]

--- a/osdc/modules/agent-sandbox/agent/server.py
+++ b/osdc/modules/agent-sandbox/agent/server.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Sandbox agent HTTP worker.
+
+A long-running worker — callable over the network like buildkitd (a runner does
+`curl sandbox-agent.ai-sandbox.svc:8080/run ...`, no K8s RBAC, just a NetworkPolicy
+allow). It runs under gVisor on the ai-sandbox fleet.
+
+Credentials: the ONLY credential the agent holds is a read-only Bedrock IRSA role
+(bound to its ServiceAccount). It clones PUBLIC repos anonymously (no token) and
+calls Bedrock directly with boto3 (which uses the IRSA web-identity credentials).
+
+Endpoints:
+  GET  /healthz  -> {"status": "ok"}
+  POST /run      -> body {"repo","ref","task","model"?}; returns
+                    {"cloned": bool, "file_count": int, "top_level": [str],
+                     "report": str, "errors": {...}}
+
+Single worker, one task at a time (prototype).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import tempfile
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+PORT = int(os.environ.get("PORT", "8080"))
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+DEFAULT_MODEL = os.environ.get("BEDROCK_MODEL_ID", "")
+CLONE_TIMEOUT_S = 120
+
+
+def clone_repo(repo: str, ref: str, dest: str) -> int:
+    """Shallow, anonymous clone of a public repo. Returns the tracked-file count."""
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "--branch", ref, f"https://github.com/{repo}.git", dest],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=CLONE_TIMEOUT_S,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    )
+    listing = subprocess.run(
+        ["git", "-C", dest, "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return len([line for line in listing.stdout.splitlines() if line.strip()])
+
+
+def top_level_entries(dest: str) -> list[str]:
+    """Top-level tracked entries (`dir/` for trees). Grounding for the prompt: with
+    only a file *count* the model invents a plausible listing, so the report says
+    nothing about the repo the agent actually cloned."""
+    listing = subprocess.run(
+        ["git", "-C", dest, "ls-tree", "--name-only", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    names = [line.strip() for line in listing.stdout.splitlines() if line.strip()]
+    return [f"{n}/" if os.path.isdir(os.path.join(dest, n)) else n for n in names]
+
+
+def invoke_bedrock(model: str, prompt: str) -> str:
+    """Call Bedrock InvokeModel directly via boto3 (signed with the pod's IRSA creds)."""
+    body = json.dumps(
+        {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": prompt}]}],
+        }
+    )
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    resp = client.invoke_model(modelId=model, body=body, contentType="application/json", accept="application/json")
+    payload = json.loads(resp["body"].read())
+    content = payload.get("content") or []
+    return content[0]["text"] if content else ""
+
+
+def build_prompt(repo: str, ref: str, task: str, file_count: int, entries: list[str]) -> str:
+    """Prompt the model with what the agent actually observed in the clone, and
+    tell it not to fill gaps — an ungrounded answer looks identical to a correct
+    one, which would make the canary's 'Bedrock returned a report' assertion
+    meaningless."""
+    lines = [
+        f"You are inspecting a checkout of {repo} at ref {ref}.",
+        f"It has {file_count} tracked files.",
+    ]
+    if entries:
+        lines += ["", "Top-level entries (complete list, `/` marks a directory):", *(f"  {e}" for e in entries)]
+    lines += [
+        "",
+        f"Task: {task}",
+        "",
+        "Answer only from the listing above. If it doesn't contain the answer, say so "
+        "instead of guessing — do not invent paths.",
+    ]
+    return "\n".join(lines)
+
+
+def run_task(spec: dict) -> dict:
+    """Clone the repo, then (optionally) ask Bedrock about it. Never raises —
+    each stage's failure is captured so callers see exactly what worked."""
+    repo = spec["repo"]
+    ref = spec.get("ref", "main")
+    task = spec.get("task", "Summarize this repository.")
+    model = spec.get("model") or DEFAULT_MODEL
+    result: dict = {"cloned": False, "file_count": 0, "top_level": [], "report": "", "errors": {}}
+
+    with tempfile.TemporaryDirectory() as workdir:
+        try:
+            result["file_count"] = clone_repo(repo, ref, workdir)
+            result["cloned"] = True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            result["errors"]["clone"] = getattr(exc, "stderr", None) or str(exc)
+            return result
+
+        if not model:
+            result["errors"]["bedrock"] = "no model configured (set BEDROCK_MODEL_ID or pass 'model')"
+            return result
+
+        try:
+            entries = top_level_entries(workdir)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            # Grounding is best-effort — a repo we can't list is still worth asking about.
+            result["errors"]["listing"] = getattr(exc, "stderr", None) or str(exc)
+            entries = []
+        result["top_level"] = entries
+
+        prompt = build_prompt(repo, ref, task, result["file_count"], entries)
+        try:
+            result["report"] = invoke_bedrock(model, prompt)
+        except (BotoCoreError, ClientError, KeyError, ValueError) as exc:
+            result["errors"]["bedrock"] = str(exc)
+
+    return result
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/healthz":
+            self._send(200, {"status": "ok"})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if self.path != "/run":
+            self._send(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            spec = json.loads(self.rfile.read(length) or "{}")
+            if not spec.get("repo"):
+                raise ValueError("missing 'repo'")
+        except (ValueError, json.JSONDecodeError) as exc:
+            self._send(400, {"error": str(exc)})
+            return
+        self._send(200, run_task(spec))
+
+    def log_message(self, fmt: str, *args) -> None:
+        print(f"[sandbox-agent] {fmt % args}")
+
+
+class HTTPServerV6(HTTPServer):
+    # OSDC EKS is IPv6-only: the pod IP (and the readiness probe / Service target)
+    # are IPv6, so the listener must bind :: — a default AF_INET server binds
+    # 0.0.0.0 and is unreachable on this cluster.
+    address_family = socket.AF_INET6
+
+
+def main() -> None:
+    server = HTTPServerV6(("::", PORT), Handler)
+    print(f"[sandbox-agent] listening on [::]:{PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/osdc/modules/agent-sandbox/agent/test_server.py
+++ b/osdc/modules/agent-sandbox/agent/test_server.py
@@ -1,0 +1,302 @@
+"""Tests for the sandbox agent worker (server.py).
+
+boto3 is installed in the agent image, not in this repo's venv, so it is stubbed
+into sys.modules before importing the worker. Everything else runs for real:
+`top_level_entries` against a real git repo, and the HTTP surface against a real
+socket.
+"""
+
+import json
+import subprocess
+import sys
+import types
+import urllib.error
+import urllib.request
+from threading import Thread
+
+import pytest
+
+
+def _install_boto3_stub() -> None:
+    """Minimal stand-ins for the two AWS imports server.py makes at module scope."""
+    if "boto3" not in sys.modules:
+        boto3 = types.ModuleType("boto3")
+        boto3.client = lambda *a, **kw: None  # replaced per-test via monkeypatch
+        sys.modules["boto3"] = boto3
+    if "botocore.exceptions" not in sys.modules:
+        botocore = sys.modules.setdefault("botocore", types.ModuleType("botocore"))
+        exceptions = types.ModuleType("botocore.exceptions")
+
+        class BotoCoreError(Exception):
+            pass
+
+        class ClientError(Exception):
+            pass
+
+        exceptions.BotoCoreError = BotoCoreError
+        exceptions.ClientError = ClientError
+        botocore.exceptions = exceptions
+        sys.modules["botocore.exceptions"] = exceptions
+
+
+_install_boto3_stub()
+
+import server  # noqa: E402  (must follow the boto3 stub)
+
+
+def _git_repo(path, entries):
+    """A real git repo with `entries` (paths ending in / become directories)."""
+    path.mkdir(parents=True, exist_ok=True)
+    for entry in entries:
+        target = path / entry.rstrip("/")
+        if entry.endswith("/"):
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "keep.txt").write_text("x\n")
+        else:
+            target.write_text("x\n")
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "init"], check=True, env={**env, "PATH": "/usr/bin:/bin"})
+    return path
+
+
+class TestCloneRepo:
+    """`clone_repo` hardcodes https://github.com/<repo>.git (it only ever clones
+    public repos). Point that URL at a local repo with git's `insteadOf` rewrite so
+    the real clone path is exercised without touching the network."""
+
+    @pytest.fixture
+    def local_github(self, tmp_path, monkeypatch):
+        origin = _git_repo(tmp_path / "origin" / "org" / "repo.git", ["README.md", "setup.py", "torch/"])
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text(
+            f'[url "{(tmp_path / "origin").as_uri()}/"]\n\tinsteadOf = https://github.com/\n',
+        )
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        return origin
+
+    def test_counts_tracked_files(self, local_github, tmp_path):
+        # 3 tracked files: README.md, setup.py, torch/keep.txt
+        assert server.clone_repo("org/repo", "main", str(tmp_path / "dest")) == 3
+
+    def test_missing_ref_raises(self, local_github, tmp_path):
+        with pytest.raises(subprocess.CalledProcessError):
+            server.clone_repo("org/repo", "no-such-branch", str(tmp_path / "dest"))
+
+    def test_terminal_prompts_stay_disabled(self, local_github, tmp_path, monkeypatch):
+        """A credential prompt would hang the worker forever instead of failing."""
+        captured = {}
+        real_run = subprocess.run
+
+        def spy(cmd, **kwargs):
+            captured.setdefault("env", kwargs.get("env"))
+            return real_run(cmd, **kwargs)
+
+        monkeypatch.setattr(server.subprocess, "run", spy)
+        server.clone_repo("org/repo", "main", str(tmp_path / "dest"))
+        assert captured["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+class TestTopLevelEntries:
+    def test_marks_directories_with_slash(self, tmp_path):
+        repo = _git_repo(tmp_path / "repo", ["README.md", "setup.py", "torch/"])
+        assert sorted(server.top_level_entries(str(repo))) == ["README.md", "setup.py", "torch/"]
+
+    def test_lists_only_top_level(self, tmp_path):
+        repo = _git_repo(tmp_path / "repo", ["aten/", "torch/"])
+        entries = server.top_level_entries(str(repo))
+        assert entries == ["aten/", "torch/"], "nested files must not appear as top-level entries"
+
+    def test_raises_outside_a_repo(self, tmp_path):
+        with pytest.raises(subprocess.CalledProcessError):
+            server.top_level_entries(str(tmp_path))
+
+
+class TestBuildPrompt:
+    def test_includes_the_real_listing(self):
+        prompt = server.build_prompt("pytorch/pytorch", "main", "List the files.", 21952, ["README.md", "torch/"])
+        assert "pytorch/pytorch" in prompt
+        assert "21952 tracked files" in prompt
+        assert "README.md" in prompt
+        assert "torch/" in prompt
+        assert "List the files." in prompt
+
+    def test_forbids_guessing(self):
+        """Without this the model invents a plausible listing and the canary's
+        'Bedrock returned a report' assertion proves nothing."""
+        prompt = server.build_prompt("r", "main", "t", 1, ["a"])
+        assert "do not invent paths" in prompt
+
+    def test_omits_the_listing_section_when_empty(self):
+        prompt = server.build_prompt("r", "main", "t", 0, [])
+        assert "Top-level entries" not in prompt
+
+
+class TestInvokeBedrock:
+    def test_sends_the_messages_api_body_and_returns_the_text(self, monkeypatch):
+        captured = {}
+
+        class FakeClient:
+            def invoke_model(self, **kwargs):
+                captured.update(kwargs)
+                payload = json.dumps({"content": [{"type": "text", "text": "the report"}]})
+                return {"body": types.SimpleNamespace(read=lambda: payload.encode())}
+
+        monkeypatch.setattr(server.boto3, "client", lambda *a, **kw: FakeClient(), raising=False)
+        assert server.invoke_bedrock("us.anthropic.claude-haiku-4-5-20251001-v1:0", "hello") == "the report"
+
+        assert captured["modelId"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        body = json.loads(captured["body"])
+        assert body["anthropic_version"] == "bedrock-2023-05-31"
+        assert body["messages"] == [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+
+    def test_empty_content_yields_empty_report(self, monkeypatch):
+        class FakeClient:
+            def invoke_model(self, **kwargs):
+                return {"body": types.SimpleNamespace(read=lambda: b'{"content": []}')}
+
+        monkeypatch.setattr(server.boto3, "client", lambda *a, **kw: FakeClient(), raising=False)
+        assert server.invoke_bedrock("m", "hello") == ""
+
+
+class TestRunTask:
+    """Each stage's failure must be captured, never raised — callers need to see
+    exactly which part of the credential path worked."""
+
+    def test_clone_failure_stops_before_bedrock(self, monkeypatch):
+        def boom(*a, **kw):
+            raise subprocess.CalledProcessError(128, "git", stderr="could not read Username")
+
+        monkeypatch.setattr(server, "clone_repo", boom)
+        monkeypatch.setattr(server, "invoke_bedrock", lambda *a: pytest.fail("must not call Bedrock"))
+
+        result = server.run_task({"repo": "org/private", "model": "m"})
+        assert result["cloned"] is False
+        assert "could not read Username" in result["errors"]["clone"]
+        assert result["report"] == ""
+
+    def test_missing_model_is_reported(self, monkeypatch):
+        monkeypatch.setattr(server, "clone_repo", lambda *a, **kw: 7)
+        monkeypatch.setattr(server, "DEFAULT_MODEL", "")
+
+        result = server.run_task({"repo": "org/repo"})
+        assert result["cloned"] is True
+        assert result["file_count"] == 7
+        assert result["errors"]["bedrock"].startswith("no model configured")
+
+    def test_spec_model_overrides_the_default(self, monkeypatch):
+        monkeypatch.setattr(server, "clone_repo", lambda *a, **kw: 1)
+        monkeypatch.setattr(server, "top_level_entries", lambda dest: ["README.md"])
+        monkeypatch.setattr(server, "invoke_bedrock", lambda model, prompt: f"used {model}")
+
+        result = server.run_task({"repo": "org/repo", "model": "us.anthropic.override"})
+        assert result["report"] == "used us.anthropic.override"
+        assert result["top_level"] == ["README.md"]
+        assert result["errors"] == {}
+
+    def test_listing_failure_still_asks_bedrock(self, monkeypatch):
+        """Grounding is best-effort: a repo we can't list is still worth asking about."""
+
+        def boom(dest):
+            raise subprocess.CalledProcessError(128, "git ls-tree", stderr="not a repository")
+
+        monkeypatch.setattr(server, "clone_repo", lambda *a, **kw: 1)
+        monkeypatch.setattr(server, "top_level_entries", boom)
+        monkeypatch.setattr(server, "invoke_bedrock", lambda model, prompt: "report anyway")
+
+        result = server.run_task({"repo": "org/repo", "model": "m"})
+        assert result["report"] == "report anyway"
+        assert result["top_level"] == []
+        assert "not a repository" in result["errors"]["listing"]
+        assert "bedrock" not in result["errors"]
+
+    def test_bedrock_failure_is_captured(self, monkeypatch):
+        def boom(model, prompt):
+            raise server.ClientError("AccessDeniedException: not authorized")
+
+        monkeypatch.setattr(server, "clone_repo", lambda *a, **kw: 1)
+        monkeypatch.setattr(server, "top_level_entries", lambda dest: ["README.md"])
+        monkeypatch.setattr(server, "invoke_bedrock", boom)
+
+        result = server.run_task({"repo": "org/repo", "model": "m"})
+        assert result["cloned"] is True
+        assert "AccessDeniedException" in result["errors"]["bedrock"]
+
+
+@pytest.fixture
+def worker():
+    """The real HTTP worker on an ephemeral port (IPv6, as in the IPv6-only cluster)."""
+    httpd = server.HTTPServerV6(("::1", 0), server.Handler)
+    Thread(target=httpd.serve_forever, daemon=True).start()
+    yield f"http://[::1]:{httpd.server_address[1]}"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+# Ignore any ambient HTTP(S)_PROXY — these requests go to a loopback socket.
+_opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+def _get(url):
+    return _opener.open(url, timeout=10)
+
+
+def _post(url, payload):
+    req = urllib.request.Request(  # noqa: S310  (loopback http:// built in-test)
+        url, data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"}
+    )
+    return json.loads(_opener.open(req, timeout=10).read())
+
+
+class TestHTTPSurface:
+    def test_healthz(self, worker):
+        assert json.loads(_get(f"{worker}/healthz").read()) == {"status": "ok"}
+
+    def test_unknown_path_is_404(self, worker):
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _get(f"{worker}/nope")
+        assert exc.value.code == 404
+
+    def test_run_requires_repo(self, worker):
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(f"{worker}/run", {"task": "no repo given"})
+        assert exc.value.code == 400
+        assert "missing 'repo'" in json.loads(exc.value.read())["error"]
+
+    def test_post_to_unknown_path_is_404(self, worker):
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(f"{worker}/nope", {"repo": "org/repo"})
+        assert exc.value.code == 404
+
+    def test_run_returns_the_task_result(self, worker, monkeypatch):
+        monkeypatch.setattr(server, "run_task", lambda spec: {"cloned": True, "report": f"ran {spec['repo']}"})
+        assert _post(f"{worker}/run", {"repo": "org/repo"}) == {"cloned": True, "report": "ran org/repo"}
+
+
+class TestMain:
+    def test_binds_every_ipv6_interface(self, monkeypatch):
+        """Regression guard: binding 0.0.0.0 (the HTTPServer default) leaves the
+        worker unreachable on the IPv6-only cluster — the readiness probe and the
+        Service both target the pod's IPv6 address."""
+        bound = {}
+
+        class FakeServer:
+            def __init__(self, address, handler):
+                bound["address"] = address
+                bound["handler"] = handler
+
+            def serve_forever(self):
+                bound["served"] = True
+
+        monkeypatch.setattr(server, "HTTPServerV6", FakeServer)
+        server.main()
+
+        assert bound["address"] == ("::", server.PORT)
+        assert bound["handler"] is server.Handler
+        assert bound["served"] is True
+
+    def test_server_is_ipv6(self):
+        import socket as _socket
+
+        assert server.HTTPServerV6.address_family == _socket.AF_INET6

--- a/osdc/modules/agent-sandbox/deploy.sh
+++ b/osdc/modules/agent-sandbox/deploy.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# agent-sandbox module deploy. Called by: just deploy-module <cluster> agent-sandbox
+# Args: $1=cluster-id  $2=cluster-name  $3=region
+#
+# Deploys the sandbox:
+#   1. Reads the sandbox-agent IRSA role ARN (read-only Bedrock) from terraform.
+#   2. Applies the namespace, gvisor RuntimeClass, service account, the
+#      sandbox-agent worker + Service, and the NetworkPolicies. The agent image +
+#      region are substituted from clusters.yaml.
+#   3. Annotates the sandbox-agent SA with the IRSA role so the agent can call
+#      Bedrock directly (no proxy).
+#
+# No proxies, no operator secrets: the agent clones public repos anonymously and
+# calls Bedrock with its own scoped IRSA role.
+
+CLUSTER="$1"
+export CNAME="$2"
+export REGION="$3"
+MODULE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${OSDC_ROOT:-$(cd "$MODULE_DIR/../.." && pwd)}"
+UPSTREAM_ROOT="${OSDC_UPSTREAM:-$REPO_ROOT}"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/mise-activate.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/kubectl-apply.sh"
+# shellcheck source=/dev/null
+source "$UPSTREAM_ROOT/scripts/state-config.sh"
+: "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
+CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
+
+NAMESPACE=ai-sandbox
+BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
+AGENT_IMAGE=$(uv run "$CFG" "$CLUSTER" agent_sandbox.agent_image "")
+if [[ -z "$AGENT_IMAGE" ]]; then
+  echo "[agent-sandbox] ERROR: agent_sandbox.agent_image not set for $CLUSTER in clusters.yaml" >&2
+  exit 1
+fi
+# Bedrock model for /run. Required: without it the agent clones but every task
+# returns errors.bedrock="no model configured".
+BEDROCK_MODEL_ID=$(uv run "$CFG" "$CLUSTER" agent_sandbox.model_id "")
+if [[ -z "$BEDROCK_MODEL_ID" ]]; then
+  echo "[agent-sandbox] ERROR: agent_sandbox.model_id not set for $CLUSTER in clusters.yaml" >&2
+  exit 1
+fi
+
+# --- Read terraform outputs (sandbox-agent Bedrock IRSA role) ---
+echo "[agent-sandbox] Reading terraform outputs..."
+cd "$MODULE_DIR/terraform"
+tofu init -reconfigure \
+  -backend-config="bucket=${BUCKET_CFG}" \
+  -backend-config="key=${CLUSTER}/agent-sandbox/terraform.tfstate" \
+  -backend-config="region=${STATE_REGION}" \
+  -backend-config="dynamodb_table=ciforge-terraform-locks" \
+  >/dev/null 2>&1
+AGENT_ROLE_ARN=$(tofu output -raw agent_role_arn)
+cd - >/dev/null
+echo "[agent-sandbox] sandbox-agent Bedrock IRSA role: ${AGENT_ROLE_ARN}"
+
+# --- Apply manifests (substitute the agent image + region + model into sandbox-agent) ---
+echo "[agent-sandbox] Applying base manifests (agent image: ${AGENT_IMAGE}, model: ${BEDROCK_MODEL_ID})..."
+kubectl kustomize "$MODULE_DIR/kubernetes/base/" \
+  | sed -e "s|__AGENT_IMAGE__|${AGENT_IMAGE}|g" \
+    -e "s|__AWS_REGION__|${REGION}|g" \
+    -e "s|__BEDROCK_MODEL_ID__|${BEDROCK_MODEL_ID}|g" \
+  | kubectl_apply_if_changed -f -
+
+# --- Prune the removed credential-proxy resources (idempotent) ---
+# The mitmproxy (agent-vault) + aws-sigv4-proxy were dropped from this module;
+# kubectl apply won't delete resources no longer in the manifest set, so remove
+# them explicitly. Operator-provided secrets (agent-vault-ca, agent-sandbox-creds)
+# are left alone — they were created out-of-band and deleting them is the
+# operator's call.
+echo "[agent-sandbox] Pruning removed proxy resources (if present)..."
+kubectl delete deployment,service,serviceaccount agent-vault sigv4-proxy \
+  -n "$NAMESPACE" --ignore-not-found
+kubectl delete configmap agent-vault-config -n "$NAMESPACE" --ignore-not-found
+# Stale NetworkPolicies from the proxy design: the old `default-deny` (now
+# `default-deny-ingress`) plus the proxy/agent egress policies. Leaving them would
+# keep egress restricted, contradicting the open-egress prototype.
+kubectl delete networkpolicy default-deny proxy-ingress proxy-egress sandbox-agent-egress \
+  -n "$NAMESPACE" --ignore-not-found
+
+# --- Annotate the sandbox-agent SA with its Bedrock IRSA role ---
+# The pod-identity webhook injects the web-identity token from this annotation
+# (independent of automountServiceAccountToken: false). Restart so running pods
+# pick up a changed role.
+kubectl annotate sa sandbox-agent -n "$NAMESPACE" \
+  eks.amazonaws.com/role-arn="$AGENT_ROLE_ARN" --overwrite
+kubectl rollout restart deployment/sandbox-agent -n "$NAMESPACE"
+
+echo "[agent-sandbox] Waiting for rollout..."
+kubectl rollout status deployment/sandbox-agent -n "$NAMESPACE" --timeout=10m || true
+
+echo "[agent-sandbox] Deployed. The sandbox is callable from arc-runners like buildkitd:"
+echo "    curl -sf -X POST http://sandbox-agent.ai-sandbox.svc.cluster.local:8080/run \\"
+echo "      -d '{\"repo\":\"pytorch/pytorch\",\"ref\":\"main\",\"task\":\"...\"}'"

--- a/osdc/modules/agent-sandbox/kubernetes/base/kustomization.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/kustomization.yaml
@@ -1,0 +1,12 @@
+# Agent-sandbox Kubernetes resources (namespace-scoped + the cluster-scoped
+# gvisor RuntimeClass). deploy.sh substitutes __AGENT_IMAGE__ / __AWS_REGION__ in
+# sandbox-agent.yaml at apply time (kustomize can't read clusters.yaml).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - runtimeclass.yaml
+  - serviceaccounts.yaml
+  - sandbox-agent.yaml
+  - networkpolicy.yaml

--- a/osdc/modules/agent-sandbox/kubernetes/base/namespace.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox

--- a/osdc/modules/agent-sandbox/kubernetes/base/networkpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/networkpolicy.yaml
@@ -1,0 +1,49 @@
+# Network policy for the ai-sandbox namespace.
+#
+# PROTOTYPE: egress is OPEN — the agent has internet access (clones public GitHub
+# and calls Bedrock directly). Egress lockdown (a dedicated egress-restricted
+# subnet / Security-Groups-for-Pods) is deferred Phase-2 hardening; see the module
+# README and the design doc §6. So this file only restricts INGRESS: the worker is
+# reachable from the arc-runners namespace (BuildKit parity), nothing else.
+#
+# Note: under IPv6-only AWS VPC CNI, NetworkPolicy is best-effort (it doesn't apply
+# to the IPv4-egress interface), so it is defense-in-depth, not a hard boundary.
+
+# Deny all ingress by default; the allow below re-opens the worker to arc-runners.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+
+---
+# Agent ingress: callable from arc-runners over the network, like buildkitd
+# (mirrors buildkit's buildkitd-lb-ingress). The runner needs NO K8s RBAC — just
+# this network allow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-agent-ingress
+  namespace: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      app: sandbox-agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: arc-runners
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/osdc/modules/agent-sandbox/kubernetes/base/runtimeclass.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/runtimeclass.yaml
@@ -1,0 +1,26 @@
+# gVisor RuntimeClass. Cluster-scoped. The handler "runsc" is registered in
+# containerd on the ai-sandbox fleet by nodepools-agent-sandbox/scripts/install-gvisor.sh.
+#
+# The scheduling block auto-stamps every pod that sets runtimeClassName: gvisor
+# with the nodeSelector + tolerations for the ai-sandbox fleet, so the agent Job
+# spec doesn't have to repeat them and cannot accidentally land on a non-gVisor
+# node (a node without the runsc handler would fail to start the pod).
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+  labels:
+    osdc.io/module: agent-sandbox
+handler: runsc
+scheduling:
+  nodeSelector:
+    node-fleet: ai-sandbox
+  tolerations:
+    - key: node-fleet
+      operator: Equal
+      value: ai-sandbox
+      effect: NoSchedule
+    - key: instance-type
+      operator: Equal
+      value: c7i.8xlarge
+      effect: NoSchedule

--- a/osdc/modules/agent-sandbox/kubernetes/base/sandbox-agent.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/sandbox-agent.yaml
@@ -1,0 +1,85 @@
+# The sandbox worker: a long-running HTTP service on the gVisor fleet, callable
+# over the network like buildkitd. __AGENT_IMAGE__ / __AWS_REGION__ /
+# __BEDROCK_MODEL_ID__ are substituted by deploy.sh (from clusters.yaml
+# agent_sandbox.agent_image and agent_sandbox.model_id).
+#
+# runtimeClassName: gvisor pins it to the ai-sandbox fleet and runs it under runsc.
+# The only credential it holds is the read-only Bedrock IRSA role bound to the
+# sandbox-agent SA (annotated by deploy.sh) — used directly by boto3. It clones
+# public repos anonymously; no proxies, no mounted secrets.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-agent
+  namespace: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox
+    app: sandbox-agent
+spec:
+  # Prototype: one warm worker, one task at a time (like buildkitd max-parallelism=1).
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sandbox-agent
+  template:
+    metadata:
+      labels:
+        app: sandbox-agent
+        osdc.io/module: agent-sandbox
+    spec:
+      runtimeClassName: gvisor
+      serviceAccountName: sandbox-agent
+      automountServiceAccountToken: false
+      containers:
+        - name: agent
+          image: __AGENT_IMAGE__
+          # Prototype uses a mutable :prototype tag; re-pull on every start so a
+          # fresh push is picked up.
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            # Region for boto3 / Bedrock. IRSA injects AWS_ROLE_ARN +
+            # AWS_WEB_IDENTITY_TOKEN_FILE automatically (from the SA annotation).
+            - name: AWS_REGION
+              value: "__AWS_REGION__"
+            # Default model for /run when the caller doesn't pass "model".
+            # A cross-region inference profile ID — see clusters.yaml.
+            - name: BEDROCK_MODEL_ID
+              value: "__BEDROCK_MODEL_ID__"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-agent
+  namespace: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox
+    app: sandbox-agent
+spec:
+  selector:
+    app: sandbox-agent
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/osdc/modules/agent-sandbox/kubernetes/base/serviceaccounts.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/serviceaccounts.yaml
@@ -1,0 +1,17 @@
+# Service account for the sandbox agent worker.
+#
+#   sandbox-agent : the untrusted agent pod. NO Role/RoleBinding — zero K8s API
+#                   perms — and automountServiceAccountToken disabled so a
+#                   compromised agent can't reach the K8s API. It IS bound to a
+#                   read-only Bedrock IRSA role (annotated at deploy time from the
+#                   terraform output); IRSA injects its own projected web-identity
+#                   token independently of the disabled default SA token. That
+#                   Bedrock role is the ONLY credential the agent holds.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-agent
+  namespace: ai-sandbox
+  labels:
+    osdc.io/module: agent-sandbox
+automountServiceAccountToken: false

--- a/osdc/modules/agent-sandbox/terraform/backend.tf
+++ b/osdc/modules/agent-sandbox/terraform/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/osdc/modules/agent-sandbox/terraform/main.tf
+++ b/osdc/modules/agent-sandbox/terraform/main.tf
@@ -1,0 +1,120 @@
+# Read-only IRSA role for the sandbox-agent service account — the ONLY credential
+# the agent holds. Scoped to Bedrock model invocation and nothing else. The agent
+# calls Bedrock directly (AWS SDK signs with this role's STS creds); there is no
+# proxy. IMDS is unreachable from pods (hop-limit 1), so the agent is confined to
+# this scoped role and can never assume the broad node instance role.
+#
+# Created in the cluster's own state: `just deploy-module <cluster> agent-sandbox`
+# runs this (terraform phase) before the k8s phase.
+
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "terraform_remote_state" "base" {
+  backend = "s3"
+
+  config = {
+    bucket         = var.state_bucket
+    key            = "${var.cluster_id}/base/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "ciforge-terraform-locks"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  oidc_provider_arn = data.terraform_remote_state.base.outputs.oidc_provider_arn
+  oidc_provider     = data.terraform_remote_state.base.outputs.oidc_provider
+
+  namespace       = "ai-sandbox"
+  service_account = "sandbox-agent"
+
+  account_id = data.aws_caller_identity.current.account_id
+
+  # Bedrock invoke targets.
+  #
+  # Every current Anthropic model on Bedrock is INFERENCE_PROFILE-only — the
+  # Claude 3 generation still listed as ON_DEMAND is refused by the provider
+  # ("marked by provider as Legacy"), so the agent must call a cross-region
+  # profile (e.g. us.anthropic.claude-haiku-4-5-...). Such a call is authorized
+  # against BOTH the inference-profile ARN in the calling region AND the
+  # underlying foundation-model ARN in whichever region the profile routes to
+  # (a `us.` profile can land in us-east-1/us-east-2/us-west-2, and AWS may add
+  # more). Hence the region wildcard on foundation-model: without it the invoke
+  # fails AccessDenied whenever routing leaves ${var.aws_region}.
+  #
+  # Still InvokeModel-only, and still scoped to this account's profiles. Tighten
+  # to specific model IDs once the agent's model is fixed.
+  bedrock_resources = [
+    "arn:aws:bedrock:*::foundation-model/*",
+    "arn:aws:bedrock:${var.aws_region}:${local.account_id}:inference-profile/*",
+  ]
+
+  tags = {
+    Cluster = var.cluster_name
+    Project = "ciforge"
+    Module  = "agent-sandbox"
+  }
+}
+
+resource "aws_iam_role" "agent" {
+  name = "${var.cluster_name}-agent-sandbox-bedrock"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Effect = "Allow"
+      Principal = {
+        Federated = local.oidc_provider_arn
+      }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+          "${local.oidc_provider}:sub" = "system:serviceaccount:${local.namespace}:${local.service_account}"
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "agent" {
+  name = "${var.cluster_name}-agent-sandbox-bedrock"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "BedrockInvoke"
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+        ]
+        Resource = local.bedrock_resources
+      },
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "agent" {
+  policy_arn = aws_iam_policy.agent.arn
+  role       = aws_iam_role.agent.name
+}

--- a/osdc/modules/agent-sandbox/terraform/outputs.tf
+++ b/osdc/modules/agent-sandbox/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "agent_role_arn" {
+  description = "IRSA role ARN for the sandbox-agent service account (read-only Bedrock invoke)"
+  value       = aws_iam_role.agent.arn
+}

--- a/osdc/modules/agent-sandbox/terraform/variables.tf
+++ b/osdc/modules/agent-sandbox/terraform/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "state_bucket" {
+  description = "S3 bucket for terraform state (used to read base outputs)"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "Cluster identifier in clusters.yaml (e.g. meta-staging-aws-ue1)"
+  type        = string
+}

--- a/osdc/modules/agent-sandbox/tests/smoke/conftest.py
+++ b/osdc/modules/agent-sandbox/tests/smoke/conftest.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from smoke_conftest import *  # noqa: F403

--- a/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
+++ b/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
@@ -1,0 +1,129 @@
+"""Smoke tests for the agent-sandbox module (no-proxy model).
+
+Validates the deployed sandbox: namespace, the gvisor RuntimeClass, the
+sandbox-agent worker + Service (callable from arc-runners), the credential model
+(agent SA holds ONLY a read-only Bedrock IRSA role, no K8s token, no K8s RBAC),
+and the ingress-only NetworkPolicy (egress is open in the prototype).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from helpers import assert_deployment_ready, filter_services, run_kubectl
+
+pytestmark = [pytest.mark.live]
+
+NAMESPACE = "ai-sandbox"
+IRSA_KEY = "eks.amazonaws.com/role-arn"
+
+
+class TestAgentSandboxNamespace:
+    def test_namespace_exists(self, all_namespaces: dict) -> None:
+        names = [ns["metadata"]["name"] for ns in all_namespaces.get("items", [])]
+        assert NAMESPACE in names, f"Namespace '{NAMESPACE}' not found — agent-sandbox not deployed."
+
+
+class TestAgentSandboxRuntimeClass:
+    """The gvisor RuntimeClass is the isolation boundary for agent pods."""
+
+    def test_gvisor_runtimeclass_exists(self) -> None:
+        rc = run_kubectl(["get", "runtimeclass", "gvisor"])
+        assert rc["handler"] == "runsc", f"gvisor RuntimeClass must use handler 'runsc', got {rc.get('handler')!r}."
+
+    def test_gvisor_pins_sandbox_fleet(self) -> None:
+        rc = run_kubectl(["get", "runtimeclass", "gvisor"])
+        node_selector = rc.get("scheduling", {}).get("nodeSelector", {})
+        assert node_selector.get("node-fleet") == "ai-sandbox", (
+            f"gvisor RuntimeClass must pin node-fleet=ai-sandbox, got {node_selector!r}."
+        )
+
+
+class TestSandboxWorker:
+    """The callable worker — a Deployment + Service reachable from arc-runners, like buildkitd."""
+
+    def test_worker_ready(self, all_deployments: dict) -> None:
+        assert_deployment_ready(all_deployments, NAMESPACE, "sandbox-agent")
+
+    def test_worker_service_exists(self, all_services: dict) -> None:
+        svcs = filter_services(all_services, namespace=NAMESPACE, name="sandbox-agent")
+        assert len(svcs) == 1, f"Expected Service 'sandbox-agent' in '{NAMESPACE}'."
+
+    def test_worker_runs_under_gvisor(self, all_deployments: dict) -> None:
+        dep = next(d for d in all_deployments["items"] if d["metadata"]["name"] == "sandbox-agent")
+        rc = dep["spec"]["template"]["spec"].get("runtimeClassName")
+        assert rc == "gvisor", f"sandbox-agent must set runtimeClassName: gvisor, got {rc!r}."
+
+    def test_worker_has_invokable_bedrock_model(self, all_deployments: dict) -> None:
+        """BEDROCK_MODEL_ID must be set to a cross-region inference profile.
+
+        Without it every /run returns errors.bedrock="no model configured". A bare
+        foundation-model ID is also wrong: Anthropic models on Bedrock are
+        INFERENCE_PROFILE-only (the ON_DEMAND Claude 3 is refused as
+        provider-legacy), so the ID needs a `us.`/`global.` routing prefix.
+        """
+        dep = next(d for d in all_deployments["items"] if d["metadata"]["name"] == "sandbox-agent")
+        env = {e["name"]: e.get("value", "") for e in dep["spec"]["template"]["spec"]["containers"][0].get("env", [])}
+        model = env.get("BEDROCK_MODEL_ID", "")
+        assert model, "sandbox-agent must set BEDROCK_MODEL_ID — set agent_sandbox.model_id in clusters.yaml."
+        assert model.startswith(("us.", "global.", "eu.", "apac.")), (
+            f"BEDROCK_MODEL_ID must be a cross-region inference profile ID, got {model!r}."
+        )
+
+    def test_callable_from_arc_runners(self) -> None:
+        """A NetworkPolicy must allow arc-runners to reach the worker (buildkitd
+        parity: network access, not RBAC, is the entry point)."""
+        np = run_kubectl(["get", "networkpolicy", "sandbox-agent-ingress"], namespace=NAMESPACE)
+        froms = [f for rule in np["spec"].get("ingress", []) for f in rule.get("from", [])]
+        allowed_ns = {
+            f.get("namespaceSelector", {}).get("matchLabels", {}).get("kubernetes.io/metadata.name") for f in froms
+        }
+        assert "arc-runners" in allowed_ns, (
+            f"sandbox-agent-ingress must allow the arc-runners namespace; got {allowed_ns}."
+        )
+
+
+class TestAgentSandboxCredentials:
+    def test_agent_sa_holds_only_bedrock_irsa(self) -> None:
+        """The agent SA is bound to exactly one credential — a read-only Bedrock
+        IRSA role — and does NOT automount a K8s token."""
+        sa = run_kubectl(["get", "serviceaccount", "sandbox-agent"], namespace=NAMESPACE)
+        assert sa.get("automountServiceAccountToken") is False, (
+            "sandbox-agent SA must set automountServiceAccountToken: false."
+        )
+        ann = sa.get("metadata", {}).get("annotations", {})
+        assert IRSA_KEY in ann, (
+            "sandbox-agent SA must carry the Bedrock IRSA annotation — deploy.sh did not annotate it."
+        )
+        assert ann[IRSA_KEY].startswith("arn:aws:iam::"), f"IRSA annotation is not an IAM role ARN: {ann[IRSA_KEY]}"
+
+    def test_agent_sa_has_no_rbac(self) -> None:
+        """The agent SA must not be able to touch the K8s API at all."""
+        subject = f"system:serviceaccount:{NAMESPACE}:sandbox-agent"
+        for verb, resource in (("create", "pods"), ("get", "secrets"), ("list", "pods")):
+            # `auth can-i` exits non-zero for "no"; run it directly (run_kubectl uses check=True).
+            proc = subprocess.run(
+                ["kubectl", "-n", NAMESPACE, "auth", "can-i", verb, resource, f"--as={subject}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert proc.stdout.strip() == "no", (
+                f"sandbox-agent SA must NOT be able to {verb} {resource}; got {proc.stdout.strip()!r}."
+            )
+
+
+class TestAgentSandboxNetworkPolicies:
+    def test_ingress_restricted_egress_open(self) -> None:
+        """Prototype: ingress locked to arc-runners; egress is OPEN (no egress policy)."""
+        nps = run_kubectl(["get", "networkpolicies"], namespace=NAMESPACE)
+        items = nps.get("items", [])
+        names = {np["metadata"]["name"] for np in items}
+        assert {"default-deny-ingress", "sandbox-agent-ingress"} <= names, (
+            f"expected ingress policies default-deny-ingress + sandbox-agent-ingress; got {sorted(names)}."
+        )
+        egress_policies = [np["metadata"]["name"] for np in items if "Egress" in np["spec"].get("policyTypes", [])]
+        assert not egress_policies, (
+            f"prototype egress must be OPEN — no Egress NetworkPolicy expected, found {egress_policies}."
+        )


### PR DESCRIPTION
Phase-1 PoC of the [AI Agent Sandbox design](https://docs.google.com/document/d/1Iyp05vtBULwQ2RmPD60n6-lgzT9l_nmE4XVWcEI0lxk/edit). `sandbox-agent` is a long-running HTTP worker on the gVisor fleet that clones a public repo and asks Bedrock about it. A runner calls it over the network exactly like buildkitd — `curl sandbox-agent.ai-sandbox.svc:8080/run` — gated by a NetworkPolicy allowing the `arc-runners` namespace, so **the caller needs no RBAC**.

The agent holds **exactly one credential**: a read-only Bedrock IRSA role. It clones public GitHub anonymously, has no K8s RBAC and no token automount, and IMDS hop-limit 1 keeps the node role out of reach.

Bedrock must be a `us.` inference profile — Anthropic models in us-east-1 are `INFERENCE_PROFILE`-only and the one still advertising `ON_DEMAND` (Claude 3 Haiku) is refused as provider-legacy — so the IAM policy grants `InvokeModel` on `foundation-model/*` across regions, which is what cross-region routing authorizes against.

Prototype limits are listed in the module README: egress is **open**, the worker is warm rather than per-task-ephemeral, and output is trusted as-is. No cluster enables this module yet.

**Stack** (review bottom-up, 2/5 — this PR):
1. nodepools-agent-sandbox: gVisor fleet (#986)
2. **agent-sandbox module** ← this PR
3. canary integration test
4. enable on ue1 staging
5. build the agent image in deploy.sh

`server.py` has 100% unit coverage (real git clone via `insteadOf`, real HTTP against a socket); smoke tests cover the isolation and credential assertions. `just lint` 12/13 (hadolint on `runner-base` is pre-existing on main).