### PR TITLE
Cap the hf-cache rclone per-socket TCP receive buffer

### DIFF
--- a/osdc/modules/hf-cache/deploy.sh
+++ b/osdc/modules/hf-cache/deploy.sh
@@ -30,6 +30,10 @@ RCLONE_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.rclone_image "rclone/rclone:1.6
 TAINT_REMOVER_IMAGE=$(uv run "$CFG" "$CLUSTER" hf_cache.taint_remover_image \
   "public.ecr.aws/amazonlinux/amazonlinux:2023")
 VFS_CACHE_MAX_SIZE=$(uv run "$CFG" "$CLUSTER" hf_cache.vfs_cache_max_size "75%")
+# Per-socket TCP receive-buffer ceiling for the rclone pod netns; socket memory is what
+# OOM-kills the mount (see mount-daemonset.yaml.tpl). 512Ki x ~280 conns keeps sock well
+# inside the smallest tier; intra-region S3 BDP needs far less.
+TCP_RMEM_MAX=$(uv run "$CFG" "$CLUSTER" hf_cache.tcp_rmem_max "524288")
 # rclone RSS scales with job concurrency ~ GPU count, so memory is tiered by
 # instance-gpu-count and reserved (request == limit). One DaemonSet per tier; the
 # affinity keeps them exclusive. Fields:
@@ -119,6 +123,7 @@ render_mount_ds() {
     -e "s|__RCLONE_MEMORY_LIMIT__|${4}|g" \
     -e "s|__GOMEMLIMIT__|${gomemlimit}|g" \
     -e "s|__BUFFER_SIZE__|${5}|g" \
+    -e "s|__TCP_RMEM_MAX__|${TCP_RMEM_MAX}|g" \
     "$MODULE_DIR/kubernetes/mount-daemonset.yaml.tpl"
 }
 

--- a/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
+++ b/osdc/modules/hf-cache/kubernetes/mount-daemonset.yaml.tpl
@@ -9,7 +9,7 @@
 #
 # Placeholders (deploy.sh): __NAMESPACE__ __BUCKET__ __REGION__ __RCLONE_IMAGE__
 # __VFS_CACHE_MAX_SIZE__ __TAINT_REMOVER_IMAGE__ __RCLONE_MEMORY_LIMIT__ __GOMEMLIMIT__
-# __DS_NAME__ __GPU_OP__ __MULTI_GPU_COUNTS__ __BUFFER_SIZE__
+# __DS_NAME__ __GPU_OP__ __MULTI_GPU_COUNTS__ __BUFFER_SIZE__ __TCP_RMEM_MAX__
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -114,6 +114,18 @@ spec:
               set -eu
               MOUNT=/mnt/hf_cache
               CACHE=/mnt/hf-cache-vfs
+
+              # Cap the per-socket TCP receive buffer. Under cgroup v2 socket memory is
+              # charged to the container, and it -- not the Go heap or page cache -- is what
+              # OOM-kills this mount: a kill on the 640Mi tier was measured at sock=501Mi,
+              # anon=132Mi, file=0Mi, with 277 concurrent S3 connections autotuning to ~1.6Mi
+              # each. rclone has no flag to cap VFS read concurrency, so bound the per-socket
+              # ceiling instead. Namespaced to this pod's netns (the DaemonSet is not
+              # hostNetwork), so it cannot affect the node or other pods. Non-fatal: a failed
+              # write must not take the mount down.
+              printf '4096\t87380\t%s' "__TCP_RMEM_MAX__" > /proc/sys/net/ipv4/tcp_rmem 2>/dev/null \
+                || echo "WARNING: could not cap tcp_rmem; socket memory is unbounded"
+              echo "tcp_rmem: $(cat /proc/sys/net/ipv4/tcp_rmem 2>/dev/null)"
               # Clear a stale FUSE left by a crash so rclone can remount. fusermount3 is
               # the FUSE3 binary in the rclone image (fusermount is not installed); it
               # clears just the FUSE, leaving the bind mount (a plain umount would drop it).

--- a/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
+++ b/osdc/modules/hf-cache/tests/smoke/test_hf_cache.py
@@ -104,6 +104,17 @@ class TestHfCacheMountDaemonSet:
             "a soft ceiling with headroom, not the hard cap."
         )
 
+    def test_caps_tcp_receive_buffer(self, mount_pod_spec: dict) -> None:
+        """Socket memory is charged to the container cgroup and is what OOM-kills the mount;
+        rclone has no VFS read-concurrency cap, so the per-socket ceiling is bounded instead."""
+        cmd = " ".join(mount_pod_spec["containers"][0].get("command", []))
+        assert "/proc/sys/net/ipv4/tcp_rmem" in cmd, (
+            "rclone must cap tcp_rmem in its own netns — socket buffers are what breach the limit."
+        )
+        assert not mount_pod_spec.get("hostNetwork"), (
+            "the mount must not be hostNetwork: the tcp_rmem cap would then apply node-wide."
+        )
+
     def test_hostpath_bidirectional(self, mount_pod_spec: dict) -> None:
         # rclone mounts the parent /mnt (not /mnt/hf_cache) so a dead FUSE can't block
         # container creation — see the self-heal rationale in mount-daemonset.yaml.tpl.


### PR DESCRIPTION
Caps `net.ipv4.tcp_rmem` max at 512Ki in the rclone pod's own netns.

## Why
The gpu1 mounts are being OOM-killed on `meta-prod-aws-ue2` and now `meta-prod-aws-ue1`. The kernel OOM report shows it's **socket memory** — not the Go heap, not page cache. Six sampled kills, near-identical:

```
memory: usage 655772kB, limit 655360kB
  sock   492-502 Mi   ← 76% of the limit
  anon   130-143 Mi   ← well under GOMEMLIMIT=576MiB
  file         0 Mi
```

Under cgroup v2 socket buffers are charged to the container. Polling gpu1/`g5.16xlarge` mounts on **ue1, where both AMIs run side by side**, isolates the cause:

| AMI | kernel | connections | peak sock | per conn |
|---|---|---|---|---|
| 20260803 | 6.18.39 | 245–292 | **233 Mi** | 0.69–0.91 Mi |
| 20260817 | 6.1.180 | 45–254 | **472 Mi** | 1.47–1.92 Mi |

Connection count is unchanged — the old AMI peaked *higher*. The new kernel charges ~2× the socket memory for the same traffic, which consumes the tier's entire margin:

```
old:  233 sock + 135 anon + ~20  ≈ 390 Mi of 640  ✓
new:  472 sock + 135 anon + ~20  ≈ 627 Mi of 640  ✗
```

rclone 1.69.1 has no flag to cap VFS read concurrency (`--s3-upload-concurrency` is upload-only, `--transfers` gates uploads), so bound the per-socket ceiling instead: 512Ki × ~290 conns ≈ 145 Mi.

## Safety
- Writes to the **pod's own netns** (not `hostNetwork`) — cannot affect the node or other pods. Smoke test asserts both.
- Verified writable from the privileged container via a no-op write.
- Non-fatal; effective value logged. Tunable via `hf_cache.tcp_rmem_max`.
- No throughput cost: intra-region S3 BDP is far below 512Ki.

## Related
#1023 (640Mi → 1Gi) is complementary headroom — 627 Mi fits with margin. #1022 (`GOMAXPROCS`) targets `anon`, which is ~135 Mi on both kernels; I'd close it. Pinning the GPU AMI glob is a separate discussion.

Deploy: `just deploy-module <cluster> hf-cache`