### PR TITLE
Enable the agent sandbox on meta-staging-aws-ue1

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -262,15 +262,27 @@ clusters:
         arm64_max: 8
     pypi_cache:
       replicas: 1
+    agent_sandbox:
+      # PROTOTYPE. Built + pushed to the in-cluster Harbor `osdc` project; nodes
+      # pull it via the harbor:30002 mirror (see modules/agent-sandbox/README.md).
+      agent_image: "harbor:30002/osdc/ci-agent-sandbox:prototype"
+      # Bedrock model the agent invokes. Must be a cross-region inference profile
+      # ID (`us.` prefix), not a bare foundation-model ID: every Anthropic model
+      # in us-east-1 is INFERENCE_PROFILE-only, and the Claude 3 generation that
+      # still advertises ON_DEMAND is refused as provider-legacy. Haiku 4.5 is
+      # the cheapest active model.
+      model_id: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
     modules:
       - karpenter
       - arc
       - hf-cache
       - nodepools
+      - nodepools-agent-sandbox
       - bin-pack-scheduler
       - arc-runners
       - keda
       - buildkit
+      - agent-sandbox
       - zombie-cleanup
       - harbor-cache-recovery
       - monitoring


### PR DESCRIPTION
Turns on `nodepools-agent-sandbox` (gVisor fleet) and `agent-sandbox` on ue1 staging only, which also activates the `AGENT_SANDBOX` canary job, and sets the Bedrock model — a `us.` inference profile, since Anthropic models in us-east-1 are `INFERENCE_PROFILE`-only.

Staging only; no prod cluster lists these modules. The fleet scales from zero, so the idle cost is one warm sandbox pod.

Verified on `meta-staging-aws-ue1`: `/run` returns `cloned=true`, 21952 files, 74 top-level entries, `errors={}`, and a grounded Bedrock report (asked which top-level file pins the Python build requirements → `requirements-build.txt`).

**Stack** (review bottom-up, 4/5 — this PR):
1. nodepools-agent-sandbox: gVisor fleet (#986)
2. agent-sandbox module (#987)
3. canary integration test (#988)
4. **enable on ue1 staging** ← this PR
5. build the agent image in deploy.sh