### PR TITLE
Pin GOMAXPROCS=2 on the hf-cache rclone mounts

### DIFF
--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -107,6 +107,9 @@ spec:
             # not k8s Mi/Gi), so it tracks __RCLONE_MEMORY_LIMIT__ without runtime arithmetic.
             - name: GOMEMLIMIT
               value: "__GOMEMLIMIT__"
+            # Pre-Go-1.25 image: unset, this takes the host vCPU count, not limits.cpu.
+            - name: GOMAXPROCS
+              value: "2"
           command:
             - /bin/sh
             - -c

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -7,6 +7,8 @@ rendered with the /mnt/hf_cache mount.
 
 from __future__ import annotations
 
+import math
+
 import pytest
 from helpers import assert_daemonset_healthy, filter_daemonsets, run_kubectl
 
@@ -102,6 +104,19 @@ class TestHfCacheMountDaemonSet:
         assert 0 < gml_mib < limit_mib, (
             f"GOMEMLIMIT ({gml_mib}MiB) must be >0 and below the container limit ({limit}) — "
             "a soft ceiling with headroom, not the hard cap."
+        )
+
+    def test_gomaxprocs_pinned_to_cpu_limit(self, mount_pod_spec: dict) -> None:
+        """Unset, Go takes the host vCPU count rather than limits.cpu."""
+        rclone = mount_pod_spec["containers"][0]
+        gomaxprocs = next((e.get("value") for e in rclone.get("env", []) if e["name"] == "GOMAXPROCS"), None)
+        assert gomaxprocs is not None, "rclone must pin GOMAXPROCS."
+        assert gomaxprocs.isdigit(), f"GOMAXPROCS must be an integer; got {gomaxprocs!r}."
+
+        cpu_limit = rclone.get("resources", {}).get("limits", {}).get("cpu", "")
+        cpu_cores = int(cpu_limit[:-1]) / 1000 if cpu_limit.endswith("m") else float(cpu_limit)
+        assert int(gomaxprocs) <= max(2, math.ceil(cpu_cores)), (
+            f"GOMAXPROCS ({gomaxprocs}) exceeds the CPU limit ({cpu_limit})."
         )
 
     def test_hostpath_bidirectional(self, mount_pod_spec: dict) -> None:


### PR DESCRIPTION
Adds `GOMAXPROCS=2` to the rclone container in `mount-daemonset.yaml.tpl`, plus a smoke test. One env line, no memory change.

## Why
`GOMEMLIMIT` is a soft ceiling the GC can only honour if it gets CPU. The rclone 1.69.1 image predates Go 1.25's cgroup-aware `GOMAXPROCS`, so unset it sizes from `runtime.NumCPU()` — 35 measured on a g5.16xlarge — against the container's 1-CPU quota. Dozens of Ps allocating concurrently while GC assists are throttled to one CPU lets the heap overshoot the soft limit and breach the hard cgroup ceiling.

`2` is what Go 1.25 computes for a 1-CPU limit. Same pathology and fix as #1018.

## Notes
- Correct hygiene on its own merits, but **not established as the cause** of the current gpu1 OOMs on `meta-prod-aws-ue2` — that started with a GPU AMI/kernel roll whose mechanism is still unidentified, and `GOMAXPROCS` only bounds the heap side. #1023 raises the gpu1 reserve; the AMI glob is tracked separately.
- Redundant once the rclone image moves to Go 1.25+.
- The test asserts the pin doesn't exceed `max(2, ceil(limits.cpu))`, so lowering the CPU limit without revisiting it fails.