### PR TITLE
OSDC: Add S3 gateway VPC endpoint to keep in-region S3 off the NAT gateways

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -71,6 +71,7 @@ Reference documentation in `docs/`:
 | `docs/observability-estimates.md` | Per-unit cost estimates for metrics cardinality and log volume (Grafana Cloud billing) |
 | `docs/operations.md` | Operational prerequisites — AWS CLI, mise, working directory setup for cluster management |
 | `docs/ipv6-cluster-recreation.md` | Operator runbook for destroying and recreating an OSDC cluster as IPv6-only (accepted data losses: Harbor S3, EFS pypi-cache) |
+| `docs/s3-gateway-endpoint.md` | Why every VPC needs an S3 gateway endpoint — NAT data-processing analysis, the Harbor redirect interaction, and the inline-route Terraform gotcha |
 | `docs/loki_query.md` | CLI queries against Grafana Cloud Loki when kubectl logs is unavailable |
 | `docs/mimir_query.md` | CLI queries against Grafana Cloud Mimir (Prometheus metrics, no in-cluster Prometheus) |
 | `docs/runner_naming_convention.md` | Runner label format and the ~42 character name limit (ARC/K8s/Cilium constraints) |

--- a/osdc/docs/s3-gateway-endpoint.md
+++ b/osdc/docs/s3-gateway-endpoint.md
@@ -1,0 +1,140 @@
+# S3 Gateway VPC Endpoint
+
+Why every OSDC VPC needs one, what it fixes, and what it does not cover.
+
+## The problem
+
+`NatGateway-Bytes` was the single largest line item on the OSDC AWS bill — larger
+than all runner compute combined on a per-line basis. July 2026, grouped by the
+`Cluster` cost-allocation tag:
+
+| Cluster | Gross | Volume |
+|---|---|---|
+| `meta-prod-aws-ue2` | $126,855 | 2,819 TB |
+| `meta-prod-aws-ue1` | $124,765 | 2,773 TB |
+| `meta-prod-aws-uw1` | $1,269 | 26 TB |
+| `pytorch-re-prod-production` + 3× staging | $368 | 8 TB |
+| *(account discount line, untagged)* | −$104,001 | — |
+| **Net fleet total** | **$149,257** | 5,631 TB |
+
+That is pure NAT gateway *data processing* at $0.045/GB — separate from the
+$0.045/hr per-gateway rental, which is only ~$100/mo per cluster. The processing
+fee was running 1,240× the rental fee.
+
+## What was generating it
+
+Regressing daily `NatGateway-Bytes` against daily S3 GET count
+(`Requests-Tier2`) for `meta-prod-aws-ue1`, 7–31 July 2026:
+
+```
+n = 25 days
+Pearson r  = 0.9729      r² = 0.9465
+slope      = 64.3 MB per S3 GET
+intercept  = −6,186 GB/day   (statistically zero)
+```
+
+An intercept indistinguishable from zero means there is effectively no non-S3
+traffic on the NAT gateways. 64.3 MB/GET is the size profile of a container
+image layer blob. Direction confirms it: 2,720 TB inbound vs 257 TB outbound.
+
+Two design choices combined to route all of it through NAT:
+
+1. **Harbor redirects layer pulls to S3.** `base/helm/harbor/values.yaml` sets
+   `disableredirect: false`, so the registry 307-redirects containerd to a
+   presigned `<bucket>.s3.<region>.amazonaws.com` URL and the node pulls the blob
+   directly. This is deliberate and correct — it keeps multi-TB/day of bandwidth
+   off the Harbor registry pods.
+2. **No S3 gateway endpoint existed.** The OSDC VPC module was written from
+   scratch and never had one. (The legacy ALI VPCs do — six S3 gateway endpoints
+   in us-east-1 alone.) With no endpoint, S3 traffic matched the `0.0.0.0/0` NAT
+   route.
+
+Nodes are dual-stack, so this is not an IPv6 artifact: subnets carry both an
+IPv4 CIDR and a `/64`, `EnableDns64` is `false`, and the standard S3 endpoint is
+IPv4-only. S3 traffic leaves the ENI as IPv4 and hits the NAT route.
+
+## The fix
+
+`aws_vpc_endpoint.s3` in `modules/eks/terraform/modules/vpc/main.tf`, associated
+with every private route table. Gateway endpoints have **no hourly charge and no
+per-GB charge**, and in-region EC2→S3 transfer is free, so the endpoint installs
+a more-specific prefix-list route and those bytes cost nothing.
+
+Keep `disableredirect: false`. With the endpoint in place the redirect is
+strictly optimal:
+
+| Config | Layer bytes path | Rate |
+|---|---|---|
+| redirect on, no endpoint (old) | node → NAT GW → S3 | $0.045/GB |
+| redirect off, no endpoint | node → Harbor pod (often cross-AZ) → NAT → S3 | $0.02/GB cross-AZ + $0.045/GB NAT |
+| redirect on, endpoint (current) | node → gateway endpoint → S3 | **$0** |
+
+## Terraform gotcha: inline routes vs endpoint routes
+
+`aws_route_table.private` uses inline `route` blocks, which are authoritative —
+Terraform normally deletes routes it did not declare. Gateway endpoint routes are
+created by `ModifyVpcEndpoint`, not `CreateRoute`, so they *cannot* be declared
+inline. The AWS provider skips `vpce-`-prefixed gateway routes when diffing route
+tables, so the two resources coexist.
+
+**Always run a second `tofu plan` after applying this to a new cluster and confirm
+it is clean.** If a future provider version regresses that behaviour, the fix is
+to split the private route tables into `aws_route_table` + separate `aws_route`
+resources before re-applying.
+
+## What it does not cover
+
+- **Cross-region S3.** The prefix list is regional. PyTorch's public `ossci-*`
+  buckets live in us-east-1, so a us-west-2 or us-west-1 cluster reading them
+  still pays NAT plus cross-region transfer. Watch `NatGateway-Bytes` on
+  `meta-prod-aws-uw2` specifically once it takes traffic — its residual will be
+  structurally higher than ue1/ue2's.
+- **Non-S3 internet egress.** pip, `docker.io` proxy-cache misses, GitHub. At
+  ue1 this was inside the noise floor before the fix; it becomes the residual
+  after. Re-measure rather than assuming it stays negligible.
+- **The underlying volume.** ~100 TB/day of layer pulls is still happening, it is
+  just free now. With ~6,000 Karpenter node launches/day and a ~500 GiB
+  node-local image cache (`base/kubernetes/image-cache-janitor/`), every cold
+  node pulls ~16 GB from scratch. Reducing that is a separate workstream (lazy
+  loading / SOCI, AMI pre-bake, longer node TTL).
+
+## Verification
+
+```bash
+CLUSTER=meta-prod-aws-ue1
+REGION=$(yq ".clusters.$CLUSTER.region" clusters.yaml)
+VPC=$(aws eks describe-cluster --name "$CLUSTER" --region "$REGION" \
+        --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+
+# Endpoint exists and is available
+aws ec2 describe-vpc-endpoints --region "$REGION" \
+  --filters "Name=vpc-id,Values=$VPC" "Name=service-name,Values=com.amazonaws.$REGION.s3" \
+  --query 'VpcEndpoints[].{id:VpcEndpointId,type:VpcEndpointType,state:State,rtbs:RouteTableIds}'
+
+# Prefix-list route present on each private route table
+aws ec2 describe-route-tables --region "$REGION" \
+  --filters "Name=vpc-id,Values=$VPC" "Name=tag:Name,Values=*-private-*" \
+  --query 'RouteTables[].{rtb:RouteTableId,vpce:Routes[?starts_with(GatewayId || ``, `vpce-`)].GatewayId}'
+```
+
+`modules/eks/tests/smoke/test_eks.py::TestS3GatewayEndpoint` asserts all three
+invariants (gateway type, available, associated with every private route table),
+so `just smoke-test <cluster>` covers this going forward.
+
+The behavioural check is `AWS/NATGateway` → `BytesInFromDestination`, which should
+collapse by >90% within an hour of a normal traffic period.
+
+## Rollback
+
+Delete the endpoint. Traffic falls back to the `0.0.0.0/0` NAT route immediately;
+there is no data-plane state to drain.
+
+## Risks reviewed before rollout
+
+- **Source-IP allowlists** are the usual way a gateway endpoint breaks things —
+  the source becomes a private IP plus an `aws:SourceVpce` condition key rather
+  than a NAT EIP. Checked: `<cluster>-harbor-registry` and
+  `pytorch-hf-model-cache-<cluster>` have no bucket policy at all.
+- **Endpoint policy** is left at the default full-access. A restrictive policy
+  here would silently break job-level S3 reads.
+- **Route table limits**: private tables carry 4 routes; the cap is 50.

