### PR TITLE
[CRCR] Update Terrafile to Release v20260831-210041-custom

### DIFF
--- a/crcr/Terrafile
+++ b/crcr/Terrafile
@@ -3,7 +3,7 @@ terraform-aws-vpc:
   rev: "3ffbd46fb1c7733e1b34d8666893280454e27436"
 crcr:
   source: "pytorch/test-infra"
-  tag: "v20260806-144538"
+  tag: "v20260831-210041-custom"
   assets:
     - "cross-repo-ci-webhook.zip"
     - "cross-repo-ci-callback.zip"


### PR DESCRIPTION
Update the CRCR lambda pin to the latest test-infra release:
https://github.com/pytorch/test-infra/releases/tag/v20260831-210041-custom

Previous pin: `v20260806-144538`.

Both assets the CRCR terraform consumes are present in the release:

| asset | consumed by |
| --- | --- |
| `cross-repo-ci-webhook.zip` | `crcr/aws/webhook.tf` |
| `cross-repo-ci-callback.zip` | `crcr/aws/callback.tf` |
