### PR TITLE
Build the agent image in deploy.sh instead of by hand

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -263,9 +263,6 @@ clusters:
     pypi_cache:
       replicas: 1
     agent_sandbox:
-      # PROTOTYPE. Built + pushed to the in-cluster Harbor `osdc` project; nodes
-      # pull it via the harbor:30002 mirror (see modules/agent-sandbox/README.md).
-      agent_image: "harbor:30002/osdc/ci-agent-sandbox:prototype"
       # Bedrock model the agent invokes. Must be a cross-region inference profile
       # ID (`us.` prefix), not a bare foundation-model ID: every Anthropic model
       # in us-east-1 is INFERENCE_PROFILE-only, and the Claude 3 generation that

--- a/osdc/modules/agent-sandbox/README.md
+++ b/osdc/modules/agent-sandbox/README.md
@@ -42,23 +42,13 @@ with its scoped IRSA role.
 - `POST /run` body `{"repo","ref","task","model"?}` →
   `{"cloned":bool,"file_count":int,"report":str,"errors":{…}}`
 
-## One-time prerequisite: build + push the agent image
+## The agent image
 
-Push to the in-cluster Harbor `osdc` project (nodes pull anonymously via the
-`harbor:30002` mirror; `clusters.yaml` already points `agent_sandbox.agent_image`
-at `harbor:30002/osdc/ci-agent-sandbox:prototype`):
-
-```bash
-docker buildx build --platform linux/amd64 -t ci-agent-sandbox:prototype \
-  -o type=docker,dest=/tmp/agent.tar modules/agent-sandbox/agent
-
-HARBOR_PASS=$(kubectl get secret harbor-admin-password -n harbor-system -o jsonpath='{.data.password}' | base64 -d)
-kubectl port-forward --address 127.0.0.1 svc/harbor -n harbor-system 8081:80 >/dev/null 2>&1 &
-crane auth login 127.0.0.1:8081 -u admin -p "$HARBOR_PASS"
-crane push /tmp/agent.tar 127.0.0.1:8081/osdc/ci-agent-sandbox:prototype
-```
-
-(No secrets to create — the previous mitmproxy CA / GitHub token are gone.)
+`deploy.sh` builds it and pushes it to the in-cluster Harbor `osdc` project
+(public, so nodes pull anonymously via the `harbor:30002` mirror) — same pattern as
+`modules/zombie-cleanup`. The tag is a content hash of `agent/`, so an unchanged
+tree skips the build and a code change deploys a new immutable tag. Requires a
+local docker daemon. No secrets to create.
 
 ## Deploy
 

--- a/osdc/modules/agent-sandbox/agent/Dockerfile
+++ b/osdc/modules/agent-sandbox/agent/Dockerfile
@@ -4,10 +4,8 @@
 # It clones PUBLIC repos anonymously (no token) and calls Bedrock directly via
 # boto3 (which picks up the pod's IRSA web-identity credentials). No proxies.
 #
-# Build + push once to the in-cluster Harbor osdc project (see README):
-#   docker buildx build --platform linux/amd64 -t ci-agent-sandbox:prototype \
-#     -o type=docker,dest=/tmp/agent.tar modules/agent-sandbox/agent
-#   crane push /tmp/agent.tar <harbor>/osdc/ci-agent-sandbox:prototype
+# Built and pushed to the in-cluster Harbor osdc project by the module's deploy.sh
+# under a content-hash tag — not built by hand. See the module README.
 FROM public.ecr.aws/docker/library/debian:12-slim
 
 RUN apt-get update \

--- a/osdc/modules/agent-sandbox/deploy.sh
+++ b/osdc/modules/agent-sandbox/deploy.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 # Args: $1=cluster-id  $2=cluster-name  $3=region
 #
 # Deploys the sandbox:
-#   1. Reads the sandbox-agent IRSA role ARN (read-only Bedrock) from terraform.
-#   2. Applies the namespace, gvisor RuntimeClass, service account, the
-#      sandbox-agent worker + Service, and the NetworkPolicies. The agent image +
-#      region are substituted from clusters.yaml.
-#   3. Annotates the sandbox-agent SA with the IRSA role so the agent can call
+#   1. Builds the agent image and pushes it to the in-cluster Harbor `osdc`
+#      project under a content-hash tag (skipped if that tag already exists).
+#   2. Reads the sandbox-agent IRSA role ARN (read-only Bedrock) from terraform.
+#   3. Applies the namespace, gvisor RuntimeClass, service account, the
+#      sandbox-agent worker + Service, and the NetworkPolicies. The image, region
+#      and Bedrock model are substituted in.
+#   4. Annotates the sandbox-agent SA with the IRSA role so the agent can call
 #      Bedrock directly (no proxy).
 #
 # No proxies, no operator secrets: the agent clones public repos anonymously and
