### PR TITLE
Fail fast when the test-ecr-pull image tag is missing

### DIFF
--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,7 +207,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        default="pytorch-linux-jammy-py3.10-clang18",
+        # Must be a name pytorch currently builds (see their docker-builds.yml
+        # matrix). A retired name fails identically to a not-yet-built image, but
+        # permanently — clang18 was dropped for clang21 and every run hung for 2h.
+        default="pytorch-linux-jammy-py3.10-clang21",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )
     return parser.parse_args()

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,10 +207,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        # Must be a name pytorch currently builds (see their docker-builds.yml
-        # matrix). A retired name fails identically to a not-yet-built image, but
-        # permanently — clang18 was dropped for clang21 and every run hung for 2h.
-        default="pytorch-linux-jammy-py3.10-clang21",
+        # Prefer a name that encodes no toolchain version: the tag is
+        # <name>-<tree-SHA>, so anything with a compiler in it breaks on every bump
+        # (clang10 -> 12 -> 15 -> 18 -> 20 -> 21 since May 2025, four of them in the
+        # last 100 docker-builds.yml commits). The linter image has no version in its
+        # name and was renamed once in that period, for the focal -> jammy move.
+        default="pytorch-linux-jammy-linter",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )
     return parser.parse_args()

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -207,11 +207,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-drain", action="store_true", help="Skip staging pool drain entirely")
     parser.add_argument(
         "--ecr-pull-image-name",
-        # Prefer a name that encodes no toolchain version: the tag is
-        # <name>-<tree-SHA>, so anything with a compiler in it breaks on every bump
-        # (clang10 -> 12 -> 15 -> 18 -> 20 -> 21 since May 2025, four of them in the
-        # last 100 docker-builds.yml commits). The linter image has no version in its
-        # name and was renamed once in that period, for the focal -> jammy move.
         default="pytorch-linux-jammy-linter",
         help="ECR image name used by the test-ecr-pull job (debug override)",
     )

--- a/osdc/integration-tests/scripts/python/run.py
+++ b/osdc/integration-tests/scripts/python/run.py
@@ -37,6 +37,60 @@ WORKFLOW_TIMEOUT_MINUTES = 60
 POLL_INTERVAL_SECONDS = 30
 
 
+ECR_REGION = "us-east-1"
+ECR_ACCOUNT = "308535385114"
+ECR_REPOSITORY = "pytorch/ci-image"
+
+
+def verify_ecr_image_exists(tag: str) -> None:
+    """Fail now if the ECR tag is absent, instead of hanging for two hours.
+
+    test-ecr-pull runs the image as a job `container:`, so a missing tag surfaces
+    as ImagePullBackOff during "Initialize containers" — which Kubernetes retries
+    until the 7200s hook timeout. The job log shows a hang with no cause, and two
+    very different situations look identical from there: pytorch has not rebuilt
+    for the current .ci/docker tree-SHA yet (transient, worth re-running later), or
+    the image name has been retired (permanent — clang18 became clang21 and the job
+    hung on every run until someone read the ECR API by hand).
+
+    Only an unambiguous ImageNotFoundException fails the run. If the check itself
+    cannot run — no aws CLI, no credentials, throttling — warn and continue rather
+    than blocking the whole integration test on an auxiliary lookup.
+    """
+    cmd = [
+        "aws",
+        "ecr",
+        "describe-images",
+        "--region",
+        ECR_REGION,
+        "--registry-id",
+        ECR_ACCOUNT,
+        "--repository-name",
+        ECR_REPOSITORY,
+        "--image-ids",
+        f"imageTag={tag}",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        log.warning("Could not verify the ECR tag (%s) — continuing; a miss will surface as a job timeout", exc)
+        return
+
+    if proc.returncode == 0:
+        log.info("ECR pull test — tag verified present")
+        return
+
+    if "ImageNotFoundException" in proc.stderr:
+        log.error("ECR image tag does not exist: %s", tag)
+        log.error("  repository: %s/%s (%s)", ECR_ACCOUNT, ECR_REPOSITORY, ECR_REGION)
+        log.error("  Either pytorch has not built this .ci/docker tree-SHA yet, or the image name")
+        log.error("  was retired. Check their docker-builds.yml matrix and pass a current name via")
+        log.error("  --ecr-pull-image-name (the default lives in this file).")
+        sys.exit(1)
+
+    log.warning("Could not verify the ECR tag: %s", (proc.stderr or "").strip()[:200])
+
+
 def branch_name(cluster_id: str) -> str:
     """Return a cluster-specific branch name to avoid collisions between parallel runs."""
     return f"osdc-integration-test-{cluster_id}"
@@ -291,10 +345,11 @@ def main():
                 sys.exit(1)
             ecr_pull_resolved_tag = f"{ecr_image_name}-{ecr_pull_sha}"
             ecr_pull_image_url = (
-                f"308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:{ecr_pull_resolved_tag}"
+                f"{ECR_ACCOUNT}.dkr.ecr.{ECR_REGION}.amazonaws.com/{ECR_REPOSITORY}:{ecr_pull_resolved_tag}"
             )
             log.info("ECR pull test — pytorch .ci/docker tree-SHA: %s", ecr_pull_sha)
             log.info("ECR pull test — image URL: %s", ecr_pull_image_url)
+            verify_ecr_image_exists(ecr_pull_resolved_tag)
         else:
             log.info("ECR pull test — skipped (cluster has no arc-runners module)")
             ecr_pull_sha = ""

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -1296,7 +1296,7 @@ class TestParseArgs:
             ],
         ):
             args = parse_args()
