### PR TITLE
Recycle idle B200 runners before ECR auth expires

### DIFF
--- a/.github/workflows/multi-tenant-test.yml
+++ b/.github/workflows/multi-tenant-test.yml
@@ -1,0 +1,29 @@
+name: "multi-tenant: Test"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "multi-tenant/**"
+      - ".github/workflows/multi-tenant-test.yml"
+  pull_request:
+    paths:
+      - "multi-tenant/**"
+      - ".github/workflows/multi-tenant-test.yml"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: multi-tenant
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - run: python -m unittest discover -s services/ghad-manager -p "test_*.py"

--- a/multi-tenant/services/ghad-manager/ghad-manager.py
+++ b/multi-tenant/services/ghad-manager/ghad-manager.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 import grp
 import logging
 import os
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 REQUIRED_CONTAINER_NAME = "ghad-main-shared-instance-container"
 DOCKER_REPOSITORY = "308535385114.dkr.ecr.us-east-1.amazonaws.com"
 DOCKER_TAG = "latest"
+MAX_RUNNER_CONTAINER_AGE = timedelta(hours=10)
 
 
 class UserSocketsPath:
@@ -141,6 +143,36 @@ def is_container_running(client: docker.DockerClient, container_name: str) -> bo
         return False
 
 
+def recycle_idle_runner(
+    client: docker.DockerClient,
+    container_name: str,
+    now: datetime | None = None,
+) -> None:
+    """Restart an idle runner before its copied ECR credential expires."""
+    now = now or datetime.now(timezone.utc)
+    try:
+        containers = client.containers.list(filters={"name": container_name}, all=True)
+        for container in containers:
+            if container.name != container_name or container.status != "running":
+                continue
+
+            created_at = datetime.fromisoformat(
+                container.attrs["Created"].replace("Z", "+00:00")
+            )
+            if now - created_at < MAX_RUNNER_CONTAINER_AGE:
+                return
+
+            processes = container.top().get("Processes", [])
+            if any("Runner.Worker" in field for row in processes for field in row):
+                return
+
+            logger.info(f"Recycling idle runner container {container_name}")
+            container.stop()
+            return
+    except Exception as e:
+        logger.warning(f"Error recycling idle runner {container_name}: {str(e)}")
+
+
 def stop_all_containers(client: docker.DockerClient, uid: int) -> None:
     logger.info(f"Stopping all containers for user {uid}")
     try:
@@ -185,6 +217,7 @@ def start_container_if_not_running(
     user_name: str,
     docker_tag: str,
 ) -> None:
+    recycle_idle_runner(client, container_name)
     if not is_container_running(client, container_name):
         stop_all_containers(client, uid)
         prune_images(client, uid)

--- a/multi-tenant/services/ghad-manager/test_ghad_manager.py
+++ b/multi-tenant/services/ghad-manager/test_ghad_manager.py
@@ -1,0 +1,58 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+docker = types.ModuleType("docker")
+docker.DockerClient = object
+docker.types = SimpleNamespace(DeviceRequest=object)
+github = types.ModuleType("github")
+github.Auth = SimpleNamespace()
+github.Github = object
+sys.modules["docker"] = docker
+sys.modules["github"] = github
+
+module_path = Path(__file__).with_name("ghad-manager.py")
+spec = importlib.util.spec_from_file_location("ghad_manager", module_path)
+assert spec is not None and spec.loader is not None
+ghad_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ghad_manager)
+
+
+class RecycleIdleRunnerTest(unittest.TestCase):
+    def test_recycles_only_old_idle_runners(self) -> None:
+        now = datetime(2026, 8, 28, 12, tzinfo=UTC)
+        cases = [
+            (timedelta(hours=9), False, False),
+            (timedelta(hours=10), False, True),
+            (timedelta(hours=13), True, False),
+        ]
+
+        for age, busy, expected_stop in cases:
+            with self.subTest(age=age, busy=busy):
+                container = Mock()
+                container.name = ghad_manager.REQUIRED_CONTAINER_NAME
+                container.status = "running"
+                container.attrs = {"Created": (now - age).isoformat()}
+                process = "Runner.Worker" if busy else "Runner.Listener"
+                container.top.return_value = {"Processes": [["1", process]]}
+                client = SimpleNamespace(
+                    containers=SimpleNamespace(list=Mock(return_value=[container]))
+                )
+
+                ghad_manager.recycle_idle_runner(
+                    client,
+                    ghad_manager.REQUIRED_CONTAINER_NAME,
+                    now,
+                )
+
+                self.assertEqual(container.stop.called, expected_stop)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Human Note

## Agent note

### Reviewer TL;DR

- **This is a recurring fleet problem:** 22 exact expired-token failures across 12 runner slots and
  seven workflows in the 14 days ending August 27, 2026.
- **The diagnosis is unusually consistent:** every failure followed more than 12 hours without another
  job on that runner slot.
- **This PR is the smallest mitigation:** recycle an idle listener at 10 hours so the existing startup
  path creates a replacement with fresh auth.
- **A job-start hook now looks like the better steady-state design:** runner `2.336.0` schedules
  `ACTIONS_RUNNER_HOOK_JOB_STARTED` before container setup and `Initialize containers`.
- **Status:** intentionally **draft** while we compare the hook design with periodic recycling.

### Evidence that this is real

```mermaid
flowchart LR
    A[1,607 completed B200 jobs] --> B[22 exact expired-token failures]
    B --> C[12 runner slots]
    B --> D[7 workflow families]
    B --> E[Every case followed more than 12 hours of slot inactivity]
```