@@ -30,13 +32,19 @@ source "$UPSTREAM_ROOT/scripts/state-config.sh"
 : "${STATE_REGION:?state-config.sh did not export STATE_REGION}"
 CFG="$UPSTREAM_ROOT/scripts/cluster-config.py"
 
+# --- Cleanup trap (Harbor port-forward + temp files) ---
+PF_PID=""
+NETRC_FILE=""
+IMAGE_TAR=""
+cleanup() {
+  [[ -n "$PF_PID" ]] && { kill "$PF_PID" && wait "$PF_PID"; } 2>/dev/null || true
+  [[ -n "$NETRC_FILE" ]] && rm -f "$NETRC_FILE" 2>/dev/null || true
+  [[ -n "$IMAGE_TAR" ]] && rm -f "$IMAGE_TAR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
 NAMESPACE=ai-sandbox
 BUCKET_CFG=$(uv run "$CFG" "$CLUSTER" state_bucket)
-AGENT_IMAGE=$(uv run "$CFG" "$CLUSTER" agent_sandbox.agent_image "")
-if [[ -z "$AGENT_IMAGE" ]]; then
-  echo "[agent-sandbox] ERROR: agent_sandbox.agent_image not set for $CLUSTER in clusters.yaml" >&2
-  exit 1
-fi
 # Bedrock model for /run. Required: without it the agent clones but every task
 # returns errors.bedrock="no model configured".
 BEDROCK_MODEL_ID=$(uv run "$CFG" "$CLUSTER" agent_sandbox.model_id "")
@@ -44,6 +52,69 @@ if [[ -z "$BEDROCK_MODEL_ID" ]]; then
   echo "[agent-sandbox] ERROR: agent_sandbox.model_id not set for $CLUSTER in clusters.yaml" >&2
   exit 1
 fi
+
+# --- Build + push the agent image (mirrors modules/zombie-cleanup) ---
+# Content-hash tag over the image inputs, so a code change deploys a new immutable
+# tag and an unchanged tree skips the build entirely. Tests are excluded — they
+# never enter the image, and hashing them would rebuild on test-only edits.
+IMAGE="harbor:30002/osdc/ci-agent-sandbox"
+TAG=$(find "$MODULE_DIR/agent" \( -name '*.py' -o -name 'Dockerfile' \) \
+  ! -name 'test_*' ! -name 'conftest.py' -print0 | sort -z | xargs -0 cat | sha256sum | cut -c1-12)
+
+HARBOR_ADMIN_PW=$(kubectl get secret harbor-admin-password -n harbor-system \
+  -o jsonpath='{.data.password}' | base64 -d)
+NETRC_FILE=$(mktemp)
+chmod 600 "$NETRC_FILE"
+cat >"$NETRC_FILE" <<EOF
+machine localhost
+login admin
+password ${HARBOR_ADMIN_PW}
+EOF
+
+kubectl port-forward -n harbor-system svc/harbor 8081:80 &
+PF_PID=$!
+for i in $(seq 1 30); do
+  if curl -s -o /dev/null "http://localhost:8081/api/v2.0/health" 2>/dev/null; then
+    break
+  fi
+  if [[ "$i" -eq 30 ]]; then
+    echo "[agent-sandbox] ERROR: Harbor port-forward not ready after 30s" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# Nodes pull anonymously through the harbor:30002 mirror, so the project must be public.
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "http://localhost:8081/api/v2.0/projects" \
+  --netrc-file "$NETRC_FILE" \
+  -H "Content-Type: application/json" \
+  -d '{"project_name":"osdc","public":true}')
+case "$HTTP_CODE" in
+  201) echo "[agent-sandbox] Created Harbor project 'osdc'" ;;
+  409) : ;; # already exists
+  *) echo "[agent-sandbox] Warning: Harbor project creation returned HTTP $HTTP_CODE" ;;
+esac
+
+crane auth login localhost:8081 -u admin -p "$HARBOR_ADMIN_PW" --insecure
+if crane manifest "localhost:8081/osdc/ci-agent-sandbox:${TAG}" --insecure >/dev/null 2>&1; then
+  echo "[agent-sandbox] Image osdc/ci-agent-sandbox:${TAG} already exists — skipping build."
+else
+  echo "[agent-sandbox] Building agent image (tag: ${TAG})..."
+  # amd64: the ai-sandbox fleet is a single x86 instance type (defs/ai-sandbox.yaml).
+  docker build --platform linux/amd64 -t "ci-agent-sandbox:${TAG}" "$MODULE_DIR/agent"
+  echo "[agent-sandbox] Pushing image to Harbor..."
+  IMAGE_TAR=$(mktemp)
+  docker save "ci-agent-sandbox:${TAG}" -o "$IMAGE_TAR"
+  crane push "$IMAGE_TAR" "localhost:8081/osdc/ci-agent-sandbox:${TAG}" --insecure
+  rm -f "$IMAGE_TAR"
+  IMAGE_TAR=""
+fi
+
+# `wait` reaps the job so bash doesn't print "Terminated" into the deploy log.
+{ kill "$PF_PID" && wait "$PF_PID"; } 2>/dev/null || true
+PF_PID=""
+AGENT_IMAGE="${IMAGE}:${TAG}"
 
 # --- Read terraform outputs (sandbox-agent Bedrock IRSA role) ---
 echo "[agent-sandbox] Reading terraform outputs..."