--- a/osdc/docs/s3-gateway-endpoint.md
+++ b/osdc/docs/s3-gateway-endpoint.md
@@ -13,9 +13,9 @@ than all runner compute combined on a per-line basis. July 2026, grouped by the
 | `meta-prod-aws-ue2` | $126,855 | 2,819 TB |
 | `meta-prod-aws-ue1` | $124,765 | 2,773 TB |
 | `meta-prod-aws-uw1` | $1,269 | 26 TB |
-| `pytorch-re-prod-production` + 3× staging | $368 | 8 TB |
+| 3× `meta-staging-*` | $211 | 5 TB |
 | *(account discount line, untagged)* | −$104,001 | — |
-| **Net fleet total** | **$149,257** | 5,631 TB |
+| **Net fleet total** | **$149,099** | 5,623 TB |
 
 That is pure NAT gateway *data processing* at $0.045/GB — separate from the
 $0.045/hr per-gateway rental, which is only ~$100/mo per cluster. The processing
@@ -23,21 +23,12 @@ fee was running 1,240× the rental fee.
 
 ## What was generating it
 
-Regressing daily `NatGateway-Bytes` against daily S3 GET count
-(`Requests-Tier2`) for `meta-prod-aws-ue1`, 7–31 July 2026:
+Almost all of it is **Harbor serving container image layers out of S3** — daily
+NAT bytes track daily S3 GET count for `meta-prod-aws-ue1` at r² = 0.95, with no
+meaningful non-S3 remainder, and it is overwhelmingly inbound (2,720 TB in vs
+257 TB out).
 
