### PR TITLE
image-cache-janitor: reclaim orphaned BuildKit cache directories

### DIFF
--- a/osdc/base/kubernetes/image-cache-janitor/configmap.yaml
+++ b/osdc/base/kubernetes/image-cache-janitor/configmap.yaml
@@ -29,6 +29,7 @@ data:
     import json
     import logging
     import os
+    import shutil
     import socket
     import subprocess
     import sys
@@ -50,6 +51,18 @@ data:
     IMAGE_CACHE_TARGET_GI = int(os.environ.get("IMAGE_CACHE_TARGET_GI", "400"))
     CHECK_INTERVAL_SECONDS = int(os.environ.get("CHECK_INTERVAL_SECONDS", "300"))
     METRICS_PORT = 9103
+
+    # BuildKit pods cache to <BUILDKIT_CACHE_DIR>/<pod-name> on the instance
+    # store. A pod's directory outlives the pod, and no surviving buildkitd
+    # knows about it, so buildkit's own GC can never reclaim it.
+    # Read through /proc/1/root (hostPID + privileged) rather than a hostPath
+    # mount: a DirectoryOrCreate mount would create this path on all ~786 nodes
+    # the DaemonSet covers, not just the handful running BuildKit.
+    BUILDKIT_CACHE_DIR = os.environ.get(
+        "BUILDKIT_CACHE_DIR", "/proc/1/root/mnt/k8s-disks/0/buildkit-cache"
+    )
+    BUILDKIT_ORPHAN_GRACE_SECONDS = int(os.environ.get("BUILDKIT_ORPHAN_GRACE_SECONDS", "1800"))
+    BUILDKIT_ORPHAN_DRY_RUN = os.environ.get("BUILDKIT_ORPHAN_DRY_RUN", "true").lower() == "true"
 
     # Convert GiB to bytes
     GI = 1024 ** 3
@@ -128,6 +141,55 @@ data:
 
 
     # ---------------------------------------------------------------------------
+    # Orphaned BuildKit cache directories
+    # ---------------------------------------------------------------------------
+
+    @dataclass
+    class CacheDirInfo:
+        """A directory under BUILDKIT_CACHE_DIR, named after the pod that owns it."""
+
+        name: str
+        mtime: float
+        size: int = 0
+
+
+    def parse_crictl_pod_names(json_str: str) -> set[str]:
+        """Extract pod names from ``crictl pods -o json`` output."""
+        data = json.loads(json_str)
+        names = set()
+        for pod in data.get("items", []):
+            name = (pod.get("metadata") or {}).get("name")
+            if name:
+                names.add(name)
+        return names
+
+
+    def select_orphan_cache_dirs(
+        dirs: list[CacheDirInfo],
+        live_pod_names: set[str],
+        now: float,
+        grace_seconds: int,
+    ) -> list[CacheDirInfo]:
+        """Select cache directories whose owning pod is gone.
+
+        A directory is orphaned when no pod of that name is running on the
+        node. The grace period covers the window where kubelet has created
+        the directory but the sandbox is not yet visible to crictl.
+
+        An empty live_pod_names is treated as "unknown", not "nothing is
+        running": the janitor is itself a pod on this node, so crictl always
+        reports at least one. Returning nothing keeps a transient containerd
+        hiccup from being read as "every directory is orphaned".
+        """
+        if not live_pod_names:
+            return []
+        return [
+            d for d in dirs
+            if d.name not in live_pod_names and (now - d.mtime) >= grace_seconds
+        ]
+
+
+    # ---------------------------------------------------------------------------
     # Prometheus metrics server (stdlib only, no pip dependencies)
     # ---------------------------------------------------------------------------
 
@@ -165,6 +227,12 @@ data:
              "Configured cache size limit in bytes"),
             ("image_cache_janitor_cache_target_bytes", "gauge",
              "Configured cache target size in bytes"),
