### PR TITLE
arc-runners smoke tests: key off generated scale sets for multi-org

### DIFF
--- a/osdc/modules/arc-runners/tests/smoke/conftest.py
+++ b/osdc/modules/arc-runners/tests/smoke/conftest.py
@@ -1,7 +1,7 @@
 """arc-runners smoke test fixtures.
 
 Reuses the shared smoke fixtures via star-import, then layers on arc-runners
-specific fixtures (currently: parsed runner YAMLs for the cluster under
+specific fixtures (currently: parsed generated scale sets for the cluster under
 test).
 """
 
@@ -10,62 +10,47 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+from runner_defs import (
+    GeneratedScaleSet,
+    arc_runners_module_names,
+    load_generated_scale_sets,
+)
 from smoke_conftest import *  # noqa: F403
-
-# Submodules that delegate to arc-runners/deploy.sh with their own defs/
-# (e.g. arc-runners-b200, arc-runners-h100). They share the upstream template
-# but live under their own modules/ directory and emit YAMLs into their own
-# generated/ dir. The fixture below regenerates each one separately so the
-# coherence tests see ALL listener pods, not just the base arc-runners ones.
-_ARC_RUNNERS_MODULE_PREFIX = "arc-runners"
 
 
 @pytest.fixture(scope="session")
-def generated_arc_runners(cluster_id: str, upstream_dir: Path) -> dict[str, dict]:
-    """Parse pre-generated ARC runner YAMLs across every arc-runners* module.
+def generated_scale_sets(
+    cluster_id: str,
+    upstream_dir: Path,
+    enabled_modules: list[str],
+    resolve_config,
+) -> list[GeneratedScaleSet]:
+    """Parse pre-generated ARC scale sets across every ENABLED arc-runners* module.
 
-    Multiple modules can deploy ARC runners — the canonical ``arc-runners``
-    plus per-GPU-arch variants (``arc-runners-b200``, ``arc-runners-h100``,
-    ...). Each variant owns its own ``defs/`` and ``generated/`` dir; this
-    fixture unions YAMLs across all of them so listener-pod ↔ def coherence
-    checks see the complete set deployed to the cluster.
+    Multiple modules can deploy ARC runners — the canonical ``arc-runners`` plus
+    per-GPU-arch variants (``arc-runners-b200``, ``arc-runners-h100``, ...). Each
+    owns its own ``defs/`` and ``generated/`` dir; this fixture unions the
+    generated files across the enabled ones so listener/placeholder ↔ scale-set
+    coherence checks see the complete set deployed to the cluster. Per-org
+    fan-out also emits one file per additional org (``<resource_slug>-<def>``);
+    each becomes its own entry keyed by an org-unique scale-set label.
 
-    The YAMLs are produced by ``just smoke``'s pre-generation loop, which
-    invokes ``just generate-arc-runners`` once per enabled arc-runners*
-    module before pytest starts. We do NOT regenerate from inside this
-    fixture — under pytest-xdist multiple workers would race on the shared
-    output directories. If you're running pytest directly (outside
-    ``just smoke``), run the recipe yourself for each variant first.
+    The YAMLs are produced by ``just smoke``'s pre-generation loop, which invokes
+    ``just generate-arc-runners`` once per enabled arc-runners* module before
+    pytest starts. We do NOT regenerate here — under pytest-xdist multiple
+    workers would race on the shared output directories. If you run pytest
+    directly (outside ``just smoke``), run the recipe yourself first.
 