-```
-n = 25 days
-Pearson r  = 0.9729      r² = 0.9465
-slope      = 64.3 MB per S3 GET
-intercept  = −6,186 GB/day   (statistically zero)
-```
-
-An intercept indistinguishable from zero means there is effectively no non-S3
-traffic on the NAT gateways. 64.3 MB/GET is the size profile of a container
-image layer blob. Direction confirms it: 2,720 TB inbound vs 257 TB outbound.
-
-Two design choices combined to route all of it through NAT:
+Two design choices combined to route that through NAT:
 
 1. **Harbor redirects layer pulls to S3.** `base/helm/harbor/values.yaml` sets
    `disableredirect: false`, so the registry 307-redirects containerd to a
@@ -101,8 +92,8 @@ resources before re-applying.
 ## Verification
 
 ```bash
-CLUSTER=meta-prod-aws-ue1
-REGION=$(yq ".clusters.$CLUSTER.region" clusters.yaml)
+CLUSTER=meta-staging-aws-ue1
+REGION=$(uv run scripts/cluster-config.py "$CLUSTER" region)
 VPC=$(aws eks describe-cluster --name "$CLUSTER" --region "$REGION" \
         --query 'cluster.resourcesVpcConfig.vpcId' --output text)
 
@@ -117,12 +108,48 @@ aws ec2 describe-route-tables --region "$REGION" \
   --query 'RouteTables[].{rtb:RouteTableId,vpce:Routes[?starts_with(GatewayId || ``, `vpce-`)].GatewayId}'
 ```
 
