### PR TITLE
integration-test: add --org targeting for meta-pytorch canary runs

### DIFF
--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -383,6 +383,7 @@ clusters:
           runner_group: "default"
           resource_slug: mp
           max_runners: 1
+          canary_repo: "meta-pytorch/pytorch-gha-infra"
     arc-runners-h100:
       capacity_aware_fresh_multiplier: 1.0
     nodepools-h100:

--- a/osdc/integration-tests/scripts/python/phases.py
+++ b/osdc/integration-tests/scripts/python/phases.py
@@ -81,8 +81,16 @@ def region_excluded_blocks(upstream_dir: Path, region: str) -> set[str]:
     return excluded
 
 
-def ensure_canary_repo(upstream_dir: Path) -> Path:
-    """Clone or update pytorch-canary into .scratch/ and return its path."""
+def ensure_canary_repo(
+    upstream_dir: Path,
+    canary_repo: str = CANARY_REPO,
+    commit_email: str = "osdc-integration-test@pytorch.org",
+) -> Path:
+    """Clone or update the canary repo into .scratch/ and return its path.
+
+    ``canary_repo`` and ``commit_email`` default to the pytorch path; a
+    non-primary org supplies its own repo and a generic no-reply author.
+    """
     # Register gh as git's credential helper so raw git commands (fetch, push)
     # can authenticate using GH_TOKEN — gh repo clone alone doesn't set this up.
     auth_result = run_cmd(["gh", "auth", "setup-git"], check=False)
@@ -96,7 +104,9 @@ def ensure_canary_repo(upstream_dir: Path) -> Path:
     scratch = upstream_dir / SCRATCH_DIR_NAME
     scratch.mkdir(parents=True, exist_ok=True)
 
-    canary_path = scratch / "pytorch-canary"
+    # Per-repo scratch dir keeps a second org's clone (and its origin remote)
+    # from colliding with the pytorch-canary checkout when both are exercised.
+    canary_path = scratch / canary_repo.split("/")[-1]
     if canary_path.exists():
         # Verify repo integrity before fetching
         check = run_cmd(["git", "rev-parse", "--git-dir"], cwd=canary_path, check=False)
@@ -115,13 +125,13 @@ def ensure_canary_repo(upstream_dir: Path) -> Path:
             run_cmd(["git", "fetch", "origin"], capture=False, cwd=canary_path)
 
     if not canary_path.exists():
-        log.info("  Cloning %s into %s...", CANARY_REPO, canary_path)
+        log.info("  Cloning %s into %s...", canary_repo, canary_path)
         run_cmd(
             [
                 "gh",
                 "repo",
                 "clone",
-                CANARY_REPO,
+                canary_repo,
                 str(canary_path),
                 "--",
                 "--filter=blob:none",
@@ -132,7 +142,7 @@ def ensure_canary_repo(upstream_dir: Path) -> Path:
     # Configure git identity for commits made by the test orchestrator
     run_cmd(["git", "config", "user.name", "OSDC Integration Test"], cwd=canary_path, capture=False, check=False)
     run_cmd(
-        ["git", "config", "user.email", "osdc-integration-test@pytorch.org"],
+        ["git", "config", "user.email", commit_email],
         cwd=canary_path,
         capture=False,
         check=False,
@@ -144,13 +154,13 @@ def ensure_canary_repo(upstream_dir: Path) -> Path:
 # ── Phase 0: Cleanup ───────────────────────────────────────────────────
 
 
-def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX):
+def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX, canary_repo: str = CANARY_REPO):
     """Close any stale integration test PRs and cancel running workflows."""
     log.info("Phase 0: Cleaning up stale PRs...")
 
     # Find open PRs matching our title pattern
     result = run_cmd(
-        ["gh", "pr", "list", "--repo", CANARY_REPO, "--state", "open", "--json", "number,title"],
+        ["gh", "pr", "list", "--repo", canary_repo, "--state", "open", "--json", "number,title"],
         check=False,
     )
     if result.returncode != 0:
@@ -162,20 +172,20 @@ def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX):
         if pr_title_prefix in pr.get("title", ""):
             log.info("  Closing stale PR #%d: %s", pr["number"], pr["title"])
             run_cmd(
-                ["gh", "pr", "close", str(pr["number"]), "--repo", CANARY_REPO, "--delete-branch"],
+                ["gh", "pr", "close", str(pr["number"]), "--repo", canary_repo, "--delete-branch"],
                 check=False,
             )
 
     # Cancel any running workflows on our branch
     result = run_cmd(
-        ["gh", "run", "list", "--repo", CANARY_REPO, "--branch", branch, "--status", "queued", "--json", "databaseId"],
+        ["gh", "run", "list", "--repo", canary_repo, "--branch", branch, "--status", "queued", "--json", "databaseId"],
         check=False,
     )
     if result.returncode == 0 and result.stdout.strip():
         runs = safe_json_loads(result.stdout, "list queued runs") or []
         for r in runs:
             log.info("  Cancelling queued run %s", r["databaseId"])
