### PR TITLE
agent-sandbox: enforce the task-pod isolation contract in the API server

### DIFF
--- a/osdc/modules/agent-sandbox/README.md
+++ b/osdc/modules/agent-sandbox/README.md
@@ -180,6 +180,23 @@ doesn't match — worth having if this role ever gains other statements that gra
 foundation-model access, but it lives outside this repo.
 Background: [Securing Amazon Bedrock cross-Region inference](https://aws.amazon.com/blogs/machine-learning/securing-amazon-bedrock-cross-region-inference-geographic-and-global/).
 
+## The task-pod contract, and adding a volume
+
+`dispatcher.py::job_manifest()` builds every task pod, and
+`kubernetes/base/admissionpolicy.yaml` restates the same contract in CEL so the API
+server rejects a Job that does not match it. The two are deliberately redundant;
+`dispatcher/test_admissionpolicy.py` is what keeps them from drifting apart.
+
+**Task pods declare no volumes at all.** That is a rule, not an accident of the current
+manifest: a volume is how a Secret, a `hostPath` or a projected service-account token
+would get into the untrusted side. An allowlist of safe volume shapes is expressible in
+CEL, but it is a rule you can get subtly wrong; "none" is one you cannot. So a change
+that needs one — the planned
+`GITHUB_TOKEN` init container needs a shared `emptyDir` — is not a one-line edit to
+`job_manifest()`. It has to amend the volumes rule and the init-container rule in the
+policy, re-pin their expression digests, and say in review which volume types are now
+reachable from inside gVisor and why that is acceptable.
+
 ## Integration test
 
 Runs as part of the standard canary flow, gated by the `AGENT_SANDBOX` tag

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -30,10 +30,29 @@ import dispatcher
 import pytest
 import yaml
 
-POLICY_PATH = Path(__file__).resolve().parent.parent / "kubernetes" / "base" / "admissionpolicy.yaml"
+MODULE = Path(__file__).resolve().parent.parent
+POLICY_PATH = MODULE / "kubernetes" / "base" / "admissionpolicy.yaml"
+DEPLOY_SH = MODULE / "deploy.sh"
+DISPATCHER_MANIFEST = MODULE / "kubernetes" / "base" / "dispatcher.yaml"
 
+
+def _deployed_image_repository() -> str:
+    """The repository deploy.sh actually pushes the task image to.
+
+    Read rather than restated. The repository reaches a task pod from `IMAGE=` in
+    deploy.sh and the policy names it again in a CEL literal; a third hand-written copy
+    here would make the image rule the one rule checked against the test's own opinion.
+    Change `IMAGE=` alone and the policy rejects every Job — in production, with this
+    suite green.
+    """
+    match = re.search(r'^IMAGE="([^"]+)"', DEPLOY_SH.read_text(), re.M)
+    assert match, f"no IMAGE= assignment found in {DEPLOY_SH} — the image rule has nothing to check against"
+    return match.group(1)
+
+
+IMAGE_REPOSITORY = _deployed_image_repository()
 # The tag deploy.sh substitutes is a content hash; only the repository is pinned.
-GOOD_IMAGE = "harbor:30002/osdc/ci-agent-sandbox:0123456789ab"
+GOOD_IMAGE = f"{IMAGE_REPOSITORY}:0123456789ab"
 
 
 @pytest.fixture(scope="module")
@@ -80,6 +99,19 @@ def _all_containers(job):
     return _pod(job)["containers"] + _pod(job).get("initContainers", [])
 
 
+def _nodename_rule(pod: dict, *, is_job: bool, operation: str) -> bool:
+    """The one rule whose meaning depends on the REQUEST and not only on the object.
+
+    Every other mirror is a function of a Job, which is why none of them could see the
+    bug this signature exists for: the Pod binding matches UPDATE, and by the time a task
+    pod is updated the scheduler has already set spec.nodeName through pods/binding. A
+    rule of `!has(nodeName)` therefore denied every write to a running task pod — among
+    them the Job controller's finalizer removal, without which status.succeeded never
+    reaches 1 and the dispatcher waits out its whole deadline on a task that finished.
+    """
+    return "nodeName" not in pod or (not is_job and operation == "UPDATE")
+
+
 # Each entry mirrors one `validations:` item, keyed by the exact `message:` string in the
 # YAML, and paired with a Job the rule must reject. Keeping the message as the key is what
 # makes drift loud: reword a message in the policy and this test names the rule that lost
@@ -102,7 +134,7 @@ MIRRORS = {
         lambda: a_job(hostPID=True),
     ),
     "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": (
-        lambda j: "nodeName" not in _pod(j),
+        lambda j: _nodename_rule(_pod(j), is_job=True, operation="CREATE"),
         lambda: a_job(nodeName="ip-10-0-0-1"),
     ),
     "task pods must use the default scheduler — an alternate scheduler need not honour the RuntimeClass node selector": (
@@ -126,7 +158,7 @@ MIRRORS = {
         lambda: a_job(initContainers=[{"name": "sidecar", "image": GOOD_IMAGE, "restartPolicy": "Always"}]),
     ),
     "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox": (
-        lambda j: all(c["image"].startswith("harbor:30002/osdc/ci-agent-sandbox:") for c in _all_containers(j)),
+        lambda j: all(c["image"].startswith(f"{IMAGE_REPOSITORY}:") for c in _all_containers(j)),
         lambda: a_job(
             containers=[{**a_job()["spec"]["template"]["spec"]["containers"][0], "image": "docker.io/alpine"}]
         ),
@@ -258,6 +290,26 @@ def test_each_rule_rejects_its_own_violation(message):
     assert not predicate(violating()), f"mirror does not actually enforce: {message}"
 
 
+@pytest.mark.parametrize(
+    ("pod", "is_job", "operation", "admitted"),
+    [
+        ({}, True, "CREATE", True),
+        ({"nodeName": "ip-10-0-0-1"}, True, "CREATE", False),
+        ({}, False, "CREATE", True),
+        ({"nodeName": "ip-10-0-0-1"}, False, "CREATE", False),
+        # The quadrant the Job-shaped mirrors structurally cannot reach, and the one that
+        # broke: the scheduler has bound the pod, so nodeName is set on every subsequent
+        # UPDATE the Pod binding sees.
+        ({"nodeName": "ip-10-0-0-1"}, False, "UPDATE", True),
+    ],
+)
+def test_the_nodename_rule_admits_a_bound_pod_on_update(pod, is_job, operation, admitted):
+    """Exempting UPDATE costs nothing: spec.nodeName is immutable through the pods main
+    resource, so the only writer is the pods/binding subresource this policy never
+    matched. Pinning it at CREATE is the whole of what the rule ever enforced."""
+    assert _nodename_rule(pod, is_job=is_job, operation=operation) is admitted
+
+
 def test_bindings_deny_rather_than_warn(policy, bindings):
     """A policy with no binding, or one set to Warn, enforces nothing while looking applied."""
     assert bindings, "the policy has no binding at all — it would be inert"
@@ -319,6 +371,15 @@ def test_the_job_pass_is_scoped_to_the_dispatchers_service_account(policy):
     assert "request.kind.kind != 'Job'" in expression, (
         "the condition must exempt non-Job requests, or it disables the Pod pass"
     )
+    # Substrings cannot see the edit that matters here. Turn the `||` into `&&` and both
+    # assertions above still hold, while the Pod pass — which no Pod request can satisfy
+    # once it must ALSO come from the dispatcher's service account — is switched off with
+    # this suite green. The digest below is what makes that edit fail; the two assertions
+    # stay because they name what the condition is for when it does.
+    assert {c["name"]: _digest(c["expression"]) for c in conditions} == MATCH_CONDITION_DIGESTS, (
+        "the match condition that gates the whole policy changed — re-read this test's "
+        "reasoning against the new text before re-pinning"
+    )
 
 
 # Every rule's expression, pinned by digest of its whitespace-normalised text.
@@ -333,7 +394,7 @@ EXPRESSION_DIGESTS = {
     "task pods must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)": "93161384aabc",
     "task pods must run as serviceAccountName: sandbox-agent, which holds no RBAC": "2779cb7d8a6b",
     "task pods must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox": "224303faac17",
-    "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": "cf1eae68cdb1",
+    "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": "767387bc5943",
     "task pods must use the default scheduler — an alternate scheduler need not honour the RuntimeClass node selector": "d76e4a690cdc",
     "task pods must not share host namespaces (hostNetwork/hostPID/hostIPC)": "1cafda1b80d7",
     "task pods must declare no volumes — see the module README before adding one": "0ad2da654e90",
@@ -358,8 +419,32 @@ EXPRESSION_DIGESTS = {
 }
 
 
+# The expressions every pod-level rule is READ THROUGH, and the one that decides whether
+# a request is evaluated at all. EXPRESSION_DIGESTS covers `validations` only, so before
+# this a rewrite of `variables.pod` — the ternary that keeps the Job pass and the Pod pass
+# looking at the same fields — silently changed the meaning of the twenty rules that read
+# it, with nothing in this file able to see the edit.
+MATCH_CONDITION_DIGESTS = {
+    "job-writes-come-from-the-dispatcher": "7946d5ff4d30",
+}
+VARIABLE_DIGESTS = {
+    "pod": "14b9d426b721",
+    "isJob": "e99f115a3c1c",
+    "allContainers": "b41ce25c2638",
+}
+
+
 def _digest(expression: str) -> str:
     return hashlib.sha256(re.sub(r"\s+", " ", expression).strip().encode()).hexdigest()[:12]
+
+
+def test_no_variable_changed_without_being_rechecked(policy):
+    """Every rule reads its pod spec through `variables.pod`; nothing else pins it."""
+    live = {v["name"]: _digest(v["expression"]) for v in policy["spec"]["variables"]}
+    assert live == VARIABLE_DIGESTS, {
+        "changed or unpinned": sorted(k for k in live if VARIABLE_DIGESTS.get(k) != live[k]),
+        "stale (no longer in the policy)": sorted(set(VARIABLE_DIGESTS) - set(live)),
+    }
 
 
 def test_no_expression_changed_without_its_mirror_being_rechecked(policy):
@@ -382,8 +467,64 @@ def test_no_expression_changed_without_its_mirror_being_rechecked(policy):
 
 
 def test_an_unsubstituted_task_image_is_rejected(monkeypatch):
-    """The production failure the image rule exists for: deploy.sh not substituting the
-    tag, so AGENT_IMAGE is empty and every task pod would run whatever that resolves to."""
-    monkeypatch.setattr(dispatcher, "AGENT_IMAGE", "")
-    predicate, _ = MIRRORS["task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox"]
-    assert not predicate(a_job())
+    """A last line rather than the first: the dispatcher already refuses at /run when
+    AGENT_IMAGE is empty, and a deploy.sh that failed to substitute leaves the literal
+    `__AGENT_IMAGE__` in dispatcher.yaml rather than an empty string. Both are rejected
+    here, which is what the rule is for — neither is reachable past the checks in front
+    of it today, and this is what keeps that true if one of them goes."""
+    predicate, _ = next(
+        mirror for message, mirror in MIRRORS.items() if message.startswith("task containers must run the task image")
+    )
+    for value in ("", "__AGENT_IMAGE__"):
+        monkeypatch.setattr(dispatcher, "AGENT_IMAGE", value)
+        assert not predicate(a_job()), f"an image of {value!r} must not be admitted"
+
+
+def test_the_policy_pins_the_repository_deploy_sh_actually_pushes_to(policy):
+    """The third copy of the repository, and the one nothing else compares."""
+    rule = next(
+        v for v in policy["spec"]["validations"] if v["message"].startswith("task containers must run the task image")
+    )
+    assert f"'{IMAGE_REPOSITORY}:'" in rule["expression"], (
+        f"the image rule pins {rule['expression']}, but deploy.sh pushes to {IMAGE_REPOSITORY} — "
+        "every Job would be rejected"
+    )
+    assert rule["message"].endswith(IMAGE_REPOSITORY), "the rejection message names a repository nobody deploys"
+
+
+def test_the_deadline_ceiling_admits_the_deadline_the_dispatcher_deploys(policy):
+    """The 3600 in the policy is a second copy of TASK_DEADLINE_S, which is env
+    configurable. Raise the env past the ceiling and every Job is rejected at dispatch —
+    loudly, but with nothing in this suite noticing beforehand."""
+    rule = next(v for v in policy["spec"]["validations"] if "activeDeadlineSeconds" in v["expression"])
+    ceiling = int(re.search(r"activeDeadlineSeconds <= (\d+)", rule["expression"]).group(1))
+    assert dispatcher.TASK_DEADLINE_S <= ceiling, (
+        f"the dispatcher's default deadline ({dispatcher.TASK_DEADLINE_S}s) exceeds the policy ceiling ({ceiling}s)"
+    )
+    deployed = _deployed_env("TASK_DEADLINE_S")
+    assert deployed is None or int(deployed) <= ceiling, (
+        f"dispatcher.yaml deploys TASK_DEADLINE_S={deployed}, above the policy ceiling of {ceiling}s"
+    )
+
+
+def _deployed_env(name: str) -> str | None:
+    """The literal value dispatcher.yaml sets for an env var, or None if it sets none.
+
+    A value this test cannot read is not the same as no value, and returning None for
+    both would quietly turn the comparison below into a no-op — so an `envFrom` block, or
+    a `valueFrom` on this variable, fails here instead.
+    """
+    deployment = next(
+        d
+        for d in yaml.safe_load_all(DISPATCHER_MANIFEST.read_text())
+        if d and d["kind"] == "Deployment" and d["metadata"]["name"] == "sandbox-dispatcher"
+    )
+    for container in deployment["spec"]["template"]["spec"]["containers"]:
+        assert not container.get("envFrom"), (
+            f"{container['name']} pulls env from an envFrom source, which could set {name} out of this test's sight"
+        )
+        for entry in container.get("env", []):
+            if entry["name"] == name:
+                assert "value" in entry, f"{name} is set from {entry.get('valueFrom')}, which this test cannot read"
+                return entry["value"]
+    return None

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -106,7 +106,9 @@ MIRRORS = {
     ),
     "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox": (
         lambda j: all(c["image"].startswith("harbor:30002/osdc/ci-agent-sandbox:") for c in _all_containers(j)),
-        lambda: a_job(containers=[{**a_job()["spec"]["template"]["spec"]["containers"][0], "image": "docker.io/alpine"}]),
+        lambda: a_job(
+            containers=[{**a_job()["spec"]["template"]["spec"]["containers"][0], "image": "docker.io/alpine"}]
+        ),
     ),
     "a task pod runs exactly one container": (
         lambda j: len(_pod(j)["containers"]) == 1,
@@ -127,7 +129,9 @@ MIRRORS = {
             and c.get("securityContext", {}).get("runAsNonRoot") is True
             for c in _all_containers(j)
         ),
-        lambda: _with_container(securityContext={"privileged": True, "runAsNonRoot": True, "allowPrivilegeEscalation": False}),
+        lambda: _with_container(
+            securityContext={"privileged": True, "runAsNonRoot": True, "allowPrivilegeEscalation": False}
+        ),
     ),
     "task containers must not add Linux capabilities": (
         lambda j: all(not c.get("securityContext", {}).get("capabilities", {}).get("add") for c in _all_containers(j)),
@@ -140,7 +144,9 @@ MIRRORS = {
         ),
     ),
     "task containers must not unmask /proc": (
-        lambda j: all(c.get("securityContext", {}).get("procMount", "Default") == "Default" for c in _all_containers(j)),
+        lambda j: all(
+            c.get("securityContext", {}).get("procMount", "Default") == "Default" for c in _all_containers(j)
+        ),
         lambda: _with_container(
             securityContext={"runAsNonRoot": True, "allowPrivilegeEscalation": False, "procMount": "Unmasked"}
         ),

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -11,11 +11,19 @@ mirror (adding a CEL rule without one fails here), the real job_manifest() outpu
 satisfies all of them, and each rule actually rejects the thing it names — a mirror that
 accepts everything would otherwise pass quietly.
 
+Keying on the message catches a rule ADDED without a mirror, and a message reworded away
+from its mirror. It does NOT catch the likeliest drift of all: an expression edited in
+place with its message left alone. EXPRESSION_DIGESTS closes that — every expression is
+pinned by digest, so editing one fails here until someone re-reads the mirror beside it
+and re-pins. That is the whole point of the extra step; it is meant to be mildly annoying.
+
 The mirrors are not a CEL evaluator and this file does not claim the expressions compile;
 that is the API server's job on first apply. What it does claim is that the two
 descriptions of a task pod have not diverged.
 """
 
+import hashlib
+import re
 from pathlib import Path
 
 import dispatcher
@@ -43,10 +51,23 @@ def bindings(documents):
     return [d for d in documents if d["kind"] == "ValidatingAdmissionPolicyBinding"]
 
 
+@pytest.fixture(autouse=True)
+def deployed_image(monkeypatch):
+    """The task image the dispatcher was deployed with.
+
+    Set here rather than written over the manifest afterwards. a_job() used to overwrite
+    containers[0]["image"] on the way out, which meant the image rule was the one rule
+    never checked against a value job_manifest() actually produced — it was checked
+    against the fixture. AGENT_IMAGE defaults to "" in a test process, and "" is exactly
+    what a deploy.sh that failed to substitute the tag would emit, so the old fixture hid
+    the one input the rule exists to reject.
+    """
+    monkeypatch.setattr(dispatcher, "AGENT_IMAGE", GOOD_IMAGE)
+
+
 def a_job(**pod_overrides) -> dict:
     """A real job_manifest() with the pod spec optionally mutated."""
     job = dispatcher.job_manifest("abc123456789", {"repo": "pytorch/pytorch", "task": "hello"})
-    job["spec"]["template"]["spec"]["containers"][0]["image"] = GOOD_IMAGE
     job["spec"]["template"]["spec"].update(pod_overrides)
     return job
 
@@ -298,3 +319,71 @@ def test_the_job_pass_is_scoped_to_the_dispatchers_service_account(policy):
     assert "request.kind.kind != 'Job'" in expression, (
         "the condition must exempt non-Job requests, or it disables the Pod pass"
     )
+
+
+# Every rule's expression, pinned by digest of its whitespace-normalised text.
+#
+# The MIRRORS table above is keyed by MESSAGE, which cannot see an expression edited in
+# place with its message untouched — and that is the drift most likely to actually happen,
+# because tightening a rule rarely changes what it is called. Pinning the expression means
+# such an edit fails here, and the only way to make it pass is to open the mirror beside it
+# and decide whether it still describes the rule. Re-pin deliberately, never by pasting the
+# digest the failure prints without reading the diff it is telling you about.
+EXPRESSION_DIGESTS = {
+    "task pods must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)": "93161384aabc",
+    "task pods must run as serviceAccountName: sandbox-agent, which holds no RBAC": "2779cb7d8a6b",
+    "task pods must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox": "224303faac17",
+    "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": "cf1eae68cdb1",
+    "task pods must use the default scheduler — an alternate scheduler need not honour the RuntimeClass node selector": "d76e4a690cdc",
+    "task pods must not share host namespaces (hostNetwork/hostPID/hostIPC)": "1cafda1b80d7",
+    "task pods must declare no volumes — see the module README before adding one": "0ad2da654e90",
+    "task pods must claim no devices — a resource claim can attach host hardware and its mounts": "164b13576611",
+    "task pods must set no sysctls": "64b91d2f9f8f",
+    "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox": "2d6ca10e9119",
+    "a task pod runs exactly one container": "88ba5a9fb243",
+    "task pods must declare no init containers": "37fef9251087",
+    "task containers must not use envFrom — it pulls a whole Secret or ConfigMap into the sandbox": "89e7123f9143",
+    "task container env must be literal values — valueFrom reads Secrets, ConfigMaps and pod fields into the sandbox": "794a441e820d",
+    "task containers must set allowPrivilegeEscalation: false and runAsNonRoot: true, and must not be privileged": "97536754281c",
+    "task containers must not add Linux capabilities": "ddba99823b9e",
+    "task containers must not unmask /proc": "9befcf62623e",
+    "task containers must not publish a hostPort": "aadf2d231816",
+    "task containers must set cpu, memory and ephemeral-storage limits": "c6288f00cdd5",
+    "task containers must request exactly what they limit (Guaranteed QoS)": "e3569a0a6e49",
+    "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it": "3bf5faca144b",
+    "task Jobs must run one pod at a time (parallelism: 1)": "240258b6ce47",
+    "task Jobs must run exactly one pod (completions: 1)": "dd57deb1df82",
+    "task Jobs must set backoffLimit: 0 — a retry re-clones and re-prompts the model, and bills for it": "80f672103226",
+    "task Job pod templates must carry the app: sandbox-task label": "ab1151632d34",
+}
+
+
+def _digest(expression: str) -> str:
+    return hashlib.sha256(re.sub(r"\s+", " ", expression).strip().encode()).hexdigest()[:12]
+
+
+def test_no_expression_changed_without_its_mirror_being_rechecked(policy):
+    """Keying the mirrors by message leaves in-place expression edits invisible."""
+    live = {v["message"]: _digest(v["expression"]) for v in policy["spec"]["validations"]}
+    drifted = {
+        message: digest
+        for message, digest in live.items()
+        if message in EXPRESSION_DIGESTS and EXPRESSION_DIGESTS[message] != digest
+    }
+    assert not drifted, (
+        "the CEL expression changed but its message did not, so nothing else in this file "
+        f"would have noticed: {sorted(drifted)}. Re-read each rule's Python mirror, then "
+        f"re-pin: {drifted}"
+    )
+    assert set(live) == set(EXPRESSION_DIGESTS), {
+        "unpinned (add to EXPRESSION_DIGESTS)": sorted(set(live) - set(EXPRESSION_DIGESTS)),
+        "stale (no longer in the policy)": sorted(set(EXPRESSION_DIGESTS) - set(live)),
+    }
+
+
+def test_an_unsubstituted_task_image_is_rejected(monkeypatch):
+    """The production failure the image rule exists for: deploy.sh not substituting the
+    tag, so AGENT_IMAGE is empty and every task pod would run whatever that resolves to."""
+    monkeypatch.setattr(dispatcher, "AGENT_IMAGE", "")
+    predicate, _ = MIRRORS["task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox"]
+    assert not predicate(a_job())

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -1,0 +1,189 @@
+"""The task-Job admission policy, checked against the Job the dispatcher actually builds.
+
+admissionpolicy.yaml is a second copy of the isolation contract that job_manifest()
+already implements, written in CEL and enforced by the API server. Two copies of one
+contract drift, and the way they drift is silent: job_manifest() changes, the cluster
+starts rejecting every task, and the first symptom is a dispatch error in production.
+
+So each CEL validation is mirrored here as a Python predicate, keyed by the policy's own
+message string. The test then asserts three things: every validation in the YAML has a
+mirror (adding a CEL rule without one fails here), the real job_manifest() output
+satisfies all of them, and each rule actually rejects the thing it names — a mirror that
+accepts everything would otherwise pass quietly.
+
+The mirrors are not a CEL evaluator and this file does not claim the expressions compile;
+that is the API server's job on first apply. What it does claim is that the two
+descriptions of a task pod have not diverged.
+"""
+
+from pathlib import Path
+
+import dispatcher
+import pytest
+import yaml
+
+POLICY_PATH = Path(__file__).resolve().parent.parent / "kubernetes" / "base" / "admissionpolicy.yaml"
+
+# The tag deploy.sh substitutes is a content hash; only the repository is pinned.
+GOOD_IMAGE = "harbor:30002/osdc/ci-agent-sandbox:0123456789ab"
+
+
+@pytest.fixture(scope="module")
+def documents():
+    return list(yaml.safe_load_all(POLICY_PATH.read_text()))
+
+
+@pytest.fixture(scope="module")
+def policy(documents):
+    return next(d for d in documents if d["kind"] == "ValidatingAdmissionPolicy")
+
+
+@pytest.fixture(scope="module")
+def binding(documents):
+    return next(d for d in documents if d["kind"] == "ValidatingAdmissionPolicyBinding")
+
+
+def a_job(**pod_overrides) -> dict:
+    """A real job_manifest() with the pod spec optionally mutated."""
+    job = dispatcher.job_manifest("abc123456789", {"repo": "pytorch/pytorch", "task": "hello"})
+    job["spec"]["template"]["spec"]["containers"][0]["image"] = GOOD_IMAGE
+    job["spec"]["template"]["spec"].update(pod_overrides)
+    return job
+
+
+def _pod(job):
+    return job["spec"]["template"]["spec"]
+
+
+def _all_containers(job):
+    return _pod(job)["containers"] + _pod(job).get("initContainers", [])
+
+
+# Each entry mirrors one `validations:` item, keyed by the exact `message:` string in the
+# YAML, and paired with a Job the rule must reject. Keeping the message as the key is what
+# makes drift loud: reword a message in the policy and this test names the rule that lost
+# its mirror.
+MIRRORS = {
+    "task Jobs must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)": (
+        lambda j: _pod(j).get("runtimeClassName") == "gvisor",
+        lambda: a_job(runtimeClassName="runc"),
+    ),
+    "task Jobs must run as serviceAccountName: sandbox-agent, which holds no RBAC": (
+        lambda j: _pod(j).get("serviceAccountName") == "sandbox-agent",
+        lambda: a_job(serviceAccountName="sandbox-dispatcher"),
+    ),
+    "task Jobs must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox": (
+        lambda j: _pod(j).get("automountServiceAccountToken") is False,
+        lambda: a_job(automountServiceAccountToken=True),
+    ),
+    "task Jobs must not share host namespaces (hostNetwork/hostPID/hostIPC)": (
+        lambda j: not any(_pod(j).get(k) for k in ("hostNetwork", "hostPID", "hostIPC")),
+        lambda: a_job(hostPID=True),
+    ),
+    "task Jobs must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": (
+        lambda j: "nodeName" not in _pod(j),
+        lambda: a_job(nodeName="ip-10-0-0-1"),
+    ),
+    "task Jobs must declare no volumes — see the module README before adding one": (
+        lambda j: not _pod(j).get("volumes"),
+        lambda: a_job(volumes=[{"name": "host", "hostPath": {"path": "/"}}]),
+    ),
+    "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox": (
+        lambda j: all(c["image"].startswith("harbor:30002/osdc/ci-agent-sandbox:") for c in _all_containers(j)),
+        lambda: a_job(containers=[{**a_job()["spec"]["template"]["spec"]["containers"][0], "image": "docker.io/alpine"}]),
+    ),
+    "a task Job runs exactly one container": (
+        lambda j: len(_pod(j)["containers"]) == 1,
+        lambda: a_job(containers=a_job()["spec"]["template"]["spec"]["containers"] * 2),
+    ),
+    "task containers must not use envFrom — it pulls a whole Secret or ConfigMap into the sandbox": (
+        lambda j: all(not c.get("envFrom") for c in _all_containers(j)),
+        lambda: _with_container(envFrom=[{"secretRef": {"name": "bedrock"}}]),
+    ),
+    "task container env must be literal values — valueFrom reads Secrets, ConfigMaps and pod fields into the sandbox": (
+        lambda j: all(all("valueFrom" not in e for e in c.get("env", [])) for c in _all_containers(j)),
+        lambda: _with_container(env=[{"name": "X", "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}}}]),
+    ),
+    "task containers must set allowPrivilegeEscalation: false and runAsNonRoot: true, and must not be privileged": (
+        lambda j: all(
+            c.get("securityContext", {}).get("allowPrivilegeEscalation") is False
+            and c.get("securityContext", {}).get("privileged") in (None, False)
+            and c.get("securityContext", {}).get("runAsNonRoot") is True
+            for c in _all_containers(j)
+        ),
+        lambda: _with_container(securityContext={"privileged": True, "runAsNonRoot": True, "allowPrivilegeEscalation": False}),
+    ),
+    "task containers must not add Linux capabilities": (
+        lambda j: all(not c.get("securityContext", {}).get("capabilities", {}).get("add") for c in _all_containers(j)),
+        lambda: _with_container(
+            securityContext={
+                "runAsNonRoot": True,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"add": ["SYS_ADMIN"]},
+            }
+        ),
+    ),
+    "task containers must set cpu, memory and ephemeral-storage limits": (
+        lambda j: all(
+            {"cpu", "memory", "ephemeral-storage"} <= set(c.get("resources", {}).get("limits", {}))
+            for c in _all_containers(j)
+        ),
+        lambda: _with_container(resources={"requests": {"cpu": "2"}}),
+    ),
+    "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it": (
+        lambda j: 0 < j["spec"].get("activeDeadlineSeconds", 0) <= 3600,
+        lambda: _without_deadline(),
+    ),
+}
+
+
+def _with_container(**container_overrides) -> dict:
+    """A Job whose single container carries the given overrides."""
+    job = a_job()
+    _pod(job)["containers"][0].update(container_overrides)
+    return job
+
+
+def _without_deadline() -> dict:
+    job = a_job()
+    del job["spec"]["activeDeadlineSeconds"]
+    return job
+
+
+def test_every_validation_has_a_mirror(policy):
+    """A CEL rule added without a Python mirror is a rule this file silently stops covering."""
+    messages = {v["message"] for v in policy["spec"]["validations"]}
+    assert messages == set(MIRRORS), {
+        "unmirrored (add to MIRRORS)": sorted(messages - set(MIRRORS)),
+        "stale (no longer in the policy)": sorted(set(MIRRORS) - messages),
+    }
+
+
+@pytest.mark.parametrize("message", sorted(MIRRORS))
+def test_real_job_manifest_satisfies_the_policy(message):
+    """What dispatcher.py builds today would be admitted."""
+    predicate, _ = MIRRORS[message]
+    assert predicate(a_job()), f"job_manifest() violates: {message}"
+
+
+@pytest.mark.parametrize("message", sorted(MIRRORS))
+def test_each_rule_rejects_its_own_violation(message):
+    """A mirror that accepts everything passes the test above for the wrong reason."""
+    predicate, violating = MIRRORS[message]
+    assert not predicate(violating()), f"mirror does not actually enforce: {message}"
+
+
+def test_binding_denies_rather_than_warns(policy, binding):
+    """A policy with no binding, or a binding set to Warn, enforces nothing while looking applied."""
+    assert binding["spec"]["policyName"] == policy["metadata"]["name"]
+    assert binding["spec"]["validationActions"] == ["Deny"]
+    assert binding["spec"]["matchResources"]["namespaceSelector"]["matchLabels"] == {
+        "kubernetes.io/metadata.name": "ai-sandbox"
+    }
+
+
+def test_policy_fails_closed_and_covers_job_writes(policy):
+    assert policy["spec"]["failurePolicy"] == "Fail"
+    rule = policy["spec"]["matchConstraints"]["resourceRules"][0]
+    assert rule["apiGroups"] == ["batch"] and rule["resources"] == ["jobs"]
+    assert set(rule["operations"]) == {"CREATE", "UPDATE"}

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -172,6 +172,14 @@ MIRRORS = {
         lambda j: j["spec"].get("backoffLimit") == 0,
         lambda: _with_job_field(backoffLimit=6),
     ),
+    "task Job pod templates must carry the app: sandbox-task label": (
+        lambda j: j["spec"]["template"]["metadata"]["labels"].get("app") == "sandbox-task",
+        lambda: _with_template_labels({"app": "something-else"}),
+    ),
+    "task containers must request exactly what they limit (Guaranteed QoS)": (
+        lambda j: all(c["resources"]["requests"] == c["resources"]["limits"] for c in _all_containers(j)),
+        lambda: _with_container(resources={"requests": {"cpu": "1"}, "limits": {"cpu": "8"}}),
+    ),
 }
 
 
@@ -185,6 +193,12 @@ def _with_container(**container_overrides) -> dict:
 def _with_job_field(**job_overrides) -> dict:
     job = a_job()
     job["spec"].update(job_overrides)
+    return job
+
+
+def _with_template_labels(labels: dict) -> dict:
+    job = a_job()
+    job["spec"]["template"]["metadata"]["labels"] = labels
     return job
 
 
@@ -262,3 +276,19 @@ def test_policy_fails_closed_and_covers_both_kinds(policy):
     }
     assert (("batch",), ("jobs",), frozenset({"CREATE", "UPDATE"})) in rules
     assert (("",), ("pods",), frozenset({"CREATE", "UPDATE"})) in rules
+
+
+def test_the_job_pass_is_scoped_to_the_dispatchers_service_account(policy):
+    """Scoping it to the one process holding create-Job RBAC is what lets the namespace
+    also hold an ordinary maintenance Job (the JWKS refresher) without that Job having to
+    satisfy a contract written for untrusted agent workloads.
+
+    The Pod pass must stay unconditional: pods are created by the Job controller, so a
+    blanket userInfo condition would switch the second pass off entirely."""
+    conditions = policy["spec"]["matchConditions"]
+    assert len(conditions) == 1
+    expression = conditions[0]["expression"]
+    assert "system:serviceaccount:ai-sandbox:sandbox-dispatcher" in expression
+    assert "request.kind.kind != 'Job'" in expression, (
+        "the condition must exempt non-Job requests, or it disables the Pod pass"
+    )

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -215,6 +215,25 @@ MIRRORS = {
         ),
         lambda: _with_container(resources={"requests": {"cpu": "2"}}),
     ),
+    "task containers must limit cpu, memory and ephemeral-storage and nothing else — any other key is an unapproved resource, device requests among them": (
+        lambda j: all(
+            set(c.get("resources", {}).get("limits", {})) <= {"cpu", "memory", "ephemeral-storage"}
+            for c in _all_containers(j)
+        ),
+        # requests mirrors limits on purpose: Kubernetes requires that of an extended
+        # resource, so this counterexample satisfies both the rule above and Guaranteed
+        # QoS, and only this rule can reject it. That is the whole finding.
+        lambda: _with_container(
+            resources={
+                "requests": {"cpu": "2", "memory": "8Gi", "ephemeral-storage": "50Gi", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "2", "memory": "8Gi", "ephemeral-storage": "50Gi", "nvidia.com/gpu": "1"},
+            }
+        ),
+    ),
+    "task pods must not set terminationGracePeriodSeconds above 60 — the Job deadline triggers termination, this caps the grace period configured for it": (
+        lambda j: _pod(j).get("terminationGracePeriodSeconds", 30) <= 60,
+        lambda: a_job(terminationGracePeriodSeconds=3600),
+    ),
     "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it": (
         lambda j: 0 < j["spec"].get("activeDeadlineSeconds", 0) <= 3600,
         lambda: _without_job_field("activeDeadlineSeconds"),
@@ -265,6 +284,24 @@ def _without_job_field(name: str) -> dict:
     job = a_job()
     del job["spec"][name]
     return job
+
+
+def test_validation_messages_are_distinct(policy):
+    """Both coverage tables are keyed by message, so a repeat is a rule that loses both.
+
+    MIRRORS and EXPRESSION_DIGESTS are dicts keyed by the `message:` string, and the two
+    tests below them compare KEY SETS. Give two validations the same message and each
+    table keeps one entry for the pair, both set comparisons still pass, and one of the
+    two rules is left with no Python mirror and no pinned expression — which is the
+    coverage those tests exist to guarantee. What fails, if anything does, depends on
+    which of the two came last in the file. This is the assertion that does not.
+    """
+    messages = [v["message"] for v in policy["spec"]["validations"]]
+    duplicates = sorted({m for m in messages if messages.count(m) > 1})
+    assert not duplicates, (
+        "two validations share a message, so MIRRORS and EXPRESSION_DIGESTS each hold one "
+        f"entry for the pair and neither key-set comparison can see it: {duplicates}"
+    )
 
 
 def test_every_validation_has_a_mirror(policy):
@@ -382,7 +419,12 @@ def test_the_job_pass_is_scoped_to_the_dispatchers_service_account(policy):
     )
 
 
-# Every rule's expression, pinned by digest of its whitespace-normalised text.
+# Every rule's expression, pinned by digest of its WHITESPACE-NORMALISED text — _digest()
+# collapses every run of whitespace before hashing, so that a rule rewrapped across lines
+# is not reported as a change. The cost is the one blind spot this table has: whitespace
+# INSIDE a quoted CEL string literal is a semantic change that leaves the digest alone,
+# and nothing else in this file would see it either. No expression here contains a literal
+# with a space in it today; if one ever does, that rule needs its own assertion.
 #
 # The MIRRORS table above is keyed by MESSAGE, which cannot see an expression edited in
 # place with its message untouched — and that is the drift most likely to actually happen,
@@ -410,7 +452,9 @@ EXPRESSION_DIGESTS = {
     "task containers must not unmask /proc": "9befcf62623e",
     "task containers must not publish a hostPort": "aadf2d231816",
     "task containers must set cpu, memory and ephemeral-storage limits": "c6288f00cdd5",
+    "task containers must limit cpu, memory and ephemeral-storage and nothing else — any other key is an unapproved resource, device requests among them": "890db686ccb0",
     "task containers must request exactly what they limit (Guaranteed QoS)": "e3569a0a6e49",
+    "task pods must not set terminationGracePeriodSeconds above 60 — the Job deadline triggers termination, this caps the grace period configured for it": "4490bf5bfaf0",
     "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it": "3bf5faca144b",
     "task Jobs must run one pod at a time (parallelism: 1)": "240258b6ce47",
     "task Jobs must run exactly one pod (completions: 1)": "dd57deb1df82",

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -39,8 +39,8 @@ def policy(documents):
 
 
 @pytest.fixture(scope="module")
-def binding(documents):
-    return next(d for d in documents if d["kind"] == "ValidatingAdmissionPolicyBinding")
+def bindings(documents):
+    return [d for d in documents if d["kind"] == "ValidatingAdmissionPolicyBinding"]
 
 
 def a_job(**pod_overrides) -> dict:
@@ -64,35 +64,51 @@ def _all_containers(job):
 # makes drift loud: reword a message in the policy and this test names the rule that lost
 # its mirror.
 MIRRORS = {
-    "task Jobs must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)": (
+    "task pods must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)": (
         lambda j: _pod(j).get("runtimeClassName") == "gvisor",
         lambda: a_job(runtimeClassName="runc"),
     ),
-    "task Jobs must run as serviceAccountName: sandbox-agent, which holds no RBAC": (
+    "task pods must run as serviceAccountName: sandbox-agent, which holds no RBAC": (
         lambda j: _pod(j).get("serviceAccountName") == "sandbox-agent",
         lambda: a_job(serviceAccountName="sandbox-dispatcher"),
     ),
-    "task Jobs must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox": (
+    "task pods must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox": (
         lambda j: _pod(j).get("automountServiceAccountToken") is False,
         lambda: a_job(automountServiceAccountToken=True),
     ),
-    "task Jobs must not share host namespaces (hostNetwork/hostPID/hostIPC)": (
+    "task pods must not share host namespaces (hostNetwork/hostPID/hostIPC)": (
         lambda j: not any(_pod(j).get(k) for k in ("hostNetwork", "hostPID", "hostIPC")),
         lambda: a_job(hostPID=True),
     ),
-    "task Jobs must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": (
+    "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector": (
         lambda j: "nodeName" not in _pod(j),
         lambda: a_job(nodeName="ip-10-0-0-1"),
     ),
-    "task Jobs must declare no volumes — see the module README before adding one": (
+    "task pods must use the default scheduler — an alternate scheduler need not honour the RuntimeClass node selector": (
+        lambda j: _pod(j).get("schedulerName", "default-scheduler") == "default-scheduler",
+        lambda: a_job(schedulerName="my-scheduler"),
+    ),
+    "task pods must declare no volumes — see the module README before adding one": (
         lambda j: not _pod(j).get("volumes"),
         lambda: a_job(volumes=[{"name": "host", "hostPath": {"path": "/"}}]),
+    ),
+    "task pods must claim no devices — a resource claim can attach host hardware and its mounts": (
+        lambda j: not _pod(j).get("resourceClaims"),
+        lambda: a_job(resourceClaims=[{"name": "gpu", "resourceClaimName": "gpu"}]),
+    ),
+    "task pods must set no sysctls": (
+        lambda j: not _pod(j).get("securityContext", {}).get("sysctls"),
+        lambda: a_job(securityContext={"sysctls": [{"name": "net.core.somaxconn", "value": "1024"}]}),
+    ),
+    "task pods must declare no init containers": (
+        lambda j: not _pod(j).get("initContainers"),
+        lambda: a_job(initContainers=[{"name": "sidecar", "image": GOOD_IMAGE, "restartPolicy": "Always"}]),
     ),
     "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox": (
         lambda j: all(c["image"].startswith("harbor:30002/osdc/ci-agent-sandbox:") for c in _all_containers(j)),
         lambda: a_job(containers=[{**a_job()["spec"]["template"]["spec"]["containers"][0], "image": "docker.io/alpine"}]),
     ),
-    "a task Job runs exactly one container": (
+    "a task pod runs exactly one container": (
         lambda j: len(_pod(j)["containers"]) == 1,
         lambda: a_job(containers=a_job()["spec"]["template"]["spec"]["containers"] * 2),
     ),
@@ -123,6 +139,16 @@ MIRRORS = {
             }
         ),
     ),
+    "task containers must not unmask /proc": (
+        lambda j: all(c.get("securityContext", {}).get("procMount", "Default") == "Default" for c in _all_containers(j)),
+        lambda: _with_container(
+            securityContext={"runAsNonRoot": True, "allowPrivilegeEscalation": False, "procMount": "Unmasked"}
+        ),
+    ),
+    "task containers must not publish a hostPort": (
+        lambda j: all("hostPort" not in p for c in _all_containers(j) for p in c.get("ports", [])),
+        lambda: _with_container(ports=[{"containerPort": 8080, "hostPort": 8080}]),
+    ),
     "task containers must set cpu, memory and ephemeral-storage limits": (
         lambda j: all(
             {"cpu", "memory", "ephemeral-storage"} <= set(c.get("resources", {}).get("limits", {}))
@@ -132,7 +158,19 @@ MIRRORS = {
     ),
     "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it": (
         lambda j: 0 < j["spec"].get("activeDeadlineSeconds", 0) <= 3600,
-        lambda: _without_deadline(),
+        lambda: _without_job_field("activeDeadlineSeconds"),
+    ),
+    "task Jobs must run one pod at a time (parallelism: 1)": (
+        lambda j: j["spec"].get("parallelism", 1) == 1,
+        lambda: _with_job_field(parallelism=20),
+    ),
+    "task Jobs must run exactly one pod (completions: 1)": (
+        lambda j: j["spec"].get("completions", 1) == 1,
+        lambda: _with_job_field(completions=20),
+    ),
+    "task Jobs must set backoffLimit: 0 — a retry re-clones and re-prompts the model, and bills for it": (
+        lambda j: j["spec"].get("backoffLimit") == 0,
+        lambda: _with_job_field(backoffLimit=6),
     ),
 }
 
@@ -144,9 +182,15 @@ def _with_container(**container_overrides) -> dict:
     return job
 
 
-def _without_deadline() -> dict:
+def _with_job_field(**job_overrides) -> dict:
     job = a_job()
-    del job["spec"]["activeDeadlineSeconds"]
+    job["spec"].update(job_overrides)
+    return job
+
+
+def _without_job_field(name: str) -> dict:
+    job = a_job()
+    del job["spec"][name]
     return job
 
 
@@ -173,17 +217,48 @@ def test_each_rule_rejects_its_own_violation(message):
     assert not predicate(violating()), f"mirror does not actually enforce: {message}"
 
 
-def test_binding_denies_rather_than_warns(policy, binding):
-    """A policy with no binding, or a binding set to Warn, enforces nothing while looking applied."""
-    assert binding["spec"]["policyName"] == policy["metadata"]["name"]
-    assert binding["spec"]["validationActions"] == ["Deny"]
-    assert binding["spec"]["matchResources"]["namespaceSelector"]["matchLabels"] == {
-        "kubernetes.io/metadata.name": "ai-sandbox"
-    }
+def test_bindings_deny_rather_than_warn(policy, bindings):
+    """A policy with no binding, or one set to Warn, enforces nothing while looking applied."""
+    assert bindings, "the policy has no binding at all — it would be inert"
+    for b in bindings:
+        assert b["spec"]["policyName"] == policy["metadata"]["name"]
+        assert b["spec"]["validationActions"] == ["Deny"]
+        assert b["spec"]["matchResources"]["namespaceSelector"]["matchLabels"] == {
+            "kubernetes.io/metadata.name": "ai-sandbox"
+        }
 
 
-def test_policy_fails_closed_and_covers_job_writes(policy):
+def _binding_for(bindings, resource):
+    matches = [
+        b for b in bindings if any(r["resources"] == [resource] for r in b["spec"]["matchResources"]["resourceRules"])
+    ]
+    assert len(matches) == 1, f"expected exactly one binding covering {resource}, found {len(matches)}"
+    return matches[0]
+
+
+def test_the_job_pass_is_not_label_scoped(bindings):
+    """A Job that simply omitted the label would otherwise skip the policy entirely —
+    which is the bug this policy exists to catch."""
+    assert "objectSelector" not in _binding_for(bindings, "jobs")["spec"]["matchResources"]
+
+
+def test_the_pod_pass_selects_the_label_the_job_template_stamps(bindings):
+    """Validating only the Job template leaves the window a mutating webhook writes into:
+    the pod is created later, by the Job controller, from a template already passed. That
+    second pass is label-scoped, so a label drift in job_manifest() would silently switch
+    it off rather than fail anything — hence this test rather than a comment."""
+    selector = _binding_for(bindings, "pods")["spec"]["matchResources"]["objectSelector"]["matchLabels"]
+    template_labels = a_job()["spec"]["template"]["metadata"]["labels"]
+    assert selector.items() <= template_labels.items(), (
+        f"pod binding selects {selector}, but the Job template stamps {template_labels}"
+    )
+
+
+def test_policy_fails_closed_and_covers_both_kinds(policy):
     assert policy["spec"]["failurePolicy"] == "Fail"
-    rule = policy["spec"]["matchConstraints"]["resourceRules"][0]
-    assert rule["apiGroups"] == ["batch"] and rule["resources"] == ["jobs"]
-    assert set(rule["operations"]) == {"CREATE", "UPDATE"}
+    rules = {
+        (tuple(r["apiGroups"]), tuple(r["resources"]), frozenset(r["operations"]))
+        for r in policy["spec"]["matchConstraints"]["resourceRules"]
+    }
+    assert (("batch",), ("jobs",), frozenset({"CREATE", "UPDATE"})) in rules
+    assert (("",), ("pods",), frozenset({"CREATE", "UPDATE"})) in rules

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -498,7 +498,7 @@ def test_the_deadline_ceiling_admits_the_deadline_the_dispatcher_deploys(policy)
     loudly, but with nothing in this suite noticing beforehand."""
     rule = next(v for v in policy["spec"]["validations"] if "activeDeadlineSeconds" in v["expression"])
     ceiling = int(re.search(r"activeDeadlineSeconds <= (\d+)", rule["expression"]).group(1))
-    assert dispatcher.TASK_DEADLINE_S <= ceiling, (
+    assert ceiling >= dispatcher.TASK_DEADLINE_S, (
         f"the dispatcher's default deadline ({dispatcher.TASK_DEADLINE_S}s) exceeds the policy ceiling ({ceiling}s)"
     )
     deployed = _deployed_env("TASK_DEADLINE_S")

--- a/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
+++ b/osdc/modules/agent-sandbox/dispatcher/test_admissionpolicy.py
@@ -34,6 +34,7 @@ MODULE = Path(__file__).resolve().parent.parent
 POLICY_PATH = MODULE / "kubernetes" / "base" / "admissionpolicy.yaml"
 DEPLOY_SH = MODULE / "deploy.sh"
 DISPATCHER_MANIFEST = MODULE / "kubernetes" / "base" / "dispatcher.yaml"
+KUSTOMIZATION = MODULE / "kubernetes" / "base" / "kustomization.yaml"
 
 
 def _deployed_image_repository() -> str:
@@ -338,6 +339,10 @@ def test_each_rule_rejects_its_own_violation(message):
         # broke: the scheduler has bound the pod, so nodeName is set on every subsequent
         # UPDATE the Pod binding sees.
         ({"nodeName": "ip-10-0-0-1"}, False, "UPDATE", True),
+        # The fourth quadrant, and the one that keeps the exemption honest: a Job template
+        # is never bound by the scheduler, so nothing sets nodeName there. Drop the
+        # `not is_job` guard from the mirror and only this case reddens.
+        ({"nodeName": "ip-10-0-0-1"}, True, "UPDATE", False),
     ],
 )
 def test_the_nodename_rule_admits_a_bound_pod_on_update(pod, is_job, operation, admitted):
@@ -359,8 +364,12 @@ def test_bindings_deny_rather_than_warn(policy, bindings):
 
 
 def _binding_for(bindings, resource):
+    # Membership rather than list equality: the ephemeral-container gap the policy file
+    # prescribes closing is spelled `resources: ["pods", "pods/ephemeralcontainers"]` on
+    # the existing rule, and an `==` here would then report the Pod binding as missing —
+    # sending whoever makes that change after a helper rather than after their change.
     matches = [
-        b for b in bindings if any(r["resources"] == [resource] for r in b["spec"]["matchResources"]["resourceRules"])
+        b for b in bindings if any(resource in r["resources"] for r in b["spec"]["matchResources"]["resourceRules"])
     ]
     assert len(matches) == 1, f"expected exactly one binding covering {resource}, found {len(matches)}"
     return matches[0]
@@ -384,27 +393,183 @@ def test_the_pod_pass_selects_the_label_the_job_template_stamps(bindings):
     )
 
 
+# A Job field reached through `object`/`oldObject` rather than through `variables.pod`.
+#
+# `\s*` around the dots because CEL allows it there, and that is where an evasion would sit
+# (`object.spec .parallelism`). `\b` rather than a hand-built lookbehind: three rounds of
+# review each found a new hole in a cleverer predecessor — collapsing whitespace globally
+# welded `'app' in object.spec…` into one token and hid the real rule at the bottom of the
+# policy; collapsing it around dots then hid `'app' in .object.spec…`. A lexer is the only
+# thing that ends that regress, and a lexer is far too much machinery for a spelling lint.
+#
+# So this errs deliberately toward MATCHING. `variables.object.spec.x` — a member access on a
+# variable named `object`, which does not exist — would be flagged, as would a dotted path
+# inside a string literal such as `'registry/object.spec.image'`. Both cost a spurious RED on
+# a safe rule, which a maintainer reads and dismisses; the failure this test exists to prevent
+# is the opposite one, and is not on that list. Known misses, unchanged: a parenthesised
+# `(object.spec).suspend`, an access split by a CEL comment, and a future `variables` alias.
+_JOB_FIELD_ACCESS = re.compile(r"""(?<!['"])\b(?:old)?[Oo]bject\s*\.\s*spec\s*\.""")
+
+
+def _reaches_a_job_field(expression: str) -> bool:
+    return bool(_JOB_FIELD_ACCESS.search(expression))
+
+
+def test_the_kustomization_does_not_rewrite_the_dispatcher_identity():
+    """Why reading the identity off the source manifest is sound TODAY.
+
+    The test above derives `system:serviceaccount:<ns>:<sa>` from dispatcher.yaml, which is
+    the deployed value only because the base applies the manifests as written. Add a
+    `namespace:` or a name prefix here and the cluster sees a subject the policy's
+    matchCondition does not name — the Job pass switches off silently, and deriving from
+    source would go on agreeing with itself.
+
+    Scope, stated rather than implied: this is a denylist of the directives that can rewrite
+    an identity, so it is a tripwire on the deployment path staying simple, NOT a proof that
+    no rendering can change it. The complete answer is to render the kustomization and compare
+    the rendered Deployment against the rendered policy condition, which needs a kustomize
+    binary this unit suite does not have.
+    """
+    kustomization = yaml.safe_load(KUSTOMIZATION.read_text())
+    # Case-insensitively: kustomize decodes through Go's JSON decoder, which matches field
+    # names without regard to case, so a `Namespace:` key would apply and an exact-match
+    # denylist would not see it.
+    declared = {k.lower(): v for k, v in kustomization.items()}
+    rewriters = sorted(
+        k
+        for k in (
+            "namespace",
+            "namePrefix",
+            "nameSuffix",
+            "patches",
+            "patchesStrategicMerge",
+            "patchesJson6902",
+            "replacements",
+            "components",
+            "transformers",
+            # `nameReference` is transformer CONFIG, not a top-level key — but
+            # `configurations` is what loads one, and a custom ConfigMap nameReference
+            # pointed at spec/template/spec/serviceAccountName rewrites the identity with
+            # every other directive here untouched. `vars` is the deprecated route to the same.
+            "configurations",
+            "vars",
+            # Deprecated, but still accepted, and it takes a DIRECTORY — the same nested
+            # route the resources check below closes.
+            "bases",
+        )
+        if declared.get(k.lower())
+    )
+    assert not rewriters, (
+        f"{KUSTOMIZATION.name} now applies {rewriters}, which can change the identity the "
+        "dispatcher presents — derive it from the rendered output instead of dispatcher.yaml"
+    )
+
+    # A directory entry is a NESTED kustomization, which carries its own transformers — it
+    # could apply `namespace:` to the Deployment while every check above passes and
+    # dispatcher.yaml still reads the old subject. Requiring a bare filename in THIS
+    # directory, not merely something `is_file()` resolves, is what keeps the manifest this
+    # test reads and the manifest that deploys as the same file: `sub/x.yaml`, an absolute
+    # path and a symlink out of the tree all satisfy `is_file()` and none of them would.
+    def is_local_manifest(entry: str) -> bool:
+        path = KUSTOMIZATION.parent / entry
+        return entry == Path(entry).name and path.is_file() and not path.is_symlink()
+
+    resources = declared.get("resources") or []
+    nested = sorted(e for e in resources if not is_local_manifest(e))
+    assert not nested, (
+        f"{KUSTOMIZATION.name} pulls in {nested}, which is not a plain manifest in this "
+        "directory — a nested kustomization can rewrite the identity out of this test's sight"
+    )
+    # The check above bounds what MAY be deployed; this one is what makes the two manifests
+    # the test reads the ones that ARE. Swap dispatcher.yaml for a same-directory
+    # dispatcher-v2.yaml carrying a different subject and everything above stays green while
+    # the identity test goes on reading a file nobody applies.
+    for manifest in (DISPATCHER_MANIFEST, POLICY_PATH):
+        assert manifest.name in resources, (
+            f"{manifest.name} is no longer in {KUSTOMIZATION.name}'s resources, so the file "
+            "the identity tests read is not the file this module deploys"
+        )
+
+
+def test_job_only_rules_are_guarded_for_the_pod_pass(policy):
+    """One policy matches two kinds, so a rule reaching `object.spec` needs a kind guard.
+
+    Five validations reach Job fields through `object.spec` rather than through
+    `variables.pod`, and all five carry the `!variables.isJob ||` prefix. Nothing else
+    requires it, so this enforces the SPELLING CONVENTION rather than proving each rule
+    unsafe without it. Before this test, a sixth Job-level bound written without the prefix
+    shipped a green unit suite. What that costs depends on the shape. A
+    `!has(object.spec.ttlSeconds...)`
+    rule is harmless — `has()` on an absent field of a dynamically typed object is simply
+    false. A rule that DEREFERENCES the field (`object.spec.ttlSecondsAfterFinished == 0`)
+    hits `no such key` on every task pod, and failurePolicy: Fail turns that evaluation
+    error into a denial: the Job controller can create no pod, and every /run hangs to its
+    deadline pointing at the Job controller rather than at the new rule.
+
+    Three things this does NOT prove, so nobody reads it as more than it is. It is textual,
+    so it sees neither an access through a future `variables` alias nor a parenthesised
+    spelling like `(object.spec).suspend`; a leading guard is not proof the whole expression
+    is protected, since a lower-precedence ternary later in the same expression can put a
+    dereference outside it; and the guard is not the only thing that can make a rule safe —
+    the `parallelism` and `completions` rules would also admit an absent field through their
+    own `!has(...)`. Splitting the Job bounds into a second policy whose matchConstraints
+    name only batch/jobs is what would make the guarantee structural instead.
+    """
+    unguarded = [
+        v["message"]
+        for v in policy["spec"]["validations"]
+        if _reaches_a_job_field(v["expression"]) and not v["expression"].lstrip().startswith("!variables.isJob ||")
+    ]
+    assert not unguarded, (
+        "these rules reach a Job field through object.spec without the `!variables.isJob ||` "
+        f"guard, so the Pod pass may deny every task pod: {unguarded}"
+    )
+
+
 def test_policy_fails_closed_and_covers_both_kinds(policy):
     assert policy["spec"]["failurePolicy"] == "Fail"
-    rules = {
-        (tuple(r["apiGroups"]), tuple(r["resources"]), frozenset(r["operations"]))
-        for r in policy["spec"]["matchConstraints"]["resourceRules"]
-    }
-    assert (("batch",), ("jobs",), frozenset({"CREATE", "UPDATE"})) in rules
-    assert (("",), ("pods",), frozenset({"CREATE", "UPDATE"})) in rules
+
+    # Membership, for the same reason _binding_for uses it: adding
+    # `pods/ephemeralcontainers` to the pods rule — the change this policy file prescribes
+    # — must not make this assertion claim the policy stopped covering pods.
+    # ONLY the resources list is relaxed to membership, and only so that adding
+    # `pods/ephemeralcontainers` — the change this policy file prescribes — does not make
+    # this assertion claim the Pod pass disappeared. apiGroups and operations stay exact:
+    # widening either is a change that should be read rather than absorbed here.
+    def covers(api_group: str, resource: str) -> bool:
+        return any(
+            r["apiGroups"] == [api_group]
+            and resource in r["resources"]
+            and set(r["operations"]) == {"CREATE", "UPDATE"}
+            for r in policy["spec"]["matchConstraints"]["resourceRules"]
+        )
+
+    assert covers("batch", "jobs"), "the Job pass matches nothing"
+    assert covers("", "pods"), "the Pod pass matches nothing"
 
 
 def test_the_job_pass_is_scoped_to_the_dispatchers_service_account(policy):
     """Scoping it to the one process holding create-Job RBAC is what lets the namespace
-    also hold an ordinary maintenance Job (the JWKS refresher) without that Job having to
+    also hold an ordinary maintenance Job (none exists today) without that Job having to
     satisfy a contract written for untrusted agent workloads.
+
+    The username is DERIVED from the Deployment rather than restated here, for the same
+    reason the image repository is read out of deploy.sh: a hand-written copy would make
+    the one value that gates the whole Job pass the one value checked against this test's
+    own opinion. Its drift also fails open — rename the SA or the namespace everywhere but
+    admissionpolicy.yaml and no Job request satisfies the condition, so every Job the
+    dispatcher creates is admitted unchecked, silently and with this suite green.
 
     The Pod pass must stay unconditional: pods are created by the Job controller, so a
     blanket userInfo condition would switch the second pass off entirely."""
     conditions = policy["spec"]["matchConditions"]
     assert len(conditions) == 1
     expression = conditions[0]["expression"]
-    assert "system:serviceaccount:ai-sandbox:sandbox-dispatcher" in expression
+    assert f"'{_deployed_dispatcher_identity()}'" in expression, (
+        f"the condition names a subject the module does not deploy; the Deployment runs as "
+        f"{_deployed_dispatcher_identity()}, so no Job request would satisfy it and the Job "
+        f"pass would be off: {expression}"
+    )
     assert "request.kind.kind != 'Job'" in expression, (
         "the condition must exempt non-Job requests, or it disables the Pod pass"
     )
@@ -466,8 +631,8 @@ EXPRESSION_DIGESTS = {
 # The expressions every pod-level rule is READ THROUGH, and the one that decides whether
 # a request is evaluated at all. EXPRESSION_DIGESTS covers `validations` only, so before
 # this a rewrite of `variables.pod` — the ternary that keeps the Job pass and the Pod pass
-# looking at the same fields — silently changed the meaning of the twenty rules that read
-# it, with nothing in this file able to see the edit.
+# looking at the same fields — silently changed the meaning of every pod-level rule that
+# reads it, with nothing in this file able to see the edit.
 MATCH_CONDITION_DIGESTS = {
     "job-writes-come-from-the-dispatcher": "7946d5ff4d30",
 }
@@ -551,6 +716,28 @@ def test_the_deadline_ceiling_admits_the_deadline_the_dispatcher_deploys(policy)
     )
 
 
+def _dispatcher_deployment() -> dict:
+    return next(
+        d
+        for d in yaml.safe_load_all(DISPATCHER_MANIFEST.read_text())
+        if d and d["kind"] == "Deployment" and d["metadata"]["name"] == "sandbox-dispatcher"
+    )
+
+
+def _deployed_dispatcher_identity() -> str:
+    """The API-server username the dispatcher actually presents, read off its Deployment.
+
+    Read from the source manifest rather than from a rendered kustomization, which is only
+    sound while the base applies no identity-changing transformer.
+    test_the_kustomization_does_not_rewrite_the_dispatcher_identity is a tripwire on the
+    directives that could — a denylist, not a proof that none can.
+    """
+    deployment = _dispatcher_deployment()
+    namespace = deployment["metadata"]["namespace"]
+    service_account = deployment["spec"]["template"]["spec"]["serviceAccountName"]
+    return f"system:serviceaccount:{namespace}:{service_account}"
+
+
 def _deployed_env(name: str) -> str | None:
     """The literal value dispatcher.yaml sets for an env var, or None if it sets none.
 
@@ -558,11 +745,7 @@ def _deployed_env(name: str) -> str | None:
     both would quietly turn the comparison below into a no-op — so an `envFrom` block, or
     a `valueFrom` on this variable, fails here instead.
     """
-    deployment = next(
-        d
-        for d in yaml.safe_load_all(DISPATCHER_MANIFEST.read_text())
-        if d and d["kind"] == "Deployment" and d["metadata"]["name"] == "sandbox-dispatcher"
-    )
+    deployment = _dispatcher_deployment()
     for container in deployment["spec"]["template"]["spec"]["containers"]:
         assert not container.get("envFrom"), (
             f"{container['name']} pulls env from an envFrom source, which could set {name} out of this test's sight"

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -40,6 +40,19 @@
 #     Pod pass. No mutating webhook is configured in this repo today.
 #   - A Job created by some OTHER identity with create-Job RBAC (a cluster admin) is not
 #     checked by the Job pass. Its pods still are, if they carry the task label.
+#   - An EPHEMERAL container attached to a running task pod is the same shape of gap as
+#     the one above, and needs less: matchConstraints names `pods`, which does not cover
+#     the `pods/ephemeralcontainers` subresource, and allContainers below sums containers
+#     and initContainers only — so a `kubectl debug` container would carry whatever image
+#     and securityContext it liked. Nothing in this module can do it, because neither the
+#     dispatcher's Role nor sandbox-agent grants that subresource; anyone else holding it
+#     in this cluster was not enumerated here. Closing it is three changes, not one: a
+#     `pods/ephemeralcontainers` rule in matchConstraints, the SAME rule added to the Pod
+#     binding below, and a validation rejecting `ephemeralContainers` outright. Rejection
+#     rather than folding them into allContainers, because an ephemeral container cannot
+#     carry resource requirements at all, so every rule here that demands limits would
+#     deny it — an allowlist for debug containers would be a separate design, not a
+#     wider `allContainers`.
 #   - It pins the image repository, not a digest — see the image rule for why.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -230,6 +243,27 @@ spec:
           'ephemeral-storage' in c.resources.limits)
       reason: Forbidden
       message: "task containers must set cpu, memory and ephemeral-storage limits"
+    # Present is not the same as "only these", and the difference is a device. The rule
+    # above admits a fourth key, and an extended resource is exactly that: Kubernetes
+    # already requires `nvidia.com/gpu`'s request to equal its limit, so such a key also
+    # satisfies the Guaranteed-QoS rule below by construction, and attaches hardware
+    # through the resources map rather than through resourceClaims — which is the door
+    # the resourceClaims rule above exists to close. Nothing lands today only because the
+    # ai-sandbox fleet advertises no device plugin, and that is a fleet shape rather than
+    # a rule.
+    #
+    # Written as an ALLOWLIST rather than a device denylist, so it also excludes keys that
+    # are not devices at all (hugepages-2Mi and the rest) — anything outside the three the
+    # dispatcher sizes a task with is a resource nobody here has approved.
+    #
+    # `all` over a MAP binds its iteration variable to the KEYS, so this tests key names
+    # and not quantities.
+    - expression: >-
+        variables.allContainers.all(c,
+          !has(c.resources) || !has(c.resources.limits) ||
+          c.resources.limits.all(k, k in ['cpu', 'memory', 'ephemeral-storage']))
+      reason: Forbidden
+      message: "task containers must limit cpu, memory and ephemeral-storage and nothing else — any other key is an unapproved resource, device requests among them"
     # Guaranteed QoS: requests == limits is what keeps fleet capacity a division rather
     # than a guess, and stops a task pod being the first thing evicted under pressure.
     #
@@ -246,6 +280,22 @@ spec:
           has(c.resources.requests) && c.resources.requests == c.resources.limits)
       reason: Forbidden
       message: "task containers must request exactly what they limit (Guaranteed QoS)"
+    # The deadline in the Job block below TRIGGERS termination; it does not bound when the
+    # node comes back. Deletion honours terminationGracePeriodSeconds, so a container that
+    # ignores SIGTERM goes on holding its node afterwards, and with the field unbounded
+    # that wait is unbounded too. This caps the configured value, which is the only part
+    # of it we set. It is deliberately NOT a hard bound on time past the deadline: the
+    # controller terminates asynchronously, and the kubelet may extend the grace once for
+    # a preStop hook. Read it as removing the unbounded case, not as a guarantee.
+    #
+    # `!has(...) ||` rather than the `has(...) &&` shape the isolation rules use, because
+    # here absence is correct: the Job template legitimately carries no value, and the
+    # API server defaults the field to 30 on the pod the controller then creates.
+    - expression: >-
+        !has(variables.pod.terminationGracePeriodSeconds) ||
+        variables.pod.terminationGracePeriodSeconds <= 60
+      reason: Forbidden
+      message: "task pods must not set terminationGracePeriodSeconds above 60 — the Job deadline triggers termination, this caps the grace period configured for it"
 
     # --- Job-level bounds, skipped on the Pod pass (a Pod has no such fields) ---------
     #

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -1,0 +1,174 @@
+# Cluster-side enforcement of the task-pod isolation contract.
+#
+# Today every isolation property of a task pod — gVisor, no service-account token, no
+# volumes, the task image and nothing else — is enforced by one Python function,
+# dispatcher.py's job_manifest(). The API server accepts whatever that function emits,
+# so a bug or a careless refactor there is enough to produce a task pod with no gVisor
+# and a mounted token, and nothing in the cluster would notice. RBAC does not help: the
+# dispatcher legitimately holds `create jobs`, and "create a Job" is not a verb that can
+# be narrowed to "create a Job shaped like this".
+#
+# This policy is the second copy of that contract, in the API server rather than in the
+# process that could be compromised. It is deliberately redundant with job_manifest() —
+# that is the point. Anything it rejects is either an attack or a bug in the dispatcher.
+#
+# It is also what makes it safe to put OIDC verification inside the dispatcher process
+# rather than in a separate pod in front of it: the worst case of a parser bug there is
+# arbitrary Job creation with the dispatcher's RBAC, and this bounds what an arbitrary
+# Job is allowed to look like.
+#
+# SCOPE: every Job in ai-sandbox, not just the dispatcher's. Fail-closed on purpose — a
+# future migration/maintenance Job in this namespace has to satisfy these rules or
+# explicitly amend them, rather than quietly getting a pod the sandbox contract forbids.
+#
+# NOT COVERED, and worth knowing before relying on this: it validates Jobs, not Pods. The
+# dispatcher has no `create pods` RBAC, so the Job template is the whole surface it can
+# reach — but a future grant of pod-create would route around this policy, and the
+# policy would need a Pod rule scoped to the sandbox-agent service account to follow.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: agent-sandbox-task-jobs
+  labels:
+    osdc.io/module: agent-sandbox
+spec:
+  # Fail: an API-server-side evaluation error (a malformed object reaching an
+  # expression, the policy failing to compile) rejects the Job. The alternative,
+  # Ignore, turns any such error into a silently unenforced isolation contract.
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+  variables:
+    # The Job's pod template. Everything below reads through this rather than
+    # re-spelling the path, so a wrong path is one edit rather than fifteen.
+    - name: pod
+      expression: "object.spec.template.spec"
+    # initContainers is absent today (v1 clones inside the task container). It is
+    # folded in here so that when the GITHUB_TOKEN init-container lands, it is covered
+    # by the image and privilege rules by default instead of by remembering to.
+    - name: allContainers
+      expression: >-
+        object.spec.template.spec.containers +
+        (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
+  validations:
+    # --- Isolation: the three properties the whole design rests on -----------------
+    #
+    # Each is written `has(x) && x == ...` rather than `!has(x) || x == ...`: an absent
+    # field must be a rejection, not a pass. A Job template that omits
+    # serviceAccountName does not inherit sandbox-agent — it gets `default` when the
+    # pod is created, which is a token-mounting account.
+    - expression: "has(variables.pod.runtimeClassName) && variables.pod.runtimeClassName == 'gvisor'"
+      reason: Forbidden
+      message: "task Jobs must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)"
+    - expression: "has(variables.pod.serviceAccountName) && variables.pod.serviceAccountName == 'sandbox-agent'"
+      reason: Forbidden
+      message: "task Jobs must run as serviceAccountName: sandbox-agent, which holds no RBAC"
+    - expression: "has(variables.pod.automountServiceAccountToken) && variables.pod.automountServiceAccountToken == false"
+      reason: Forbidden
+      message: "task Jobs must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox"
+
+    # --- No path from the pod to the node or to another pod's data -----------------
+    - expression: >-
+        (!has(variables.pod.hostNetwork) || !variables.pod.hostNetwork) &&
+        (!has(variables.pod.hostPID) || !variables.pod.hostPID) &&
+        (!has(variables.pod.hostIPC) || !variables.pod.hostIPC)
+      reason: Forbidden
+      message: "task Jobs must not share host namespaces (hostNetwork/hostPID/hostIPC)"
+    - expression: "!has(variables.pod.nodeName)"
+      reason: Forbidden
+      message: "task Jobs must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector"
+    # Volumes are how a secret, a hostPath or a projected token would get in. v1 task
+    # pods declare none at all, so the rule can be "none" rather than an allowlist of
+    # shapes; the init-container work that needs a shared emptyDir amends this line and
+    # says so in review.
+    - expression: "!has(variables.pod.volumes) || size(variables.pod.volumes) == 0"
+      reason: Forbidden
+      message: "task Jobs must declare no volumes — see the module README before adding one"
+
+    # --- The image, and nothing that can smuggle another one in --------------------
+    #
+    # The literal registry path is deliberate: this is security policy, so it belongs in
+    # git history and code review rather than in a deploy-time substitution. It pins the
+    # repository, not the tag — deploy.sh builds a fresh content-hash tag on every
+    # deploy, and pinning the tag here would reject in-flight Jobs from the previous
+    # dispatcher replicas for the length of every rollout.
+    - expression: "variables.allContainers.all(c, c.image.startsWith('harbor:30002/osdc/ci-agent-sandbox:'))"
+      reason: Forbidden
+      message: "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox"
+    - expression: "size(variables.pod.containers) == 1"
+      reason: Forbidden
+      message: "a task Job runs exactly one container"
+
+    # --- Nothing reads a Secret into the task pod ----------------------------------
+    #
+    # The task pod is the untrusted side and holds no identity by design; the sigv4
+    # proxy exists so that even the Bedrock credential stays outside it. envFrom and
+    # env[].valueFrom are the two ways a Secret or ConfigMap becomes an environment
+    # variable without a volume, so both are closed alongside the volumes rule above.
+    - expression: "variables.allContainers.all(c, !has(c.envFrom) || size(c.envFrom) == 0)"
+      reason: Forbidden
+      message: "task containers must not use envFrom — it pulls a whole Secret or ConfigMap into the sandbox"
+    - expression: "variables.allContainers.all(c, !has(c.env) || c.env.all(e, !has(e.valueFrom)))"
+      reason: Forbidden
+      message: "task container env must be literal values — valueFrom reads Secrets, ConfigMaps and pod fields into the sandbox"
+
+    # --- Privilege ------------------------------------------------------------------
+    - expression: >-
+        variables.allContainers.all(c,
+          has(c.securityContext) &&
+          has(c.securityContext.allowPrivilegeEscalation) && c.securityContext.allowPrivilegeEscalation == false &&
+          (!has(c.securityContext.privileged) || c.securityContext.privileged == false) &&
+          has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == true)
+      reason: Forbidden
+      message: "task containers must set allowPrivilegeEscalation: false and runAsNonRoot: true, and must not be privileged"
+    - expression: >-
+        variables.allContainers.all(c,
+          !has(c.securityContext) || !has(c.securityContext.capabilities) ||
+          !has(c.securityContext.capabilities.add) || size(c.securityContext.capabilities.add) == 0)
+      reason: Forbidden
+      message: "task containers must not add Linux capabilities"
+
+    # --- Cost and blast radius -------------------------------------------------------
+    #
+    # The ResourceQuota is the namespace-wide ceiling; these are the per-Job bounds it
+    # assumes. A Job with no limits is admitted by the quota only until the quota's own
+    # limits.* entries reject it, which surfaces as an unschedulable pod rather than a
+    # clear rejection — this says which rule was broken.
+    # `in` rather than has(): resources.limits is a map, and the CEL has() macro takes a
+    # field selection, which 'ephemeral-storage' cannot be spelled as.
+    - expression: >-
+        variables.allContainers.all(c,
+          has(c.resources) && has(c.resources.limits) &&
+          'cpu' in c.resources.limits && 'memory' in c.resources.limits &&
+          'ephemeral-storage' in c.resources.limits)
+      reason: Forbidden
+      message: "task containers must set cpu, memory and ephemeral-storage limits"
+    - expression: "has(object.spec.activeDeadlineSeconds) && object.spec.activeDeadlineSeconds <= 3600"
+      reason: Forbidden
+      message: "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it"
+
+---
+# The binding is what actually turns the policy on, and it is scoped to ai-sandbox by
+# namespace name. A ValidatingAdmissionPolicy with no binding is inert — a policy that
+# looks enforced in `kubectl get` and enforces nothing is the failure mode this comment
+# exists to prevent.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: agent-sandbox-task-jobs
+  labels:
+    osdc.io/module: agent-sandbox
+spec:
+  policyName: agent-sandbox-task-jobs
+  # Deny, not Warn or Audit: a warning on a Job that escapes the sandbox is a log line
+  # nobody reads. The dispatcher surfaces the rejection to its caller as a dispatch
+  # error, so a genuine bug here is loud rather than silent.
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ai-sandbox

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -210,8 +210,15 @@ spec:
       message: "task containers must set cpu, memory and ephemeral-storage limits"
     # Guaranteed QoS: requests == limits is what keeps fleet capacity a division rather
     # than a guess, and stops a task pod being the first thing evicted under pressure.
-    # Quantity equality in CEL is numeric, so "2" and "2000m" compare equal and this does
-    # not quietly become a formatting rule.
+    #
+    # This is a STRING comparison, not a numeric one — assume "2" and "2000m" do NOT
+    # compare equal here. (An earlier revision of this file claimed the opposite. Nothing
+    # we could run settles it: Kubernetes ships a `quantity()` CEL conversion library,
+    # which would have no purpose if a raw field access already yielded a number, so the
+    # string reading is the safe one to design against.) That is acceptable because
+    # job_manifest() emits the identical string on both sides, and because the failure
+    # direction is a rejection rather than an admission. Do not relax the rule on the
+    # assumption that it normalises units, and reach for `quantity()` if it ever needs to.
     - expression: >-
         variables.allContainers.all(c,
           has(c.resources.requests) && c.resources.requests == c.resources.limits)
@@ -255,9 +262,11 @@ spec:
 # nobody reads. The dispatcher surfaces the rejection to its caller as a dispatch error,
 # so a genuine bug here is loud rather than silent.
 #
-# Two bindings rather than one, because the two passes need different scopes. EVERY Job in
-# ai-sandbox is checked, with no label filter — a Job that simply omitted the label would
-# otherwise skip the policy entirely, which is exactly the bug this is here to catch.
+# Two bindings rather than one, because the two passes need different scopes. Neither
+# binding label-filters the Job pass — a Job that simply omitted the label would otherwise
+# skip the policy entirely, which is one of the bugs this is here to catch. The Job pass IS
+# narrowed, but by the policy's own `matchConditions` above, to Jobs created by the
+# dispatcher's service account; nothing in these bindings does it.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -27,12 +27,15 @@
 # SCOPE. The Job pass applies to Jobs created BY THE DISPATCHER'S SERVICE ACCOUNT, which
 # is the threat this exists for: a bug (or a JWT parser compromise) in the one process
 # that holds create-Job RBAC. Scoping it that way is also what lets the namespace hold an
-# ordinary maintenance Job — the JWKS refresher CronJob in oidc.yaml is the first — without
-# each one having to satisfy a contract written for untrusted agent workloads.
+# ordinary maintenance Job — none exists today — without each one having to satisfy a
+# contract written for untrusted agent workloads.
 #
 # WHAT IT STILL DOES NOT COVER, so nobody reads more into it than it does:
-#   - It does not stop a task pod REACHING the API server; that is NetworkPolicy's job,
-#     and networkpolicy.yaml documents why the IPv6-only CNI makes that best-effort.
+#   - It does not stop a task pod REACHING the API server, and NetworkPolicy does not
+#     either: sandbox-task-egress deliberately allows TCP 443 to any address, because
+#     GitHub's ranges move, and the API server answers on 443 like everything else. What
+#     keeps the task pod harmless there is that it carries no token (the automount rule
+#     above) and sandbox-agent holds no RBAC — not a network boundary.
 #   - A mutating webhook that also stripped the `app: sandbox-task` label would evade the
 #     Pod pass. No mutating webhook is configured in this repo today.
 #   - A Job created by some OTHER identity with create-Job RBAC (a cluster admin) is not
@@ -101,7 +104,18 @@ spec:
     # that is honoured by the scheduler, not by the kubelet. A pod that names its own
     # scheduler, or pins nodeName outright, is placed without anyone consulting it — and
     # a task pod on a base node sits beside the dispatcher's projected token.
-    - expression: "!has(variables.pod.nodeName)"
+    #
+    # EXEMPT ON POD UPDATE, and this is load-bearing rather than a softening. The scheduler
+    # sets spec.nodeName through the pods/binding subresource, which this policy does not
+    # match; from then on every pod this binding sees carries a nodeName. Without the
+    # exemption the rule denies every UPDATE to the pod's main resource — including the
+    # Job controller's removal of its batch.kubernetes.io/job-tracking finalizer, which is
+    # what lets status.succeeded reach 1. The dispatcher waits on exactly that field, so
+    # the visible symptom is not a security event: every task runs, prints its result, and
+    # then hangs until the dispatcher's own deadline. Nothing is lost by exempting it —
+    # spec.nodeName is immutable through the main resource, so the only writer is the
+    # binding subresource, which the rule never covered.
+    - expression: "!has(variables.pod.nodeName) || (!variables.isJob && request.operation == 'UPDATE')"
       reason: Forbidden
       message: "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector"
     - expression: "!has(variables.pod.schedulerName) || variables.pod.schedulerName == 'default-scheduler'"
@@ -194,10 +208,18 @@ spec:
 
     # --- Cost and blast radius -------------------------------------------------------
     #
-    # The ResourceQuota is the namespace-wide ceiling; these are the per-task bounds it
-    # assumes. A pod with no limits is admitted by the quota only until the quota's own
-    # limits.* entries reject it, which surfaces as an unschedulable pod rather than a
-    # clear rejection — this says which rule was broken.
+    # These rules check that limits are DECLARED, and that requests equal them. They put
+    # no ceiling on the VALUES, so one admitted task can still size itself to the whole
+    # namespace quota (25 CPU / 50Gi memory / 245Gi ephemeral in quota.yaml) and starve
+    # every other task — a denial of service against ourselves, not an escape, which is
+    # why it is a follow-up rather than a rule here: a ceiling means a fourth copy of the
+    # TASK_CPU/TASK_MEMORY/TASK_EPHEMERAL_STORAGE values, and comparing quantities needs
+    # CEL's quantity() library, which the smoke suite can exercise on a cluster but this
+    # change has no way to evaluate at review time.
+    #
+    # The quota already rejects a pod that declares no limits, since it tracks limits.*
+    # — so this rule is not what stops that pod, it is what names the reason. The quota's
+    # message is about a namespace-wide budget; this one is about the task contract.
     #
     # `in` rather than has(): resources.limits is a map, and the CEL has() macro takes a
     # field selection, which 'ephemeral-storage' cannot be spelled as.
@@ -230,6 +252,12 @@ spec:
     # One /run is one task pod. Without these, a single admitted Job could fan out to
     # `parallelism` pods and retry each of them, consuming the whole namespace quota from
     # one request that satisfied every rule above.
+    #
+    # The 3600 below is a second copy of the dispatcher's TASK_DEADLINE_S, which is env
+    # configurable and defaults to 900. Raise that env past 3600 and this rule rejects
+    # every Job — loudly, at dispatch, but with the unit suite green, so
+    # test_admissionpolicy.py reads the ceiling back out of this expression and compares
+    # it against both the dispatcher default and whatever dispatcher.yaml deploys.
     - expression: "!variables.isJob || (has(object.spec.activeDeadlineSeconds) && object.spec.activeDeadlineSeconds <= 3600)"
       reason: Forbidden
       message: "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it"

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -24,11 +24,19 @@
 # the template. The Pod pass is what closes that, scoped by the `app: sandbox-task` label
 # the Job template stamps on its pods.
 #
+# SCOPE. The Job pass applies to Jobs created BY THE DISPATCHER'S SERVICE ACCOUNT, which
+# is the threat this exists for: a bug (or a JWT parser compromise) in the one process
+# that holds create-Job RBAC. Scoping it that way is also what lets the namespace hold an
+# ordinary maintenance Job — the JWKS refresher CronJob in oidc.yaml is the first — without
+# each one having to satisfy a contract written for untrusted agent workloads.
+#
 # WHAT IT STILL DOES NOT COVER, so nobody reads more into it than it does:
 #   - It does not stop a task pod REACHING the API server; that is NetworkPolicy's job,
 #     and networkpolicy.yaml documents why the IPv6-only CNI makes that best-effort.
 #   - A mutating webhook that also stripped the `app: sandbox-task` label would evade the
 #     Pod pass. No mutating webhook is configured in this repo today.
+#   - A Job created by some OTHER identity with create-Job RBAC (a cluster admin) is not
+#     checked by the Job pass. Its pods still are, if they carry the task label.
 #   - It pins the image repository, not a digest — see the image rule for why.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -41,6 +49,13 @@ spec:
   # expression, the policy failing to compile) rejects the request. The alternative,
   # Ignore, turns any such error into a silently unenforced isolation contract.
   failurePolicy: Fail
+  # The Pod pass must stay unconditional here — pods are created by the Job controller,
+  # not by the dispatcher, so a blanket userInfo condition would switch it off entirely.
+  matchConditions:
+    - name: job-writes-come-from-the-dispatcher
+      expression: >-
+        request.kind.kind != 'Job' ||
+        request.userInfo.username == 'system:serviceaccount:ai-sandbox:sandbox-dispatcher'
   matchConstraints:
     resourceRules:
       - apiGroups: ["batch"]
@@ -193,6 +208,15 @@ spec:
           'ephemeral-storage' in c.resources.limits)
       reason: Forbidden
       message: "task containers must set cpu, memory and ephemeral-storage limits"
+    # Guaranteed QoS: requests == limits is what keeps fleet capacity a division rather
+    # than a guess, and stops a task pod being the first thing evicted under pressure.
+    # Quantity equality in CEL is numeric, so "2" and "2000m" compare equal and this does
+    # not quietly become a formatting rule.
+    - expression: >-
+        variables.allContainers.all(c,
+          has(c.resources.requests) && c.resources.requests == c.resources.limits)
+      reason: Forbidden
+      message: "task containers must request exactly what they limit (Guaranteed QoS)"
 
     # --- Job-level bounds, skipped on the Pod pass (a Pod has no such fields) ---------
     #
@@ -211,6 +235,16 @@ spec:
     - expression: "!variables.isJob || (has(object.spec.backoffLimit) && object.spec.backoffLimit == 0)"
       reason: Forbidden
       message: "task Jobs must set backoffLimit: 0 — a retry re-clones and re-prompts the model, and bills for it"
+    # This is what makes the Pod pass reachable. The Pod binding selects on
+    # app=sandbox-task, so a Job that did not stamp the label on its template would
+    # produce pods that skip the second pass entirely. Requiring it here means every Job
+    # this policy admits produces pods this policy also sees.
+    - expression: >-
+        !variables.isJob || (has(object.spec.template.metadata) && has(object.spec.template.metadata.labels) &&
+        'app' in object.spec.template.metadata.labels &&
+        object.spec.template.metadata.labels['app'] == 'sandbox-task')
+      reason: Forbidden
+      message: "task Job pod templates must carry the app: sandbox-task label"
 
 ---
 # The bindings are what actually turn the policy on. A ValidatingAdmissionPolicy with no

--- a/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/admissionpolicy.yaml
@@ -2,7 +2,7 @@
 #
 # Today every isolation property of a task pod — gVisor, no service-account token, no
 # volumes, the task image and nothing else — is enforced by one Python function,
-# dispatcher.py's job_manifest(). The API server accepts whatever that function emits,
+# the dispatcher's job_manifest(). The API server accepts whatever that function emits,
 # so a bug or a careless refactor there is enough to produce a task pod with no gVisor
 # and a mounted token, and nothing in the cluster would notice. RBAC does not help: the
 # dispatcher legitimately holds `create jobs`, and "create a Job" is not a verb that can
@@ -17,14 +17,19 @@
 # arbitrary Job creation with the dispatcher's RBAC, and this bounds what an arbitrary
 # Job is allowed to look like.
 #
-# SCOPE: every Job in ai-sandbox, not just the dispatcher's. Fail-closed on purpose — a
-# future migration/maintenance Job in this namespace has to satisfy these rules or
-# explicitly amend them, rather than quietly getting a pod the sandbox contract forbids.
+# IT IS CHECKED TWICE, on the Job and again on the Pod. Validating only the Job template
+# would leave a gap: the Pod is created later by the Job controller, and any mutating
+# admission webhook installed in the cluster (an identity injector, a service mesh) can
+# add a sidecar, a Secret volume or a projected token to it after this policy has passed
+# the template. The Pod pass is what closes that, scoped by the `app: sandbox-task` label
+# the Job template stamps on its pods.
 #
-# NOT COVERED, and worth knowing before relying on this: it validates Jobs, not Pods. The
-# dispatcher has no `create pods` RBAC, so the Job template is the whole surface it can
-# reach — but a future grant of pod-create would route around this policy, and the
-# policy would need a Pod rule scoped to the sandbox-agent service account to follow.
+# WHAT IT STILL DOES NOT COVER, so nobody reads more into it than it does:
+#   - It does not stop a task pod REACHING the API server; that is NetworkPolicy's job,
+#     and networkpolicy.yaml documents why the IPv6-only CNI makes that best-effort.
+#   - A mutating webhook that also stripped the `app: sandbox-task` label would evade the
+#     Pod pass. No mutating webhook is configured in this repo today.
+#   - It pins the image repository, not a digest — see the image rule for why.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -33,7 +38,7 @@ metadata:
     osdc.io/module: agent-sandbox
 spec:
   # Fail: an API-server-side evaluation error (a malformed object reaching an
-  # expression, the policy failing to compile) rejects the Job. The alternative,
+  # expression, the policy failing to compile) rejects the request. The alternative,
   # Ignore, turns any such error into a silently unenforced isolation contract.
   failurePolicy: Fail
   matchConstraints:
@@ -42,18 +47,22 @@ spec:
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
         resources: ["jobs"]
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
   variables:
-    # The Job's pod template. Everything below reads through this rather than
-    # re-spelling the path, so a wrong path is one edit rather than fifteen.
+    # One expression, two shapes: a Job carries the pod spec under a template, a Pod is
+    # one. Everything below reads through this rather than re-spelling either path, so
+    # the Job pass and the Pod pass cannot drift into checking different things.
     - name: pod
-      expression: "object.spec.template.spec"
-    # initContainers is absent today (v1 clones inside the task container). It is
-    # folded in here so that when the GITHUB_TOKEN init-container lands, it is covered
-    # by the image and privilege rules by default instead of by remembering to.
+      expression: "request.kind.kind == 'Job' ? object.spec.template.spec : object.spec"
+    - name: isJob
+      expression: "request.kind.kind == 'Job'"
     - name: allContainers
       expression: >-
-        object.spec.template.spec.containers +
-        (has(object.spec.template.spec.initContainers) ? object.spec.template.spec.initContainers : [])
+        variables.pod.containers +
+        (has(variables.pod.initContainers) ? variables.pod.initContainers : [])
   validations:
     # --- Isolation: the three properties the whole design rests on -----------------
     #
@@ -63,13 +72,26 @@ spec:
     # pod is created, which is a token-mounting account.
     - expression: "has(variables.pod.runtimeClassName) && variables.pod.runtimeClassName == 'gvisor'"
       reason: Forbidden
-      message: "task Jobs must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)"
+      message: "task pods must set runtimeClassName: gvisor (this is also what confines them to the ai-sandbox fleet)"
     - expression: "has(variables.pod.serviceAccountName) && variables.pod.serviceAccountName == 'sandbox-agent'"
       reason: Forbidden
-      message: "task Jobs must run as serviceAccountName: sandbox-agent, which holds no RBAC"
+      message: "task pods must run as serviceAccountName: sandbox-agent, which holds no RBAC"
     - expression: "has(variables.pod.automountServiceAccountToken) && variables.pod.automountServiceAccountToken == false"
       reason: Forbidden
-      message: "task Jobs must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox"
+      message: "task pods must set automountServiceAccountToken: false — a mounted token is API access from inside the sandbox"
+
+    # --- Placement: the RuntimeClass node selector only binds a cooperating scheduler --
+    #
+    # runtimeClassName above is what stamps the ai-sandbox nodeSelector onto the pod, but
+    # that is honoured by the scheduler, not by the kubelet. A pod that names its own
+    # scheduler, or pins nodeName outright, is placed without anyone consulting it — and
+    # a task pod on a base node sits beside the dispatcher's projected token.
+    - expression: "!has(variables.pod.nodeName)"
+      reason: Forbidden
+      message: "task pods must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector"
+    - expression: "!has(variables.pod.schedulerName) || variables.pod.schedulerName == 'default-scheduler'"
+      reason: Forbidden
+      message: "task pods must use the default scheduler — an alternate scheduler need not honour the RuntimeClass node selector"
 
     # --- No path from the pod to the node or to another pod's data -----------------
     - expression: >-
@@ -77,17 +99,22 @@ spec:
         (!has(variables.pod.hostPID) || !variables.pod.hostPID) &&
         (!has(variables.pod.hostIPC) || !variables.pod.hostIPC)
       reason: Forbidden
-      message: "task Jobs must not share host namespaces (hostNetwork/hostPID/hostIPC)"
-    - expression: "!has(variables.pod.nodeName)"
-      reason: Forbidden
-      message: "task Jobs must not pin nodeName — it bypasses the scheduler, and with it the RuntimeClass node selector"
-    # Volumes are how a secret, a hostPath or a projected token would get in. v1 task
+      message: "task pods must not share host namespaces (hostNetwork/hostPID/hostIPC)"
+    # Volumes are how a Secret, a hostPath or a projected token would get in. v1 task
     # pods declare none at all, so the rule can be "none" rather than an allowlist of
-    # shapes; the init-container work that needs a shared emptyDir amends this line and
-    # says so in review.
+    # shapes; the GITHUB_TOKEN init-container work that needs a shared emptyDir amends
+    # this line and the initContainers line below, and says so in review.
     - expression: "!has(variables.pod.volumes) || size(variables.pod.volumes) == 0"
       reason: Forbidden
-      message: "task Jobs must declare no volumes — see the module README before adding one"
+      message: "task pods must declare no volumes — see the module README before adding one"
+    - expression: "!has(variables.pod.resourceClaims) || size(variables.pod.resourceClaims) == 0"
+      reason: Forbidden
+      message: "task pods must claim no devices — a resource claim can attach host hardware and its mounts"
+    - expression: >-
+        !has(variables.pod.securityContext) || !has(variables.pod.securityContext.sysctls) ||
+        size(variables.pod.securityContext.sysctls) == 0
+      reason: Forbidden
+      message: "task pods must set no sysctls"
 
     # --- The image, and nothing that can smuggle another one in --------------------
     #
@@ -101,7 +128,14 @@ spec:
       message: "task containers must run the task image from harbor:30002/osdc/ci-agent-sandbox"
     - expression: "size(variables.pod.containers) == 1"
       reason: Forbidden
-      message: "a task Job runs exactly one container"
+      message: "a task pod runs exactly one container"
+    # Separate from the count above, because "one container" is not the same claim: on
+    # 1.35 an init container with restartPolicy: Always is a native sidecar that runs for
+    # the pod's whole life. Allowing arbitrary init containers would make the rule above
+    # cosmetic.
+    - expression: "!has(variables.pod.initContainers) || size(variables.pod.initContainers) == 0"
+      reason: Forbidden
+      message: "task pods must declare no init containers"
 
     # --- Nothing reads a Secret into the task pod ----------------------------------
     #
@@ -131,13 +165,25 @@ spec:
           !has(c.securityContext.capabilities.add) || size(c.securityContext.capabilities.add) == 0)
       reason: Forbidden
       message: "task containers must not add Linux capabilities"
+    - expression: >-
+        variables.allContainers.all(c,
+          !has(c.securityContext) || !has(c.securityContext.procMount) ||
+          c.securityContext.procMount == 'Default')
+      reason: Forbidden
+      message: "task containers must not unmask /proc"
+    # A hostPort is a listener on the node itself, reachable from outside the pod network
+    # and outside every NetworkPolicy in this namespace.
+    - expression: "variables.allContainers.all(c, !has(c.ports) || c.ports.all(p, !has(p.hostPort)))"
+      reason: Forbidden
+      message: "task containers must not publish a hostPort"
 
     # --- Cost and blast radius -------------------------------------------------------
     #
-    # The ResourceQuota is the namespace-wide ceiling; these are the per-Job bounds it
-    # assumes. A Job with no limits is admitted by the quota only until the quota's own
+    # The ResourceQuota is the namespace-wide ceiling; these are the per-task bounds it
+    # assumes. A pod with no limits is admitted by the quota only until the quota's own
     # limits.* entries reject it, which surfaces as an unschedulable pod rather than a
     # clear rejection — this says which rule was broken.
+    #
     # `in` rather than has(): resources.limits is a map, and the CEL has() macro takes a
     # field selection, which 'ephemeral-storage' cannot be spelled as.
     - expression: >-
@@ -147,15 +193,37 @@ spec:
           'ephemeral-storage' in c.resources.limits)
       reason: Forbidden
       message: "task containers must set cpu, memory and ephemeral-storage limits"
