### PR TITLE
[gpu-dev] Drop setuptools_scm and bump to 0.7.16

### DIFF
--- a/gpu-dev/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
+++ b/gpu-dev/cli-tools/gpu-dev-cli/gpu_dev_cli/cli.py
@@ -2026,7 +2026,7 @@ def submit(ctx, gpu_type, gpus, hours, disk, ref, no_persistent_disk, spot, dock
 
     try:
         if timeout >= 60:
-            wait_str = f"up to {timeout//60}h{(" " + str(timeout%60) + "m") if timeout%60 else ""}"
+            wait_str = f"up to {timeout//60}h{(' ' + str(timeout%60) + 'm') if timeout%60 else ''}"
         else:
             wait_str = f"up to {timeout}m"
         rprint(f"[cyan]⏳ Waiting for reservation {short_id} to become active ({wait_str}; can queue when cluster is full)...[/cyan]")

--- a/gpu-dev/pyproject.toml
+++ b/gpu-dev/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpu-dev"
-version = "0.7.15"
+version = "0.7.16"
 description = "CLI + Python SDK for PyTorch GPU developer server reservations"
 authors = [{name = "PyTorch Team"}]
 readme = "cli-tools/gpu-dev-cli/README.md"
@@ -19,7 +19,6 @@ dependencies = [
     "questionary>=2.1.1",
     "websockets>=12.0",
     "certifi>=2023.7.22",
-    "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -41,7 +40,6 @@ markers = [
 [project.scripts]
 gpu-dev = "gpu_dev_cli.cli:main"
 gpu-dev-ssh-proxy = "gpu_dev_cli.ssh_proxy:main"
-gpu-dev-mcp = "gpu_dev_cli.mcp_server:main"
 
 # One distribution ships BOTH the CLI (gpu_dev_cli) and the SDK (gpu_dev), from
 # their two source trees, via explicit per-package dirs.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1027

Bumps `gpu-dev` to 0.7.16, fixing a PEP 701 f-string that made the CLI fail to import on Python 3.10/3.11, removing the `gpu-dev-mcp` entry point (whose module never existed) along with the mandatory `mcp` dependency it pulled in, and dropping `setuptools_scm` so the sdist stops sweeping in 13 MB of presentation assets.

**Test Plan:**
https://github.com/pytorch/ci-infra/actions/runs/32520551906/job/96891593060?pr=1027
- Check downloaded size
- Basic function test:
```
$ SHA=$(gh api repos/pytorch/ci-infra/pulls/1027 --jq '.head.sha')
$ RUN=$(gh api "repos/pytorch/ci-infra/actions/runs?head_sha=$SHA" \
          --jq '[.workflow_runs[]|select(.name|test("Publish"))][0].id')
$ gh run download "$RUN" --repo pytorch/ci-infra -n gpu-dev-dist -D /tmp/gpu-dev-1027
$ uv venv --python 3.10 /tmp/gpu-dev-try
$ uv pip install --python /tmp/gpu-dev-try/bin/python /tmp/gpu-dev-1027/*.whl
$ source /tmp/gpu-dev-try/bin/activate

$ which gpu-dev
$ gpu-dev reserve --hours 1 --no-connect
$ gpu-dev connect <RESERVED_TARGET>
```
