### PR TITLE
Proxy the private ECR through Harbor on off-region clusters

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -77,6 +77,7 @@ Reference documentation in `docs/`:
 | `docs/current_runner_load_distribution.md` | Job counts and peak concurrency by runner type (pytorch/pytorch, from ClickHouse) |
 | `docs/node-utilization-optimization.md` | Runner-to-node packing efficiency analysis and instance type recommendations |
 | `docs/node-warmup-and-scheduling-gates.md` | Full node initialization sequence — taints, DaemonSets, init containers before job scheduling |
+| `docs/cross-region-ecr-pulls.md` | Private ECR pull-through via Harbor — why off-region clusters miss the S3 gateway endpoint, and the design that routes those pulls through the local cache |
 | `docs/arc-fork-build-deploy.md` | ARC fork (jeanschmidt/actions-runner-controller) build/release workflow and chart publishing |
 | `docs/pypi-package-cache.md` | PyPI wheel cache architecture, slug naming, S3 layout, runner integration |
 | `docs/h100-fabric-handles-imex-channels.md` | Enabling CUDA fabric handles (`CU_MEM_HANDLE_TYPE_FABRIC`) on H100 runners — IMEX channel creation, the gated fabric runner, and verification |

--- a/osdc/base/kubernetes/registry-mirror-config.yaml
+++ b/osdc/base/kubernetes/registry-mirror-config.yaml
@@ -62,7 +62,13 @@ data:
       echo "Verifying current configuration..."
 
       all_checks_pass=true
-      for registry in docker.io ghcr.io public.ecr.aws nvcr.io registry.k8s.io quay.io "harbor:${HARBOR_PORT}"; do
+      # Conditional entry must join the list, or enabling it later keeps
+      # skipping on the marker.
+      EXPECTED_REGISTRIES="docker.io ghcr.io public.ecr.aws nvcr.io registry.k8s.io quay.io harbor:${HARBOR_PORT}"
+      if [ -n "${ECR_PULLTHROUGH_REGISTRY:-}" ]; then
+        EXPECTED_REGISTRIES="${EXPECTED_REGISTRIES} ${ECR_PULLTHROUGH_REGISTRY}"
+      fi
+      for registry in ${EXPECTED_REGISTRIES}; do
         if [ ! -f "/etc/containerd/certs.d/${registry}/hosts.toml" ]; then
           echo "  Missing hosts.toml for ${registry} - will reconfigure"
           all_checks_pass=false
@@ -196,12 +202,35 @@ data:
     TOML
 
     # =========================================================================