-    - expression: "has(object.spec.activeDeadlineSeconds) && object.spec.activeDeadlineSeconds <= 3600"
+
+    # --- Job-level bounds, skipped on the Pod pass (a Pod has no such fields) ---------
+    #
+    # One /run is one task pod. Without these, a single admitted Job could fan out to
+    # `parallelism` pods and retry each of them, consuming the whole namespace quota from
+    # one request that satisfied every rule above.
+    - expression: "!variables.isJob || (has(object.spec.activeDeadlineSeconds) && object.spec.activeDeadlineSeconds <= 3600)"
       reason: Forbidden
       message: "task Jobs must set activeDeadlineSeconds, at most 3600 — an unbounded task holds a fleet node and bills for it"
+    - expression: "!variables.isJob || !has(object.spec.parallelism) || object.spec.parallelism == 1"
+      reason: Forbidden
+      message: "task Jobs must run one pod at a time (parallelism: 1)"
+    - expression: "!variables.isJob || !has(object.spec.completions) || object.spec.completions == 1"
+      reason: Forbidden
+      message: "task Jobs must run exactly one pod (completions: 1)"
+    - expression: "!variables.isJob || (has(object.spec.backoffLimit) && object.spec.backoffLimit == 0)"
+      reason: Forbidden
+      message: "task Jobs must set backoffLimit: 0 — a retry re-clones and re-prompts the model, and bills for it"
 
 ---