@@ -85,7 +156,8 @@ kubectl delete networkpolicy default-deny proxy-ingress proxy-egress sandbox-age
 # --- Annotate the sandbox-agent SA with its Bedrock IRSA role ---
 # The pod-identity webhook injects the web-identity token from this annotation
 # (independent of automountServiceAccountToken: false). Restart so running pods
-# pick up a changed role.
+# pick up a changed role — the image tag is content-addressed, so a code change
+# rolls the pods via the Deployment update above, not via this restart.
 kubectl annotate sa sandbox-agent -n "$NAMESPACE" \
   eks.amazonaws.com/role-arn="$AGENT_ROLE_ARN" --overwrite
 kubectl rollout restart deployment/sandbox-agent -n "$NAMESPACE"

--- a/osdc/modules/agent-sandbox/kubernetes/base/sandbox-agent.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/sandbox-agent.yaml
@@ -1,7 +1,7 @@
 # The sandbox worker: a long-running HTTP service on the gVisor fleet, callable
 # over the network like buildkitd. __AGENT_IMAGE__ / __AWS_REGION__ /
-# __BEDROCK_MODEL_ID__ are substituted by deploy.sh (from clusters.yaml
-# agent_sandbox.agent_image and agent_sandbox.model_id).
+# __BEDROCK_MODEL_ID__ are substituted by deploy.sh (the image it built and pushed
+# to Harbor; the model from clusters.yaml agent_sandbox.model_id).
 #
 # runtimeClassName: gvisor pins it to the ai-sandbox fleet and runs it under runsc.
 # The only credential it holds is the read-only Bedrock IRSA role bound to the
@@ -32,10 +32,9 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: agent
+          # Content-hash tag from deploy.sh — immutable, so the default
+          # IfNotPresent pull policy is correct.
           image: __AGENT_IMAGE__
-          # Prototype uses a mutable :prototype tag; re-pull on every start so a
-          # fresh push is picked up.
-          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
The module was undeployable from a clean checkout: the operator had to run `buildx` + `crane` by hand before `just deploy-module` would work, against a mutable `:prototype` tag that needed `imagePullPolicy: Always` to roll at all.

`deploy.sh` now builds and pushes the image to the in-cluster Harbor `osdc` project under a content-hash tag, mirroring `modules/zombie-cleanup` — an unchanged tree skips the build, a code change deploys a new immutable tag, and the default `IfNotPresent` pull policy becomes correct. Drops `agent_sandbox.agent_image` from `clusters.yaml`. Needs a local docker daemon, like the other image-building modules.

Verified on `meta-staging-aws-ue1`: first deploy built and pushed `ci-agent-sandbox:e78c54d7f13e`, second skipped the build, and `/run` still returns a grounded Bedrock report.

**Stack** (review bottom-up, 5/5 — this PR):
1. nodepools-agent-sandbox: gVisor fleet (#986)
2. agent-sandbox module (#987)
3. canary integration test (#988)
4. enable on ue1 staging (#989)
5. **build the agent image in deploy.sh** ← this PR