| 14-day HUD result | Value |
|---|---:|
| Exact `Your authorization token has expired` failures | **22** |
| Share of all completed B200 jobs | **1.37%** |
| Share of 362 failed B200 jobs | **6.08%** |
| Affected runner slots | **12** across `dgxb200-03` through `dgxb200-08` |
| Affected workflows | **7** |
| Previous-job gap | min **12h11m**, median **15h50m**, max **31h32m** |

Representative raw failures:

- [August 26: symmetric-memory job on `dgxb200-08-1002`](https://github.com/pytorch/pytorch/actions/runs/32948560870/job/98119593492)
- [August 27: distributed job on `dgxb200-07-1002`](https://github.com/pytorch/pytorch/actions/runs/33052078438/job/98455956557)

Both used runner `2.336.0` and failed three Docker-pull attempts before any workflow step with the exact
expired-authorization-token response. The spread across hosts and workflows argues against one bad
runner or one workflow-specific regression.

### Failure mode

```mermaid
sequenceDiagram
    participant Manager as ghad-manager
    participant Runner as Runner.Listener
    participant GitHub
    participant ECR

    Manager->>Runner: Start runner and copy ECR auth
    Note over Runner: Runner waits idle for more than 12 hours
    GitHub->>Runner: Assign a containerized job
    Runner->>ECR: Pull job image before workflow steps
    ECR-->>Runner: Authorization token expired
```

### Job-start hook: verified ordering

The exact runner version from the failing jobs adds the started hook before container setup:

```text
JobExtension.InitializeJob (actions/runner v2.336.0)
  ACTIONS_RUNNER_HOOK_JOB_STARTED
  action container-setup steps
  Initialize containers                 # job image pull happens here
  workflow steps
```

Source: [`actions/runner` v2.336.0, `JobExtension.cs`](https://github.com/actions/runner/blob/v2.336.0/src/Runner.Worker/JobExtension.cs#L301-L329)

That means the hook runs early enough to update Docker auth before the failing pull. The hook still
needs a **fresh credential source**; re-copying the runner's original 12-hour-old config would change
nothing.

A promising design is:

```mermaid
flowchart LR
    H[Host manager refreshes short-lived ECR auth] --> M[Manager-owned auth directory]
    M -->|read-only directory mount| J[Job-start hook]
    J --> C[Atomically update runner Docker config]
    C --> I[Initialize containers with fresh auth]
```

Important constraints:

- Keep long-lived AWS credentials on the host; expose only the short-lived Docker auth to the runner.
- Store the host-side config outside the runner-controlled home so a root manager never follows
  runner-created symlinks.
- Bind-mount the **directory**, not only the config file, so an atomic host-side file replacement is
  visible inside an already-running runner container.
- If the hook fails, fail clearly before container initialization rather than reaching three doomed
  Docker-pull retries.

### What the current patch does

```mermaid
flowchart TD
    A[Runner container is online] --> B{Container age at least 10 hours?}
    B -->|no| C[Keep runner]
    B -->|yes| D{Runner.Worker visible?}
    D -->|yes| C
    D -->|no| E[Stop outer listener container]
    E --> F[Existing manager startup path]
    F --> G[Replacement runner with fresh ECR auth]
```

"Recycle" does **not** reboot the DGX host or restart the user's rootless Docker daemon.

### Timing: known shape, unknown total

```text
manager polling
  threshold is noticed within the 20-second polling cadence

same monitor pass
  docker stop
    exits immediately if the listener cooperates
    otherwise waits up to the configured stop timeout (~10-second docker-py default)
  stop/remove remaining containers
  prune images and networks
  perform registry logins
  walk the shared HF cache and reset permissions
  fetch a GitHub registration token
  pull the runner image if needed
  start and register the replacement

stop-to-online total
  NOT MEASURED — could be seconds or minutes
```

The 20-second value is a polling interval, not a restart-time guarantee.

### The recycle race

```mermaid
sequenceDiagram
    participant Manager
    participant GitHub
    participant Runner as Runner.Listener

    Manager->>Runner: docker top snapshot
    Runner-->>Manager: No Runner.Worker visible
    GitHub->>Runner: A job may be assigned here
    Manager->>Runner: docker stop
    Note over GitHub,Runner: Outcome not established: requeue or infrastructure failure?
```

`docker top` is a snapshot, not a drain or lock. The setup playbook already uses this pattern for
one-off deploy restarts, but periodic reuse does not prove the assignment race is safe.

### Options

| Design | Stops runner? | Assessment |
|---|---:|---|
| **This PR: recycle at 10h** | Yes | Smallest mitigation; restart time and assignment race remain |
| **Job-start hook + live host config** | No | **Promising:** ordering is verified before container pull; needs a safe fresh-auth source |
| **ECR credential helper** | No | Clean pull-time model, but needs AWS auth without exposing host credentials |
| **Drain/unregister, then restart** | Yes | Requires a proven GitHub lifecycle/API handshake |

### Before marking ready

1. Prototype the job-start hook with a manager-owned, read-only mounted auth directory.
2. Confirm in a real job log that the hook completes before `Initialize containers` and a private ECR
   job image pulls successfully after a 12-hour boundary.
3. Keep AWS credentials host-only and verify atomic config replacement remains visible in the live
   runner.
4. If recycling remains the fallback, measure stop-to-online time and deliberately exercise assignment
   around the recycle boundary.

The evidence establishes the stale-token problem. The verified hook ordering gives us a plausible way
to solve it without periodic runner restarts.

## Test Plan

```bash
cd multi-tenant
python3 -m unittest discover -s services/ghad-manager -p "test_*.py"
python3 -m py_compile services/ghad-manager/ghad-manager.py services/ghad-manager/test_ghad_manager.py
actionlint .github/workflows/multi-tenant-test.yml
```