-# The binding is what actually turns the policy on, and it is scoped to ai-sandbox by
-# namespace name. A ValidatingAdmissionPolicy with no binding is inert — a policy that
-# looks enforced in `kubectl get` and enforces nothing is the failure mode this comment
-# exists to prevent.
+# The bindings are what actually turn the policy on. A ValidatingAdmissionPolicy with no
+# binding is inert — a policy that looks enforced in `kubectl get` and enforces nothing is
+# the failure mode this comment exists to prevent.
+#
+# Deny, not Warn or Audit: a warning about a Job that escapes the sandbox is a log line
+# nobody reads. The dispatcher surfaces the rejection to its caller as a dispatch error,
+# so a genuine bug here is loud rather than silent.
+#
+# Two bindings rather than one, because the two passes need different scopes. EVERY Job in
+# ai-sandbox is checked, with no label filter — a Job that simply omitted the label would
+# otherwise skip the policy entirely, which is exactly the bug this is here to catch.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
@@ -164,11 +232,39 @@ metadata:
     osdc.io/module: agent-sandbox
 spec:
   policyName: agent-sandbox-task-jobs
-  # Deny, not Warn or Audit: a warning on a Job that escapes the sandbox is a log line
-  # nobody reads. The dispatcher surfaces the rejection to its caller as a dispatch
-  # error, so a genuine bug here is loud rather than silent.
   validationActions: [Deny]
   matchResources:
     namespaceSelector:
       matchLabels:
         kubernetes.io/metadata.name: ai-sandbox
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+
+---
+# The Pod pass, after any mutating webhook has had its turn. Label-scoped, because the
+# namespace also holds the dispatcher and sigv4-proxy pods, which are the trusted side and
+# satisfy none of these rules by design.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: agent-sandbox-task-pods
+  labels:
+    osdc.io/module: agent-sandbox
+spec:
+  policyName: agent-sandbox-task-jobs
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ai-sandbox
+    objectSelector:
+      matchLabels:
+        app: sandbox-task
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]