-`modules/eks/tests/smoke/test_eks.py::TestS3GatewayEndpoint` asserts all three
-invariants (gateway type, available, associated with every private route table),
-so `just smoke-test <cluster>` covers this going forward.
+A single private route table is expected where `single_nat_gateway: true` (the
+staging clusters); prod gets one per AZ. What matters is that every private
+subnet maps to a table carrying the route.
 
-The behavioural check is `AWS/NATGateway` → `BytesInFromDestination`, which should
-collapse by >90% within an hour of a normal traffic period.
+`modules/eks/tests/smoke/test_eks.py::TestS3GatewayEndpoint` asserts gateway
+type, `available` state, association with every private route table, and — the
+load-bearing one — that each of those tables actually holds an `active`
+prefix-list route to the endpoint. The association alone is not enough: it can
+survive the route being pruned, which is exactly the inline-route failure mode
+above. `just smoke <cluster>` covers all four going forward.
+
+### Behavioural check
+
+`AWS/NATGateway` → `BytesInFromDestination` should collapse by >90% over a normal
+traffic period. On an idle cluster there is nothing to see — `meta-staging-aws-ue1`
+sits at ~0.2 GB/hr — so drive traffic deliberately instead:
+
+```bash
+just kubeconfig "$CLUSTER"
+
+# ~3.4 GB of in-region S3. ossci-linux is public and us-east-1, so it is inside
+# the same prefix list and needs no credentials. Base nodes are in the private
+# subnets; the toleration is what schedules the pod onto one.
+kubectl run s3-endpoint-check --rm -i --restart=Never \
+  --image=public.ecr.aws/docker/library/alpine:3.21 \
+  --overrides='{"spec":{"tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists","effect":"NoSchedule"}]}}' \
+  -- sh -c 'for i in 1 2 3; do wget -q -O /dev/null \
+      https://ossci-linux.s3.us-east-1.amazonaws.com/cuda/cuda_7.0.28_linux.run; done'
+```
+
+Then re-read the metric after ~10 minutes (NAT stats publish on a lag). The S3
+pull should be invisible against the idle floor.
+
+**Run a negative control in the same window** — a broken measurement is
+indistinguishable from success otherwise. Repeat the pod against a non-AWS host
+(e.g. a ~140 MB `cdn.kernel.org` tarball); those bytes *must* appear on the NAT
+gateway. Only the two-sided result proves anything.
+
+For per-request proof, CloudTrail S3 data events are enabled account-wide and
+carry `vpcEndpointId`. That is unambiguous, but reading them means Athena over
+the trail bucket plus delivery lag — a one-off pre-prod check, not something to
+automate.
 
 ## Rollback
 

--- a/osdc/modules/eks/terraform/main.tf
+++ b/osdc/modules/eks/terraform/main.tf
@@ -32,9 +32,10 @@ locals {
 module "vpc" {
   source = "./modules/vpc"
 
-  name = "${var.cluster_name}-vpc"
-  cidr = var.vpc_cidr
-  azs  = local.azs
+  name   = "${var.cluster_name}-vpc"
+  cidr   = var.vpc_cidr
+  azs    = local.azs
+  region = var.aws_region
 
   # Dynamic subnet sizing based on AZ count
   private_subnets = length(local.azs) == 2 ? [

--- a/osdc/modules/eks/terraform/modules/vpc/main.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/main.tf
@@ -226,3 +226,24 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = var.single_nat_gateway ? aws_route_table.private[0].id : aws_route_table.private[count.index].id
 }
+
+# S3 Gateway Endpoint — keeps in-region S3 off the NAT gateways.
+# See docs/s3-gateway-endpoint.md.
+#
+# The prefix-list routes are created by ModifyVpcEndpoint, not CreateRoute, so
+# they cannot be inline `route` blocks on aws_route_table.private above. The AWS
+# provider skips vpce- gateway routes when diffing, so the two coexist — but a
+# provider bump should be checked with a second plan.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = aws_route_table.private[*].id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name}-s3"
+    }
+  )
+}