-            run_cmd(["gh", "run", "cancel", str(r["databaseId"]), "--repo", CANARY_REPO], check=False)
+            run_cmd(["gh", "run", "cancel", str(r["databaseId"]), "--repo", canary_repo], check=False)
 
     result = run_cmd(
         [
@@ -183,7 +193,7 @@ def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX):
             "run",
             "list",
             "--repo",
-            CANARY_REPO,
+            canary_repo,
             "--branch",
             branch,
             "--status",
@@ -197,7 +207,7 @@ def cleanup_stale_prs(branch: str, pr_title_prefix: str = PR_TITLE_PREFIX):
         runs = safe_json_loads(result.stdout, "list in-progress runs") or []
         for r in runs:
             log.info("  Cancelling in-progress run %s", r["databaseId"])
-            run_cmd(["gh", "run", "cancel", str(r["databaseId"]), "--repo", CANARY_REPO], check=False)
+            run_cmd(["gh", "run", "cancel", str(r["databaseId"]), "--repo", canary_repo], check=False)
 
 
 # ── Phase 1: Staging pool clear (meta-staging-aws-uw1 only) ─────────────────────
@@ -399,6 +409,7 @@ def prepare_pr(
     workflow_content: str,
     dry_run: bool = False,
     branch: str = "osdc-integration-test",
+    canary_repo: str = CANARY_REPO,
 ) -> int | None:
     """Create a branch, add workflow files, push, and open a PR. Returns PR number."""
     log.info("Phase 2: Preparing PR...")
@@ -457,7 +468,7 @@ def prepare_pr(
             "pr",
             "create",
             "--repo",
-            CANARY_REPO,
+            canary_repo,
             "--title",
             f"{PR_TITLE_PREFIX} {now}",
             "--body",

--- a/osdc/integration-tests/scripts/python/phases_validation.py
+++ b/osdc/integration-tests/scripts/python/phases_validation.py
@@ -136,6 +136,7 @@ def wait_for_workflows(
     branch: str,
     pr_created_at: datetime,
     workflow_name: str | None = None,
+    canary_repo: str = CANARY_REPO,
 ) -> list[dict]:
     """Poll for workflow run completion. Returns list of run results.
 
@@ -171,7 +172,7 @@ def wait_for_workflows(
                     "run",
                     "list",
                     "--repo",
-                    CANARY_REPO,
+                    canary_repo,
                     "--branch",
                     branch,
                     "--json",
@@ -198,7 +199,7 @@ def wait_for_workflows(
                 run_id = r.get("databaseId")
                 if run_id and run_id not in logged_run_ids:
                     logged_run_ids.add(run_id)
-                    run_url = f"https://github.com/{CANARY_REPO}/actions/runs/{run_id}"
+                    run_url = f"https://github.com/{canary_repo}/actions/runs/{run_id}"
                     log.info("  Run: %s — %s", r.get("name", "?"), run_url)
 
             all_done = all(r.get("status") == "completed" for r in runs)
@@ -213,16 +214,16 @@ def wait_for_workflows(
             time.sleep(POLL_INTERVAL_SECONDS)
         else:
             log.warning("  Timeout reached! Collecting partial results.")
-            completed_runs = _fetch_latest_runs(branch, pr_created_at)
+            completed_runs = _fetch_latest_runs(branch, pr_created_at, canary_repo=canary_repo)
     except KeyboardInterrupt:
         log.warning("  Interrupted during workflow polling")
         raise  # Let main() handle cleanup and partial result collection
 
     # Get job details for each run
-    return _collect_run_details(completed_runs)
+    return _collect_run_details(completed_runs, canary_repo=canary_repo)
 
 
-def _fetch_latest_runs(branch: str, pr_created_at: datetime) -> list[dict]:
+def _fetch_latest_runs(branch: str, pr_created_at: datetime, canary_repo: str = CANARY_REPO) -> list[dict]:
     """Fetch the latest run list from GitHub (used on timeout and interrupt)."""
     result = run_cmd(
         [
@@ -230,7 +231,7 @@ def _fetch_latest_runs(branch: str, pr_created_at: datetime) -> list[dict]:
             "run",
             "list",
             "--repo",
-            CANARY_REPO,
+            canary_repo,
             "--branch",
             branch,
             "--json",
@@ -245,14 +246,14 @@ def _fetch_latest_runs(branch: str, pr_created_at: datetime) -> list[dict]:
     return []
 
 
-def _collect_run_details(runs: list[dict]) -> list[dict]:
+def _collect_run_details(runs: list[dict], canary_repo: str = CANARY_REPO) -> list[dict]:
     """Fetch job details and failure logs for a list of workflow runs."""
     results = []
     for run in runs:
         run_id = run["databaseId"]
         conclusion = run.get("conclusion") or "in_progress"
         result = run_cmd(
-            ["gh", "run", "view", str(run_id), "--repo", CANARY_REPO, "--json", "jobs"],
+            ["gh", "run", "view", str(run_id), "--repo", canary_repo, "--json", "jobs"],
             check=False,
         )
         jobs = []
@@ -265,7 +266,7 @@ def _collect_run_details(runs: list[dict]) -> list[dict]:
         failure_log = ""
         if conclusion == "failure":
             log_result = run_cmd(
-                ["gh", "run", "view", str(run_id), "--repo", CANARY_REPO, "--log-failed"],
+                ["gh", "run", "view", str(run_id), "--repo", canary_repo, "--log-failed"],
                 check=False,
             )
             if log_result.returncode == 0:
@@ -288,7 +289,7 @@ def _collect_run_details(runs: list[dict]) -> list[dict]:
 # ── Phase 5: Cleanup + Report ───────────────────────────────────────────
 
 
-def close_pr(pr_number: int, branch: str | None = None):
+def close_pr(pr_number: int, branch: str | None = None, canary_repo: str = CANARY_REPO):
     """Close the integration test PR and cancel associated workflows.
 
     Args:
@@ -303,7 +304,7 @@ def close_pr(pr_number: int, branch: str | None = None):
                     "run",
                     "list",
                     "--repo",
-                    CANARY_REPO,
+                    canary_repo,
                     "--branch",
                     branch,
                     "--status",
@@ -321,13 +322,13 @@ def close_pr(pr_number: int, branch: str | None = None):
             for r in runs:
                 log.info("  Cancelling %s run %s", status, r["databaseId"])
                 run_cmd(
-                    ["gh", "run", "cancel", str(r["databaseId"]), "--repo", CANARY_REPO],
+                    ["gh", "run", "cancel", str(r["databaseId"]), "--repo", canary_repo],
                     check=False,
                 )
 
     log.info("Phase 5: Closing PR #%d...", pr_number)
     run_cmd(
-        ["gh", "pr", "close", str(pr_number), "--repo", CANARY_REPO, "--delete-branch"],
+        ["gh", "pr", "close", str(pr_number), "--repo", canary_repo, "--delete-branch"],
         check=False,
     )
 

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -25,8 +25,11 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "modules" / "pypi-cache" / "scripts" / "python"))
 # Add repo-root scripts/python for the shared release-runner-group derivation.
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "python"))
+# Add arc-runners module scripts for the shared org-key derivation (multi-org targeting).
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "modules" / "arc-runners" / "scripts" / "python"))
 from fleet_naming import derive_release_runner_group  # noqa: E402
 from generate_manifests import cuda_slug  # noqa: E402