-    Returns:
-        Mapping ``def_name -> parsed first YAML document`` (the chart values
-        block, which contains ``listenerTemplate``). The second YAML doc
-        (the ConfigMap) is intentionally dropped — coherence tests only
-        need the listener env block.
+    Returns a list of :class:`GeneratedScaleSet` — the generated files are the
+    source of truth for what the cluster deploys (see the class docstring).
     """
-    modules_dir = upstream_dir / "modules"
-    generated_dirs = sorted(modules_dir.glob("arc-runners*/generated"))
-    if not generated_dirs:
+    prefix = resolve_config("arc-runners.runner_name_prefix", "")
+    enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
+    scale_sets = load_generated_scale_sets(upstream_dir, prefix, enabled_arc)
+    if not scale_sets:
         pytest.fail(
-            f"No arc-runners*/generated directories under {modules_dir}. "
+            f"No generated ARC scale sets for modules {sorted(enabled_arc)}. "
             f"Run `just generate-arc-runners {cluster_id}` first (or invoke "
             f"`just smoke {cluster_id}`, which does it for you)."
         )
-
-    out: dict[str, dict] = {}
-    for generated_dir in generated_dirs:
-        for yaml_file in sorted(generated_dir.glob("*.yaml")):
-            # Each generated YAML is a multi-doc file: doc 1 = chart values
-            # (with listenerTemplate), doc 2 = job-pod hook ConfigMap.
-            # Coherence tests only consume doc 1; keep just that.
-            docs = list(yaml.safe_load_all(yaml_file.read_text()))
-            if not docs or not isinstance(docs[0], dict):
-                pytest.fail(f"Generated YAML {yaml_file} has no parseable first document")
-            out[yaml_file.stem] = docs[0]
-    if not out:
-        pytest.fail(
-            f"No generated YAMLs found in {[str(d) for d in generated_dirs]}. "
-            f"Run `just generate-arc-runners {cluster_id}` first."
-        )
-    return out
+    return scale_sets

--- a/osdc/modules/arc-runners/tests/smoke/runner_defs.py
+++ b/osdc/modules/arc-runners/tests/smoke/runner_defs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -102,3 +103,111 @@ def def_for_listener_pod(
     if def_name is None:
         return None, None
     return def_name, defs_by_name.get(def_name)
+
+
+def scale_set_label_from_values(values: dict) -> str:
+    """The ``actions.github.com/scale-set-name`` label ARC stamps on this scale
+    set's listener and placeholder pods, read from a generated chart-values doc.
+
+    ARC labels those pods with the AutoscalingRunnerSet's Kubernetes name, which
+    the chart derives as ``resourceName | default runnerScaleSetName``
+    (gha-runner-scale-set/templates/_helpers.tpl; the controller copies that name
+    onto the listener pod, and the capacity monitor onto placeholder pods).
+    Per-org fan-out sets ``resourceName`` (``<resource_slug>-<def>``) so each org's
+    pods carry an org-unique label; the primary org leaves it unset and the label
+    is ``runnerScaleSetName`` (``<runner_name_prefix><def>``). This asymmetry is
+    why a bare prefix-strip cannot map an additional org's pods to their def.
+    """
+    resource_name = values.get("resourceName")
+    if resource_name:
+        return str(resource_name)
+    return str(values.get("runnerScaleSetName") or "")
+
+
+def scale_set_label_of_pod(pod: dict) -> str | None:
+    """The ``actions.github.com/scale-set-name`` label on a live listener or
+    placeholder pod, or None when absent."""
+    return pod.get("metadata", {}).get("labels", {}).get(SCALE_SET_NAME_LABEL)
+
+
+@dataclass(frozen=True)
+class GeneratedScaleSet:
+    """One generated ARC scale set — the parsed contents of a single
+    ``modules/<arc-runners*>/generated/*.yaml`` file.
+
+    Generated files are the source of truth for what a cluster deploys. Per-org
+    fan-out emits one file per (def, org): the primary org keyed by the bare def
+    name and each additional org by ``<resource_slug>-<def>``, each with its own
+    org-unique hook ConfigMap and scale-set label. Reconstructing expected names
+    or the pod-to-def mapping from def names alone misses every additional-org
+    scale set — read them from here instead.
+    """
+
+    resource_id: str  # generated file stem: "<def>" (primary) or "<slug>-<def>"
+    scale_set_label: str  # actions.github.com/scale-set-name on live pods
+    def_name: str  # bare runner-def name, shared across a def's orgs
+    values: dict  # doc 1: chart values (runnerScaleSetName, listenerTemplate, ...)
+    configmap: dict  # doc 2: job-pod hook ConfigMap
+
+    @property
+    def configmap_name(self) -> str:
+        """Authoritative hook ConfigMap name (doc 2 ``metadata.name``)."""
+        return (self.configmap.get("metadata") or {}).get("name", "") or ""
+
+
+def generated_dirs(upstream_dir: Path, modules: Iterable[str] | None = None) -> list[Path]:
+    """Resolve ARC generated-config directories (mirrors :func:`defs_dirs`).
+
+    If ``modules`` is provided, returns ``modules/<m>/generated`` for each — used
+    to scope to a cluster's *enabled* arc-runners* modules. If omitted, returns
+    the union of every ``arc-runners*/generated`` in the codebase.
+    """
+    if modules is not None:
+        return [upstream_dir / "modules" / m / "generated" for m in sorted(modules)]
+    return sorted((upstream_dir / "modules").glob("arc-runners*/generated"))
+
+
+def read_generated_scale_sets(dirs: Iterable[Path], runner_name_prefix: str) -> list[GeneratedScaleSet]:
+    """Parse every generated runner YAML in ``dirs`` into GeneratedScaleSet entries.
+
+    Each generated file is a two-doc YAML: doc 1 = chart values (with the
+    identity fields ``runnerScaleSetName`` / ``resourceName``), doc 2 = the hook
+    ConfigMap. ``def_name`` is recovered by stripping ``runner_name_prefix`` from
+    ``runnerScaleSetName`` — which the generator always emits as
+    ``<prefix><def>`` for every org — so the bare def is shared across a def's
+    primary and additional-org scale sets.
+    """
+    out: list[GeneratedScaleSet] = []
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        for f in sorted(d.glob("*.yaml")):
+            docs = list(yaml.safe_load_all(f.read_text()))
+            values = docs[0] if docs and isinstance(docs[0], dict) else {}
+            configmap = next(
+                (doc for doc in docs if isinstance(doc, dict) and doc.get("kind") == "ConfigMap"),
+                {},
+            )
+            def_name = def_name_from_scale_set(str(values.get("runnerScaleSetName") or ""), runner_name_prefix)
+            out.append(
+                GeneratedScaleSet(
+                    resource_id=f.stem,
+                    scale_set_label=scale_set_label_from_values(values),
+                    def_name=def_name or "",
+                    values=values,
+                    configmap=configmap,
+                )
+            )
+    return out
+
+
+def load_generated_scale_sets(
+    upstream_dir: Path, runner_name_prefix: str, modules: Iterable[str] | None = None
+) -> list[GeneratedScaleSet]:
+    """GeneratedScaleSet entries across the given arc-runners* modules' generated dirs."""
+    return read_generated_scale_sets(generated_dirs(upstream_dir, modules), runner_name_prefix)
+
+
+def scale_sets_by_label(scale_sets: Iterable[GeneratedScaleSet]) -> dict[str, GeneratedScaleSet]:
+    """Index scale sets by their (org-unique) live-pod scale-set-name label."""
+    return {s.scale_set_label: s for s in scale_sets}

--- a/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_capacity_parity.py
@@ -27,13 +27,12 @@ actually claim. Capacity reservation silently degrades.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 from helpers import filter_pods, run_kubectl
-from runner_defs import def_for_listener_pod, load_defs_by_name
+from runner_defs import GeneratedScaleSet, scale_set_label_of_pod
 
 pytestmark = [pytest.mark.live]
 
@@ -78,10 +77,6 @@ IGNORED_PLACEHOLDER_TOLERATIONS: frozenset[tuple[str, str]] = frozenset(
 )
 
 