--- a/osdc/modules/agent-sandbox/kubernetes/base/kustomization.yaml
+++ b/osdc/modules/agent-sandbox/kubernetes/base/kustomization.yaml
@@ -7,7 +7,8 @@
 # There is no Deployment for the sandbox itself: the dispatcher creates one Job per
 # request, so task pods exist only while a task runs. The Job template lives in
 # dispatcher.py rather than here — it is built per request from the task image tag
-# deploy.sh substituted above.
+# deploy.sh substituted above. admissionpolicy.yaml is the cluster-side check on what
+# that template is allowed to contain.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -16,6 +17,7 @@ resources:
   - runtimeclass.yaml
   - serviceaccounts.yaml
   - rbac.yaml
+  - admissionpolicy.yaml
   - quota.yaml
   - sigv4-proxy.yaml
   - proxy-pdb.yaml

--- a/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
+++ b/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
@@ -172,6 +172,39 @@ class TestTaskAdmissionPolicy:
             ("a mounted token", {"automountServiceAccountToken": True}),
             ("a volume", {"volumes": [{"name": "scratch", "emptyDir": {}}]}),
             ("a pinned nodeName", {"nodeName": "ip-10-0-0-1.ec2.internal"}),
+            # The two rules whose CEL is not a shape already proven by the cases above: a
+            # map-keyed `all`, and a bound on a field the API server defaults. Both are
+            # unevaluated until something here denies with them.
+            (
+                "a device request",
+                {
+                    "containers": [
+                        {
+                            "name": "task",
+                            "image": "harbor:30002/osdc/ci-agent-sandbox:admission-probe",
+                            "securityContext": {"allowPrivilegeEscalation": False, "runAsNonRoot": True},
+                            # Equal on both sides on purpose: Kubernetes requires that of
+                            # an extended resource, so this satisfies the limits-present
+                            # and Guaranteed-QoS rules and only the allowlist can say no.
+                            "resources": {
+                                "requests": {
+                                    "cpu": "1",
+                                    "memory": "1Gi",
+                                    "ephemeral-storage": "1Gi",
+                                    "nvidia.com/gpu": "1",
+                                },
+                                "limits": {
+                                    "cpu": "1",
+                                    "memory": "1Gi",
+                                    "ephemeral-storage": "1Gi",
+                                    "nvidia.com/gpu": "1",
+                                },
+                            },
+                        }
+                    ]
+                },
+            ),
+            ("a long termination grace period", {"terminationGracePeriodSeconds": 3600}),
         ],
     )
     def test_the_policy_denies_what_it_says_it_denies(self, case: str, overrides: dict) -> None:

--- a/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
+++ b/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
@@ -8,7 +8,8 @@ that task pods run as, and the NetworkPolicies. These check the security spine i
 
 There is no standing worker to assert on: the dispatcher creates one Job per request, so
 task pods exist only while a task runs. Their shape is asserted in the dispatcher's own
-unit tests, against the Job manifest it builds.
+unit tests, against the Job manifest it builds — and here against the API server, which
+is the only place the admission policy's CEL is actually evaluated.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from __future__ import annotations
 import subprocess
 
 import pytest
+import yaml
 from helpers import assert_deployment_ready, filter_deployments, filter_services, run_kubectl
 
 pytestmark = [pytest.mark.live]
@@ -57,6 +59,127 @@ class TestAgentSandboxRuntimeClass:
         node_selector = rc.get("scheduling", {}).get("nodeSelector", {})
         assert node_selector.get("node-fleet") == "ai-sandbox", (
             f"gvisor RuntimeClass must pin node-fleet=ai-sandbox, got {node_selector!r}."
+        )
+
+
+class TestTaskAdmissionPolicy:
+    """The cluster-side copy of the task-pod isolation contract.
+
+    The dispatcher's unit tests check that the two copies agree; only a live cluster can
+    check that the CEL compiles and that the API server actually denies. A policy whose
+    expressions fail to type-check is still created and reports the failure in
+    `.status.typeChecking` — under `failurePolicy: Fail` such a rule then denies every
+    matching request at runtime, so the symptom is an outage rather than a hole, and
+    `kubectl get` succeeding says nothing either way. The probes below are the assertion.
+
+    These are all CREATE probes. The nodeName rule's UPDATE branch cannot be reached from
+    here — it needs a pod the scheduler has actually bound — and is covered by the
+    integration test, which dispatches a real task and would hang out its deadline if a
+    task pod could not be updated after binding.
+    """
+
+    POLICY = "agent-sandbox-task-jobs"
+
+    def _server_dry_run(self, manifest: str) -> subprocess.CompletedProcess:
+        """Apply against the API server without persisting. Server-side dry-run runs the
+        full admission chain, this policy included."""
+        return subprocess.run(
+            ["kubectl", "-n", NAMESPACE, "apply", "--dry-run=server", "-f", "-"],
+            input=manifest,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _task_pod(self, name: str, **spec_overrides: object) -> str:
+        """A pod carrying the task label, so the Pod pass sees it. That pass is not
+        scoped to the dispatcher's service account — pods are created by the Job
+        controller — which is what lets this run under the smoke suite's own identity."""
+        spec: dict = {
+            "runtimeClassName": "gvisor",
+            "serviceAccountName": "sandbox-agent",
+            "automountServiceAccountToken": False,
+            "restartPolicy": "Never",
+            "containers": [
+                {
+                    "name": "task",
+                    "image": "harbor:30002/osdc/ci-agent-sandbox:admission-probe",
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False,
+                        "runAsNonRoot": True,
+                    },
+                    "resources": {
+                        "requests": {"cpu": "1", "memory": "1Gi", "ephemeral-storage": "1Gi"},
+                        "limits": {"cpu": "1", "memory": "1Gi", "ephemeral-storage": "1Gi"},
+                    },
+                }
+            ],
+        }
+        spec.update(spec_overrides)
+        # None means "omit the field", not "set it to null" — the rules that matter here
+        # are `has(x) && ...`, and absence is the case they exist to reject.
+        spec = {k: v for k, v in spec.items() if v is not None}
+        return yaml.safe_dump(
+            {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": name, "namespace": NAMESPACE, "labels": {"app": "sandbox-task"}},
+                "spec": spec,
+            }
+        )
+
+    def test_policy_and_both_bindings_are_deployed(self) -> None:
+        policy = run_kubectl(["get", "validatingadmissionpolicy", self.POLICY])
+        assert policy["spec"]["failurePolicy"] == "Fail"
+        bound = {
+            b["metadata"]["name"]
+            for b in run_kubectl(["get", "validatingadmissionpolicybinding"])["items"]
+            if b["spec"]["policyName"] == self.POLICY
+        }
+        assert bound == {"agent-sandbox-task-jobs", "agent-sandbox-task-pods"}, (
+            f"the policy needs both its bindings to be enforced on Jobs and on Pods; found {sorted(bound)}."
+        )
+
+    def test_the_policy_type_checks(self) -> None:
+        """A type error does not stop the policy being created; it is reported here, and
+        at runtime it becomes a denial of every matching request."""
+        policy = run_kubectl(["get", "validatingadmissionpolicy", self.POLICY])
+        status = policy.get("status", {})
+        assert status.get("observedGeneration") == policy["metadata"]["generation"], (
+            "the API server has not finished type-checking this generation of the policy yet — "
+            f"observedGeneration={status.get('observedGeneration')}, generation={policy['metadata']['generation']}."
+        )
+        assert "typeChecking" in status, "no typeChecking result on an observed policy generation"
+        failures = status["typeChecking"].get("expressionWarnings") or []
+        assert not failures, f"CEL type-check warnings on {self.POLICY}: {failures}"
+
+    def test_a_compliant_task_pod_is_admitted(self) -> None:
+        """The positive half. Without it a policy that denies everything — a broken
+        expression under failurePolicy: Fail — would look like a passing negative test."""
+        result = self._server_dry_run(self._task_pod("admission-probe-good"))
+        assert result.returncode == 0, f"a compliant task pod was rejected: {result.stderr.strip()}"
+
+    # Each violation is chosen so that NOTHING ELSE in the admission chain would reject
+    # it first: no `runtimeClassName: runc` (there is no runc RuntimeClass to resolve, so
+    # the RuntimeClass admission plugin would answer before this policy did), and an
+    # emptyDir rather than a hostPath (Pod Security would answer first). Dropping a
+    # required field, or adding a volume type nothing else objects to, leaves this policy
+    # as the only thing that can say no.
+    @pytest.mark.parametrize(
+        ("case", "overrides"),
+        [
+            ("no gvisor", {"runtimeClassName": None}),
+            ("a mounted token", {"automountServiceAccountToken": True}),
+            ("a volume", {"volumes": [{"name": "scratch", "emptyDir": {}}]}),
+            ("a pinned nodeName", {"nodeName": "ip-10-0-0-1.ec2.internal"}),
+        ],
+    )
+    def test_the_policy_denies_what_it_says_it_denies(self, case: str, overrides: dict) -> None:
+        name = "admission-probe-" + case.lower().replace(" ", "-")
+        result = self._server_dry_run(self._task_pod(name, **overrides))
+        assert result.returncode != 0, f"a task pod with {case} was ADMITTED — the policy is not enforcing."
+        assert "agent-sandbox-task-jobs" in result.stderr, (
+            f"a task pod with {case} was rejected, but not by this policy: {result.stderr.strip()}"
         )
 
 

