### PR TITLE
Raise the hf-cache 1-GPU rclone reserve to 1Gi

### DIFF
--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-a10g.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-a10g
 # Instance type: g5.8xlarge — 1-GPU A10G, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 112Gi (label keeps -113-).
 runner:
   name: l-x86aavx2-29-113-a10g
   instance_type: g5.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86aavx2-29-113-l4.yaml
@@ -1,12 +1,12 @@
 # ARC runner definition: l-x86aavx2-29-113-l4
 # Instance type: g6.8xlarge — 1-GPU L4, 32c/128Gi node
-# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 113Gi.
+# Actual K8s capacity ~118.4Gi. Max job memory after all overhead: 112Gi (label keeps -113-).
 runner:
   name: l-x86aavx2-29-113-l4
   instance_type: g6.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 113Gi
+  memory: 112Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
+++ b/osdc/modules/arc-runners/defs/l-x86iavx512-29-115-t4.yaml
@@ -2,13 +2,13 @@
 # Instance type: g4dn.8xlarge — 1-GPU T4, 32c/128Gi node
 # Actual K8s capacity ~118.4Gi after VM overhead. With kubelet reserved,
 # DaemonSets, sidecar (750m/512Mi), and hooks overhead (320m/522Mi),
-# max job memory is 115Gi.
+# max job memory is 114Gi (label keeps -115-).
 runner:
   name: l-x86iavx512-29-115-t4
   instance_type: g4dn.8xlarge
   disk_size: 150
   vcpu: 29
-  memory: 115Gi
+  memory: 114Gi
   gpu: 1
   proactive_capacity: 0
   hud_failure_base_capacity: 30

--- a/osdc/modules/hf-cache/README.md
+++ b/osdc/modules/hf-cache/README.md
@@ -15,15 +15,18 @@ get the path bind-mounted read-only via the gated `# BEGIN_HF_CACHE` block in
 
 rclone's memory is **reserved** (`request == limit`) and **tiered by GPU count**
 (`karpenter.k8s.aws/instance-gpu-count`), since RSS scales with job concurrency:
-`deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU → 1Gi,
-1-GPU → 640Mi, and the CPU catch-all → 640Mi. See `MOUNT_TIERS` in `deploy.sh`.
+`deploy.sh` renders one DaemonSet per tier — 8-GPU → 4Gi, 4-GPU → 2Gi, 2-GPU / 1-GPU → 1Gi,
+and the CPU catch-all → 640Mi. See `MOUNT_TIERS` in `deploy.sh`.
+
+The 1-GPU tier is paired with a matching trim in the a10g/l4/t4 runner defs; raising one
+without the other strands those runners.
 
 To keep RSS inside those reserves, `--buffer-size` (rclone's per-open-file read-ahead
 — the dominant RSS driver when a model opens many shards) is set **per tier** in
 `deploy.sh`, because peak concurrent opens scale with a node's pod density, not its GPU
 count: the packed CPU catch-all (big 48xl/metal nodes, many runner pods sharing one
 mount) runs `--buffer-size 0` (read-ahead off; reads served from the `--vfs-cache-mode
-full` on-disk cache), the tight 640Mi 1-GPU tier also uses `0`, and the roomier multi-GPU
+full` on-disk cache), the 1-GPU tier also uses `0`, and the roomier multi-GPU
 tiers keep `4M`.
 Together with the per-tier `GOMEMLIMIT`, this keeps concurrent large-model (safetensors)
 reads from OOM-killing rclone; a dead FUSE mount otherwise surfaces as a spurious

--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -39,15 +39,14 @@ VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
 # <buffer-size> is rclone's per-open-file read-ahead; rclone RAM ~= buffer-size x
 # concurrent open files. The two tight tiers run 0 (read-ahead off; reads served from
 # the vfs-cache-mode full on-disk cache): the packed CPU catch-all (48xl/metal, many