--- a/osdc/modules/eks/terraform/modules/vpc/outputs.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/outputs.tf
@@ -55,3 +55,8 @@ output "egress_only_internet_gateway_id" {
   description = "The ID of the Egress-Only Internet Gateway (IPv6 outbound from private subnets)"
   value       = aws_egress_only_internet_gateway.this.id
 }
+
+output "s3_vpc_endpoint_id" {
+  description = "The ID of the S3 Gateway VPC Endpoint (keeps in-region S3 traffic off the NAT gateways)"
+  value       = aws_vpc_endpoint.s3.id
+}

--- a/osdc/modules/eks/terraform/modules/vpc/variables.tf
+++ b/osdc/modules/eks/terraform/modules/vpc/variables.tf
@@ -9,6 +9,11 @@ variable "cidr" {
   default     = "10.0.0.0/16"
 }
 
+variable "region" {
+  description = "AWS region — used to build the S3 gateway endpoint service name"
+  type        = string
+}
+
 variable "azs" {
   description = "Availability zones"
   type        = list(string)

--- a/osdc/modules/eks/terraform/outputs.tf
+++ b/osdc/modules/eks/terraform/outputs.tf
@@ -22,6 +22,11 @@ output "vpc_ipv6_cidr_block" {
   value = module.vpc.vpc_ipv6_cidr_block
 }
 
+output "s3_vpc_endpoint_id" {
+  description = "S3 Gateway VPC Endpoint — keeps in-region S3 traffic off the NAT gateways"
+  value       = module.vpc.s3_vpc_endpoint_id
+}
+
 output "private_subnet_ids" {
   value = module.vpc.private_subnet_ids
 }

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -295,6 +295,26 @@ class TestS3GatewayEndpoint:
             f"route table(s) {sorted(missing)}; nodes in those subnets still reach S3 over the NAT gateway."
         )
 
+        # The association above is the endpoint's view. Assert the route itself
+        # exists, because that is what actually diverts the traffic and it can
+        # be removed out from under the association — a Terraform provider that
+        # stops skipping vpce- routes when diffing aws_route_table.private would
+        # prune it, leaving the association intact and the bill unchanged.
+        endpoint_id = s3_endpoint.get("VpcEndpointId")
+        for rtb in result.get("RouteTables", []):
+            vpce_routes = [
+                r
+                for r in rtb.get("Routes", [])
+                if r.get("DestinationPrefixListId") and r.get("GatewayId") == endpoint_id
+            ]
+            assert vpce_routes, (
+                f"Route table {rtb['RouteTableId']} has no prefix-list route to {endpoint_id}. "
+                f"Routes present: {rtb.get('Routes')}"
+            )
+            assert vpce_routes[0].get("State") == "active", (
+                f"S3 prefix-list route in {rtb['RouteTableId']} is {vpce_routes[0].get('State')!r}, not active"
+            )
+
 
 # ============================================================================
 # ECR Images

--- a/osdc/modules/eks/tests/smoke/test_eks.py
+++ b/osdc/modules/eks/tests/smoke/test_eks.py
@@ -228,6 +228,75 @@ class TestEKSIPv6Config:
 
 
 # ============================================================================