-def _normalize_name(name: str) -> str:
-    return name.replace(".", "-").replace("_", "-")
-
-
 def _proactive_capacity_from_generated(generated_doc: dict) -> int:
     """Return the CAPACITY_AWARE_PROACTIVE_CAPACITY env value from a generated YAML.
 
@@ -107,8 +102,8 @@ def _proactive_capacity_from_generated(generated_doc: dict) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _load_workflow_pod_template(runner_name: str) -> dict[str, Any] | None:
-    """Load the workflow pod template from the hook ConfigMap.
+def _load_workflow_pod_template(cm_name: str) -> dict[str, Any] | None:
+    """Load the workflow pod template from the named hook ConfigMap.
 
     The ConfigMap's job-pod.yaml uses ``$job`` as the container name (a hook
     DSL placeholder), so we cannot validate it as a Pod object — just navigate
@@ -121,7 +116,6 @@ def _load_workflow_pod_template(runner_name: str) -> dict[str, Any] | None:
     (timeouts, network issues, malformed JSON from kubectl) propagate so the
     test fails loudly instead of silently degrading to a misleading None.
     """
-    cm_name = f"arc-runner-hook-{_normalize_name(runner_name)}"
     try:
         cm = run_kubectl(["get", "configmap", cm_name], namespace=NAMESPACE)
     except subprocess.CalledProcessError:
@@ -277,79 +271,69 @@ class TestPlaceholderSchedulingParity:
     def test_workflow_placeholder_parity(
         self,
         all_pods: dict,
-        upstream_dir: Path,
         enabled_modules: list[str],
-        resolve_config,
-        generated_arc_runners: dict[str, dict],
+        generated_scale_sets: list[GeneratedScaleSet],
     ) -> None:
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
-        defs_by_name = load_defs_by_name(upstream_dir)
-        # Only scale sets that opted into proactive capacity will have
-        # placeholders running. Use the GENERATED YAML's
-        # CAPACITY_AWARE_PROACTIVE_CAPACITY env value (post-override) — not
-        # the raw def — so cluster-specific overrides like
-        # `proactive_capacity_max` on staging correctly skip all defs.
-        proactive_defs = {
-            name: d
-            for name, d in defs_by_name.items()
-            if name in generated_arc_runners and _proactive_capacity_from_generated(generated_arc_runners[name]) > 0
+        # Only scale sets that opted into proactive capacity run placeholders.
+        # Use the GENERATED YAML's CAPACITY_AWARE_PROACTIVE_CAPACITY env value
+        # (post-override) — not the raw def — so cluster-specific overrides like
+        # `proactive_capacity_max` on staging correctly skip all scale sets.
+        # Key by the org-unique scale-set-name label: per-org fan-out gives each
+        # org its own scale set (and its own hook ConfigMap) sharing a def, so a
+        # def-keyed grouping would conflate the two orgs' placeholders.
+        proactive = {
+            s.scale_set_label: s for s in generated_scale_sets if _proactive_capacity_from_generated(s.values) > 0
         }
-        if not proactive_defs:
+        if not proactive:
             pytest.skip("no scale sets with proactive_capacity > 0")
 
-        # Per-cluster prefix that ARC strips off the scale-set-name label
-        # (e.g. "c-mt-" → label "c-mt-l-arm64g3-61-463" maps to def
-        # "l-arm64g3-61-463"). We MUST use exact match against the stripped
-        # name — endswith() would collide if a rel-* def's name shared a
-        # suffix with a non-rel def (rel-X ↔ X), causing placeholders to be
-        # attributed to the
-        # wrong def and silently breaking parity attribution.
-        runner_name_prefix = resolve_config("arc-runners.runner_name_prefix", "")
-
-        # Group live placeholder pods by their owning runner def via the
-        # scale-set-name label + exact-match lookup (not suffix-match).
+        # Group live placeholder pods by their owning scale set via the
+        # scale-set-name label (org-unique — resourceName for additional orgs,
+        # runnerScaleSetName for the primary). ARC's capacity monitor stamps this
+        # label from the AutoscalingRunnerSet's Kubernetes name, so it matches the
+        # generated scale_set_label exactly (no prefix stripping needed).
         all_ph_pods = filter_pods(all_pods, namespace=NAMESPACE, labels=WORKFLOW_PLACEHOLDER_LABELS)
-        ph_pods_by_def: dict[str, list[dict]] = {name: [] for name in proactive_defs}
+        ph_pods_by_label: dict[str, list[dict]] = {label: [] for label in proactive}
         unattributed: list[str] = []
         for pod in all_ph_pods:
-            def_name, _runner = def_for_listener_pod(pod, defs_by_name, runner_name_prefix)
             pod_name = pod.get("metadata", {}).get("name", "?")
-            if def_name is None:
-                # Missing/invalid scale-set-name label or wrong cluster prefix.
-                label_val = pod.get("metadata", {}).get("labels", {}).get(LABEL_SCALE_SET, "<missing>")
-                unattributed.append(
-                    f"{pod_name}: cannot map placeholder to def "
-                    f"({LABEL_SCALE_SET}={label_val!r}, prefix={runner_name_prefix!r})"
-                )
+            label = scale_set_label_of_pod(pod)
+            if not label:
+                unattributed.append(f"{pod_name}: placeholder missing {LABEL_SCALE_SET!r} label")
                 continue
-            if def_name not in proactive_defs:
-                # Placeholder exists but its def doesn't have proactive_capacity > 0
-                # locally — likely a stale scale-set or a def removed without
+            if label not in proactive:
+                # Placeholder for a scale set without proactive_capacity > 0
+                # locally — likely a stale scale-set or a def/org removed without
                 # the corresponding placeholders being cleaned up. Skip silently;
                 # the env-var coherence test in test_runners.py catches stale
                 # scale-sets directly.
                 continue
-            ph_pods_by_def[def_name].append(pod)
+            ph_pods_by_label[label].append(pod)
 
         problems: list[str] = list(unattributed)
         info: list[str] = []
 
-        for runner_name, _runner in proactive_defs.items():
-            ph_pods = ph_pods_by_def[runner_name]
+        for label, scale_set in proactive.items():
+            ph_pods = ph_pods_by_label[label]
             if not ph_pods:
                 # Informational, not a failure — placeholders may be in
                 # between cycles or all preempted/Pending right now. Report
                 # the effective (post-override) proactive_capacity from the
                 # generated YAML, not the raw def value.
-                effective = _proactive_capacity_from_generated(generated_arc_runners[runner_name])
-                info.append(f"{runner_name}: no live workflow placeholders (proactive={effective})")
+                effective = _proactive_capacity_from_generated(scale_set.values)
+                info.append(f"{label}: no live workflow placeholders (proactive={effective})")
                 continue
 
-            workflow_spec = _load_workflow_pod_template(runner_name)
+            # Load the workflow template from THIS scale set's own hook ConfigMap
+            # (org-specific: arc-runner-hook-<slug>-<def> for an additional org).
+            workflow_spec = _load_workflow_pod_template(scale_set.configmap_name)
             if workflow_spec is None:
-                problems.append(f"{runner_name}: workflow pod template (hook ConfigMap) missing or empty")
+                problems.append(
+                    f"{label}: workflow pod template (hook ConfigMap {scale_set.configmap_name}) missing or empty"
+                )
                 continue
 
             for pod in ph_pods:
@@ -359,14 +343,14 @@ class TestPlaceholderSchedulingParity:
                 missing = _missing_required_terms(ph_spec, workflow_spec)
                 for term in missing:
                     problems.append(
-                        f"[{runner_name}] {pod_name}: workflow requires affinity term not present on "
+                        f"[{label}] {pod_name}: workflow requires affinity term not present on "
                         f"placeholder — expected {term}"
                     )
 
                 excess = _excess_tolerations(ph_spec, workflow_spec)
                 for tol in excess:
                     problems.append(
-                        f"[{runner_name}] {pod_name}: placeholder tolerates {tol} which the workflow "
+                        f"[{label}] {pod_name}: placeholder tolerates {tol} which the workflow "
                         f"pod does not — placeholder could land where workflow cannot"
                     )
 

--- a/osdc/modules/arc-runners/tests/smoke/test_runner_defs.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runner_defs.py
@@ -7,7 +7,14 @@ via `pytest test_runner_defs.py`.
 from __future__ import annotations
 
 import pytest
-from runner_defs import def_for_listener_pod, def_name_from_scale_set
+from runner_defs import (
+    def_for_listener_pod,
+    def_name_from_scale_set,
+    read_generated_scale_sets,
+    scale_set_label_from_values,
+    scale_set_label_of_pod,
+    scale_sets_by_label,
+)
 from test_capacity_parity import _proactive_capacity_from_generated
 from test_runners import _capacity_aware_env, _listener_env_from_generated_yaml
 
@@ -161,6 +168,109 @@ class TestProactiveCapacityFromGenerated:
     def test_returns_zero_when_value_unparseable(self):
         assert _proactive_capacity_from_generated(self._doc("not-an-int")) == 0
         assert _proactive_capacity_from_generated(self._doc(None)) == 0
+
+
+class TestScaleSetLabelFromValues:
+    """The live pod scale-set-name label derived from a generated chart-values doc."""
+
+    def test_primary_uses_runner_scale_set_name(self):
+        assert scale_set_label_from_values({"runnerScaleSetName": "mt-l-x86iamx-8-16"}) == "mt-l-x86iamx-8-16"
+
+    def test_additional_org_uses_resource_name(self):
+        # Additional-org fan-out sets resourceName; runnerScaleSetName stays the
+        # shared GitHub label — the K8s label follows resourceName.
+        values = {"runnerScaleSetName": "mt-l-x86iamx-8-16", "resourceName": "mp-l-x86iamx-8-16"}
+        assert scale_set_label_from_values(values) == "mp-l-x86iamx-8-16"
+
+    def test_missing_returns_empty(self):
+        assert scale_set_label_from_values({}) == ""
+
+
+class TestScaleSetLabelOfPod:
+    def test_reads_label(self):
+        pod = {"metadata": {"labels": {"actions.github.com/scale-set-name": "mp-l-x86iamx-8-16"}}}
+        assert scale_set_label_of_pod(pod) == "mp-l-x86iamx-8-16"
+
+    def test_missing_label_returns_none(self):
+        assert scale_set_label_of_pod({"metadata": {"labels": {}}}) is None
+        assert scale_set_label_of_pod({}) is None
+
+
+def _write_generated(path, resource_id, runner_scale_set_name, resource_name=None, cluster_index="0"):
+    """Write a minimal two-doc generated runner YAML mirroring the generator."""
+    resource_line = f'resourceName: "{resource_name}"\n' if resource_name else ""
+    path.write_text(
+        f'runnerScaleSetName: "{runner_scale_set_name}"\n'
+        f"{resource_line}"
+        "listenerTemplate:\n"
+        "  spec:\n"
+        "    containers:\n"
+        "      - name: listener\n"
+        "        env:\n"
+        "          - name: CAPACITY_AWARE_CLUSTER_INDEX\n"
+        f'            value: "{cluster_index}"\n'
+        "---\n"
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata:\n"
+        f"  name: arc-runner-hook-{resource_id}\n"
+        "  namespace: arc-runners\n"
+    )
+
+
+class TestReadGeneratedScaleSets:
+    """The generated-files reader that is the source of truth for org-aware checks."""
+
+    def test_multi_org_pair(self, tmp_path):
+        # One def fanned out to primary (pytorch) + additional org (mp), exactly
+        # as the generator emits it.
+        _write_generated(tmp_path / "l-x86iamx-8-16.yaml", "l-x86iamx-8-16", "mt-l-x86iamx-8-16", cluster_index="1")
+        _write_generated(
+            tmp_path / "mp-l-x86iamx-8-16.yaml",
+            "mp-l-x86iamx-8-16",
+            "mt-l-x86iamx-8-16",
+            resource_name="mp-l-x86iamx-8-16",
+            cluster_index="0",
+        )
+
+        scale_sets = read_generated_scale_sets([tmp_path], "mt-")
+        assert len(scale_sets) == 2
+        by_label = scale_sets_by_label(scale_sets)
+
+        # Org-unique labels: primary keeps the prefixed name, mp uses resourceName.
+        assert set(by_label) == {"mt-l-x86iamx-8-16", "mp-l-x86iamx-8-16"}
+        primary = by_label["mt-l-x86iamx-8-16"]
+        mp = by_label["mp-l-x86iamx-8-16"]
+
+        # Both map back to the SAME bare def, but to DIFFERENT org-unique CMs.
+        assert primary.def_name == mp.def_name == "l-x86iamx-8-16"
+        assert primary.configmap_name == "arc-runner-hook-l-x86iamx-8-16"
+        assert mp.configmap_name == "arc-runner-hook-mp-l-x86iamx-8-16"
+        assert primary.resource_id == "l-x86iamx-8-16"
+        assert mp.resource_id == "mp-l-x86iamx-8-16"
+        # Per-org values are preserved (different shard index here).
+        assert (
+            _capacity_aware_env(_listener_env_from_generated_yaml(primary.values))["CAPACITY_AWARE_CLUSTER_INDEX"][
+                "value"
+            ]
+            == "1"
+        )
+        assert (
+            _capacity_aware_env(_listener_env_from_generated_yaml(mp.values))["CAPACITY_AWARE_CLUSTER_INDEX"]["value"]
+            == "0"
+        )
+
+    def test_single_org_matches_def_name_reconstruction(self, tmp_path):
+        # Without an additional org the label is the prefixed name and the CM
+        # name matches the classic arc-runner-hook-<def> reconstruction.
+        _write_generated(tmp_path / "l-x86iamx-8-16.yaml", "l-x86iamx-8-16", "mt-l-x86iamx-8-16")
+        (scale_set,) = read_generated_scale_sets([tmp_path], "mt-")
+        assert scale_set.scale_set_label == "mt-l-x86iamx-8-16"
+        assert scale_set.def_name == "l-x86iamx-8-16"
+        assert scale_set.configmap_name == "arc-runner-hook-l-x86iamx-8-16"
+
+    def test_missing_dir_is_skipped(self, tmp_path):
+        assert read_generated_scale_sets([tmp_path / "does-not-exist"], "mt-") == []
 
 
 if __name__ == "__main__":

--- a/osdc/modules/arc-runners/tests/smoke/test_runners.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_runners.py
@@ -13,7 +13,14 @@ from pathlib import Path
 import pytest
 import yaml
 from helpers import filter_pods, find_helm_release, run_kubectl
-from runner_defs import arc_runners_module_names, def_for_listener_pod, load_defs_by_name, load_runner_defs
+from runner_defs import (
+    SCALE_SET_NAME_LABEL,
+    GeneratedScaleSet,
+    arc_runners_module_names,
+    load_runner_defs,
+    scale_set_label_of_pod,
+    scale_sets_by_label,
+)
 
 pytestmark = [pytest.mark.live]
 
@@ -80,17 +87,23 @@ class TestRunnerDefs:
 class TestRunnerConfigMaps:
     """Verify ConfigMaps exist for each runner definition."""
 
-    def test_configmaps_for_all_defs(self, upstream_dir: Path, enabled_modules: list[str]) -> None:
-        """Each runner def has a matching ConfigMap in arc-runners namespace."""
+    def test_configmaps_for_all_defs(
+        self, upstream_dir: Path, enabled_modules: list[str], generated_scale_sets: list[GeneratedScaleSet]
+    ) -> None:
+        """Each generated scale set has a matching hook ConfigMap in arc-runners namespace.
+
+        Expected names come from the generated files (the source of truth for what
+        this cluster deploys), so per-org fan-out CMs (arc-runner-hook-<slug>-<def>)
+        are covered — a def-name reconstruction would miss them.
+        """
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
-        # Scope to arc-runners* modules actually enabled on this cluster — defs
-        # from unenabled-but-present-in-codebase variants would otherwise be
-        # expected as CMs that genuinely don't exist on this cluster.
+        # Scope actual CMs to arc-runners* modules enabled on this cluster —
+        # generated_scale_sets is already scoped to the same set.
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
 
-        defs = _load_all_defs(upstream_dir, enabled_arc)
+        expected = {s.configmap_name for s in generated_scale_sets}
         result = run_kubectl(["get", "configmaps", "-l", MODULE_LABEL_KEY, "-o", "json"], namespace=NAMESPACE)
         cm_names = {
             item["metadata"]["name"]
@@ -98,13 +111,8 @@ class TestRunnerConfigMaps:
             if item.get("metadata", {}).get("labels", {}).get(MODULE_LABEL_KEY) in enabled_arc
         }
 
-        missing = []
-        for d in defs:
-            expected = f"arc-runner-hook-{_normalize_name(d['name'])}"
-            if expected not in cm_names:
-                missing.append(expected)
-
-        assert not missing, f"Missing ConfigMaps for runner defs: {missing}"
+        missing = sorted(expected - cm_names)
+        assert not missing, f"Missing ConfigMaps for generated scale sets: {missing}"
 
 
 # ============================================================================
@@ -127,35 +135,31 @@ class TestRunnerConfigMapEnvVars:
         }
     )
 