-# runner pods on one mount) and the 640Mi 1-GPU tier, where even 1M x ~146 shards
-# (~146MB) eats headroom rclone's heap/metadata needs. (1-GPU is 640Mi not 1Gi: 1Gi
-# strands the a10g/l4/t4 runners on the 8xl 1-GPU nodes; 640Mi still fits per
-# analyze_node_utilization.) The roomier multi-GPU tiers (1-4Gi) keep 4M for prefetch.
-# FOLLOW-UP: the GPU-only PR drops CPU (nvidia.com/gpu nodeSelector); then collapse the
-# first two rows into "hf-cache-mount NotIn 2,4,8 640Mi" (1-GPU + rest, both 640Mi).
+# runner pods on one mount) and the 1-GPU tier, where even 1M x ~146 shards
+# (~146MB) eats headroom rclone's heap/metadata needs.
+# The roomier multi-GPU tiers (1-4Gi) keep 4M for prefetch.
+# 1-GPU is 1Gi: 640Mi OOM-killed the tier. Paired with a 1Gi trim in the a10g/l4/t4
+# runner defs -- without it they no longer fit the 8xl 1-GPU nodes.
 MOUNT_TIERS=(
   "hf-cache-mount NotIn 1,2,4,8 640Mi 0"
-  "hf-cache-mount-gpu1 In 1 640Mi 0"
+  "hf-cache-mount-gpu1 In 1 1Gi 0"
   "hf-cache-mount-gpu2 In 2 1Gi 4M"
   "hf-cache-mount-gpu4 In 4 2Gi 4M"
   "hf-cache-mount-gpu8 In 8 4Gi 4M"

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -144,9 +144,9 @@ spec:
               #     served from the vfs-cache-mode full on-disk cache. High pod density
               #     means many concurrent readers on one mount, so any non-zero buffer
               #     OOMs the small reserve.
-              #   1-GPU tier (640Mi) → 0: like CPU. rclone RAM ~= buffer-size x concurrent
+              #   1-GPU tier (1Gi) → 0: like CPU. rclone RAM ~= buffer-size x concurrent
               #     open files, so even 1M x ~146 shards (~146MB) eats headroom the rclone
-              #     heap/metadata needs at 512Mi; read-ahead off, served from the disk cache.
+              #     heap/metadata needs; read-ahead off, served from the disk cache.
               #   multi-GPU tiers (1-4Gi) → 4M: roomier reserve, so keep more prefetch.
               rclone mount \
                 ":s3,provider=AWS,env_auth=true,region=__REGION__:__BUCKET__" \

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -26,7 +26,7 @@ GPU_COUNT_LABEL = "karpenter.k8s.aws/instance-gpu-count"
 # deploy.sh MOUNT_TIERS.
 MOUNT_TIERS = {
     "hf-cache-mount": ("NotIn", {"1", "2", "4", "8"}, "640Mi"),
-    "hf-cache-mount-gpu1": ("In", {"1"}, "640Mi"),
+    "hf-cache-mount-gpu1": ("In", {"1"}, "1Gi"),
     "hf-cache-mount-gpu2": ("In", {"2"}, "1Gi"),
     "hf-cache-mount-gpu4": ("In", {"4"}, "2Gi"),
     "hf-cache-mount-gpu8": ("In", {"8"}, "4Gi"),

--- a/osdc/scripts/python/daemonset_overhead.py
+++ b/osdc/scripts/python/daemonset_overhead.py
@@ -63,7 +63,7 @@ TEMPLATED_DAEMONSETS: list[DaemonSetOverhead] = [
 ]
 
 # Reserved hf-cache memory (MiB) by GPU count (MOUNT_TIERS); other counts + CPU get the base.
-HF_CACHE_TIER_MIB = {1: 640, 2: 1024, 4: 2048, 8: 4096}
+HF_CACHE_TIER_MIB = {1: 1024, 2: 1024, 4: 2048, 8: 4096}
 
 
 def hf_cache_gpu_topup_mib(gpu_count: int) -> int:

--- a/osdc/scripts/python/test_daemonset_overhead.py
+++ b/osdc/scripts/python/test_daemonset_overhead.py
@@ -516,7 +516,7 @@ class TestRealManifests:
         assert base.memory_mib == 640  # CPU / catch-all tier
 
         # base + top-up == the reserved memory tier for each GPU count (MOUNT_TIERS)
-        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 640
+        assert base.memory_mib + hf_cache_gpu_topup_mib(1) == 1024  # 1-GPU floored at 1Gi
         assert base.memory_mib + hf_cache_gpu_topup_mib(2) == 1024
         assert base.memory_mib + hf_cache_gpu_topup_mib(4) == 2048
         assert base.memory_mib + hf_cache_gpu_topup_mib(8) == 4096


### PR DESCRIPTION
Raises the `hf-cache-mount-gpu1` tier 640Mi → 1Gi, with the matching 1Gi trim on the 1-GPU runner defs.

## Why
640Mi OOM-killed 39 gpu1 mounts on `meta-prod-aws-ue2` in a day (baseline 1-3) and is still climbing — 55 flagged at 22:00Z. An rclone OOM drops the FUSE node-wide → spurious `LocalEntryNotFoundError` in jobs.

It started when the GPU AMI rolled to nvidia `1.32-v20260818` (kernel 6.18.39 → 6.1.180); pinning that glob is tracked separately.

**The mechanism is not identified.** A matched-pair diff of the two AMIs (same instance type, same GPU count) found no configuration difference: same cgroup v2, same `memory.max`/`high`/`oom.group`, same `vm.dirty_*` and reclaim sysctls, same THP, same xfs-on-NVMe mount, same kubelet reserves and eviction thresholds, MGLRU disabled on both. Only the kernel binary and kubelet version differ, and kubelet writes identical cgroup knobs.

What *is* established is that the reserve is the only variable separating the OOMing tier from the clean ones, under the same kernel and the same timm workload:

| tier | reserve | AMI | OOM rate |
|---|---|---|---|
| cpu | 640Mi | old | 0% (700 mounts) |
| gpu1 | 640Mi | new | **19.4%** (206 mounts) |
| gpu4 | 2Gi | new | 0% (81) |
| gpu8 | 4Gi | new | 0% (65) |

`GOMEMLIMIT` doesn't substitute — it was already set to 576MiB on this tier when the kills happened, and it's a soft, heap-only ceiling. An old-AMI gpu4 mount was observed pinned at 1.98Gi of its 2Gi limit having reclaimed 73M pages with zero OOM kills, so this workload saturates whatever memcg it's given and survives only while reclaim keeps up. More headroom buys more room for that.

## Runner defs trimmed 1Gi
The reserve is `request == limit`, and the 8xl 1-GPU nodes have only 280Mi (a10g/l4) and 168Mi (t4) of margin. `just analyze-utilization` drops both node types to **0 pods** with the bump alone, so a10g/l4 go 113→112Gi and t4 115→114Gi. Labels keep their `-NNN-`. Verified back to 1 pod/node.

## Notes
- `buffer-size` stays `0`.
- Mitigation, not a root-cause fix. Follow-ups: pin the AMI glob; and `memory.high` is currently `max` on these cgroups, so there's no proactive reclaim before the hard OOM — setting it may be a better lever than raising the ceiling, and would also test the reclaim hypothesis.
- #1022 pins `GOMAXPROCS` on the same DaemonSets — complementary, bounds the heap side.

Deploy: redeploy `hf-cache` + `arc-runners`.