--- a/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
+++ b/osdc/modules/agent-sandbox/tests/smoke/test_agent_sandbox.py
@@ -14,11 +14,12 @@ is the only place the admission policy's CEL is actually evaluated.
 
 from __future__ import annotations
 
+import re
 import subprocess
 
 import pytest
 import yaml
-from helpers import assert_deployment_ready, filter_deployments, filter_services, run_kubectl
+from helpers import DEFAULT_TIMEOUT, assert_deployment_ready, filter_deployments, filter_services, run_kubectl
 
 pytestmark = [pytest.mark.live]
 
@@ -66,11 +67,12 @@ class TestTaskAdmissionPolicy:
     """The cluster-side copy of the task-pod isolation contract.
 
     The dispatcher's unit tests check that the two copies agree; only a live cluster can
-    check that the CEL compiles and that the API server actually denies. A policy whose
-    expressions fail to type-check is still created and reports the failure in
-    `.status.typeChecking` — under `failurePolicy: Fail` such a rule then denies every
-    matching request at runtime, so the symptom is an outage rather than a hole, and
-    `kubectl get` succeeding says nothing either way. The probes below are the assertion.
+    check that the CEL compiles and that the API server actually denies. `kubectl get`
+    succeeding says nothing either way — the object is accepted before any request has been
+    evaluated against it — and under `failurePolicy: Fail` an expression that errors at
+    evaluation time denies the request, so the symptom is an outage rather than a hole. The
+    dry-run probes below are what settle that. `.status.typeChecking` is a separate,
+    advisory, schema-level signal and is read with that distinction in mind.
 
     These are all CREATE probes. The nodeName rule's UPDATE branch cannot be reached from
     here — it needs a pod the scheduler has actually bound — and is covered by the
@@ -82,13 +84,19 @@ class TestTaskAdmissionPolicy:
 
     def _server_dry_run(self, manifest: str) -> subprocess.CompletedProcess:
         """Apply against the API server without persisting. Server-side dry-run runs the