-    def test_pypi_cache_env_vars_present(self, upstream_dir: Path, enabled_modules: list[str]) -> None:
-        """Each runner ConfigMap's job-pod.yaml has all pypi-cache env vars."""
+    def test_pypi_cache_env_vars_present(
+        self, upstream_dir: Path, enabled_modules: list[str], generated_scale_sets: list[GeneratedScaleSet]
+    ) -> None:
+        """Each generated scale set's deployed ConfigMap job-pod.yaml has all pypi-cache env vars."""
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
         if "pypi-cache" not in enabled_modules:
             pytest.skip("pypi-cache module not enabled — env vars are intentionally stripped from runner ConfigMaps")
 
-        # Scope to arc-runners* modules actually enabled on this cluster — defs
-        # from unenabled-but-present-in-codebase variants would otherwise be
-        # expected as CMs that genuinely don't exist on this cluster.
+        # Scope actual CMs to arc-runners* modules enabled on this cluster —
+        # generated_scale_sets is already scoped to the same set.
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
 
-        defs = _load_all_defs(upstream_dir, enabled_arc)
         result = run_kubectl(["get", "configmaps", "-l", MODULE_LABEL_KEY, "-o", "json"], namespace=NAMESPACE)
-        items = [
-            item
+        items = {
+            item["metadata"]["name"]: item
             for item in result.get("items", [])
             if item.get("metadata", {}).get("labels", {}).get(MODULE_LABEL_KEY) in enabled_arc
-        ]
+        }
 
         missing_vars: list[str] = []