+from generate_runners import org_key_of  # noqa: E402
 from resolve_pytorch_image import resolve_ci_docker_hash
 
 log = logging.getLogger("osdc-integration-test")
@@ -104,6 +107,34 @@ def is_prod_cluster(cluster_id: str) -> bool:
     `<org>-<env>-<cloud>-<region>` id (meta-prod-aws-uw1, lf-prod-aws-ue1)."""
     parts = cluster_id.split("-")
     return len(parts) >= 2 and parts[1] == "prod"
+
+
+def resolve_org_target(cfg: dict, org: str | None) -> tuple[str, str]:
+    """Resolve the ``(canary_repo, runner_group)`` pair for the target GitHub org.
+
+    With ``org`` unset or equal to the cluster's primary org key, returns the
+    unchanged pytorch path: ``CANARY_REPO`` and the cluster's ``runner_group``
+    (falling back to ``default``). Otherwise the matching
+    ``arc-runners.additional_orgs`` entry supplies the canary repo and runner
+    group. An unknown org, or a matched entry missing ``canary_repo``, is a
+    fatal misconfiguration.
+    """
+    primary_key = org_key_of(resolve(cfg, "arc-runners.github_config_url", ""))
+    if org is None or org == primary_key:
+        return CANARY_REPO, resolve(cfg, "arc-runners.runner_group") or "default"
+
+    for entry in resolve(cfg, "arc-runners.additional_orgs", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        if org_key_of(entry.get("github_config_url")) == org:
+            canary_repo = entry.get("canary_repo")
+            if not canary_repo:
+                log.error("arc-runners.additional_orgs entry for org '%s' is missing 'canary_repo'", org)
+                sys.exit(1)
+            return canary_repo, entry.get("runner_group") or "default"
+
+    log.error("Unknown --org '%s': not the primary org and no matching arc-runners.additional_orgs entry", org)
+    sys.exit(1)
 
 
 # ── Subprocess helpers ──────────────────────────────────────────────────
@@ -210,6 +241,12 @@ def parse_args() -> argparse.Namespace:
         default="pytorch-linux-jammy-py3.10-clang18",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )
+    parser.add_argument(
+        "--org",
+        default=None,
+        help="Target GitHub org key from arc-runners.additional_orgs (e.g. 'meta-pytorch'). "
+        "Defaults to the cluster's primary org (the pytorch/pytorch-canary path).",
+    )
     return parser.parse_args()
 
 
@@ -240,9 +277,9 @@ def main():
     cluster_name = resolve(cfg, "cluster_name")
     region = resolve(cfg, "region", "")
     prefix = resolve(cfg, "arc-runners.runner_name_prefix", "")
-    cluster_runner_group = resolve(cfg, "arc-runners.runner_group")
-    runner_group = cluster_runner_group or "default"
-    release_runner_group = derive_release_runner_group(cluster_runner_group)
+    canary_repo, target_runner_group = resolve_org_target(cfg, args.org)
+    runner_group = target_runner_group
+    release_runner_group = derive_release_runner_group(target_runner_group)
     cluster_modules = cfg["cluster"].get("modules", [])
 
     # Build pypi-cache slug list: always "cpu", plus one per configured CUDA version
@@ -260,6 +297,7 @@ def main():
     branch = branch_name(args.cluster_id)
 
     log.info("Integration test for cluster: %s (%s)", args.cluster_id, cluster_name)
+    log.info("  Target canary repo: %s", canary_repo)
     log.info("  Runner prefix: '%s'", prefix)
     log.info("  Runner group: '%s'", runner_group)
     log.info("  Release runner group: '%s'", release_runner_group)
@@ -298,14 +336,18 @@ def main():
             ecr_pull_resolved_tag = ""
 
         # Phase 0: Cleanup
-        cleanup_stale_prs(branch)
+        cleanup_stale_prs(branch, canary_repo=canary_repo)
 
         # Phase 1: Staging pool clear
         if not args.dry_run and not args.skip_drain:
             clear_staging_pools(args.cluster_id, force=args.force)
 
-        # Clone / update canary repo
-        canary_path = ensure_canary_repo(args.upstream_dir)
+        # Clone / update canary repo. Non-primary orgs author commits under a
+        # generic no-reply identity; the primary path keeps ensure_canary_repo's default.
+        commit_kwargs = {}
+        if canary_repo != CANARY_REPO:
+            commit_kwargs["commit_email"] = "osdc-integration-test@users.noreply.github.com"
+        canary_path = ensure_canary_repo(args.upstream_dir, canary_repo=canary_repo, **commit_kwargs)
 
         # Phase 2: Prepare PR
         workflow_content = generate_workflow(
@@ -323,7 +365,9 @@ def main():
             region=region,
         )
         pr_created_at = datetime.now(tz=UTC)
-        pr_number = prepare_pr(canary_path, args.upstream_dir, workflow_content, args.dry_run, branch)
+        pr_number = prepare_pr(
+            canary_path, args.upstream_dir, workflow_content, args.dry_run, branch, canary_repo=canary_repo
+        )
 
         if args.dry_run:
             log.info("DRY RUN complete. No PR created.")
@@ -340,7 +384,7 @@ def main():
         )
 
         # Phase 4: Collect workflow results
-        workflow_results = wait_for_workflows(branch, pr_created_at)
+        workflow_results = wait_for_workflows(branch, pr_created_at, canary_repo=canary_repo)
 
         # Phase 5: Report
         overall_pass = print_report(
@@ -366,9 +410,9 @@ def main():
             from phases_validation import _collect_run_details, _fetch_latest_runs
 
             try:
-                runs = _fetch_latest_runs(branch, pr_created_at)
+                runs = _fetch_latest_runs(branch, pr_created_at, canary_repo=canary_repo)
                 if runs:
-                    workflow_results = _collect_run_details(runs)
+                    workflow_results = _collect_run_details(runs, canary_repo=canary_repo)
             except KeyboardInterrupt:
                 pass  # double Ctrl+C — skip fetch, print what we have
 
@@ -382,7 +426,7 @@ def main():
 
     finally:
         if pr_number is not None and not args.keep_pr:
-            close_pr(pr_number, branch=branch)
+            close_pr(pr_number, branch=branch, canary_repo=canary_repo)
         elif pr_number is not None and args.keep_pr:
             log.info("Keeping PR #%d open (--keep-pr).", pr_number)
 

--- a/osdc/integration-tests/scripts/python/test_phases_validation.py
+++ b/osdc/integration-tests/scripts/python/test_phases_validation.py
@@ -426,6 +426,35 @@ class TestWaitForWorkflows:
         assert expected_effective < WORKFLOW_TIMEOUT_MINUTES
         assert expected_effective >= 10
 
+    @patch("phases_validation.time.sleep")
+    @patch("phases_validation.run_cmd")
+    def test_threads_custom_canary_repo(self, mock_run, mock_sleep):
+        """The run-list poll and the collect-details run view both target the custom repo."""
+        from phases_validation import wait_for_workflows
+
+        completed = {
+            "databaseId": 1,
+            "status": "completed",
+            "conclusion": "success",
+            "name": "wf",
+            "createdAt": "2026-03-20T13:00:00Z",
+        }
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps([completed]), stderr=""),  # run list
+            MagicMock(returncode=0, stdout=json.dumps({"jobs": []}), stderr=""),  # run view (collect)
+        ]
+
+        wait_for_workflows(
+            "branch",
+            datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC),
+            canary_repo="meta-pytorch/pytorch-gha-infra",
+        )
+
+        for call in mock_run.call_args_list:
+            argv = call[0][0]
+            assert "meta-pytorch/pytorch-gha-infra" in argv
+            assert "pytorch/pytorch-canary" not in argv
+
 
 # ── close_pr ───────────────────────────────────────────────────────────
 
@@ -563,6 +592,27 @@ class TestClosePr:
         close_pr(42, branch="test-branch")
 
         assert mock_run.call_count == 3
+
+    @patch("phases_validation.run_cmd")
+    def test_threads_custom_canary_repo(self, mock_run):
+        """close_pr targets the custom repo for both cancel and PR-close calls."""
+        from phases_validation import close_pr
+
+        queued_runs = json.dumps([{"databaseId": 100}])
+        empty = json.dumps([])
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=queued_runs, stderr=""),  # queued list
+            MagicMock(returncode=0, stdout="", stderr=""),  # cancel 100
+            MagicMock(returncode=0, stdout=empty, stderr=""),  # in_progress list
+            MagicMock(returncode=0, stdout="", stderr=""),  # pr close
+        ]
+
+        close_pr(42, branch="test-branch", canary_repo="meta-pytorch/pytorch-gha-infra")
+
+        for call in mock_run.call_args_list:
+            argv = call[0][0]
+            assert "meta-pytorch/pytorch-gha-infra" in argv
+            assert "pytorch/pytorch-canary" not in argv
 
 
 # ── run_parallel_validation (skip paths) ──────────────────────────────
@@ -958,6 +1008,22 @@ class TestFetchLatestRuns:
 
         assert result == []
 
+    @patch("phases_validation.run_cmd")
+    def test_threads_custom_canary_repo(self, mock_run):
+        from phases_validation import _fetch_latest_runs
+
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
+
+        _fetch_latest_runs(
+            "test-branch",
+            datetime(2026, 3, 20, 12, 0, 0, tzinfo=UTC),
+            canary_repo="meta-pytorch/pytorch-gha-infra",
+        )
+
+        argv = mock_run.call_args_list[0][0][0]
+        assert "meta-pytorch/pytorch-gha-infra" in argv
+        assert "pytorch/pytorch-canary" not in argv
+
 
 # ── _collect_run_details ───────────────────────────────────────────────
 
@@ -1047,3 +1113,22 @@ class TestCollectRunDetails:
         assert results[0]["conclusion"] == "in_progress"
         # No --log-failed call for in_progress
         assert mock_run.call_count == 1
+
+    @patch("phases_validation.run_cmd")
+    def test_threads_custom_canary_repo(self, mock_run):
+        from phases_validation import _collect_run_details
+
+        runs = [
+            {"databaseId": 10, "conclusion": "failure", "name": "build", "status": "completed"},
+        ]
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({"jobs": []}), stderr=""),  # run view --json
+            MagicMock(returncode=0, stdout="log", stderr=""),  # run view --log-failed
+        ]
+
+        _collect_run_details(runs, canary_repo="meta-pytorch/pytorch-gha-infra")
+
+        for call in mock_run.call_args_list:
+            argv = call[0][0]
+            assert "meta-pytorch/pytorch-gha-infra" in argv
+            assert "pytorch/pytorch-canary" not in argv

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -16,6 +16,7 @@ from phases import (
     region_excluded_blocks,
 )
 from run import (
+    CANARY_REPO,
     branch_name,
     format_duration,
     gh_api,
@@ -25,6 +26,7 @@ from run import (
     normalize_modules,
     parse_args,
     resolve,
+    resolve_org_target,
     run_cmd_with_retry,
     safe_json_loads,
 )
@@ -48,7 +50,17 @@ def clusters_yaml(tmp_path):
                 "modules": ["eks", "karpenter", "nodepools", "arc", "arc-runners"],
                 "harbor": {"core_replicas": 1},
                 "monitoring": {"grafana_cloud_url": "https://staging.example.com"},
-                "arc-runners": {"runner_group": "meta-prod-rg"},
+                "arc-runners": {
+                    "github_config_url": "https://github.com/pytorch",
+                    "runner_group": "meta-prod-rg",
+                    "additional_orgs": [
+                        {
+                            "github_config_url": "https://github.com/meta-pytorch",
+                            "canary_repo": "meta-pytorch/pytorch-gha-infra",
+                            "runner_group": "mp-rg",
+                        },
+                    ],
+                },
             },
             "meta-prod-aws-ue2": {
                 "cluster_name": "meta-prod-aws-ue2",
@@ -782,6 +794,112 @@ class TestReleaseRunnerGroupResolution:
         assert release_runner_group == "release-runners"
 
 
+# ── resolve_org_target ────────────────────────────────────────────────────
+
+
+class TestResolveOrgTarget:
+    def test_none_returns_primary_path(self, cfg_staging):
+        repo, group = resolve_org_target(cfg_staging, None)
+        assert repo == CANARY_REPO
+        assert group == "meta-prod-rg"
+
+    def test_primary_org_key_returns_primary_path(self, cfg_staging):
+        # Explicitly naming the primary org resolves to the same unchanged path.
+        repo, group = resolve_org_target(cfg_staging, "pytorch")
+        assert repo == CANARY_REPO
+        assert group == "meta-prod-rg"
+
+    def test_additional_org_returns_its_repo_and_group(self, cfg_staging):
+        repo, group = resolve_org_target(cfg_staging, "meta-pytorch")
+        assert repo == "meta-pytorch/pytorch-gha-infra"
+        assert group == "mp-rg"
+
+    def test_malformed_non_dict_entry_is_skipped(self):
+        # A non-dict additional_orgs entry (malformed clusters.yaml) is skipped,
+        # not crashed on; the valid entry after it still resolves.
+        cfg = {
+            "cluster": {
+                "arc-runners": {
+                    "github_config_url": "https://github.com/pytorch",
+                    "runner_group": "primary-rg",
+                    "additional_orgs": [
+                        "not-a-dict",
+                        {
+                            "github_config_url": "https://github.com/meta-pytorch",
+                            "canary_repo": "meta-pytorch/pytorch-gha-infra",
+                            "runner_group": "mp-rg",
+                        },
+                    ],
+                }
+            },
+            "defaults": {},
+        }
+        repo, group = resolve_org_target(cfg, "meta-pytorch")
+        assert repo == "meta-pytorch/pytorch-gha-infra"
+        assert group == "mp-rg"
+
+    def test_primary_without_runner_group_defaults(self):
+        cfg = {"cluster": {"arc-runners": {"github_config_url": "https://github.com/pytorch"}}, "defaults": {}}
+        repo, group = resolve_org_target(cfg, None)
+        assert repo == CANARY_REPO
+        assert group == "default"
+
+    def test_additional_org_without_runner_group_defaults(self):
+        cfg = {
+            "cluster": {
+                "arc-runners": {
+                    "github_config_url": "https://github.com/pytorch",
+                    "runner_group": "primary-rg",
+                    "additional_orgs": [
+                        {
+                            "github_config_url": "https://github.com/meta-pytorch",
+                            "canary_repo": "meta-pytorch/pytorch-gha-infra",
+                        },
+                    ],
+                }
+            },
+            "defaults": {},
+        }
+        repo, group = resolve_org_target(cfg, "meta-pytorch")
+        assert repo == "meta-pytorch/pytorch-gha-infra"
+        assert group == "default"
+
+    def test_additional_org_missing_canary_repo_exits(self):
+        cfg = {
+            "cluster": {
+                "arc-runners": {
+                    "github_config_url": "https://github.com/pytorch",
+                    "runner_group": "primary-rg",
+                    "additional_orgs": [
+                        {"github_config_url": "https://github.com/meta-pytorch", "runner_group": "mp-rg"},
+                    ],
+                }
+            },
+            "defaults": {},
+        }
+        with pytest.raises(SystemExit):
+            resolve_org_target(cfg, "meta-pytorch")
+
+    def test_unknown_org_exits(self, cfg_staging):
+        with pytest.raises(SystemExit):
+            resolve_org_target(cfg_staging, "totally-unknown-org")
+
+    def test_workflow_runner_group_reflects_additional_org(self, cfg_staging, workflow_template):
+        # End-to-end: the group resolve_org_target picks for a secondary org must
+        # land in the rendered workflow's {{RUNNER_GROUP}} placeholder.
+        _, group = resolve_org_target(cfg_staging, "meta-pytorch")
+        result = generate_workflow(
+            workflow_template,
+            "cbr",
+            "meta-staging-aws-uw1",
+            "meta-staging-aws-uw1",
+            cluster_modules=["arc-runners"],
+            runner_group=group,
+        )
+        assert 'group: "mp-rg"' in result
+        assert "{{RUNNER_GROUP}}" not in result
+
+
 # ── format_duration ───────────────────────────────────────────────────────
 
 
@@ -868,6 +986,21 @@ class TestCleanupStalePrs:
         cleanup_stale_prs("osdc-integration-test-meta-staging-aws-uw1")
         # pr list + 2 run list calls, no close/cancel calls
         assert mock_run.call_count == 3
+
+    @patch("phases.run_cmd")
+    def test_threads_custom_canary_repo(self, mock_run):
+        empty = json.dumps([])
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=empty),  # pr list
+            MagicMock(returncode=0, stdout=empty),  # queued runs
+            MagicMock(returncode=0, stdout=empty),  # in_progress runs
+        ]
+        cleanup_stale_prs("branch", canary_repo="meta-pytorch/pytorch-gha-infra")
+        # Every gh call must target the org's canary repo, never the default.
+        for call in mock_run.call_args_list:
+            argv = call[0][0]
+            assert "meta-pytorch/pytorch-gha-infra" in argv
+            assert "pytorch/pytorch-canary" not in argv
 
 
 # ── prepare_pr ────────────────────────────────────────────────────────────
@@ -960,6 +1093,39 @@ class TestPreparePr:
         )
 
         assert result is None
+
+    @patch("phases.run_cmd")
+    def test_pr_create_uses_custom_canary_repo(self, mock_run, workflow_template, tmp_path):
+        canary = tmp_path / "canary"
+        canary.mkdir()
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # git fetch
+            MagicMock(returncode=0),  # git checkout
+            MagicMock(returncode=0),  # git add
+            MagicMock(returncode=1),  # git diff --cached → changes
+            MagicMock(returncode=0),  # git commit
+            MagicMock(returncode=0),  # git push
+            MagicMock(
+                returncode=0,
+                stdout="https://github.com/meta-pytorch/pytorch-gha-infra/pull/7\n",
+                stderr="",
+            ),
+        ]
+
+        result = prepare_pr(
+            canary_path=canary,
+            upstream_dir=workflow_template,
+            workflow_content="name: test\n",
+            branch="osdc-integration-test-meta-prod-aws-uw1",
+            dry_run=False,
+            canary_repo="meta-pytorch/pytorch-gha-infra",
+        )
+
+        assert result == 7
+        create_call = mock_run.call_args_list[6][0][0]
+        assert "meta-pytorch/pytorch-gha-infra" in create_call
+        assert "pytorch/pytorch-canary" not in create_call
 
 
 # ── ensure_canary_repo ───────────────────────────────────────────────────
@@ -1086,6 +1252,35 @@ class TestEnsureCanaryRepo:
             ensure_canary_repo(upstream)
 
         assert "gh auth setup-git failed" in caplog.text
+
+    @patch("phases.run_cmd")
+    def test_clones_custom_repo_with_custom_email(self, mock_run, tmp_path):
+        upstream = tmp_path / "upstream"
+        upstream.mkdir()
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = ensure_canary_repo(
+            upstream,
+            canary_repo="meta-pytorch/pytorch-gha-infra",
+            commit_email="osdc-integration-test@users.noreply.github.com",
+        )
+
+        # A second org gets its own scratch dir (repo name), never the shared pytorch-canary one.
+        assert result == upstream / ".scratch" / "pytorch-gha-infra"
+
+        clone_call = mock_run.call_args_list[1][0][0]
+        assert "meta-pytorch/pytorch-gha-infra" in clone_call
+        assert "pytorch/pytorch-canary" not in clone_call
+        assert str(result) in clone_call
+
+        email_call = mock_run.call_args_list[3][0][0]
+        assert email_call == [
+            "git",
+            "config",
+            "user.email",
+            "osdc-integration-test@users.noreply.github.com",
+        ]
 
 
 # ── branch_name ──────────────────────────────────────────────────────────
@@ -1242,6 +1437,7 @@ class TestParseArgs:
         assert args.keep_pr is False
         assert args.force is False
         assert args.skip_drain is False
+        assert args.org is None
 
     def test_all_flags(self):
         with patch(
@@ -1317,6 +1513,44 @@ class TestParseArgs:
         ):
             args = parse_args()
         assert args.ecr_pull_image_name == "foo"
+
+    def test_org_default_none(self):
+        with patch(
+            "sys.argv",
+            [
+                "run.py",
+                "--cluster-id",
+                "meta-staging-aws-uw1",
+                "--clusters-yaml",
+                "/tmp/c.yaml",
+                "--upstream-dir",
+                "/tmp/upstream",
+                "--root-dir",
+                "/tmp/root",
+            ],
+        ):
+            args = parse_args()
+        assert args.org is None
+
+    def test_org_override(self):
+        with patch(
+            "sys.argv",
+            [
+                "run.py",
+                "--cluster-id",
+                "meta-prod-aws-uw1",
+                "--clusters-yaml",
+                "/tmp/c.yaml",
+                "--upstream-dir",
+                "/tmp/upstream",
+                "--root-dir",
+                "/tmp/root",
+                "--org",
+                "meta-pytorch",
+            ],
+        ):
+            args = parse_args()
+        assert args.org == "meta-pytorch"
 
 
 # ── clear_staging_pools ──────────────────────────────────────────────────
@@ -1532,6 +1766,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1572,6 +1807,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1613,6 +1849,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1650,6 +1887,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1687,6 +1925,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1745,6 +1984,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="no-arc-cluster",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1786,6 +2026,7 @@ class TestMain:
 
         mock_parse_args.return_value = MagicMock(
             cluster_id="meta-staging-aws-uw1",
+            org=None,
             clusters_yaml=clusters_yaml,
             upstream_dir=tmp_path,
             root_dir=tmp_path,
@@ -1812,6 +2053,85 @@ class TestMain:
 
         assert exc_info.value.code == 1
         mock_gen.assert_not_called()
+
+    @patch("run.parse_args")
+    def test_main_org_targets_additional_org(self, mock_parse_args, clusters_yaml, tmp_path):
+        """--org routes cleanup/clone/PR to the additional org's canary repo + group."""
+        from run import main
+
+        mock_parse_args.return_value = MagicMock(
+            cluster_id="meta-staging-aws-uw1",
+            org="meta-pytorch",
+            clusters_yaml=clusters_yaml,
+            upstream_dir=tmp_path,
+            root_dir=tmp_path,
+            run_smoke=False,
+            run_compactor=False,
+            skip_smoke=True,
+            skip_compactor=True,
+            dry_run=True,
+            keep_pr=False,
+            force=True,
+            skip_drain=True,
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+        )
+
+        with (
+            patch("phases.cleanup_stale_prs") as mock_cleanup,
+            patch("phases.ensure_canary_repo", return_value=tmp_path) as mock_ensure,
+            patch("run.resolve_ci_docker_hash", return_value="abc"),
+            patch("phases.generate_workflow", return_value="wf") as mock_gen,
+            patch("phases.prepare_pr", return_value=None) as mock_prepare,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 0
+        assert mock_cleanup.call_args.kwargs["canary_repo"] == "meta-pytorch/pytorch-gha-infra"
+        assert mock_ensure.call_args.kwargs["canary_repo"] == "meta-pytorch/pytorch-gha-infra"
+        assert mock_ensure.call_args.kwargs["commit_email"] == "osdc-integration-test@users.noreply.github.com"
+        assert mock_gen.call_args.kwargs["runner_group"] == "mp-rg"
+        assert mock_prepare.call_args.kwargs["canary_repo"] == "meta-pytorch/pytorch-gha-infra"
+
+    @patch("run.parse_args")
+    def test_main_default_org_keeps_pytorch_identity(self, mock_parse_args, clusters_yaml, tmp_path):
+        """No --org keeps the pytorch canary repo and omits the no-reply email override."""
+        from run import main
+
+        mock_parse_args.return_value = MagicMock(
+            cluster_id="meta-staging-aws-uw1",
+            org=None,
+            clusters_yaml=clusters_yaml,
+            upstream_dir=tmp_path,
+            root_dir=tmp_path,
+            run_smoke=False,
+            run_compactor=False,
+            skip_smoke=True,
+            skip_compactor=True,
+            dry_run=True,
+            keep_pr=False,
+            force=True,
+            skip_drain=True,
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+        )
+
+        with (
+            patch("phases.cleanup_stale_prs") as mock_cleanup,
+            patch("phases.ensure_canary_repo", return_value=tmp_path) as mock_ensure,
+            patch("run.resolve_ci_docker_hash", return_value="abc"),
+            patch("phases.generate_workflow", return_value="wf") as mock_gen,
+            patch("phases.prepare_pr", return_value=None) as mock_prepare,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 0
+        assert mock_cleanup.call_args.kwargs["canary_repo"] == CANARY_REPO
+        assert mock_ensure.call_args.kwargs["canary_repo"] == CANARY_REPO
+        # Primary path relies on ensure_canary_repo's default author — no override passed.
+        assert "commit_email" not in mock_ensure.call_args.kwargs
+        assert mock_gen.call_args.kwargs["runner_group"] == "meta-prod-rg"
+        assert mock_prepare.call_args.kwargs["canary_repo"] == CANARY_REPO
 
 
 # ── region-gated GPU blocks (hf-cache large-read on L4/g6) ─────────────────


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #1001
* #1003
* #1002
* #1000
* #999

**Impact:** OSDC integration-test tooling + meta-staging cluster config (meta-pytorch runners). pytorch/pytorch-canary path unchanged.
**Risk:** low

Adds an `--org` flag to the integration-test runner that routes the whole PR lifecycle (cleanup, clone, PR create/poll/close) to a secondary org's canary repo and runner group, resolved from `arc-runners.additional_orgs`. Wires the three meta-staging clusters onto the `0.14.1-jeanschmidt.19` chart with a `meta-pytorch` fan-out entry and gives the uw1 prod entry its `canary_repo`.

The multi-org fan-out lets one cluster serve meta-pytorch alongside pytorch. To actually exercise the meta-pytorch runners end-to-end we need the integration test to drive a meta-pytorch canary repo instead of the hard-coded `pytorch/pytorch-canary`. Staging runs the base arc-runners module, so `just integration-test <staging> --org meta-pytorch` is where this path gets validated.

- Default (no `--org`) behaviour is byte-identical to before — same repo, same group, same commit author; secondary orgs get their own scratch checkout and a generic no-reply commit identity.
- Unknown org, or a matched `additional_orgs` entry missing `canary_repo`, is a fatal misconfiguration (exit 1).
- Requires operator/GitHub-side setup before staging deploy: the `meta-pytorch` App, per-cluster `<cluster>-meta-pytorch` secrets, and the `default` / `default-release-runners` runner groups granting `meta-pytorch/pytorch-gha-infra`.
- uw1 H100 integration is a no-op (template has no H100 jobs); validate that cluster via a manual one-job PR.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>