+            ("image_cache_janitor_buildkit_orphan_dirs", "gauge",
+             "Orphaned BuildKit cache directories found in the last cycle"),
+            ("image_cache_janitor_buildkit_orphan_bytes", "gauge",
+             "Bytes held by orphaned BuildKit cache directories"),
+            ("image_cache_janitor_buildkit_reclaimed_bytes_total", "counter",
+             "Total bytes reclaimed from orphaned BuildKit cache directories"),
         ]
 
         def __init__(self) -> None:
@@ -257,9 +325,84 @@ data:
             return False
 
 
+    # (dir name, mtime) -> size. Sizing a multi-hundred-GB cache is expensive,
+    # and under dry run the same orphans persist across every cycle.
+    _SIZE_CACHE: dict[tuple[str, float], int] = {}
+
+
+    def _dir_size_bytes(path: str) -> int:
+        """Best-effort directory size via du. Returns 0 if it fails or times out."""
+        try:
+            out = subprocess.run(
+                ["du", "-sb", path], capture_output=True, text=True, check=True, timeout=120,
+            )
+            return int(out.stdout.split()[0])
+        except (subprocess.SubprocessError, ValueError, IndexError):
+            log.warning("Could not size %s", path)
+            return 0
+
+
+    def _scan_cache_dirs() -> list[CacheDirInfo]:
+        """List directories directly under BUILDKIT_CACHE_DIR."""
+        dirs: list[CacheDirInfo] = []
+        with os.scandir(BUILDKIT_CACHE_DIR) as entries:
+            for entry in entries:
+                if entry.is_dir(follow_symlinks=False):
+                    dirs.append(CacheDirInfo(name=entry.name, mtime=entry.stat().st_mtime))
+        return dirs
+
+
     # ---------------------------------------------------------------------------
     # GC cycle
     # ---------------------------------------------------------------------------