-        for d in defs:
-            cm_name = f"arc-runner-hook-{_normalize_name(d['name'])}"
-            cm = None
-            for item in items:
-                if item["metadata"]["name"] == cm_name:
-                    cm = item
-                    break
+        for scale_set in generated_scale_sets:
+            cm_name = scale_set.configmap_name
+            cm = items.get(cm_name)
             if cm is None:
                 continue  # TestRunnerConfigMaps covers missing CMs
 
@@ -187,26 +191,24 @@ class TestRunnerHelmReleases:
     """Verify Helm releases exist for each runner definition."""
 
     def test_helm_releases_for_all_defs(
-        self, upstream_dir: Path, all_helm_releases: list[dict], enabled_modules: list[str]
+        self, all_helm_releases: list[dict], enabled_modules: list[str], generated_scale_sets: list[GeneratedScaleSet]
     ) -> None:
-        """Each runner def has a matching Helm release."""
+        """Each generated scale set has a matching Helm release.
+
+        deploy.sh installs one release per generated file, named
+        ``arc-<normalized resource_id>`` — so per-org fan-out releases
+        (arc-<slug>-<def>) are covered.
+        """
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
-        # Scope to arc-runners* modules actually enabled on this cluster — defs
-        # from unenabled-but-present-in-codebase variants would otherwise be
-        # expected as releases that genuinely don't exist on this cluster.
-        enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
-
-        defs = _load_all_defs(upstream_dir, enabled_arc)
         missing = []
-        for d in defs:
-            release_name = f"arc-{_normalize_name(d['name'])}"
-            release = find_helm_release(all_helm_releases, release_name)
-            if release is None:
+        for scale_set in generated_scale_sets:
+            release_name = f"arc-{_normalize_name(scale_set.resource_id)}"
+            if find_helm_release(all_helm_releases, release_name) is None:
                 missing.append(release_name)
 
-        assert not missing, f"Missing Helm releases for runner defs: {missing}"
+        assert not missing, f"Missing Helm releases for generated scale sets: {missing}"
 
 
 # ============================================================================
@@ -217,18 +219,23 @@ class TestRunnerHelmReleases:
 class TestNoStaleRunners:
     """Verify no orphaned ConfigMaps exist that don't match any runner def."""
 
-    def test_no_stale_configmaps(self, upstream_dir: Path, enabled_modules: list[str]) -> None:
-        """All ConfigMaps with the arc-runners label match a known runner def."""
+    def test_no_stale_configmaps(
+        self, upstream_dir: Path, enabled_modules: list[str], generated_scale_sets: list[GeneratedScaleSet]
+    ) -> None:
+        """Every deployed arc-runners ConfigMap matches a generated scale set.
+
+        Expected names come from the generated files, so per-org fan-out CMs
+        (arc-runner-hook-<slug>-<def>) are legitimate — reconstructing expected
+        names from def names alone would flag every additional-org CM as stale.
+        """
         if "arc-runners" not in enabled_modules:
             pytest.skip("arc-runners module not enabled")
 
-        # Scope to arc-runners* modules actually enabled on this cluster — defs
-        # from unenabled-but-present-in-codebase variants would otherwise be
-        # expected as CMs that genuinely don't exist on this cluster.
+        # Scope actual CMs to arc-runners* modules enabled on this cluster —
+        # generated_scale_sets is already scoped to the same set.
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
 
-        defs = _load_all_defs(upstream_dir, enabled_arc)
-        expected_cms = {f"arc-runner-hook-{_normalize_name(d['name'])}" for d in defs}
+        expected_cms = {s.configmap_name for s in generated_scale_sets}
 
         result = run_kubectl(["get", "configmaps", "-l", MODULE_LABEL_KEY, "-o", "json"], namespace=NAMESPACE)
         actual_cms = {
@@ -238,7 +245,7 @@ class TestNoStaleRunners:
         }
 
         stale = actual_cms - expected_cms
-        assert not stale, f"Stale ConfigMaps (no matching def): {stale}"
+        assert not stale, f"Stale ConfigMaps (no matching generated scale set): {stale}"
 
 
 # ============================================================================
