### PR TITLE
Add cluster RBAC for listener node reads

### DIFF
--- a/osdc/modules/arc/kubernetes/listener-node-reader-rbac.yaml
+++ b/osdc/modules/arc/kubernetes/listener-node-reader-rbac.yaml
@@ -1,0 +1,39 @@
+# Cluster-scoped RBAC for the capacity monitor running in listener pods.
+# Grants read-only access to Node objects so the capacity monitor's placeholder
+# schedulability check can read Spec.Unschedulable (cordon) and Spec.Taints to
+# decide whether a placeholder still holds a node a replacement runner could be
+# scheduled onto.
+#
+# Scope: cluster-wide because Node is a cluster-scoped resource. The namespaced
+# pod/configmap grants for the same capacity monitor live in
+# capacity-monitor-rbac.yaml.
+#
+# We bind to the system:serviceaccounts:arc-systems group rather than a specific
+# SA because there is one listener SA per scale set, dynamically named
+# (<scale-set>-<hash>-listener) and created by the ARC controller — the same
+# reason capacity-monitor-rbac.yaml binds the group.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: arc-listener-node-reader
+  labels:
+    app.kubernetes.io/part-of: actions-runner-controller
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arc-listener-node-reader
+  labels:
+    app.kubernetes.io/part-of: actions-runner-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: arc-listener-node-reader
+subjects:
+  - kind: Group
+    name: system:serviceaccounts:arc-systems
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1001
* #1003
* #1002
* #1000
* __->__ #999

----

- New ClusterRole arc-listener-node-reader granting get/list/watch on Nodes
- ClusterRoleBinding to the system:serviceaccounts:arc-systems group
- Enables the capacity monitor to read Node Spec.Unschedulable and Spec.Taints

Notes:
Node is cluster-scoped, so this grant must be cluster-wide, complementing the
namespaced pod/configmap grants in capacity-monitor-rbac.yaml. It binds the
arc-systems SA group rather than a named SA because each scale set gets a
dynamically named listener SA (<scale-set>-<hash>-listener) created by the ARC
controller. The placeholder schedulability check uses cordon/taint state to
decide whether a placeholder still holds a node a replacement runner could
schedule onto. This manifest is not yet wired into modules/arc/deploy.sh, which
currently applies only capacity-monitor-rbac.yaml.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>