### PR TITLE
Add the agent-sandbox canary integration test

### DIFF
--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -43,6 +43,9 @@ TAG_REQUIREMENTS: dict[str, list[str]] = {
     "BUILDKIT": ["arc-runners", "buildkit"],
     "CACHE_ENFORCER": ["arc-runners", "cache-enforcer"],
     "RELEASE": ["arc-runners"],
+    # The sandbox job runs on a normal runner and calls the sandbox Service over
+    # the network, so it needs both arc-runners and the agent-sandbox module.
+    "AGENT_SANDBOX": ["arc-runners", "agent-sandbox"],
 }
 
 INVERSE_TAG_EXCLUSIONS: dict[str, list[str]] = {

--- a/osdc/integration-tests/workflows/integration-test.yaml.tpl
+++ b/osdc/integration-tests/workflows/integration-test.yaml.tpl
@@ -1955,3 +1955,64 @@ jobs:
           echo "PASS: built $(basename "$WHL")"
   # END_RELEASE
 
+
+  # BEGIN_AGENT_SANDBOX
+  # ── AI Agent Sandbox ──────────────────────────────────────────────────
+  # Call the sandbox over the network from a regular runner — exactly like a
+  # runner calls buildkitd. Proves: (1) the sandbox Service is reachable from
+  # arc-runners (NetworkPolicy allow, no RBAC), (2) it clones a public repo
+  # anonymously — no token on the runner or in the agent, and (3) it really
+  # invokes Bedrock with its read-only IRSA role (the only credential it holds).
+  test-agent-sandbox:
+    runs-on: { group: "{{RUNNER_GROUP}}", labels: ["{{PREFIX}}l-x86iamx-8-32"] }
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    env:
+      SANDBOX: http://sandbox-agent.ai-sandbox.svc.cluster.local:8080
+    steps:
+      - name: Install curl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends curl
+      - name: Health check (reachable from a regular runner, like buildkitd)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsS "$SANDBOX/healthz"
+          echo ""
+          echo "PASS: sandbox Service reachable from arc-runners"
+      - name: Run a task through the sandbox (anonymous clone + real Bedrock call)
+        shell: bash
+        run: |
+          set -euo pipefail
+          RESP=$(curl -fsS -m 300 -X POST "$SANDBOX/run" \
+            -H 'Content-Type: application/json' \
+            -d '{"repo":"pytorch/pytorch","ref":"main","task":"List the top-level files."}')
+          echo "Response: $RESP"
+          if ! echo "$RESP" | grep -q '"cloned": *true'; then
+            echo "FAIL: sandbox did not clone the repo"
+            exit 1
+          fi
+          echo "PASS: sandbox cloned a public repo anonymously — no token on the runner or agent"
+          # Bedrock is a hard assertion: a model is configured (clusters.yaml
+          # agent_sandbox.model_id) and the agent's IRSA role is the only
+          # credential it holds, so a non-empty report proves the whole
+          # credential path works. errors.bedrock means it did not.
+          if echo "$RESP" | grep -q '"bedrock"'; then
+            echo "FAIL: Bedrock invocation errored — see errors.bedrock above"
+            echo "  (model not enabled in this region, or the IRSA role lacks bedrock:InvokeModel"
+            echo "   on the inference profile / cross-region foundation models)"
+            exit 1
+          fi
+          if echo "$RESP" | grep -q '"report": *""'; then
+            echo "FAIL: Bedrock returned an empty report"
+            exit 1
+          fi
+          # The prompt is grounded in the clone's real top-level listing, so an
+          # empty top_level means the model was answering from nothing.
+          if echo "$RESP" | grep -q '"top_level": *\[\]'; then
+            echo "FAIL: prompt was not grounded — top_level listing is empty"
+            exit 1
+          fi
+          echo "PASS: Bedrock InvokeModel via the agent's read-only IRSA role returned a report"
+  # END_AGENT_SANDBOX


### PR DESCRIPTION
`test-agent-sandbox`, gated by the `AGENT_SANDBOX` tag (requires `arc-runners` + `agent-sandbox`), calls the sandbox from a normal runner exactly like a runner calls buildkitd, and asserts all three properties: the Service is reachable from `arc-runners` with no RBAC, the repo clones with no token anywhere, and Bedrock really answers.

Bedrock is a **hard** assertion — `errors.bedrock`, an empty report, or an ungrounded prompt (empty `top_level`) all fail the job. It used to be a `WARN`, which let a green run hide the fact that Bedrock was never actually invoked.

Inert until a cluster enables the modules (PR 4 of this stack).

**Stack** (review bottom-up, 3/5 — this PR):
1. nodepools-agent-sandbox: gVisor fleet (#986)
2. agent-sandbox module (#987)
3. **canary integration test** ← this PR
4. enable on ue1 staging
5. build the agent image in deploy.sh