@@ -296,10 +303,8 @@ class TestListenerCapacityAwareEnvVars:
     def test_listener_env_vars_match_generated_yaml(
         self,
         all_pods: dict,
-        upstream_dir: Path,
         enabled_modules: list[str],
-        resolve_config,
-        generated_arc_runners: dict[str, dict],
+        generated_scale_sets: list[GeneratedScaleSet],
     ) -> None:
         """Each listener pod's CAPACITY_AWARE_* env vars match its generated YAML.
 
@@ -317,10 +322,13 @@ class TestListenerCapacityAwareEnvVars:
             f"No listener pods found in '{LISTENER_NAMESPACE}' with labels {LISTENER_LABELS}"
         )
 
-        runner_name_prefix = resolve_config("arc-runners.runner_name_prefix", "")
-        # Reuse load_defs_by_name only for the listener→def mapping helper —
-        # value comparisons go through generated_arc_runners.
-        defs_by_name = load_defs_by_name(upstream_dir)
+        # Map each listener pod to its generated scale set via the org-unique
+        # scale-set-name label (resourceName for additional orgs, runnerScaleSetName
+        # for the primary). Per-org fan-out gives the two orgs DIFFERENT labels but
+        # the SAME underlying def, and their listener env differs (e.g. the
+        # CAPACITY_AWARE_CLUSTER_INDEX/COUNT per-org shard) — so a def-keyed lookup
+        # would compare a pod against the wrong org's YAML.
+        by_label = scale_sets_by_label(generated_scale_sets)
 
         problems: list[str] = []
         for pod in listener_pods:
@@ -331,23 +339,22 @@ class TestListenerCapacityAwareEnvVars:
                 problems.append(f"{pod_name}: no '{LISTENER_CONTAINER_NAME}' container")
                 continue
 
-            def_name, _runner = def_for_listener_pod(pod, defs_by_name, runner_name_prefix)
-            if def_name is None:
+            label = scale_set_label_of_pod(pod)
+            if not label:
+                problems.append(f"{pod_name}: missing '{SCALE_SET_NAME_LABEL}' label")
+                continue
+
+            scale_set = by_label.get(label)
+            if scale_set is None:
                 problems.append(
-                    f"{pod_name}: missing/invalid 'actions.github.com/scale-set-name' label "
-                    f"(prefix={runner_name_prefix!r})"
+                    f"{pod_name}: no generated scale set for {SCALE_SET_NAME_LABEL}={label!r} (stale scale-set?)"
                 )
                 continue
 
-            generated = generated_arc_runners.get(def_name)
-            if generated is None:
-                problems.append(f"{pod_name}: no generated YAML found for def {def_name!r} (stale scale-set?)")
-                continue
-
-            generated_env = _capacity_aware_env(_listener_env_from_generated_yaml(generated))
+            generated_env = _capacity_aware_env(_listener_env_from_generated_yaml(scale_set.values))
             if not generated_env:
                 problems.append(
-                    f"{pod_name} (def={def_name}): generated YAML has no CAPACITY_AWARE_* env vars in "
+                    f"{pod_name} (scale-set={label}): generated YAML has no CAPACITY_AWARE_* env vars in "
                     f"listenerTemplate — template/generator regression?"
                 )
                 continue
@@ -359,13 +366,13 @@ class TestListenerCapacityAwareEnvVars:
             for var, want_entry in generated_env.items():
                 got_entry = deployed_env.get(var)
                 if got_entry is None:
-                    problems.append(f"{pod_name} (def={def_name}): missing env var {var!r}")
+                    problems.append(f"{pod_name} (scale-set={label}): missing env var {var!r}")
                     continue
                 want_sig = self._env_value_signature(want_entry)
                 got_sig = self._env_value_signature(got_entry)
                 if want_sig != got_sig:
                     problems.append(
-                        f"{pod_name} (def={def_name}): {var} mismatch — generated {want_sig!r}, deployed {got_sig!r}"
+                        f"{pod_name} (scale-set={label}): {var} mismatch — generated {want_sig!r}, deployed {got_sig!r}"
                     )
 
             # Catch the reverse: env vars deployed but no longer in the
@@ -373,7 +380,7 @@ class TestListenerCapacityAwareEnvVars:
             extra = sorted(deployed_env.keys() - generated_env.keys())
             if extra:
                 problems.append(
-                    f"{pod_name} (def={def_name}): unexpected CAPACITY_AWARE_* env vars not in generated YAML: {extra}"
+                    f"{pod_name} (scale-set={label}): unexpected CAPACITY_AWARE_* env vars not in generated YAML: {extra}"
                 )
 
         assert not problems, "Listener CAPACITY_AWARE_* env-var coherence failures:\n" + "\n".join(problems)

--- a/osdc/modules/arc-runners/tests/smoke/test_scheduler_name.py
+++ b/osdc/modules/arc-runners/tests/smoke/test_scheduler_name.py
@@ -6,10 +6,11 @@ import pytest
 import yaml
 from helpers import filter_pods, run_kubectl
 from runner_defs import (
+    GeneratedScaleSet,
     arc_runners_module_names,
-    def_for_listener_pod,
     load_defs_by_name,
-    load_runner_defs,
+    scale_set_label_of_pod,
+    scale_sets_by_label,
 )
 
 pytestmark = [pytest.mark.live]
@@ -21,10 +22,6 @@ LISTENER_CONTAINER_NAME = "listener"
 MODULE_LABEL_KEY = "osdc.io/module"
 SCHEDULER_MODULE = "bin-pack-scheduler"
 SCHEDULER_ENV_VAR = "CAPACITY_AWARE_WORKFLOW_SCHEDULER_NAME"
-
-
-def _normalize_name(name: str) -> str:
-    return name.replace(".", "-").replace("_", "-")
 
 
 def _effective_scheduler_name(runner_def: dict, cluster_default: str) -> str:
@@ -58,42 +55,35 @@ class TestSchedulerName:
         upstream_dir: Path,
         enabled_modules: list[str],
         resolve_config,
+        generated_scale_sets: list[GeneratedScaleSet],
     ) -> None:
         cluster_default = resolve_config("arc-runners.scheduler_name", "")
         _skip_unless_scheduler_configured(enabled_modules, cluster_default)
 
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
         defs_by_name = load_defs_by_name(upstream_dir, enabled_arc)
-
-        modules_dir = upstream_dir / "modules"
-        generated_files = []
-        for module in sorted(enabled_arc):
-            generated_files.extend(sorted((modules_dir / module / "generated").glob("*.yaml")))
-        assert generated_files, f"No generated YAMLs found for arc-runners modules: {sorted(enabled_arc)}"
+        assert generated_scale_sets, f"No generated scale sets for arc-runners modules: {sorted(enabled_arc)}"
 
         problems: list[str] = []
-        for yaml_file in generated_files:
-            def_name = yaml_file.stem
-            runner = defs_by_name.get(def_name)
+        for scale_set in generated_scale_sets:
+            # def_name is recovered from runnerScaleSetName (shared across a def's
+            # orgs), not the file stem — an additional org's stem (<slug>-<def>)
+            # is not a def key.
+            runner = defs_by_name.get(scale_set.def_name)
             if runner is None:
-                problems.append(f"{yaml_file}: no runner def matches stem {def_name!r}")
+                problems.append(f"{scale_set.resource_id}: no runner def matches def name {scale_set.def_name!r}")
                 continue
             expected = _effective_scheduler_name(runner, cluster_default)
-            docs = list(yaml.safe_load_all(yaml_file.read_text()))
-            cm_doc = next(
-                (d for d in docs if isinstance(d, dict) and d.get("kind") == "ConfigMap"),
-                None,
-            )
-            if cm_doc is None:
-                problems.append(f"{yaml_file}: no ConfigMap document in generated YAML")
+            if not scale_set.configmap:
+                problems.append(f"{scale_set.resource_id}: no ConfigMap document in generated YAML")
                 continue
-            pod = _workflow_pod_from_cm_data(cm_doc.get("data", {}) or {})
+            pod = _workflow_pod_from_cm_data(scale_set.configmap.get("data", {}) or {})
             if pod is None:
-                problems.append(f"{yaml_file}: ConfigMap has no parseable job-pod.yaml")
+                problems.append(f"{scale_set.resource_id}: ConfigMap has no parseable job-pod.yaml")
                 continue
             got = pod.get("spec", {}).get("schedulerName", "")
             if got != expected:
-                problems.append(f"{def_name}: generated schedulerName={got!r}, expected {expected!r}")
+                problems.append(f"{scale_set.resource_id}: generated schedulerName={got!r}, expected {expected!r}")
 
         assert not problems, "Generated workflow pod schedulerName mismatches:\n" + "\n".join(problems)
 
@@ -102,12 +92,13 @@ class TestSchedulerName:
         upstream_dir: Path,
         enabled_modules: list[str],
         resolve_config,
+        generated_scale_sets: list[GeneratedScaleSet],
     ) -> None:
         cluster_default = resolve_config("arc-runners.scheduler_name", "")
         _skip_unless_scheduler_configured(enabled_modules, cluster_default)
 
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
-        defs = load_runner_defs(upstream_dir, enabled_arc)
+        defs_by_name = load_defs_by_name(upstream_dir, enabled_arc)
 
         result = run_kubectl(["get", "configmaps", "-l", MODULE_LABEL_KEY, "-o", "json"], namespace=NAMESPACE)
         cms_by_name = {
@@ -117,19 +108,22 @@ class TestSchedulerName:
         }
 
         problems: list[str] = []
-        for runner in defs:
-            cm_name = f"arc-runner-hook-{_normalize_name(runner['name'])}"
-            cm = cms_by_name.get(cm_name)
+        for scale_set in generated_scale_sets:
+            cm = cms_by_name.get(scale_set.configmap_name)
             if cm is None:
+                continue
+            runner = defs_by_name.get(scale_set.def_name)
+            if runner is None:
+                problems.append(f"{scale_set.configmap_name}: no runner def matches def name {scale_set.def_name!r}")
                 continue
             expected = _effective_scheduler_name(runner, cluster_default)
             pod = _workflow_pod_from_cm_data(cm.get("data", {}) or {})
             if pod is None:
-                problems.append(f"{cm_name}: no parseable job-pod.yaml in deployed ConfigMap")
+                problems.append(f"{scale_set.configmap_name}: no parseable job-pod.yaml in deployed ConfigMap")
                 continue
             got = pod.get("spec", {}).get("schedulerName", "")
             if got != expected:
-                problems.append(f"{cm_name}: deployed schedulerName={got!r}, expected {expected!r}")
+                problems.append(f"{scale_set.configmap_name}: deployed schedulerName={got!r}, expected {expected!r}")
 
         assert not problems, "Deployed hook ConfigMap schedulerName mismatches:\n" + "\n".join(problems)
 
@@ -139,13 +133,16 @@ class TestSchedulerName:
         upstream_dir: Path,
         enabled_modules: list[str],
         resolve_config,
+        generated_scale_sets: list[GeneratedScaleSet],
     ) -> None:
         cluster_default = resolve_config("arc-runners.scheduler_name", "")
         _skip_unless_scheduler_configured(enabled_modules, cluster_default)
 
         enabled_arc = arc_runners_module_names(upstream_dir) & set(enabled_modules)
         defs_by_name = load_defs_by_name(upstream_dir, enabled_arc)
-        runner_name_prefix = resolve_config("arc-runners.runner_name_prefix", "")
+        # Attribute each listener pod to its scale set by the org-unique
+        # scale-set-name label, then to the shared underlying def.
+        by_label = scale_sets_by_label(generated_scale_sets)
 
         listener_pods = filter_pods(all_pods, namespace=LISTENER_NAMESPACE, labels=LISTENER_LABELS)
         assert len(listener_pods) >= 1, (
@@ -161,18 +158,22 @@ class TestSchedulerName:
                 problems.append(f"{pod_name}: no '{LISTENER_CONTAINER_NAME}' container")
                 continue
 
-            def_name, runner = def_for_listener_pod(pod, defs_by_name, runner_name_prefix)
-            if def_name is None or runner is None:
+            label = scale_set_label_of_pod(pod)
+            scale_set = by_label.get(label) if label else None
+            if scale_set is None:
+                continue
+            runner = defs_by_name.get(scale_set.def_name)
+            if runner is None:
                 continue
 
             expected = _effective_scheduler_name(runner, cluster_default)
             env_by_name = {e["name"]: e for e in listener.get("env", []) or []}
             entry = env_by_name.get(SCHEDULER_ENV_VAR)
             if entry is None:
-                problems.append(f"{pod_name} (def={def_name}): missing env var {SCHEDULER_ENV_VAR!r}")
+                problems.append(f"{pod_name} (scale-set={label}): missing env var {SCHEDULER_ENV_VAR!r}")
                 continue
             got = entry.get("value", "") or ""
             if got != expected:
-                problems.append(f"{pod_name} (def={def_name}): {SCHEDULER_ENV_VAR}={got!r}, expected {expected!r}")
+                problems.append(f"{pod_name} (scale-set={label}): {SCHEDULER_ENV_VAR}={got!r}, expected {expected!r}")
 
         assert not problems, f"Listener {SCHEDULER_ENV_VAR} mismatches:\n" + "\n".join(problems)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #1001
* #1003
* __->__ #1002
* #1000
* #999

Reworks the module smoke tests from def-name keying to a GeneratedScaleSet model that
reads the generated files as the source of truth (indexed by the org-unique
scale-set-name label). A def-keyed model conflates the two orgs' listeners/placeholders/
ConfigMaps that share a def, or flags every additional-org resource as stale. Single-org
clusters are unaffected.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>