### PR TITLE
test-ecr-pull: pick a CI image that isn't tied to a compiler version

### DIFF
--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,7 +207,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        default="pytorch-linux-jammy-py3.10-clang18",
+        # Must be a name pytorch currently builds (see their docker-builds.yml
+        # matrix). A retired name fails identically to a not-yet-built image, but
+        # permanently — clang18 was dropped for clang21 and every run hung for 2h.
+        default="pytorch-linux-jammy-py3.10-clang21",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )
     return parser.parse_args()

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,10 +207,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        # Must be a name pytorch currently builds (see their docker-builds.yml
-        # matrix). A retired name fails identically to a not-yet-built image, but
-        # permanently — clang18 was dropped for clang21 and every run hung for 2h.
-        default="pytorch-linux-jammy-py3.10-clang21",
+        # Prefer a name that encodes no toolchain version: the tag is
+        # <name>-<tree-SHA>, so anything with a compiler in it breaks on every bump
+        # (clang10 -> 12 -> 15 -> 18 -> 20 -> 21 since May 2025, four of them in the
+        # last 100 docker-builds.yml commits). The linter image has no version in its
+        # name and was renamed once in that period, for the focal -> jammy move.
+        default="pytorch-linux-jammy-linter",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )
     return parser.parse_args()

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,11 +207,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        # Prefer a name that encodes no toolchain version: the tag is
-        # <name>-<tree-SHA>, so anything with a compiler in it breaks on every bump
-        # (clang10 -> 12 -> 15 -> 18 -> 20 -> 21 since May 2025, four of them in the
-        # last 100 docker-builds.yml commits). The linter image has no version in its
-        # name and was renamed once in that period, for the focal -> jammy move.
         default="pytorch-linux-jammy-linter",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -1296,7 +1296,7 @@ class TestParseArgs:
             ],
         ):
             args = parse_args()
-        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang18"
+        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang21"
 
     def test_ecr_pull_image_name_override(self):
         with patch(
@@ -1698,7 +1698,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         import logging
@@ -1718,11 +1718,11 @@ class TestMain:
         mock_resolve.assert_called_once_with()
         kwargs = mock_gen.call_args.kwargs
         assert kwargs["ecr_pull_sha"] == "abc123"
-        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang18-abc123"
+        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang21-abc123"
         assert "tree-SHA: abc123" in caplog.text
         assert (
             "image URL: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:"
-            "pytorch-linux-jammy-py3.10-clang18-abc123"
+            "pytorch-linux-jammy-py3.10-clang21-abc123"
         ) in caplog.text
 
     @patch("run.parse_args")
@@ -1756,7 +1756,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         import logging
@@ -1797,7 +1797,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         with (

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -1296,7 +1296,7 @@ class TestParseArgs:
             ],
         ):
             args = parse_args()
-        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang21"
+        assert args.ecr_pull_image_name == "pytorch-linux-jammy-linter"
 
     def test_ecr_pull_image_name_override(self):
         with patch(
@@ -1698,7 +1698,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         import logging
@@ -1718,11 +1718,11 @@ class TestMain:
         mock_resolve.assert_called_once_with()
         kwargs = mock_gen.call_args.kwargs
         assert kwargs["ecr_pull_sha"] == "abc123"
-        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang21-abc123"
+        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-linter-abc123"
         assert "tree-SHA: abc123" in caplog.text
         assert (
             "image URL: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:"
-            "pytorch-linux-jammy-py3.10-clang21-abc123"
+            "pytorch-linux-jammy-linter-abc123"
         ) in caplog.text
 
     @patch("run.parse_args")
@@ -1756,7 +1756,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         import logging
@@ -1797,7 +1797,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         with (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1013
* __->__ #1012

The job's tag is <image-name>-<tree-SHA of pytorch/pytorch:.ci/docker>, and the
name was pinned to pytorch-linux-jammy-py3.10-clang18. pytorch has since moved CPU
x86 builds to clang21 and dropped clang18 from their docker-builds matrix, so that
tag no longer exists for any tree-SHA and the job fails on every run — as a 2h hang
rather than an error, because a missing `container:` image is ImagePullBackOff and
Kubernetes retries until the 7200s hook timeout (canary run 31779767652).

Any name carrying a compiler version has this problem. Since May 2025 the clang
images went clang10 -> 12 -> 15 -> 18 -> 20 -> 21, four of those renames inside the
last 100 commits to docker-builds.yml. So switch to pytorch-linux-jammy-linter,
which encodes no toolchain at all: zero renames over the same period, and it is the
smallest candidate at 2.2 GB (clang21 2.65 GB, rocm-n-py3 24.6 GB) which suits a
test whose only job is to prove a pull works.

Not immune, just far less exposed: it did rename once, focal -> jammy, and jammy ->
noble is already underway. That takes the breakage rate from every compiler bump to
roughly every distro bump, and the next commit makes it fail in seconds with the
reason instead of hanging.

Verified: pytorch-linux-jammy-linter-9546ec02... exists in ECR at the current
tree-SHA; the clang18 tag returns ImageNotFoundException.