### PR TITLE
Fix the ECR-gate smoke test crashing where the flag is off

### DIFF
--- a/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
+++ b/osdc/base/kubernetes/tests/smoke/test_base_kubernetes.py
@@ -1,5 +1,7 @@
 """Smoke tests for base Kubernetes resources (DaemonSets, StorageClass, nodes)."""
 
+import json
+
 import pytest
 from helpers import assert_daemonset_healthy, filter_services, run_kubectl
 
@@ -28,14 +30,20 @@ class TestBaseDaemonSets:
     def test_registry_mirror_ecr_gate_matches_cluster_config(self, all_daemonsets, resolve_config):
         """Both directions: a stale ConfigMap routes CI pulls at a Harbor with no ECR endpoint."""
         enabled = bool(resolve_config("harbor.ecr_pullthrough", False))
-        result = run_kubectl(["get", "configmap", "registry-mirror-ecr", "--ignore-not-found"], namespace=NAMESPACE)
-        present = bool(result) and result.get("kind") == "ConfigMap"
+        # --ignore-not-found prints nothing when absent, which is not JSON — so read
+        # it raw and parse only when there is something to parse.
+        raw = run_kubectl(
+            ["get", "configmap", "registry-mirror-ecr", "--ignore-not-found", "-o", "json"],
+            namespace=NAMESPACE,
+            json_output=False,
+        )
+        present = bool(raw.strip())
         assert present == enabled, (
             f"harbor.ecr_pullthrough={enabled} but registry-mirror-ecr ConfigMap "
             f"{'exists' if present else 'is missing'} in {NAMESPACE}"
         )
         if enabled:
-            registry = result.get("data", {}).get("registry", "")
+            registry = json.loads(raw).get("data", {}).get("registry", "")
             msg = f"registry-mirror-ecr points at {registry!r}, which is not an ECR registry host"
             assert ".dkr.ecr." in registry, msg
             assert registry.endswith(".amazonaws.com"), msg


### PR DESCRIPTION
`just smoke` fails on every cluster with `harbor.ecr_pullthrough` off — the ConfigMap is correctly absent and the test crashes instead of passing:

```
base/kubernetes/tests/smoke/test_base_kubernetes.py:31: in test_registry_mirror_ecr_gate_matches_cluster_config
    result = run_kubectl(["get", "configmap", "registry-mirror-ecr", "--ignore-not-found"], ...)
E   json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

`--ignore-not-found` prints nothing when the resource is missing, and `run_kubectl`'s default `json_output=True` feeds that empty string to `json.loads`. Reads it raw now and parses only when non-empty.

Affects `meta-staging-aws-uw1`, `meta-staging-aws-ue1`, `meta-prod-aws-ue1`, `lf-prod-aws-ue1`. My mistake in #1035 — I only exercised it on staging-ue2, where the flag is on and the output is valid JSON, so the absent branch never ran.

No infrastructure impact: the ConfigMap's absence on those clusters is correct.

**Tested:** `just test` OK. `just lint` fails only on the pre-existing hadolint finding at `base/docker/runner-base/Dockerfile:36`.