-        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang18"
+        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang21"
 
     def test_ecr_pull_image_name_override(self):
         with patch(
@@ -1698,7 +1698,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         import logging
@@ -1718,11 +1718,11 @@ class TestMain:
         mock_resolve.assert_called_once_with()
         kwargs = mock_gen.call_args.kwargs
         assert kwargs["ecr_pull_sha"] == "abc123"
-        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang18-abc123"
+        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang21-abc123"
         assert "tree-SHA: abc123" in caplog.text
         assert (
             "image URL: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:"
-            "pytorch-linux-jammy-py3.10-clang18-abc123"
+            "pytorch-linux-jammy-py3.10-clang21-abc123"
         ) in caplog.text
 
     @patch("run.parse_args")
@@ -1756,7 +1756,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         import logging
@@ -1797,7 +1797,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang18",
+            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
         )
 
         with (

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -1296,7 +1296,7 @@ class TestParseArgs:
             ],
         ):
             args = parse_args()
-        assert args.ecr_pull_image_name == "pytorch-linux-jammy-py3.10-clang21"
+        assert args.ecr_pull_image_name == "pytorch-linux-jammy-linter"
 
     def test_ecr_pull_image_name_override(self):
         with patch(
@@ -1698,7 +1698,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         import logging
@@ -1718,11 +1718,11 @@ class TestMain:
         mock_resolve.assert_called_once_with()
         kwargs = mock_gen.call_args.kwargs
         assert kwargs["ecr_pull_sha"] == "abc123"
-        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-py3.10-clang21-abc123"
+        assert kwargs["ecr_pull_resolved_tag"] == "pytorch-linux-jammy-linter-abc123"
         assert "tree-SHA: abc123" in caplog.text
         assert (
             "image URL: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:"
-            "pytorch-linux-jammy-py3.10-clang21-abc123"
+            "pytorch-linux-jammy-linter-abc123"
         ) in caplog.text
 
     @patch("run.parse_args")
@@ -1756,7 +1756,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         import logging
@@ -1797,7 +1797,7 @@ class TestMain:
             keep_pr=False,
             force=True,
             skip_drain=True,
-            ecr_pull_image_name="pytorch-linux-jammy-py3.10-clang21",
+            ecr_pull_image_name="pytorch-linux-jammy-linter",
         )
 
         with (

--- a/osdc/integration-tests/scripts/python/test_run.py
+++ b/osdc/integration-tests/scripts/python/test_run.py
@@ -27,6 +27,7 @@ from run import (
     resolve,
     run_cmd_with_retry,
     safe_json_loads,
+    verify_ecr_image_exists,
 )
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
@@ -1549,6 +1550,7 @@ class TestMain:
             patch("phases.cleanup_stale_prs"),
             patch("phases.ensure_canary_repo"),
             patch("phases.generate_workflow", return_value="wf content"),
+            patch("run.verify_ecr_image_exists"),
             patch("run.resolve_ci_docker_hash", return_value="abc"),
             patch(
                 "phases.prepare_pr",
@@ -1589,6 +1591,7 @@ class TestMain:
             patch("phases.cleanup_stale_prs"),
             patch("phases.ensure_canary_repo", return_value=tmp_path),
             patch("phases.generate_workflow", return_value="wf"),
+            patch("run.verify_ecr_image_exists"),
             patch("run.resolve_ci_docker_hash", return_value="abc"),
             patch("phases.prepare_pr", return_value=99),
             patch("phases_validation.run_parallel_validation", side_effect=KeyboardInterrupt),
@@ -1630,6 +1633,7 @@ class TestMain:
             patch("phases.cleanup_stale_prs"),
             patch("phases.ensure_canary_repo", return_value=tmp_path),
             patch("phases.generate_workflow", return_value="wf"),
+            patch("run.verify_ecr_image_exists"),
             patch("run.resolve_ci_docker_hash", return_value="abc"),
             patch("phases.prepare_pr", return_value=99),
             patch("phases_validation.run_parallel_validation", return_value={}),
@@ -1668,6 +1672,7 @@ class TestMain:
             patch("phases.clear_staging_pools") as mock_clear,
             patch("phases.ensure_canary_repo", return_value=tmp_path),
             patch("phases.generate_workflow", return_value="wf"),
+            patch("run.verify_ecr_image_exists"),
             patch("run.resolve_ci_docker_hash", return_value="abc"),
             patch("phases.prepare_pr", return_value=None),
             patch("phases_validation.run_parallel_validation") as mock_validation,
@@ -1706,6 +1711,7 @@ class TestMain:
         with (
             patch("phases.cleanup_stale_prs"),
             patch("phases.ensure_canary_repo", return_value=tmp_path),
+            patch("run.verify_ecr_image_exists"),
             patch("run.resolve_ci_docker_hash", return_value="abc123") as mock_resolve,
             patch("phases.generate_workflow", return_value="wf") as mock_gen,
             patch("phases.prepare_pr", return_value=None),
@@ -1917,3 +1923,39 @@ class TestRegionExcludedBlocks:
     def test_missing_fleet_def_returns_empty(self, tmp_path):
         # No modules/nodepools/defs tree → FileNotFoundError handled → empty.
         assert region_excluded_blocks(tmp_path, "us-west-1") == set()
+
+
+class TestVerifyEcrImageExists:
+    """A missing tag must fail here, not two hours later as an unexplained job
+    timeout — but an unavailable checker must not block the whole run."""
+
+    @patch("run.subprocess.run")
+    def test_present_tag_passes(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        verify_ecr_image_exists("pytorch-linux-jammy-py3.10-clang21-abc123")
+        assert "imageTag=pytorch-linux-jammy-py3.10-clang21-abc123" in mock_run.call_args[0][0]
+
+    @patch("run.subprocess.run")
+    def test_missing_tag_exits(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=254,
+            stdout="",
+            stderr="An error occurred (ImageNotFoundException) when calling the DescribeImages operation",
+        )
+        with pytest.raises(SystemExit) as exc:
+            verify_ecr_image_exists("pytorch-linux-jammy-py3.10-clang18-abc123")
+        assert exc.value.code == 1
+
+    @patch("run.subprocess.run", side_effect=FileNotFoundError("aws not found"))
+    def test_missing_aws_cli_warns_and_continues(self, _mock_run):
+        verify_ecr_image_exists("any-tag")  # must not raise
+
+    @patch("run.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="aws", timeout=60))
+    def test_timeout_warns_and_continues(self, _mock_run):
+        verify_ecr_image_exists("any-tag")  # must not raise
+
+    @patch("run.subprocess.run")
+    def test_other_aws_error_warns_and_continues(self, mock_run):
+        """Credentials or throttling problems are not evidence the tag is absent."""
+        mock_run.return_value = MagicMock(returncode=255, stdout="", stderr="ExpiredTokenException")
+        verify_ecr_image_exists("any-tag")  # must not raise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1013
* #1012

A missing tag surfaces as ImagePullBackOff inside the job container, which
Kubernetes retries until the 7200s hook timeout. The job log shows a two-hour hang
with no stated cause, and the two situations behind it are indistinguishable from
there: pytorch has not rebuilt for the current .ci/docker tree-SHA (transient), or
the image name has been retired (permanent). Diagnosing the clang18 -> clang21
rename meant querying the ECR API by hand.

run.py already resolves the tag before draining the cluster, so verify it there and
exit with the tag, repository and next step. Only an unambiguous
ImageNotFoundException fails the run: a missing aws CLI, expired credentials or
throttling warn and continue, since an auxiliary lookup should not block the whole
integration test.

Verified against real ECR — clang21 at the current tree-SHA verifies present, and
the retired clang18 name exits 1 immediately instead of hanging.