-        full admission chain, this policy included."""
+        full admission chain, this policy included.
+
+        Bounded, like run_kubectl: kubectl's own request timeout defaults to unbounded, so
+        an API server that accepts the connection and never answers — or a kubeconfig exec
+        credential plugin waiting on input — would park an xdist worker forever and hang
+        `just smoke` rather than failing it."""
         return subprocess.run(
-            ["kubectl", "-n", NAMESPACE, "apply", "--dry-run=server", "-f", "-"],
+            ["kubectl", "-n", NAMESPACE, "apply", "--dry-run=server", "--request-timeout=60s", "-f", "-"],
             input=manifest,
             capture_output=True,
             text=True,
             check=False,
+            timeout=DEFAULT_TIMEOUT,
         )
 
     def _task_pod(self, name: str, **spec_overrides: object) -> str:
@@ -128,6 +136,32 @@ class TestTaskAdmissionPolicy:
             }
         )
 
+    # `<gvk>:` at the start of a line, one block per matched kind. Anchored and whole-token on
+    # purpose: a substring test for "v1, Kind=Pod" also swallows "example.com/v1, Kind=Pod"
+    # and "v1, Kind=PodTemplate". Leading indent tolerated, because an indented block would
+    # otherwise go unparsed and therefore unnoticed. `ERROR:` is deliberately NOT required:
+    # a Job block reporting something else ("expression must evaluate to bool") has to be
+    # seen too, and keying on the GVK rather than on the message keeps that true.
+    _GVK_HEADER = re.compile(r"^[ \t]*(\S+, Kind=\S+?):", re.MULTILINE)
+    EXPECTED_TYPE_CHECK_KIND = "v1, Kind=Pod"
+
+    @classmethod
+    def _is_expected_pod_diagnostic(cls, warning: str) -> bool:
+        """True only if every diagnostic BLOCK in this entry is against the Pod kind.
+
+        Attribution is by GVK block, not by counting `ERROR:` tokens. One GVK's compilation
+        can report several errors under a single header, and a CEL source line echoed into
+        the message can itself contain the token — a count would then reject an ordinary
+        Pod-only entry and restore the permanent red this whole predicate exists to remove.
+        What must not be ignored is text belonging to NO block, which is what the head check
+        below rejects: an entry whose text starts before any header this test recognises.
+        """
+        headers = cls._GVK_HEADER.findall(warning)
+        if not headers or set(headers) != {cls.EXPECTED_TYPE_CHECK_KIND}:
+            return False
+        head = warning[: cls._GVK_HEADER.search(warning).start()]
+        return not head.strip()
+
     def test_policy_and_both_bindings_are_deployed(self) -> None:
         policy = run_kubectl(["get", "validatingadmissionpolicy", self.POLICY])
         assert policy["spec"]["failurePolicy"] == "Fail"