+    # Private ECR (opt-in) — routes CI image pulls through Harbor
+    # =========================================================================
+    # See docs/cross-region-ecr-pulls.md.
+    if [ -n "${ECR_PULLTHROUGH_REGISTRY:-}" ]; then
+      echo "[ecr] Configuring ${ECR_PULLTHROUGH_REGISTRY} mirror..."
+      mkdir -p "/etc/containerd/certs.d/${ECR_PULLTHROUGH_REGISTRY}"
+      cat > "/etc/containerd/certs.d/${ECR_PULLTHROUGH_REGISTRY}/hosts.toml" <<TOML
+    server = "https://${ECR_PULLTHROUGH_REGISTRY}"
+
+    [host."http://harbor:${HARBOR_PORT}/v2/ecr-cache"]
+      capabilities = ["pull", "resolve"]
+      skip_verify = true
+      override_path = true
+
+    [host."https://${ECR_PULLTHROUGH_REGISTRY}"]
+      capabilities = ["pull", "resolve"]
+    TOML
+    else
+      echo "[ecr] Private ECR pull-through not enabled on this cluster - skipping"
+      rm -rf /etc/containerd/certs.d/*.dkr.ecr.*.amazonaws.com 2>/dev/null || true
+    fi
+
+    # =========================================================================
     # Summary
     # =========================================================================
     echo ""
     echo "=== Registry Mirror Configuration Complete ==="
     echo "Harbor endpoint: http://harbor:${HARBOR_PORT}"
-    echo "Configured mirrors for: docker.io, ghcr.io, public.ecr.aws, nvcr.io, registry.k8s.io, quay.io"
+    echo "Configured mirrors for: ${EXPECTED_REGISTRIES:-docker.io ghcr.io public.ecr.aws nvcr.io registry.k8s.io quay.io}"
     echo "Configured direct registry: harbor:${HARBOR_PORT}"
     echo ""
     echo "Note: containerd 1.6+ dynamically watches certs.d/ - no restart needed"
@@ -282,6 +311,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: ECR_PULLTHROUGH_REGISTRY
+              valueFrom:
+                configMapKeyRef:
+                  name: registry-mirror-ecr
+                  key: registry
+                  optional: true
 
           securityContext:
             privileged: true

--- a/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
+++ b/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
@@ -1,7 +1,7 @@
 """Smoke tests for base Kubernetes resources (DaemonSets, StorageClass, nodes)."""
 
 import pytest
-from helpers import assert_daemonset_healthy, filter_services
+from helpers import assert_daemonset_healthy, filter_services, run_kubectl
 
 pytestmark = [pytest.mark.live]
 
@@ -24,6 +24,38 @@ class TestBaseDaemonSets:
 
     def test_registry_mirror_config(self, all_daemonsets, all_nodes):
         assert_daemonset_healthy(all_daemonsets, all_nodes, NAMESPACE, "registry-mirror-config")
+
+    def test_registry_mirror_ecr_gate_matches_cluster_config(self, all_daemonsets, resolve_config):
+        """Both directions: a stale ConfigMap routes CI pulls at a Harbor with no ECR endpoint."""
+        enabled = bool(resolve_config("harbor.ecr_pullthrough", False))
+        result = run_kubectl(["get", "configmap", "registry-mirror-ecr", "--ignore-not-found"], namespace=NAMESPACE)
+        present = bool(result) and result.get("kind") == "ConfigMap"
+        assert present == enabled, (
+            f"harbor.ecr_pullthrough={enabled} but registry-mirror-ecr ConfigMap "
+            f"{'exists' if present else 'is missing'} in {NAMESPACE}"
+        )
+        if enabled:
+            registry = result.get("data", {}).get("registry", "")
+            msg = f"registry-mirror-ecr points at {registry!r}, which is not an ECR registry host"
+            assert ".dkr.ecr." in registry, msg
+            assert registry.endswith(".amazonaws.com"), msg
+
+    def test_registry_mirror_reads_the_ecr_gate_optionally(self, all_daemonsets):
+        """optional: true is load-bearing — without it the DaemonSet fails to start fleet-wide."""
+        ds = next(
+            (d for d in all_daemonsets.get("items", []) if d["metadata"]["name"] == "registry-mirror-config"),
+            None,
+        )
+        assert ds is not None, "registry-mirror-config DaemonSet not found"
+        containers = ds["spec"]["template"]["spec"].get("containers", [])
+        env = [e for c in containers for e in c.get("env", []) if e.get("name") == "ECR_PULLTHROUGH_REGISTRY"]
+        assert env, "registry-mirror-config has no ECR_PULLTHROUGH_REGISTRY env var"
+        ref = env[0].get("valueFrom", {}).get("configMapKeyRef", {})
+        assert ref.get("name") == "registry-mirror-ecr", f"unexpected configMapKeyRef: {ref}"
+        assert ref.get("optional") is True, (
+            "ECR_PULLTHROUGH_REGISTRY must be optional: true — every cluster without the "
+            "ConfigMap would otherwise fail to start the DaemonSet"
+        )
 
     def test_node_performance_tuning(self, all_daemonsets, all_nodes):
         assert_daemonset_healthy(all_daemonsets, all_nodes, NAMESPACE, "node-performance-tuning", allow_zero=True)

--- a/osdc/clusters.yaml
+++ b/osdc/clusters.yaml
@@ -45,6 +45,10 @@ defaults:
     registry_replicas: 4
     nginx_replicas: 6
     pdb_max_unavailable: 1  # conservative: at most 1 pod down per component
+    # Registry holding the PyTorch CI images, for harbor.ecr_pullthrough. Not
+    # derived from the deploying account: LF clusters are in 391835788720 and
+    # pull these same images cross-account.
+    ecr_pullthrough_registry: "308535385114.dkr.ecr.us-east-1.amazonaws.com"
 
   # --- Module defaults ---
   karpenter:
@@ -310,6 +314,10 @@ clusters:
       registry_replicas: 1
       nginx_replicas: 1
       pdb_max_unavailable: "100%"  # aggressive: staging has 1 replica each
+      # Proxy the private us-east-1 ECR through Harbor so CI image layers are
+      # served from this cluster's own bucket instead of cross-region S3.
+      # Staging-only while the ECR adapter's auth is being validated.
+      ecr_pullthrough: true
     karpenter:
       replicas: 1
       log_level: debug

--- a/osdc/docs/cross-region-ecr-pulls.md
+++ b/osdc/docs/cross-region-ecr-pulls.md
@@ -1,0 +1,66 @@
+# Private ECR pull-through via Harbor
+
+## Problem
+
+The PyTorch CI images live in one registry, `308535385114.dkr.ecr.us-east-1.amazonaws.com`
+(hardcoded as `ECR_REGISTRY` in `pytorch/pytorch`'s `docker-builds.yml`). ECR serves layer
+downloads by redirecting to `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com`
+— an S3 host with no AAAA record, in **its own** region.
+
+A cluster in us-east-1 matches that address against its local S3 prefix list and takes the
+gateway endpoint. A cluster anywhere else does not: the prefix list only covers its own
+region's S3, so the pull falls through to `0.0.0.0/0` and pays NAT plus inter-region
+transfer, on every layer of every image.
+
+## Design
+
+Register the private ECR as a seventh Harbor proxy-cache upstream, alongside docker.io,
+ghcr.io, public.ecr.aws, nvcr.io, registry.k8s.io and quay.io, and point containerd at it.
+
+Nodes then pull from Harbor instead of ECR. The first pull of a layer fetches it
+cross-region once and stores it in the cluster's own Harbor bucket; every later pull is
+served from there over `s3.dualstack.<region>`, which resolves IPv6-first and egresses via
+the egress-only gateway.
+
+| Piece | Where |
+|---|---|
+| Harbor registry endpoint + `ecr-cache` proxy project | `scripts/python/configure_harbor_projects.py` |
+| ECR read permission | `modules/eks/terraform/modules/harbor/main.tf` |
+| containerd mirror | `base/kubernetes/registry-mirror-config.yaml` |
+| Per-cluster gate `harbor.ecr_pullthrough` | `clusters.yaml`, wired in `justfile` |
+
+## Constraints that shaped it
+
+**The endpoint type must be `aws-ecr`, not `docker-registry`.** ECR tokens expire every 12
+hours; only Harbor's ECR adapter performs the `GetAuthorizationToken` exchange and refreshes
+them. A generic V2 endpoint would authenticate once and then rot.
+
+**Credentials must be passed explicitly.** The proxy cache runs in `harbor-core`, which uses
+the `default` ServiceAccount with no IRSA annotation, and base nodes set
+`http_put_response_hop_limit = 1` so pods cannot reach IMDS. Core therefore has no ambient
+AWS identity of any kind. The policy attaches to the existing `harbor_s3` IAM user — the
+same no-IRSA workaround the S3 driver already documents in that file — and the key pair is
+handed to Harbor at endpoint-creation time.
+
+**The gate is the presence of a ConfigMap.** `registry-mirror-config` is applied by plain
+kustomize with no per-cluster substitution, so the DaemonSet reads `registry-mirror-ecr`
+with `optional: true`; absent means off. Two consequences:
+
+- The DaemonSet reads it as an env var, so it only takes effect at pod start. The kustomize
+  apply runs before Harbor deploys, so `_deploy-harbor` restarts the DaemonSet when the
+  value changes.
+- The script's marker-file check must include the conditional registry in its expected list,
+  or a cluster that enables the flag later keeps skipping on the marker and never writes the
+  mirror.
+
+**The registry is always us-east-1**, regardless of the cluster's own region. That is where
+the images are; pointing at a local ECR would find nothing.
+
+## Scope
+
+No effect on `meta-prod-aws-ue1` — its ECR pulls are already same-region and served by the
+S3 gateway endpoint. This is for the off-region clusters: `ue2`, `uw1`, and `uw2` before it
+takes traffic.
+
+Enabling it on a cluster starts with a cold Harbor bucket, so the cache-miss path still
+crosses regions once per layer while it warms.

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -1898,6 +1898,31 @@ _deploy-harbor cluster:
 
     # Configure proxy cache projects
     echo "Configuring proxy cache projects..."
+    ECR_PULLTHROUGH=$(uv run "{{UPSTREAM}}/scripts/cluster-config.py" "{{cluster}}" harbor.ecr_pullthrough "false")
+    ECR_HOST=$(uv run "{{UPSTREAM}}/scripts/cluster-config.py" "{{cluster}}" harbor.ecr_pullthrough_registry)
+    if [[ "$ECR_PULLTHROUGH" == "true" ]]; then
+        # Same IAM user as S3: the ECR adapter shares the no-IRSA constraint.
+        export HARBOR_ECR_URL="https://${ECR_HOST}" HARBOR_S3_KEY HARBOR_S3_SECRET
+        ECR_CM_WANT="${ECR_HOST}"
+    else
+        ECR_CM_WANT=""
+    fi
+    # Env var, so only read at pod start — restart only when it changes.
+    ECR_CM_HAVE=$(kubectl get configmap registry-mirror-ecr -n kube-system \
+        -o jsonpath='{.data.registry}' 2>/dev/null || echo "")
+    if [[ "$ECR_CM_WANT" != "$ECR_CM_HAVE" ]]; then
+        if [[ -n "$ECR_CM_WANT" ]]; then
+            kubectl create configmap registry-mirror-ecr \
+                --namespace kube-system \
+                --from-literal=registry="${ECR_CM_WANT}" \
+                --dry-run=client -o yaml | kubectl apply -f -
+        else
+            kubectl delete configmap registry-mirror-ecr --namespace kube-system \
+                --ignore-not-found >/dev/null
+        fi
+        echo "  ECR pull-through changed ('${ECR_CM_HAVE}' -> '${ECR_CM_WANT}'), restarting registry-mirror-config"
+        kubectl rollout restart daemonset/registry-mirror-config -n kube-system
+    fi
     just _configure-harbor-projects
     echo ""
     echo "Harbor deployed."
@@ -1951,6 +1976,11 @@ _configure-harbor-projects:
         echo "  Waiting for Harbor API (attempt $hp_attempt/$HP_MAX_RETRIES)..."
         sleep 5
     done
+
+    if [[ -n "${HARBOR_ECR_URL:-}" ]]; then
+        CRED_ARGS="${CRED_ARGS} --ecr-registry-url ${HARBOR_ECR_URL}"
+        CRED_ARGS="${CRED_ARGS} --ecr-access-key ${HARBOR_S3_KEY} --ecr-secret-key ${HARBOR_S3_SECRET}"
+    fi
 
     uv run {{SCRIPTS}}/python/configure_harbor_projects.py \
         --harbor-url http://localhost:8080 \

--- a/osdc/modules/eks/terraform/modules/harbor/main.tf
+++ b/osdc/modules/eks/terraform/modules/harbor/main.tf
@@ -102,6 +102,39 @@ resource "aws_iam_role_policy_attachment" "harbor_registry" {
   policy_arn = aws_iam_policy.harbor_registry.arn
 }
 
+# GetAuthorizationToken takes no resource qualifier — AWS requires "*".
+resource "aws_iam_policy" "harbor_ecr_pullthrough" {
+  name        = "${var.cluster_name}-harbor-ecr-pullthrough"
+  description = "Harbor proxy-cache read access to private ECR for ${var.cluster_name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowEcrAuth"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowEcrPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:ListImages"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
 # IAM User for Harbor S3 access (static credentials)
 # The goharbor/distribution S3 driver hardcodes its AWS credential chain
 # and does not support IRSA (web identity tokens). A static IAM user is
@@ -114,6 +147,13 @@ resource "aws_iam_user" "harbor_s3" {
 resource "aws_iam_user_policy_attachment" "harbor_s3" {
   user       = aws_iam_user.harbor_s3.name
   policy_arn = aws_iam_policy.harbor_registry.arn
+}
+
+# User, not the IRSA role: the proxy cache runs in harbor-core, which uses the
+# default ServiceAccount and cannot reach IMDS.
+resource "aws_iam_user_policy_attachment" "harbor_ecr_pullthrough" {
+  user       = aws_iam_user.harbor_s3.name
+  policy_arn = aws_iam_policy.harbor_ecr_pullthrough.arn
 }
 
 resource "aws_iam_access_key" "harbor_s3" {

--- a/osdc/scripts/python/configure_harbor_projects.py
+++ b/osdc/scripts/python/configure_harbor_projects.py
@@ -73,6 +73,14 @@ REGISTRIES = [
     },
 ]
 
+# aws-ecr, not docker-registry: ECR tokens expire every 12h and only this
+# adapter refreshes them.
+ECR_REGISTRY = {
+    "name": "ecr-private",
+    "type": "aws-ecr",
+    "project_name": "ecr-cache",
+}
+
 DEFAULT_HARBOR_URL = "http://localhost:30002"
 DEFAULT_ADMIN_PASSWORD = None
 
@@ -347,6 +355,21 @@ def main():
         help="GitHub personal access token for ghcr.io",
     )
     parser.add_argument(
+        "--ecr-registry-url",
+        default=None,
+        help="Private ECR registry URL (e.g. https://<acct>.dkr.ecr.us-east-1.amazonaws.com). Omit to skip.",
+    )
+    parser.add_argument(
+        "--ecr-access-key",
+        default=None,
+        help="AWS access key id for the ECR proxy-cache endpoint",
+    )
+    parser.add_argument(
+        "--ecr-secret-key",
+        default=None,
+        help="AWS secret access key for the ECR proxy-cache endpoint",
+    )
+    parser.add_argument(
         "--no-wait",
         action="store_true",
         help="Don't wait for Harbor to be ready",
@@ -372,6 +395,17 @@ def main():
             "access_secret": args.github_token,
         }
         log_info("GitHub (ghcr.io) credentials provided")
+
+    if args.ecr_registry_url:
+        if not (args.ecr_access_key and args.ecr_secret_key):
+            parser.error("--ecr-registry-url requires --ecr-access-key and --ecr-secret-key")
+        REGISTRIES.append({**ECR_REGISTRY, "url": args.ecr_registry_url})
+        registry_credentials[ECR_REGISTRY["name"]] = {
+            "type": "basic",
+            "access_key": args.ecr_access_key,
+            "access_secret": args.ecr_secret_key,
+        }
+        log_info(f"Private ECR proxy cache enabled -> {args.ecr_registry_url}")
 
     session = create_session(args.harbor_url, args.admin_password)
 

--- a/osdc/scripts/python/test_configure_harbor_projects.py
+++ b/osdc/scripts/python/test_configure_harbor_projects.py
@@ -582,6 +582,9 @@ class TestMain:
             dockerhub_token=None,
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=False,
         )
         mock_create_session.return_value = MagicMock()
@@ -617,6 +620,9 @@ class TestMain:
             dockerhub_token=None,
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=True,
         )
         mock_create_session.return_value = MagicMock()
@@ -646,6 +652,9 @@ class TestMain:
             dockerhub_token=None,
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=True,
         )
         mock_create_session.return_value = MagicMock()
@@ -677,6 +686,9 @@ class TestMain:
             dockerhub_token=None,
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=True,
         )
         mock_create_session.return_value = MagicMock()
@@ -709,6 +721,9 @@ class TestMain:
             dockerhub_token=None,
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=False,
         )
         mock_create_session.return_value = MagicMock()
@@ -743,6 +758,9 @@ class TestMain:
             dockerhub_token=None,
             github_username="ghuser",
             github_token="ghtoken",
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=True,
         )
         mock_create_session.return_value = MagicMock()
@@ -786,6 +804,9 @@ class TestMain:
             dockerhub_token="tok",
             github_username=None,
             github_token=None,
+            ecr_registry_url=None,
+            ecr_access_key=None,
+            ecr_secret_key=None,
             no_wait=True,
         )
         mock_create_session.return_value = MagicMock()
@@ -806,3 +827,59 @@ class TestMain:
                 break
         else:
             pytest.fail("dockerhub registry call not found")
+
+
+class TestPrivateEcrPullthrough:
+    """The optional aws-ecr endpoint appended by --ecr-registry-url."""
+
+    ECR_URL = "https://308535385114.dkr.ecr.us-east-1.amazonaws.com"
+
+    def _args(self, **over):
+        base = {
+            "harbor_url": HARBOR_URL,
+            "admin_password": "pw",
+            "dockerhub_username": None,
+            "dockerhub_token": None,
+            "github_username": None,
+            "github_token": None,
+            "ecr_registry_url": None,
+            "ecr_access_key": None,
+            "ecr_secret_key": None,
+            "no_wait": True,
+        }
+        base.update(over)
+        return argparse.Namespace(**base)
+
+    @patch("configure_harbor_projects.create_proxy_cache_project", return_value=True)
+    @patch("configure_harbor_projects.ensure_registry_endpoint", return_value=True)
+    @patch("configure_harbor_projects.fetch_csrf_token")
+    @patch("configure_harbor_projects.create_session")
+    @patch("configure_harbor_projects.argparse.ArgumentParser.parse_args")
+    def test_absent_by_default(self, mock_args, mock_sess, mock_csrf, mock_ensure, mock_proj):
+        mock_args.return_value = self._args()
+        mock_sess.return_value = MagicMock()
+        assert main() == 0
+        names = [c.args[2]["name"] for c in mock_ensure.call_args_list]
+        assert "ecr-private" not in names
+
+    @patch("configure_harbor_projects.create_proxy_cache_project", return_value=True)
+    @patch("configure_harbor_projects.ensure_registry_endpoint", return_value=True)
+    @patch("configure_harbor_projects.fetch_csrf_token")
+    @patch("configure_harbor_projects.create_session")
+    @patch("configure_harbor_projects.argparse.ArgumentParser.parse_args")
+    def test_registered_as_aws_ecr_with_credentials(self, mock_args, mock_sess, mock_csrf, mock_ensure, mock_proj):
+        """type must be aws-ecr — docker-registry cannot refresh the 12h ECR token."""
+        mock_args.return_value = self._args(ecr_registry_url=self.ECR_URL, ecr_access_key="AKIA", ecr_secret_key="shh")
+        mock_sess.return_value = MagicMock()
+        assert main() == 0
+        call = next(c for c in mock_ensure.call_args_list if c.args[2]["name"] == "ecr-private")
+        registry, creds = call.args[2], call.args[3]
+        assert registry["type"] == "aws-ecr"
+        assert registry["url"] == self.ECR_URL
+        assert creds == {"type": "basic", "access_key": "AKIA", "access_secret": "shh"}
+
+    @patch("configure_harbor_projects.argparse.ArgumentParser.parse_args")
+    def test_url_without_credentials_is_rejected(self, mock_args):
+        mock_args.return_value = self._args(ecr_registry_url=self.ECR_URL)
+        with pytest.raises(SystemExit):
+            main()


### PR DESCRIPTION
Follow-up to #1032, which cut `meta-prod-aws-ue1`'s NAT traffic 71% and did nothing for `ue2` or `uw1`.

Every cluster pulls the PyTorch CI images from us-east-1 ECR, and ECR redirects layer downloads to an IPv4-only bucket **in its own region**. ue1 is us-east-1, so those bytes match its prefix list and take the gateway endpoint. Off-region clusters miss the prefix list and pay NAT plus inter-region on every pull.

So route those pulls through Harbor's proxy cache, as a seventh entry alongside the six upstreams it already handles.

## Validated on `meta-staging-aws-ue2`

| | |
|---|---|
| Harbor → private ECR auth | `aws-ecr` endpoint, `status: healthy` |
| Proxy + cache | `ecr-cache/pytorch/…`, bucket 6.2 → 8.77 GB |
| Cache **miss** (cross-region) | 8,763 MB on the NAT gateway — one-time per layer |
| Cache **hit**, cold node | **4.0 GiB pulled, NAT flat at 16.1 / 12.4 MB** (idle floor ~15 MB) |

4 GiB reached a node that had never held the image and the NAT gateway did not move.

Gated on `harbor.ecr_pullthrough`, default off, enabled only on `meta-staging-aws-ue2`. Does not help ue1 — its ECR pulls are already same-region.

Background and measurements: `docs/cross-region-ecr-pulls.md`.

**Tested:** `just test` OK (3 unit + 2 smoke cases). `tofu fmt`/`validate` clean. `just lint` fails only on a pre-existing hadolint finding at `base/docker/runner-base/Dockerfile:36`.

**Not yet exercised:** the containerd mirror path. Validation above pulled `harbor:30002/ecr-cache/...` directly, which bypasses the rewrite. Deploying to staging-ue2 and pulling by the real ECR reference is what takes this out of draft.