### PR TITLE
Add a packer build for the ai-sandbox gVisor AMI

### DIFF
--- a/osdc/.gitignore
+++ b/osdc/.gitignore
@@ -24,3 +24,7 @@ modules/*/generated/
 .DS_Store
 .env
 
+
+# Packer build artifacts (AMI IDs from the last local build)
+modules/*/packer/manifest.json
+modules/*/packer/.packer.d/

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -2189,6 +2189,36 @@ smoke cluster:
     echo "Smoke tests completed in ${elapsed}"
     exit $rc
 
+# Build the ai-sandbox gVisor AMI (nodepools-agent-sandbox) in a cluster's region
+#
+# The ai-sandbox fleet selects this AMI by tag, so it must exist before the fleet
+# can launch a node. Rebuild to pick up AL2023 CVE fixes or a newer gVisor —
+# unlike the al2023@latest fleets, this one only moves when the AMI is rebuilt.
+build-agent-sandbox-ami cluster *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    REGION=$(uv run {{CFG}} "$CLUSTER" region)
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+    K8S_VERSION=$(uv run {{CFG}} "$CLUSTER" eks_version)
+    PACKER_DIR="{{UPSTREAM}}/modules/nodepools-agent-sandbox/packer"
+
+    echo "Building ai-sandbox gVisor AMI for $CLUSTER ($REGION, k8s $K8S_VERSION)..."
+    cd "$PACKER_DIR"
+    packer init .
+    packer build \
+        -var "aws_region=${REGION}" \
+        -var "cluster_name=${CNAME}" \
+        -var "k8s_version=${K8S_VERSION}" \
+        {{args}} .
+
+    echo ""
+    echo "Built. The ai-sandbox fleet picks it up on the next node launch;"
+    echo "existing nodes keep their current AMI until they are recycled:"
+    echo "    just recycle-nodes $CLUSTER"
+
 # Run full integration test against a cluster
 integration-test cluster *args:
     #!/usr/bin/env bash

--- a/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
+++ b/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
@@ -1,0 +1,147 @@
+# Custom EKS AL2023 AMI with gVisor (runsc) baked in, for the ai-sandbox fleet.
+#
+# Build:  just build-agent-sandbox-ami <cluster>
+#
+# Why an AMI instead of a userData script: on a Karpenter-managed fleet the node
+# must be ready the moment it registers. Installing runsc at boot meant fetching
+# binaries over the network on every scale-up and then RESTARTING containerd
+# after kubelet had already started — a restart that races anything already
+# scheduled on the node. Baking it means containerd starts once, correct.
+#
+# The runsc runtime handler is registered by dropping a nodeadm NodeConfig at
+# /etc/eks/nodeadm.d/. nodeadm merges configs from that directory with the
+# user-data config and generates /etc/containerd/config.toml *before* starting
+# containerd, so the handler exists at first start. Writing config.toml directly
+# in the image would not work — nodeadm regenerates it at every boot.
+#
+# The source AMI is resolved from the EKS-optimized AL2023 SSM parameter at build
+# time, so each rebuild picks up the current patched base. That freshness is now
+# a rebuild cadence rather than automatic: the stock fleets track
+# `alias: al2023@latest` and pick up CVE fixes on node rotation, while this fleet
+# only moves when the AMI is rebuilt. See the module README.
+
+packer {
+  required_version = ">= 1.10"
+
+  required_plugins {
+    amazon = {
+      version = ">= 1.3"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "aws_region" {
+  description = "Region to build the AMI in (must be the cluster's region — AMIs are regional)"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Cluster this AMI is built for; recorded in tags"
+  type        = string
+}
+
+variable "k8s_version" {
+  description = "Kubernetes minor version of the EKS-optimized base AMI (must match the cluster)"
+  type        = string
+}
+
+variable "gvisor_release" {
+  description = "gVisor release date to pin (yyyymmdd), from https://gvisor.dev/docs/user_guide/install/"
+  type        = string
+  # Pinned deliberately: the previous userData script fetched `latest`, so two
+  # nodes launched a day apart could run different runsc builds. Bump this
+  # explicitly and rebuild.
+  default = "20260803"
+}
+
+variable "subnet_filter_name" {
+  description = "Name tag pattern for the build subnet; must have outbound internet (fetches the gVisor release)"
+  type        = string
+  default     = "*-vpc-public-*"
+}
+
+variable "build_instance_type" {
+  description = "Instance type used only for the build"
+  type        = string
+  default     = "c7i.xlarge"
+}
+
+locals {
+  ami_name = "osdc-ai-sandbox-gvisor-k8s${var.k8s_version}-${var.gvisor_release}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+# Latest EKS-optimized AL2023 AMI for this Kubernetes version.
+data "amazon-parameterstore" "eks_al2023" {
+  name   = "/aws/service/eks/optimized-ami/${var.k8s_version}/amazon-linux-2023/x86_64/standard/recommended/image_id"
+  region = var.aws_region
+}
+
+source "amazon-ebs" "ai_sandbox" {
+  region        = var.aws_region
+  source_ami    = data.amazon-parameterstore.eks_al2023.value
+  instance_type = var.build_instance_type
+  ssh_username  = "ec2-user"
+  ami_name      = local.ami_name
+  ami_description = "EKS AL2023 + gVisor ${var.gvisor_release} for the OSDC ai-sandbox fleet"
+
+  # IMDSv2. Two separate reasons, both required:
+  #   * metadata_options applies to the BUILD instance. An org SCP explicitly
+  #     denies ec2:RunInstances unless ec2:MetadataHttpTokens=required, so a
+  #     build without this fails with UnauthorizedOperation.
+  #   * imds_support makes the resulting AMI default to IMDSv2-only. The sandbox
+  #     threat model leans on IMDS being unreachable from pods (hop limit 1), and
+  #     IMDSv1 would let a compromised agent bypass that with a plain GET.
+  imds_support = "v2.0"
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  # Build in the cluster VPC's public subnet — the account has no reliable
+  # default VPC, and the build needs egress to fetch the gVisor release.
+  subnet_filter {
+    filters = {
+      "tag:Name" = "${var.cluster_name}${var.subnet_filter_name}"
+    }
+    most_free = true
+    random    = false
+  }
+  associate_public_ip_address = true
+
+  # Karpenter selects this AMI by tag (see defs/ai-sandbox.yaml) rather than by
+  # name glob, so the naming scheme can change without touching the nodepool.
+  tags = {
+    Name           = local.ami_name
+    "osdc.io/ami"  = "ai-sandbox-gvisor"
+    "osdc.io/module" = "nodepools-agent-sandbox"
+    Cluster        = var.cluster_name
+    GvisorRelease  = var.gvisor_release
+    K8sVersion     = var.k8s_version
+    SourceAMI      = data.amazon-parameterstore.eks_al2023.value
+    Project        = "ciforge"
+  }
+  snapshot_tags = {
+    Name          = local.ami_name
+    "osdc.io/ami" = "ai-sandbox-gvisor"
+  }
+}
+
+build {
+  name    = "ai-sandbox-gvisor"
+  sources = ["source.amazon-ebs.ai_sandbox"]
+
+  provisioner "shell" {
+    script           = "${path.root}/scripts/install-gvisor.sh"
+    environment_vars = ["GVISOR_RELEASE=${var.gvisor_release}"]
+    # {{ .Vars }} is required: overriding execute_command drops the default
+    # environment_vars injection, and the script hard-fails without GVISOR_RELEASE.
+    execute_command = "{{ .Vars }} sudo -E bash -eux '{{ .Path }}'"
+  }
+
+  post-processor "manifest" {
+    output     = "${path.root}/manifest.json"
+    strip_path = true
+  }
+}

--- a/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
+++ b/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
@@ -95,7 +95,9 @@ source "amazon-ebs" "ai_sandbox" {
 
   # Otherwise Packer opens :22 to 0.0.0.0/0 for the build. The address comes from
   # checkip.amazonaws.com, so if the builder's SSH egress differs (NAT pool, VPN)
-  # SSH hangs — pass -var 'temporary_security_group_source_cidrs=[...]' instead.
+  # SSH hangs — replace this line with temporary_security_group_source_cidrs =
+  # ["x.x.x.x/32"]. Both are builder settings, not -var inputs, and setting both
+  # is an error.
   temporary_security_group_source_public_ip = true
 
   # Karpenter selects by tag (defs/ai-sandbox.yaml), so the name is free to change.

--- a/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
+++ b/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
@@ -62,9 +62,9 @@ variable "subnet_filter_name" {
 }
 
 variable "build_instance_type" {
-  description = "Instance type used only for the build"
+  description = "Instance type used only for the build (any x86_64 will do; matches the fleet's family)"
   type        = string
-  default     = "c7i.xlarge"
+  default     = "c7a.xlarge"
 }
 
 locals {

--- a/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
+++ b/osdc/modules/nodepools-agent-sandbox/packer/ai-sandbox-gvisor.pkr.hcl
@@ -78,11 +78,11 @@ data "amazon-parameterstore" "eks_al2023" {
 }
 
 source "amazon-ebs" "ai_sandbox" {
-  region        = var.aws_region
-  source_ami    = data.amazon-parameterstore.eks_al2023.value
-  instance_type = var.build_instance_type
-  ssh_username  = "ec2-user"
-  ami_name      = local.ami_name
+  region          = var.aws_region
+  source_ami      = data.amazon-parameterstore.eks_al2023.value
+  instance_type   = var.build_instance_type
+  ssh_username    = "ec2-user"
+  ami_name        = local.ami_name
   ami_description = "EKS AL2023 + gVisor ${var.gvisor_release} for the OSDC ai-sandbox fleet"
 
   # IMDSv2. Two separate reasons, both required:
@@ -110,17 +110,32 @@ source "amazon-ebs" "ai_sandbox" {
   }
   associate_public_ip_address = true
 
+  # Packer's throwaway security group otherwise opens port 22 to 0.0.0.0/0 for the
+  # life of the build ("Authorizing access to port 22 from [0.0.0.0/0]"). The
+  # keypair is ephemeral and the window is minutes, but this image becomes the
+  # host OS for a fleet that runs untrusted code — a compromise here is a write
+  # into that image, so narrow the ingress to the builder's own address.
+  #
+  # If the builder sits behind a NAT pool whose egress address differs from the
+  # one detected here, SSH will hang; pin the range explicitly instead:
+  #   -var 'temporary_security_group_source_cidrs=["<corp cidr>"]'
+  # The stronger fix is ssh_interface = "session_manager" (no ingress rule and no
+  # public IP at all), deferred until this build runs in CI: it needs the
+  # session-manager-plugin on PATH (not mise-managed), an SSM instance profile,
+  # and an outbound WebSocket the corporate proxy may not permit.
+  temporary_security_group_source_public_ip = true
+
   # Karpenter selects this AMI by tag (see defs/ai-sandbox.yaml) rather than by
   # name glob, so the naming scheme can change without touching the nodepool.
   tags = {
-    Name           = local.ami_name
-    "osdc.io/ami"  = "ai-sandbox-gvisor"
+    Name             = local.ami_name
+    "osdc.io/ami"    = "ai-sandbox-gvisor"
     "osdc.io/module" = "nodepools-agent-sandbox"
-    Cluster        = var.cluster_name
-    GvisorRelease  = var.gvisor_release
-    K8sVersion     = var.k8s_version
-    SourceAMI      = data.amazon-parameterstore.eks_al2023.value
-    Project        = "ciforge"
+    Cluster          = var.cluster_name
+    GvisorRelease    = var.gvisor_release
+    K8sVersion       = var.k8s_version
+    SourceAMI        = data.amazon-parameterstore.eks_al2023.value
+    Project          = "ciforge"
   }
   snapshot_tags = {
     Name          = local.ami_name

--- a/osdc/modules/nodepools-agent-sandbox/packer/scripts/install-gvisor.sh
+++ b/osdc/modules/nodepools-agent-sandbox/packer/scripts/install-gvisor.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Bake gVisor (runsc) into the ai-sandbox AMI. Runs once at IMAGE BUILD time
+# under packer — never at node boot.
+#
+# Two things this deliberately does NOT do, both of which the previous userData
+# version did:
+#   * fetch anything at node boot — the binaries are in the image
+#   * touch /etc/containerd/config.toml or restart containerd — nodeadm
+#     regenerates that file at every boot, and restarting containerd after
+#     kubelet has started races whatever is already running on the node
+#
+# Instead the runtime handler is declared as a nodeadm NodeConfig drop-in.
+# nodeadm merges /etc/eks/nodeadm.d/* with the user-data config and writes
+# /etc/containerd/config.toml BEFORE starting containerd, so runsc is registered
+# at containerd's first start.
+set -euxo pipefail
+
+: "${GVISOR_RELEASE:?GVISOR_RELEASE must be set (yyyymmdd release to pin)}"
+
+ARCH="$(uname -m)"
+URL_BASE="https://storage.googleapis.com/gvisor/releases/release/${GVISOR_RELEASE}/${ARCH}"
+
+install_bin() {
+  local name="$1"
+  curl -fsSL "${URL_BASE}/${name}" -o "/usr/local/bin/${name}"
+  curl -fsSL "${URL_BASE}/${name}.sha512" -o "/tmp/${name}.sha512"
+  (cd /usr/local/bin && sha512sum -c "/tmp/${name}.sha512")
+  chmod 0755 "/usr/local/bin/${name}"
+  rm -f "/tmp/${name}.sha512"
+}
+
+install_bin runsc
+install_bin containerd-shim-runsc-v1
+
+# EKS AL2023 ships containerd v2.x, whose config is `version = 3` and whose CRI
+# plugin key is `io.containerd.cri.v1.runtime` (NOT the containerd-1.x
+# `io.containerd.grpc.v1.cri` — a v1-style stanza is silently ignored and runsc
+# never registers). This stanza is additive; the default runc runtime is
+# untouched, so anything without runtimeClassName still runs under runc.
+install -d -m 0755 /etc/eks/nodeadm.d
+cat >/etc/eks/nodeadm.d/10-gvisor.yaml <<'EOF'
+# Baked into the ai-sandbox AMI by modules/nodepools-agent-sandbox/packer.
+# Merged by nodeadm into /etc/containerd/config.toml before containerd starts.
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  containerd:
+    config: |
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc]
+        runtime_type = "io.containerd.runsc.v1"
+EOF
+chmod 0644 /etc/eks/nodeadm.d/10-gvisor.yaml
+
+# Fail the build rather than ship an image whose runsc can't run. `runsc do`
+# exercises the full sandbox (platform detection included) in one shot.
+runsc --version
+# "do" is a runsc subcommand, quoted so shellcheck doesn't read it as the shell keyword.
+runsc --network=none "do" /bin/true
+
+echo "gVisor ${GVISOR_RELEASE} baked: $(runsc --version | head -1)"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #994
* #993
* #992
* #997
* #996
* #991
* __->__ #1005

Builds an EKS-optimized AL2023 image with gVisor (runsc) baked in, for the
ai-sandbox fleet added next in the stack. Nothing consumes it yet.

Why an AMI rather than installing runsc from userData on a Karpenter fleet
(review feedback on the first version): a boot-time install fetched the release
over the network on every scale-up and tracked `latest`, so two nodes launched a
day apart could differ; it edited /etc/containerd/config.toml, which nodeadm
regenerates at every boot anyway; and it then restarted containerd, after kubelet
had started, racing anything already scheduled on the node.

Registering the runtime handler without that restart is the crux. nodeadm merges
NodeConfig files from /etc/eks/nodeadm.d/ with the user-data config and writes
containerd's config BEFORE starting it, so the image ships the runsc stanza there
and the handler exists at containerd's first start. A drop-in under
/etc/containerd/config.d/ would not work: the generated config has no `imports`.
The stanza must use the `io.containerd.cri.v1.runtime` key — EKS AL2023 ships
containerd v2.x with `version = 3` config, and a containerd-1.x
`io.containerd.grpc.v1.cri` stanza is silently ignored, so runsc would never
register.

The gVisor release is pinned rather than `latest`, and the build fails rather
than shipping an image whose runsc cannot run (`runsc do /bin/true`). The source
AMI resolves from the EKS SSM parameter at build time, so each rebuild picks up
the current patched base.

IMDSv2 is required on the build instance — an org SCP explicitly denies
ec2:RunInstances unless ec2:MetadataHttpTokens=required — and the resulting AMI
is IMDSv2-only, which is what keeps the node role out of reach of a compromised
agent (IMDSv1 would bypass the hop-limit-1 protection with a plain GET).

    just build-agent-sandbox-ami <cluster>

AMIs are regional, so this runs once per cluster region.