@@ -141,8 +175,33 @@ class TestTaskAdmissionPolicy:
         )
 
     def test_the_policy_type_checks(self) -> None:
-        """A type error does not stop the policy being created; it is reported here, and
-        at runtime it becomes a denial of every matching request."""
+        """Type checking is advisory, and against Pod it is EXPECTED to complain.
+
+        The API server type-checks every expression against every GVK matchConstraints
+        resolves to, and this policy names two. Job-level rules reach fields a PodSpec does
+        not have (`parallelism`, `completions`, `backoffLimit`, `template`) behind a
+        `!variables.isJob ||` guard the static checker cannot follow, so each produces a
+        `v1, Kind=Pod` diagnostic here, permanently, on a policy that is working correctly.
+        Runtime is unaffected: VAP compiles `object` as DynType for evaluation, which is why
+        type checking is warnings-only rather than a denial. Asserting the list is empty
+        would turn `just smoke` red on every cluster with this module enabled.
+
+        So SUPPRESS the one recognised shape rather than filter for the failing one: an entry
+        is expected only if every `<gvk>:` block it carries is against `v1, Kind=Pod`.
+        Everything else reddens — a Job-side diagnostic, an entry combining both kinds, an
+        entry with no warning text, an entry whose text starts before any header this test
+        recognises. Suppressing by substring instead would have swallowed
+        `example.com/v1, Kind=Pod` and `v1, Kind=PodTemplate`, and a payload-format change
+        would have turned the assertion permanently vacuous — worse than the red it removes.
+
+        Three limits stated rather than papered over. An empty warning list is legitimate, so
+        this cannot detect that suppression is over-broad. A rule wrong against Pod ALONE is
+        suppressed; `test_job_only_rules_are_guarded_for_the_pod_pass` covers the shapes of
+        that visible statically, and splitting this into a Jobs policy and a Pods policy is
+        what would recover the rest. And the header format below has not been observed on a
+        live cluster — if the real payload differs, this reddens with the raw entries in the
+        message, which is the signal needed to pin the format down.
+        """
         policy = run_kubectl(["get", "validatingadmissionpolicy", self.POLICY])
         status = policy.get("status", {})
         assert status.get("observedGeneration") == policy["metadata"]["generation"], (
@@ -150,8 +209,12 @@ class TestTaskAdmissionPolicy:
             f"observedGeneration={status.get('observedGeneration')}, generation={policy['metadata']['generation']}."
         )
         assert "typeChecking" in status, "no typeChecking result on an observed policy generation"
-        failures = status["typeChecking"].get("expressionWarnings") or []
-        assert not failures, f"CEL type-check warnings on {self.POLICY}: {failures}"
+        warnings = status["typeChecking"].get("expressionWarnings") or []
+        failures = [w for w in warnings if not self._is_expected_pod_diagnostic(w.get("warning", ""))]
+        assert not failures, (
+            f"CEL type-check warnings on {self.POLICY} that are not the expected Pod-side "
+            f"diagnostics from the guarded Job-only rules: {failures}"
+        )
 
     def test_a_compliant_task_pod_is_admitted(self) -> None:
         """The positive half. Without it a policy that denies everything — a broken


### PR DESCRIPTION
✴️ iz2: Every isolation property of an agent task pod — gVisor, no service-account token, no volumes, the task image and nothing else — is currently enforced by one Python function, the dispatcher's `job_manifest()`. The API server accepts whatever that function emits, so a bug or a careless refactor there is enough to produce a task pod with no gVisor and a mounted token, and nothing in the cluster would notice.

RBAC cannot narrow this. The dispatcher legitimately holds `create jobs`, and "create a Job" is not a verb that can be expressed as "create a Job shaped like this".

This adds a `ValidatingAdmissionPolicy` that restates the same contract in the API server. It is deliberately redundant with `job_manifest()` — that is the point. Anything it rejects is either an attack or a dispatcher bug.

It is also the precondition for the next PR in this stack: it is what makes it safe to put a JWT parser inside the process that holds create-Job RBAC, rather than in a separate pod in front of it. The worst case of a parser compromise becomes arbitrary Job creation, and this bounds what an arbitrary Job may look like.

## Shape

- **Checked twice, on the Job and again on the Pod.** Validating only the Job template leaves a window: the Pod is created later by the Job controller, and any mutating webhook in the cluster gets to add a sidecar, a Secret volume or a projected token to it in between. The Pod pass is a second binding, label-scoped to `app: sandbox-task` so it does not catch the dispatcher and proxy pods.
- **The Job pass is scoped to the dispatcher's service account**, which is the threat this exists for. That is also what lets the namespace hold an ordinary maintenance Job without each one having to satisfy a contract written for untrusted workloads.
- **`failurePolicy: Fail`, `validationActions: [Deny]`.** An evaluation error rejects the request rather than silently unenforcing the contract, and a warning about a Job escaping the sandbox is a log line nobody reads.

The rules cover runtime class, service account, token automount, host namespaces, `nodeName`/`schedulerName`, volumes, resource claims, sysctls, image repository, container and init-container counts, `envFrom`/`valueFrom`, privilege and capabilities, `procMount`, host ports, resource limits and Guaranteed QoS, `terminationGracePeriodSeconds`, and Job-level `parallelism`/`completions`/`backoffLimit`/`activeDeadlineSeconds`.

Some of these exist because the obvious rule was not enough on its own. `initContainers` had to be banned outright or "exactly one container" is cosmetic — on 1.35 an init container with `restartPolicy: Always` is a native sidecar. `schedulerName` had to be pinned because the RuntimeClass node selector binds a cooperating scheduler, not the kubelet. And `parallelism`/`completions` had to be bounded or one admitted Job could fan out to the whole namespace quota.

Two more of that kind, both added after review. Requiring `cpu`/`memory`/`ephemeral-storage` limits to be *present* was not enough, because a fourth key was still permitted — and Kubernetes already requires an extended resource's request to equal its limit, so `nvidia.com/gpu: 1` satisfied both that rule and Guaranteed QoS by construction, attaching a device through the resources map rather than through `resourceClaims`, which is the door the `resourceClaims` rule exists to close. The limits map is now an allowlist of exactly those three keys. Separately, `activeDeadlineSeconds` was not a bound on how long a task pod holds a node: the deadline triggers termination, deletion then honours `terminationGracePeriodSeconds`, and that field was unbounded, so a container ignoring SIGTERM kept its node afterwards. It is now capped at 60 — not a hard bound on time past the deadline, since the controller terminates asynchronously and the kubelet may extend the grace once for a preStop hook, but it removes the unbounded case. Neither rule changes the Job `job_manifest()` builds today, which sets exactly those three limit keys and no grace period.

**One rule is scoped to CREATE, and that is load-bearing.** The Pod pass matches UPDATE as well, and by the time a task pod is updated the scheduler has bound it, so `spec.nodeName` is set on every object that binding sees. An unqualified `!has(nodeName)` therefore denied every write to a running task pod's main resource — among them the Job controller's removal of its `batch.kubernetes.io/job-tracking` finalizer, which is what lets `status.succeeded` reach 1. The dispatcher waits on exactly that field, so the symptom was not a security event: every task would run, print its result, and then hang until the 900s deadline. The rule now exempts Pod UPDATE, which costs nothing — `spec.nodeName` is immutable through the main resource, and the only writer is the `pods/binding` subresource this policy never matched.

## What it does not cover

Stated in the file so nobody reads more into it than it does: it does not stop a task pod *reaching* the API server, and NetworkPolicy does not either — `sandbox-task-egress` deliberately allows 443 to any address because GitHub's ranges move, and the API server answers on 443 like everything else. What keeps the task pod harmless there is that it carries no token and `sandbox-agent` holds no RBAC. Separately: a mutating webhook that also stripped the task label would evade the Pod pass; an **ephemeral container** attached to a running task pod is seen by no rule here, because `matchConstraints` names `pods` and not the `pods/ephemeralcontainers` subresource, and `allContainers` sums containers and initContainers only — nothing in this module can do it, since neither the dispatcher's Role nor `sandbox-agent` grants that subresource, and the file now records what closing it would take; and it pins the image repository rather than a digest, because `deploy.sh` builds a fresh content-hash tag per deploy and pinning the tag would reject in-flight Jobs from the previous replica for the length of every rollout.

The resource rules now also constrain *which* limit keys may appear, but they still bound no VALUES — so one admitted task can still size itself to the whole namespace quota. That is a denial of service against ourselves rather than an escape, and a ceiling needs CEL's `quantity()` library plus a fourth copy of the `TASK_*` values, so it is a follow-up.

Two rules I deliberately did **not** add, because both would reject the Job the dispatcher builds today and so need a paired code change: capability `drop: ALL`, and `seccompProfile: RuntimeDefault`. gVisor is the syscall boundary here in the meantime. Worth doing as a follow-up.

**One correction to an earlier revision of this description.** It said CEL compares resource quantities numerically, so `"2"` and `"2000m"` are equal, and the policy carried a comment to match. Treat that as withdrawn: assume it is a string comparison. I cannot settle it from here — no cluster, no CEL evaluator — but Kubernetes ships a `quantity()` conversion library, which would have no purpose if a raw field access already yielded a number, so the string reading is what the comment now documents and what to design against. The Guaranteed-QoS rule is unaffected either way: `job_manifest()` emits the identical string on both sides, and the failure direction is a rejection rather than an admission.

## Test plan

- Each CEL rule is mirrored as a Python predicate in `dispatcher/test_admissionpolicy.py`. The suite fails if a rule is added without a mirror, if the real `job_manifest()` output would be rejected, if a mirror does not enforce what it names, or if an expression changes without its mirror being re-read.
- Expressions are pinned by digest of their **whitespace-normalised** text, because keying only on a rule's message left the likeliest drift invisible: an expression edited in place, since tightening a rule rarely renames it. That now covers `variables` and `matchConditions` too — the ternary twenty rules read their pod spec through, and the condition that gates the whole policy, were both unpinned. Mutation-checked: flipping the matchCondition's `||` to `&&`, inverting the `pod` ternary, and weakening the gvisor rule with its message untouched each turn exactly the intended test red. Normalising whitespace is what stops a rewrapped rule reading as a change; the cost is that whitespace *inside* a quoted CEL literal is a semantic change the digest cannot see, which the comment above the table now states. No expression here contains such a literal — checked across all 31.
- **Rule messages must be pairwise distinct.** Both coverage tables are keyed by a validation's message and both coverage tests compare key sets, so two rules sharing a message collapsed to one entry in each while everything stayed green, leaving one rule with no mirror and no pinned expression. Mutation-checked with the case that motivated it: a rule added reusing an existing message, placed before the original and touching neither table, reddens only the new assertion and neither older one.
- The two rules added after review each carry a mirror, a pinned digest and a negative case. Mutation-checked: weakening the limits allowlist to accept any key, and raising the grace ceiling to 86400, each redden only the digest test; blanking either Python mirror reddens only that rule's rejects-its-own-violation case.
- The nodeName mirror takes the request as well as the object, and is checked across all four quadrants (Job/Pod × CREATE/UPDATE). The Job-shaped mirrors structurally could not express the failing case, which is why the original bug got past a suite built to catch drift.
- The image repository is read out of `deploy.sh` rather than restated, and the policy's own CEL literal is checked against it — changing `IMAGE=` alone would otherwise have rejected every Job with this suite green. The `activeDeadlineSeconds` ceiling is read back out of the expression and compared against both the dispatcher's default `TASK_DEADLINE_S` and whatever `dispatcher.yaml` deploys.
- **Smoke suite (live cluster).** Both bindings exist; the API server finished type-checking this generation with no warnings; a compliant task pod is admitted; and six non-compliant ones — no gVisor, a mounted token, a volume, a pinned `nodeName`, an `nvidia.com/gpu` request equal to its limit, and a 3600s termination grace period — are denied *by this policy*, checked by name in the rejection. Server-side dry-run, so nothing is persisted. Each violation is chosen so nothing earlier in the admission chain answers first.
- `kubectl kustomize kubernetes/base` builds clean.
- **Still not verified locally: that the CEL compiles.** No CEL evaluator or cluster here. The smoke probes above are the first thing that actually evaluates it, and the type-check assertion is what catches an expression that was created but does not type. The `nodeName` UPDATE branch is not reachable from a CREATE probe — it needs a pod the scheduler has bound — so the integration test, which dispatches a real task, is what covers it: if a task pod could not be updated after binding, that job would hang out its deadline.