+
+    def _run_buildkit_orphan_cycle() -> None:
+        """Reclaim BuildKit cache directories left behind by deleted pods."""
+        if not os.path.isdir(BUILDKIT_CACHE_DIR):
+            return  # not a BuildKit node
+
+        try:
+            live = parse_crictl_pod_names(run_crictl("pods", "-o", "json"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            log.error("Failed to list pods, skipping orphan sweep: %s", exc)
+            return
+
+        orphans = select_orphan_cache_dirs(
+            _scan_cache_dirs(), live, time.time(), BUILDKIT_ORPHAN_GRACE_SECONDS,
+        )
+        live_keys = {(d.name, d.mtime) for d in orphans}
+        for stale in [k for k in _SIZE_CACHE if k not in live_keys]:
+            del _SIZE_CACHE[stale]
+        for d in orphans:
+            key = (d.name, d.mtime)
+            if key not in _SIZE_CACHE:
+                _SIZE_CACHE[key] = _dir_size_bytes(os.path.join(BUILDKIT_CACHE_DIR, d.name))
+            d.size = _SIZE_CACHE[key]
+
+        total = sum(d.size for d in orphans)
+        metrics.set("image_cache_janitor_buildkit_orphan_dirs", float(len(orphans)))
+        metrics.set("image_cache_janitor_buildkit_orphan_bytes", float(total))
+
+        if not orphans:
+            log.info("BuildKit cache: no orphaned directories")
+            return
+
+        log.info(
+            "BuildKit cache: %d orphaned directories, %.1f GiB%s",
+            len(orphans), total / GI, " (dry run)" if BUILDKIT_ORPHAN_DRY_RUN else "",
+        )
+        if BUILDKIT_ORPHAN_DRY_RUN:
+            return
+
+        for d in orphans:
+            path = os.path.join(BUILDKIT_CACHE_DIR, d.name)
+            try:
+                shutil.rmtree(path)
+            except OSError as exc:
+                log.warning("Failed to remove %s: %s", path, exc)
+                continue
+            log.info("Reclaimed %s (%.1f GiB)", path, d.size / GI)
+            metrics.inc("image_cache_janitor_buildkit_reclaimed_bytes_total", float(d.size))
 
     def _run_gc_cycle() -> None:
         """Run one garbage collection cycle."""
@@ -342,6 +485,10 @@ data:
                 _run_gc_cycle()
             except Exception:
                 log.exception("Unexpected error in GC cycle")
+            try:
+                _run_buildkit_orphan_cycle()
+            except Exception:
+                log.exception("Unexpected error in BuildKit orphan cycle")
             time.sleep(CHECK_INTERVAL_SECONDS)
 
 

--- a/osdc/base/kubernetes/image-cache-janitor/daemonset.yaml
+++ b/osdc/base/kubernetes/image-cache-janitor/daemonset.yaml
@@ -129,6 +129,10 @@ spec:
               value: "300"
             - name: CONTAINER_RUNTIME_ENDPOINT
               value: "unix:///run/containerd/containerd.sock"
+            # Report orphaned BuildKit cache dirs without deleting them until
+            # the metrics confirm the sweep picks the right directories.
+            - name: BUILDKIT_ORPHAN_DRY_RUN
+              value: "true"
 
           securityContext:
             privileged: true

--- a/osdc/base/kubernetes/image-cache-janitor/scripts/python/janitor_lib.py
+++ b/osdc/base/kubernetes/image-cache-janitor/scripts/python/janitor_lib.py
@@ -82,6 +82,53 @@ def select_images_to_remove(
 
 
 # ---------------------------------------------------------------------------
+# Orphaned BuildKit cache directories
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheDirInfo:
+    """A directory under BUILDKIT_CACHE_DIR, named after the pod that owns it."""
+
+    name: str
+    mtime: float
+    size: int = 0
+
+
+def parse_crictl_pod_names(json_str: str) -> set[str]:
+    """Extract pod names from ``crictl pods -o json`` output."""
+    data = json.loads(json_str)
+    names = set()
+    for pod in data.get("items", []):
+        name = (pod.get("metadata") or {}).get("name")
+        if name:
+            names.add(name)
+    return names
+
+
+def select_orphan_cache_dirs(
+    dirs: list[CacheDirInfo],
+    live_pod_names: set[str],
+    now: float,
+    grace_seconds: int,
+) -> list[CacheDirInfo]:
+    """Select cache directories whose owning pod is gone.
+
+    A directory is orphaned when no pod of that name is running on the
+    node. The grace period covers the window where kubelet has created
+    the directory but the sandbox is not yet visible to crictl.
+
+    An empty live_pod_names is treated as "unknown", not "nothing is
+    running": the janitor is itself a pod on this node, so crictl always
+    reports at least one. Returning nothing keeps a transient containerd
+    hiccup from being read as "every directory is orphaned".
+    """
+    if not live_pod_names:
+        return []
+    return [d for d in dirs if d.name not in live_pod_names and (now - d.mtime) >= grace_seconds]
+
+
+# ---------------------------------------------------------------------------
 # Prometheus metrics (no HTTP server — only storage and formatting)
 # ---------------------------------------------------------------------------
 

--- a/osdc/base/kubernetes/image-cache-janitor/scripts/python/test_janitor_lib.py
+++ b/osdc/base/kubernetes/image-cache-janitor/scripts/python/test_janitor_lib.py
@@ -3,11 +3,14 @@
 import json
 
 from janitor_lib import (
+    CacheDirInfo,
     ImageInfo,
     MetricsServer,
     calculate_total_cache_size,
     parse_crictl_images,
+    parse_crictl_pod_names,
     select_images_to_remove,
+    select_orphan_cache_dirs,
 )
 
 GI = 1024**3
@@ -290,3 +293,52 @@ class TestMetricsServerFormat:
         m = MetricsServer()
         output = m.format()
         assert output.endswith("\n")
+
+
+class TestOrphanCacheDirs:
+    """Reclaiming BuildKit cache directories left behind by deleted pods."""
+
+    @staticmethod
+    def _dirs(*specs):
+        return [CacheDirInfo(name=n, mtime=m) for n, m in specs]
+
+    def test_parse_crictl_pod_names(self):
+        payload = json.dumps(
+            {"items": [{"metadata": {"name": "buildkitd-amd64-abc"}}, {"metadata": {"name": "alloy-1"}}]}
+        )
+        assert parse_crictl_pod_names(payload) == {"buildkitd-amd64-abc", "alloy-1"}
+
+    def test_no_pods_no_dirs(self):
+        assert parse_crictl_pod_names(json.dumps({"items": []})) == set()
+        assert select_orphan_cache_dirs([], set(), 1000.0, 300) == []
+
+    def test_empty_live_set_deletes_nothing(self):
+        """A blank crictl result means "unknown", never "all are orphaned".
+
+        The janitor is itself a pod on the node, so an empty list is always a
+        transient fault. Without this the enforce path would wipe every live
+        pod's cache.
+        """
+        dirs = self._dirs(("live-a", 0.0), ("live-b", 0.0))
+        assert select_orphan_cache_dirs(dirs, set(), 10_000.0, 300) == []
+
+    def test_live_pod_dir_is_kept(self):
+        dirs = self._dirs(("live", 0.0))
+        assert select_orphan_cache_dirs(dirs, {"live"}, 10_000.0, 300) == []
+
+    def test_dead_pod_dir_is_orphaned(self):
+        dirs = self._dirs(("dead", 0.0))
+        assert [d.name for d in select_orphan_cache_dirs(dirs, {"live"}, 10_000.0, 300)] == ["dead"]
+
+    def test_grace_period_protects_a_just_created_dir(self):
+        """kubelet creates the dir before crictl reports the sandbox."""
+        # A real node always has other pods running (the janitor itself, at least).
+        others = {"image-cache-janitor-xyz"}
+        dirs = self._dirs(("starting", 9_900.0))
+        assert select_orphan_cache_dirs(dirs, others, 10_000.0, 300) == []
+        assert [d.name for d in select_orphan_cache_dirs(dirs, others, 10_300.0, 300)] == ["starting"]
+
+    def test_only_dead_dirs_selected_from_a_mix(self):
+        dirs = self._dirs(("live-a", 0.0), ("dead-a", 0.0), ("live-b", 0.0), ("dead-b", 0.0))
+        got = select_orphan_cache_dirs(dirs, {"live-a", "live-b"}, 10_000.0, 300)
+        assert sorted(d.name for d in got) == ["dead-a", "dead-b"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1010
* #1008
* #1007

BuildKit pods cache to <cache>/<pod-name> on the instance store. The
directory outlives the pod and no surviving buildkitd knows about it, so
buildkit's own GC can never reclaim it. Two 8-day-old buildkit nodes were
holding 880 GB and 1194 GB there against 2 GB of containerd images — the
janitor was pruning the 2 GB and ignoring the rest.

The janitor already runs on these nodes and already has the containerd
socket, so live pod names come from `crictl pods` with no new RBAC. A
directory is orphaned when no pod of that name is running and it is older
than a grace period.

An empty pod list is treated as "unknown", not "nothing is running": the
janitor is itself a pod on the node, so crictl always reports at least
one, and without that floor a transient containerd fault would read as
"every directory is orphaned".

The cache is read through /proc/1/root rather than a hostPath mount,
which would have created the path on all ~786 nodes this DaemonSet covers
rather than the handful running BuildKit. Directory sizes are memoized so
a multi-hundred-GB orphan is measured once, not on every 300s cycle.

Ships with BUILDKIT_ORPHAN_DRY_RUN=true: it reports orphan count and bytes
as metrics but deletes nothing, so the sweep can be confirmed against real
nodes before it is allowed to remove anything.