+# VPC Endpoints
+# ============================================================================
+
+
+class TestS3GatewayEndpoint:
+    """Verify the S3 gateway endpoint keeps in-region S3 off the NAT gateways.
+
+    See docs/s3-gateway-endpoint.md.
+    """
+
+    @pytest.fixture(scope="class")
+    def s3_endpoint(self, eks_cluster_info, cluster_config):
+        region = cluster_config["cluster"].get("region", "us-west-2")
+        vpc_id = eks_cluster_info["cluster"]["resourcesVpcConfig"]["vpcId"]
+        result = run_aws(
+            [
+                "ec2",
+                "describe-vpc-endpoints",
+                "--region",
+                region,
+                "--filters",
+                f"Name=vpc-id,Values={vpc_id}",
+                f"Name=service-name,Values=com.amazonaws.{region}.s3",
+            ]
+        )
+        endpoints = result.get("VpcEndpoints", [])
+        assert endpoints, (
+            f"No S3 VPC endpoint in {vpc_id} ({region}). Every in-region S3 byte — Harbor layer "
+            f"pulls, hf-cache reads — is billed as NAT gateway data processing at $0.045/GB."
+        )
+        return endpoints[0]
+
+    def test_endpoint_is_gateway_type(self, s3_endpoint):
+        # An Interface endpoint resolves the same way but bills per hour and
+        # per GB, so it would leave most of the saving on the table.
+        endpoint_type = s3_endpoint.get("VpcEndpointType")
+        assert endpoint_type == "Gateway", f"S3 VPC endpoint type is {endpoint_type!r}, expected 'Gateway'"
+
+    def test_endpoint_is_available(self, s3_endpoint):
+        state = s3_endpoint.get("State")
+        assert state == "available", f"S3 VPC endpoint {s3_endpoint.get('VpcEndpointId')} state is {state!r}"
+
+    def test_endpoint_covers_every_private_route_table(self, s3_endpoint, eks_cluster_info, cluster_config):
+        # A route table the endpoint misses has no symptom other than the bill.
+        region = cluster_config["cluster"].get("region", "us-west-2")
+        vpc_id = eks_cluster_info["cluster"]["resourcesVpcConfig"]["vpcId"]
+        result = run_aws(
+            [
+                "ec2",
+                "describe-route-tables",
+                "--region",
+                region,
+                "--filters",
+                f"Name=vpc-id,Values={vpc_id}",
+                "Name=tag:Name,Values=*-private-*",
+            ]
+        )
+        private_rtb_ids = {rtb["RouteTableId"] for rtb in result.get("RouteTables", [])}
+        assert private_rtb_ids, f"No private route tables found in {vpc_id}"
+
+        associated = set(s3_endpoint.get("RouteTableIds", []))
+        missing = private_rtb_ids - associated
+        assert not missing, (
+            f"S3 gateway endpoint {s3_endpoint.get('VpcEndpointId')} is not associated with private "
+            f"route table(s) {sorted(missing)}; nodes in those subnets still reach S3 over the NAT gateway."
+        )
+
+
+# ============================================================================
 # ECR Images
 # ============================================================================
 


### PR DESCRIPTION
`NatGateway-Bytes` is the largest single line on the OSDC bill — $149,257 net across the fleet in July 2026 (5,631 TB), ue1 and ue2 at 99.8% of the volume. Regressing daily NAT bytes on daily S3 GET count for ue1 (Jul 7–31) gives **r² = 0.9465 at 64.3 MB/GET with an intercept of −6,186 GB/day**, i.e. zero: it is all same-region S3, at the size profile of an image layer blob. Direction agrees — 2,720 TB in vs 257 TB out.

Harbor's `disableredirect: false` sends containerd straight to a presigned S3 URL (correct — it keeps multi-TB/day off the registry pods), but no OSDC VPC ever had an S3 gateway endpoint (the legacy ALI VPCs do), so those bytes matched the `0.0.0.0/0` NAT route at $0.045/GB. Gateway endpoints are free and in-region EC2→S3 transfer is free, so this takes them to $0. The redirect stays on — with the endpoint it beats both alternatives.

**Rollout:** staging-uw1 → prod-uw2 while it is still paused → ue2 → ue1. Confirm a second `tofu plan` is clean per cluster: endpoint routes come from `ModifyVpcEndpoint`, not `CreateRoute`, so they cannot be inline `route` blocks on the private route tables.

**Tested:** `just test` OK; `tofu fmt -check -recursive` and `tofu validate` clean. `just lint` fails only on a pre-existing hadolint finding at `base/docker/runner-base/Dockerfile:36`, reproducible on a clean tree.

Details, risks reviewed, and verification commands in `docs/s3-gateway-endpoint.md`.

### Testing

Deploy on ue1 staging, run the integration tests https://github.com/pytorch/pytorch-canary/actions/runs/32757852501/job/97529425214 