### PR TITLE
[node-compactor] Quarantine GPU nodes that black-hole every GPU pod

### DIFF
--- a/osdc/base/node-compactor/scripts/python/compactor.py
+++ b/osdc/base/node-compactor/scripts/python/compactor.py
@@ -26,8 +26,9 @@ import time
 
 import metrics as m
 from discovery import build_node_states, discover_managed_nodes
+from gpu_health import select_quarantine_nodes
 from lightkube import ApiError, Client
-from models import LABEL_NODE_FLEET, Config, NodeState
+from models import LABEL_NODE_FLEET, TAINT_KEY_GPU_UNHEALTHY, Config, NodeState
 from packing import _count_spare_nodes, compute_taints, select_reserved_nodes
 from phantom import apply_pending_phantom_load
 from prometheus_client import start_http_server
@@ -45,6 +46,44 @@ log = logging.getLogger("compactor")
 def _fleet_group_key(ns: NodeState) -> str:
     """Group nodes by fleet (node-fleet label), falling back to nodepool."""
     return ns.labels.get(LABEL_NODE_FLEET) or ns.nodepool
+
+
+def quarantine_gpu_black_holes(client: Client, cfg: Config, node_states: dict[str, NodeState]) -> set[str]:
+    """Taint GPU nodes that are rejecting every GPU pod at admission.
+
+    The taint uses its own key, so none of the untaint paths below (which are
+    all keyed on ``cfg.taint_key``) can clear it under demand pressure. The
+    node drains as its healthy in-flight pods finish and Karpenter's WhenEmpty
+    policy reaps it — no running job is killed.
+
+    Returns the set of node names newly quarantined this cycle.
+    """
+    quarantine, _failure_counts = select_quarantine_nodes(node_states, cfg, _fleet_group_key)
+
+    quarantined: set[str] = set()
+    for node_name in sorted(quarantine):
+        try:
+            apply_taint(client, node_name, TAINT_KEY_GPU_UNHEALTHY, cfg.dry_run)
+            m.taint_operations_total.labels(action="gpu_quarantine", status="success").inc()
+            quarantined.add(node_name)
+        except ApiError as e:
+            if e.status.code == 404:
+                log.info("Node %s disappeared before quarantine, skipping", node_name)
+            else:
+                log.exception("Failed to quarantine node %s", node_name)
+                m.taint_operations_total.labels(action="gpu_quarantine", status="error").inc()
+        except Exception:
+            log.exception("Failed to quarantine node %s", node_name)
+            m.taint_operations_total.labels(action="gpu_quarantine", status="error").inc()
+
+    fleet_counts: dict[str, int] = {}
+    for ns in node_states.values():
+        if ns.is_gpu_quarantined:
+            fleet = _fleet_group_key(ns)
+            fleet_counts[fleet] = fleet_counts.get(fleet, 0) + 1
+    m.refresh_gauge(m.gpu_quarantined_nodes, {(fleet,): float(c) for fleet, c in fleet_counts.items()})
+
+    return quarantined
 
 
 # ============================================================================
@@ -96,6 +135,12 @@ def reconcile(
         m.refresh_gauge(m.workload_pods, {})
         m.refresh_gauge(m.tainted_nodes, {})
         return
+
+    # Quarantine GPU black holes before anything else looks at capacity. Such a
+    # node reports Ready and advertises every GPU as allocatable, so each
+    # utilization-based decision below would happily treat it as usable and
+    # keep feeding it work it can only destroy.
+    quarantine_gpu_black_holes(client, cfg, node_states)
 
     # Apply phantom load from pending pods before any utilization-based decisions.
     # This makes the compactor "see" pods that are about to land, preventing
@@ -371,6 +416,14 @@ def main() -> int:
         cfg.pending_pod_max_age_seconds,
         cfg.pending_pod_min_age_seconds,
     )
+    log.info(
+        "GPU quarantine: enabled=%s, threshold=%d failure(s) in %ds, max %.0f%% of a fleet, taint=%s",
+        cfg.gpu_quarantine_enabled,
+        cfg.gpu_quarantine_threshold,
+        cfg.gpu_quarantine_window_seconds,
+        cfg.gpu_quarantine_max_fleet_ratio * 100,
+        TAINT_KEY_GPU_UNHEALTHY,
+    )
 
     # Expose Prometheus metrics on :8080/metrics. Bind ::0 so the socket
     # accepts both IPv6 and IPv4-mapped IPv6 connections — the pod has
@@ -389,6 +442,9 @@ def main() -> int:
             "dry_run": str(cfg.dry_run),
             "taint_key": cfg.taint_key,
             "nodepool_label": cfg.nodepool_label,
+            "gpu_quarantine_enabled": str(cfg.gpu_quarantine_enabled),
+            "gpu_quarantine_threshold": str(cfg.gpu_quarantine_threshold),
+            "gpu_quarantine_window_seconds": str(cfg.gpu_quarantine_window_seconds),
         }
     )
 

--- a/osdc/base/node-compactor/scripts/python/discovery.py
+++ b/osdc/base/node-compactor/scripts/python/discovery.py
@@ -3,10 +3,12 @@
 import logging
 from datetime import UTC, datetime
 
+from gpu_health import admission_failure_time
 from lightkube import ApiError, Client
 from lightkube.resources.core_v1 import Namespace, Node, Pod
 from models import (
     ANNOTATION_CAPACITY_RESERVED,
+    TAINT_KEY_GPU_UNHEALTHY,
     Config,
     NodeState,
     PodInfo,
@@ -96,6 +98,7 @@ def build_node_states(
 
         taints = node.spec.taints or [] if node.spec else []
         is_tainted = any(t.key == cfg.taint_key for t in taints)
+        is_gpu_quarantined = any(t.key == TAINT_KEY_GPU_UNHEALTHY for t in taints)
         is_reserved = annotations.get(ANNOTATION_CAPACITY_RESERVED) == "true"
 
         node_states[name] = NodeState(
@@ -107,6 +110,7 @@ def build_node_states(
             creation_time=creation,
             is_tainted=is_tainted,
             is_reserved=is_reserved,
+            is_gpu_quarantined=is_gpu_quarantined,
             node_taints=list(taints),
             labels=dict(labels),
             annotations=dict(annotations),
@@ -192,6 +196,14 @@ def build_node_states(
         if node_name not in node_states:
             continue
         if phase in ("Succeeded", "Failed"):
+            # Terminal pods hold no resources, but a Failed pod rejected by the
+            # kubelet's device plugin allocation is the only place a GPU black
+            # hole is visible — the node itself still looks healthy. Record it
+            # before discarding the pod.
+            if phase == "Failed":
+                failed_at = admission_failure_time(pod)
+                if failed_at:
+                    node_states[node_name].admission_failures.append(failed_at)
             continue
         # Skip Terminating pods — resources will be freed imminently
         if pod.metadata and pod.metadata.deletionTimestamp:

--- a/osdc/base/node-compactor/scripts/python/gpu_health.py
+++ b/osdc/base/node-compactor/scripts/python/gpu_health.py
@@ -1,0 +1,172 @@
+"""GPU black-hole detection for the Node Compactor.
+
+A single failed GPU can silently take an entire GPU node out of service while
+the node keeps reporting ``Ready`` and keeps advertising every GPU as
+allocatable. ``nvidia-device-plugin``'s ``alignedAlloc`` builds the NVLink
+topology across ALL GPUs on the node before filtering down to the ones the pod
+actually asked for, so one lost GPU fails ``GetPreferredAllocation`` for every
+GPU pod — including pods that would have landed on a healthy GPU. The kubelet
+rejects each of those pods with ``UnexpectedAdmissionError`` and the scheduler
+immediately sends another one, so the node behaves as a black hole: it accepts
+work at full rate and destroys all of it.
+
+Nothing in the node's own status reflects this. The only place the fault is
+visible is on the pods it already killed, which is what this module reads.
+
+Detection is deliberately a symptom check rather than a hardware probe: it
+needs no NVML access, no privileged DaemonSet and no per-node agent, and it
+fires on any device-plugin allocation fault rather than only the ones a
+hardware probe was written to anticipate. The cost is that it is inherently
+post-hoc — it cannot fire until ``threshold`` pods have already died.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from models import Config, NodeState
+
+log = logging.getLogger("compactor")
+
+# Kubelet's catch-all admission rejection reason. Not GPU-specific on its own:
+# pkg/kubelet/lifecycle/predicate.go documents it as "an error during admission
+# that could not be categorized", so the message signature below is what makes
+# the match specific.
+ADMISSION_FAILURE_REASON = "UnexpectedAdmissionError"
+
+# Substring of the kubelet's rejection message identifying a device-plugin
+# preferred-allocation failure. The full message looks like:
+#   Pod was rejected: Allocate failed due to device plugin GetPreferredAllocation
+#   rpc failed with err: rpc error: code = Unknown desc = error getting list of
+#   preferred allocation devices: unable to get device link information: error
+#   getting NVLink for devices (0, 1): failed to get nvlink remote pci info:
+#   failed to get nvlink state: GPU is lost, which is unexpected
+# NOTE: TopologyAffinityError is a *different* typed admission reason and is
+# intentionally not matched here.
+ADMISSION_FAILURE_SIGNATURE = "GetPreferredAllocation"
+
+
+def admission_failure_time(pod) -> datetime | None:
+    """Return the pod's creation time if it died of a device-plugin allocation failure.
+
+    Returns None for any pod that failed for another reason, so the caller can
+    feed every Failed pod through this without pre-filtering.
+
+    Creation time is used rather than ``status.startTime`` because a pod
+    rejected at admission never starts, so ``startTime`` is unset.
+    """
+    status = getattr(pod, "status", None)
+    if status is None:
+        return None
+    if getattr(status, "reason", None) != ADMISSION_FAILURE_REASON:
+        return None
+    message = getattr(status, "message", None) or ""
+    if ADMISSION_FAILURE_SIGNATURE not in message:
+        return None
+
+    meta = getattr(pod, "metadata", None)
+    return getattr(meta, "creationTimestamp", None) if meta else None
+
+
+def count_recent_failures(ns: NodeState, cfg: Config, now: datetime) -> int:
+    """Count this node's device-plugin admission failures inside the detection window.
+
+    Windowing matters for more than promptness: rejected pod objects are left
+    behind in Failed phase and are not always reaped, so an unbounded count
+    would keep growing off stale corpses long after the fault.
+    """
+    cutoff = cfg.gpu_quarantine_window_seconds
+    return sum(1 for ts in ns.admission_failures if ts and (now - ts).total_seconds() <= cutoff)
+
+
+def select_quarantine_nodes(
+    node_states: dict[str, NodeState],
+    cfg: Config,
+    group_key,
+    now: datetime | None = None,
+) -> tuple[set[str], dict[str, int]]:
+    """Pick GPU nodes to quarantine with a NoSchedule taint.
+
+    A node qualifies when it advertises GPUs and its kubelet has rejected at
+    least ``gpu_quarantine_threshold`` pods with a device-plugin allocation
+    failure inside the detection window.
+
+    Selection is capped per fleet at ``gpu_quarantine_max_fleet_ratio`` of the
+    fleet's nodes (already-quarantined nodes count against the cap). Without
+    this a cluster-wide fault — a bad AMI, a bad driver rollout — would cordon
+    every GPU node at once and turn a degraded fleet into no fleet. Karpenter's
+    own node-repair path applies the same 20% guard for the same reason.
+
+    Returns (nodes_to_quarantine, per-node window failure counts). The counts
+    cover every GPU node with at least one failure, not just the selected ones,
+    so the metric shows pressure building before the threshold trips.
+    """
+    if not cfg.gpu_quarantine_enabled:
+        return set(), {}
+
+    now = now or datetime.now(UTC)
+
+    failure_counts: dict[str, int] = {}
+    candidates: list[NodeState] = []
+    for ns in node_states.values():
+        if ns.allocatable_gpu <= 0:
+            continue
+        count = count_recent_failures(ns, cfg, now)
+        if count:
+            failure_counts[ns.name] = count
+        if ns.is_gpu_quarantined:
+            continue
+        if count >= cfg.gpu_quarantine_threshold:
+            candidates.append(ns)
+
+    if not candidates:
+        return set(), failure_counts
+
+    # Group every GPU node by fleet so the cap is computed against fleet size,
+    # not against the candidate list.
+    fleet_sizes: dict[str, int] = {}
+    fleet_already_quarantined: dict[str, int] = {}
+    for ns in node_states.values():
+        if ns.allocatable_gpu <= 0:
+            continue
+        fleet = group_key(ns)
+        fleet_sizes[fleet] = fleet_sizes.get(fleet, 0) + 1
+        if ns.is_gpu_quarantined:
+            fleet_already_quarantined[fleet] = fleet_already_quarantined.get(fleet, 0) + 1
+
+    # Worst offenders first, name as tie-break so the choice is deterministic
+    # when a whole fleet is failing and the cap has to drop some.
+    candidates.sort(key=lambda n: (-failure_counts[n.name], n.name))
+
+    selected: set[str] = set()
+    per_fleet_new: dict[str, int] = {}
+    for ns in candidates:
+        fleet = group_key(ns)
+        cap = max(1, int(fleet_sizes[fleet] * cfg.gpu_quarantine_max_fleet_ratio))
+        used = fleet_already_quarantined.get(fleet, 0) + per_fleet_new.get(fleet, 0)
+        if used >= cap:
+            log.warning(
+                "GPU quarantine cap reached for fleet %s (%d/%d nodes): "
+                "NOT quarantining %s despite %d admission failure(s) in %ds. "
+                "A fleet-wide fault needs an operator, not more cordons.",
+                fleet,
+                used,
+                cap,
+                ns.name,
+                failure_counts[ns.name],
+                cfg.gpu_quarantine_window_seconds,
+            )
+            continue
+        selected.add(ns.name)
+        per_fleet_new[fleet] = per_fleet_new.get(fleet, 0) + 1
+        log.error(
+            "GPU black hole detected on %s (fleet %s): %d pod(s) rejected with "
+            "a device plugin allocation failure in the last %ds while the node "
+            "still advertises %d allocatable GPU(s). Quarantining.",
+            ns.name,
+            fleet,
+            failure_counts[ns.name],
+            cfg.gpu_quarantine_window_seconds,
+            ns.allocatable_gpu,
+        )
+
+    return selected, failure_counts

--- a/osdc/base/node-compactor/scripts/python/metrics.py
+++ b/osdc/base/node-compactor/scripts/python/metrics.py
@@ -74,6 +74,12 @@ reserved_nodes = Gauge(
     ["nodepool"],
 )
 
+gpu_quarantined_nodes = Gauge(
+    "compactor_gpu_quarantined_nodes",
+    "GPU nodes quarantined for rejecting pods with device plugin allocation failures",
+    ["fleet"],
+)
+
 # --- Counters ---
 
 reconcile_cycles_total = Counter(

--- a/osdc/base/node-compactor/scripts/python/models.py
+++ b/osdc/base/node-compactor/scripts/python/models.py
@@ -18,6 +18,14 @@ ANNOTATION_CAPACITY_RESERVED = "node-compactor.osdc.io/capacity-reserved"
 ANNOTATION_DO_NOT_DISRUPT = "karpenter.sh/do-not-disrupt"
 LABEL_NODE_FLEET = "node-fleet"
 
+# Quarantine taint for GPU nodes whose kubelet rejects every GPU pod at
+# admission. Deliberately NOT the same key as the consolidation taint: every
+# untaint path (remove_taint, cleanup_stale_taints, burst untaint) is keyed on
+# cfg.taint_key, so a separate key makes the quarantine structurally immune to
+# being cleared by demand pressure, cooldown, or min_nodes. The node drains as
+# its healthy in-flight pods finish and Karpenter's WhenEmpty policy reaps it.
+TAINT_KEY_GPU_UNHEALTHY = "node-compactor.osdc.io/gpu-unhealthy"
+
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -40,6 +48,10 @@ DEFAULTS = {
     "COMPACTOR_PEAK_WINDOW_SECONDS": "1800",
     "COMPACTOR_PENDING_POD_MAX_AGE_SECONDS": "14400",
     "COMPACTOR_PENDING_POD_MIN_AGE_SECONDS": "0",
+    "COMPACTOR_GPU_QUARANTINE_ENABLED": "true",
+    "COMPACTOR_GPU_QUARANTINE_THRESHOLD": "3",
+    "COMPACTOR_GPU_QUARANTINE_WINDOW_SECONDS": "300",
+    "COMPACTOR_GPU_QUARANTINE_MAX_FLEET_RATIO": "0.2",
 }
 
 
@@ -62,6 +74,12 @@ class Config:
     peak_window_seconds: int
     pending_pod_max_age_seconds: int
     pending_pod_min_age_seconds: int
+    # Defaulted so existing Config construction sites (notably test fixtures)
+    # need no change; from_env() always passes them explicitly from DEFAULTS.
+    gpu_quarantine_enabled: bool = DEFAULTS["COMPACTOR_GPU_QUARANTINE_ENABLED"] == "true"
+    gpu_quarantine_threshold: int = int(DEFAULTS["COMPACTOR_GPU_QUARANTINE_THRESHOLD"])
+    gpu_quarantine_window_seconds: int = int(DEFAULTS["COMPACTOR_GPU_QUARANTINE_WINDOW_SECONDS"])
+    gpu_quarantine_max_fleet_ratio: float = float(DEFAULTS["COMPACTOR_GPU_QUARANTINE_MAX_FLEET_RATIO"])
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -86,6 +104,10 @@ class Config:
             peak_window_seconds=int(env("COMPACTOR_PEAK_WINDOW_SECONDS")),
             pending_pod_max_age_seconds=int(env("COMPACTOR_PENDING_POD_MAX_AGE_SECONDS")),
             pending_pod_min_age_seconds=int(env("COMPACTOR_PENDING_POD_MIN_AGE_SECONDS")),
+            gpu_quarantine_enabled=env("COMPACTOR_GPU_QUARANTINE_ENABLED").lower() in ("true", "1", "yes"),
+            gpu_quarantine_threshold=int(env("COMPACTOR_GPU_QUARANTINE_THRESHOLD")),
+            gpu_quarantine_window_seconds=int(env("COMPACTOR_GPU_QUARANTINE_WINDOW_SECONDS")),
+            gpu_quarantine_max_fleet_ratio=float(env("COMPACTOR_GPU_QUARANTINE_MAX_FLEET_RATIO")),
         )
 
         if cfg.peak_window_seconds < 0:
@@ -102,6 +124,16 @@ class Config:
             raise ValueError(
                 f"COMPACTOR_PENDING_POD_MIN_AGE_SECONDS ({cfg.pending_pod_min_age_seconds}) "
                 f"must be < COMPACTOR_PENDING_POD_MAX_AGE_SECONDS ({cfg.pending_pod_max_age_seconds})"
+            )
+        if cfg.gpu_quarantine_threshold < 1:
+            raise ValueError(f"COMPACTOR_GPU_QUARANTINE_THRESHOLD must be >= 1, got {cfg.gpu_quarantine_threshold}")
+        if cfg.gpu_quarantine_window_seconds <= 0:
+            raise ValueError(
+                f"COMPACTOR_GPU_QUARANTINE_WINDOW_SECONDS must be > 0, got {cfg.gpu_quarantine_window_seconds}"
+            )
+        if not 0 < cfg.gpu_quarantine_max_fleet_ratio <= 1:
+            raise ValueError(
+                f"COMPACTOR_GPU_QUARANTINE_MAX_FLEET_RATIO must be in (0, 1], got {cfg.gpu_quarantine_max_fleet_ratio}"
             )
 
         return cfg
@@ -140,9 +172,13 @@ class NodeState:
     pods: list[PodInfo] = field(default_factory=list)
     is_tainted: bool = False
     is_reserved: bool = False  # has capacity-reservation annotation
+    is_gpu_quarantined: bool = False  # has the gpu-unhealthy taint
     node_taints: list = field(default_factory=list)  # raw taint objects from API
     labels: dict = field(default_factory=dict)  # node metadata labels
     annotations: dict = field(default_factory=dict)  # node metadata annotations
+    # Creation timestamps of pods this node's kubelet rejected with a device
+    # plugin allocation failure. Rebuilt every reconcile from live pod objects.
+    admission_failures: list[datetime] = field(default_factory=list)
 
     @property
     def workload_pods(self) -> list[PodInfo]:

--- a/osdc/base/node-compactor/scripts/python/test_compactor.py
+++ b/osdc/base/node-compactor/scripts/python/test_compactor.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from compactor import _fleet_group_key, main, reconcile
+from compactor import _fleet_group_key, main, quarantine_gpu_black_holes, reconcile
 from fit import _pods_fit_on_nodes
 from lightkube import ApiError
 from models import (
@@ -50,6 +50,10 @@ def make_config(**overrides) -> Config:
         "peak_window_seconds": 2700,
         "pending_pod_max_age_seconds": 14400,
         "pending_pod_min_age_seconds": 0,
+        "gpu_quarantine_enabled": True,
+        "gpu_quarantine_threshold": 3,
+        "gpu_quarantine_window_seconds": 300,
+        "gpu_quarantine_max_fleet_ratio": 0.2,
     }
     defaults.update(overrides)
     return Config(**defaults)
@@ -3150,3 +3154,105 @@ class TestPendingPodsInBinPack:
         to_taint, *_ = compute_taints(nodes, cfg, pending_pods=[pp])
         # Zero-request pod doesn't inflate bin_pack; surplus = 3-1 = 2 tainted
         assert len(to_taint) == 2
+
+
+class TestQuarantineGPUBlackHoles:
+    """Tests for quarantine_gpu_black_holes().
+
+    A GPU black hole reports Ready and advertises full allocatable GPUs the
+    whole time it is destroying pods, so quarantine has to run before any
+    capacity decision treats it as usable.
+    """
+
+    def _failing_node(self, name="bad", failures=3, gpu=4, fleet="g5", quarantined=False) -> NodeState:
+        ns = NodeState(
+            name=name,
+            nodepool="g5-24xlarge",
+            allocatable_cpu=96.0,
+            allocatable_memory=384 * GiB,
+            allocatable_gpu=gpu,
+            creation_time=NOW - timedelta(hours=2),
+            labels={"node-fleet": fleet},
+            is_gpu_quarantined=quarantined,
+        )
+        ns.admission_failures = [NOW - timedelta(seconds=5)] * failures
+        return ns
+
+    @patch("compactor.apply_taint")
+    def test_taints_black_hole(self, mock_apply):
+        cfg = make_config()
+        states = {"bad": self._failing_node()}
+
+        quarantined = quarantine_gpu_black_holes(MagicMock(), cfg, states)
+
+        assert quarantined == {"bad"}
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args[0][1] == "bad"
+        assert mock_apply.call_args[0][2] == "node-compactor.osdc.io/gpu-unhealthy"
+
+    @patch("compactor.apply_taint")
+    def test_healthy_node_untouched(self, mock_apply):
+        cfg = make_config()
+        states = {"ok": self._failing_node("ok", failures=0)}
+
+        quarantined = quarantine_gpu_black_holes(MagicMock(), cfg, states)
+
+        assert quarantined == set()
+        mock_apply.assert_not_called()
+
+    @patch("compactor.apply_taint")
+    def test_disabled_is_a_no_op(self, mock_apply):
+        cfg = make_config(gpu_quarantine_enabled=False)
+
+        quarantine_gpu_black_holes(MagicMock(), cfg, {"bad": self._failing_node()})
+
+        mock_apply.assert_not_called()
+
+    @patch("compactor.apply_taint")
+    def test_vanished_node_is_not_an_error(self, mock_apply):
+        """Karpenter may reap the node between our read and our patch."""
+        mock_apply.side_effect = _make_api_error(404)
+        cfg = make_config()
+
+        quarantined = quarantine_gpu_black_holes(MagicMock(), cfg, {"bad": self._failing_node()})
+
+        assert quarantined == set()
+
+    @patch("compactor.apply_taint")
+    def test_api_error_is_recorded_not_raised(self, mock_apply):
+        mock_apply.side_effect = _make_api_error(500)
+        cfg = make_config()
+
+        quarantined = quarantine_gpu_black_holes(MagicMock(), cfg, {"bad": self._failing_node()})
+
+        assert quarantined == set()
+
+    @patch("compactor.apply_taint")
+    def test_unexpected_error_does_not_break_the_cycle(self, mock_apply):
+        """One bad node must not stop the compactor reconciling the rest."""
+        mock_apply.side_effect = RuntimeError("boom")
+        cfg = make_config()
+
+        quarantined = quarantine_gpu_black_holes(MagicMock(), cfg, {"bad": self._failing_node()})
+
+        assert quarantined == set()
+
+    @patch("compactor.apply_taint")
+    def test_reconcile_quarantines_before_capacity_decisions(self, mock_apply):
+        """End-to-end through reconcile(), not just the helper."""
+        cfg = make_config()
+        client = MagicMock()
+        node = self._failing_node()
+
+        with (
+            patch("compactor.discover_managed_nodes", return_value={"bad": "g5-24xlarge"}),
+            patch("compactor.build_node_states", return_value=({"bad": node}, [])),
+            patch("compactor.check_pending_pods", return_value=(set(), 0)),
+            patch("compactor.compute_taints", return_value=(set(), set(), set(), set())),
+            patch("compactor.remove_taint"),
+        ):
+            reconcile(client, cfg, {})
+
+        assert any(call.args[2] == "node-compactor.osdc.io/gpu-unhealthy" for call in mock_apply.call_args_list), (
+            "reconcile() did not apply the quarantine taint"
+        )

--- a/osdc/base/node-compactor/scripts/python/test_discovery.py
+++ b/osdc/base/node-compactor/scripts/python/test_discovery.py
@@ -35,6 +35,10 @@ def make_config(**overrides) -> Config:
         "peak_window_seconds": 2700,
         "pending_pod_max_age_seconds": 14400,
         "pending_pod_min_age_seconds": 0,
+        "gpu_quarantine_enabled": True,
+        "gpu_quarantine_threshold": 3,
+        "gpu_quarantine_window_seconds": 300,
+        "gpu_quarantine_max_fleet_ratio": 0.2,
     }
     defaults.update(overrides)
     return Config(**defaults)
@@ -1142,3 +1146,96 @@ class TestTerminatingPodFiltering:
 
         assert len(states["node-1"].pods) == 1
         assert states["node-1"].pods[0].name == "active"
+
+
+# ============================================================================
+# GPU black-hole admission failure collection
+# ============================================================================
+
+
+class TestAdmissionFailureCollection:
+    """build_node_states() records device-plugin admission failures per node.
+
+    Failed pods hold no resources and are otherwise discarded, but they are
+    the only observable trace of a GPU black hole: the node stays Ready and
+    keeps advertising every GPU as allocatable throughout.
+    """
+
+    REAL_MESSAGE = (
+        "Pod was rejected: Allocate failed due to device plugin GetPreferredAllocation "
+        "rpc failed with err: rpc error: code = Unknown desc = error getting list of "
+        "preferred allocation devices: unable to get device link information: error "
+        "getting NVLink for devices (0, 1): failed to get nvlink remote pci info: "
+        "failed to get nvlink state: GPU is lost, which is unexpected"
+    )
+
+    def _rejected_pod(self, name: str, node_name: str = "node-1", message: str | None = None):
+        pod = make_mock_pod(name, node_name=node_name, phase="Failed")
+        pod.status.reason = "UnexpectedAdmissionError"
+        pod.status.message = self.REAL_MESSAGE if message is None else message
+        return pod
+
+    def test_records_rejected_pods(self):
+        cfg = make_config()
+        client = MagicMock()
+        node = make_mock_node("node-1", labels={"karpenter.sh/nodepool": "g5-24xlarge"})
+        pods = [self._rejected_pod(f"runner-{i}") for i in range(3)]
+        client.list.side_effect = [[node], [], pods]
+
+        states, _ = build_node_states(client, cfg, {"node-1": "pool"})
+
+        assert len(states["node-1"].admission_failures) == 3
+
+    def test_rejected_pods_do_not_consume_capacity(self):
+        """A rejected pod never ran, so it must not count as load."""
+        cfg = make_config()
+        client = MagicMock()
+        node = make_mock_node("node-1", labels={"karpenter.sh/nodepool": "g5-24xlarge"})
+        client.list.side_effect = [[node], [], [self._rejected_pod("runner-1")]]
+
+        states, _ = build_node_states(client, cfg, {"node-1": "pool"})
+
+        assert states["node-1"].pods == []
+        assert states["node-1"].cpu_used == 0
+
+    def test_ignores_unrelated_failures(self):
+        cfg = make_config()
+        client = MagicMock()
+        node = make_mock_node("node-1", labels={"karpenter.sh/nodepool": "g5-24xlarge"})
+        evicted = make_mock_pod("evicted-1", node_name="node-1", phase="Failed")
+        evicted.status.reason = "Evicted"
+        evicted.status.message = "The node was low on resource: memory"
+        client.list.side_effect = [[node], [], [evicted]]
+
+        states, _ = build_node_states(client, cfg, {"node-1": "pool"})
+
+        assert states["node-1"].admission_failures == []
+
+    def test_attributes_failures_to_the_owning_node(self):
+        cfg = make_config()
+        client = MagicMock()
+        bad = make_mock_node("bad", labels={"karpenter.sh/nodepool": "g5-24xlarge"})
+        good = make_mock_node("good", labels={"karpenter.sh/nodepool": "g5-24xlarge"})
+        pods = [self._rejected_pod("r1", node_name="bad"), self._rejected_pod("r2", node_name="bad")]
+        client.list.side_effect = [[bad, good], [], pods]
+
+        states, _ = build_node_states(client, cfg, {"bad": "pool", "good": "pool"})
+
+        assert len(states["bad"].admission_failures) == 2
+        assert states["good"].admission_failures == []
+
+    def test_detects_the_gpu_unhealthy_taint(self):
+        cfg = make_config()
+        client = MagicMock()
+        node = make_mock_node(
+            "node-1",
+            labels={"karpenter.sh/nodepool": "g5-24xlarge"},
+            taints=[make_mock_taint("node-compactor.osdc.io/gpu-unhealthy")],
+        )
+        client.list.side_effect = [[node], [], []]
+
+        states, _ = build_node_states(client, cfg, {"node-1": "pool"})
+
+        assert states["node-1"].is_gpu_quarantined is True
+        # The quarantine taint must not be mistaken for the consolidation taint.
+        assert states["node-1"].is_tainted is False

--- a/osdc/base/node-compactor/scripts/python/test_gpu_health.py
+++ b/osdc/base/node-compactor/scripts/python/test_gpu_health.py
@@ -1,0 +1,265 @@
+"""Unit tests for GPU black-hole detection."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from gpu_health import (
+    admission_failure_time,
+    count_recent_failures,
+    select_quarantine_nodes,
+)
+from models import Config, NodeState
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+NOW = datetime.now(UTC)
+
+# Verbatim kubelet rejection message from the 2026-09-03 g5.24xlarge episode.
+REAL_MESSAGE = (
+    "Pod was rejected: Allocate failed due to device plugin GetPreferredAllocation "
+    "rpc failed with err: rpc error: code = Unknown desc = error getting list of "
+    "preferred allocation devices: unable to get device link information: error "
+    "getting NVLink for devices (0, 1): failed to get nvlink remote pci info: "
+    "failed to get nvlink state: GPU is lost, which is unexpected"
+)
+
+
+def make_config(**overrides) -> Config:
+    defaults = {
+        "interval": 20,
+        "max_uptime_hours": 48,
+        "nodepool_label": "osdc.io/node-compactor",
+        "taint_key": "node-compactor.osdc.io/consolidating",
+        "min_nodes": 1,
+        "dry_run": False,
+        "taint_cooldown": 300,
+        "min_node_age": 900,
+        "fleet_cooldown": 120,
+        "taint_rate": 1.0,
+        "spare_capacity_nodes": 2,
+        "spare_capacity_ratio": 0.15,
+        "spare_capacity_threshold": 0.4,
+        "capacity_reservation_nodes": 0,
+        "peak_window_seconds": 2700,
+        "pending_pod_max_age_seconds": 14400,
+        "pending_pod_min_age_seconds": 0,
+        "gpu_quarantine_enabled": True,
+        "gpu_quarantine_threshold": 3,
+        "gpu_quarantine_window_seconds": 300,
+        "gpu_quarantine_max_fleet_ratio": 0.2,
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+def make_pod(reason: str | None, message: str | None, created: datetime | None = NOW):
+    pod = MagicMock()
+    pod.status.reason = reason
+    pod.status.message = message
+    pod.metadata.creationTimestamp = created
+    return pod
+
+
+def make_gpu_node(
+    name: str,
+    failures: int = 0,
+    age_seconds: int = 10,
+    gpus: int = 4,
+    fleet: str = "g5",
+    quarantined: bool = False,
+) -> NodeState:
+    return NodeState(
+        name=name,
+        nodepool=f"{fleet}-24xlarge",
+        allocatable_cpu=96,
+        allocatable_memory=384 * 1024**3,
+        allocatable_gpu=gpus,
+        creation_time=NOW - timedelta(hours=2),
+        labels={"node-fleet": fleet},
+        is_gpu_quarantined=quarantined,
+        admission_failures=[NOW - timedelta(seconds=age_seconds)] * failures,
+    )
+
+
+def fleet_key(ns: NodeState) -> str:
+    return ns.labels.get("node-fleet") or ns.nodepool
+
+
+# ============================================================================
+# admission_failure_time
+# ============================================================================
+
+
+class TestAdmissionFailureTime:
+    def test_matches_real_kubelet_message(self):
+        pod = make_pod("UnexpectedAdmissionError", REAL_MESSAGE)
+        assert admission_failure_time(pod) == NOW
+
+    def test_ignores_other_reasons(self):
+        pod = make_pod("Evicted", REAL_MESSAGE)
+        assert admission_failure_time(pod) is None
+
+    def test_ignores_uncategorized_failures_without_the_signature(self):
+        """UnexpectedAdmissionError is kubelet's catch-all bucket.
+
+        Matching on reason alone would quarantine nodes for unrelated
+        admission errors, so the message signature has to carry the match.
+        """
+        pod = make_pod(
+            "UnexpectedAdmissionError",
+            "Pod was rejected: Allocate failed due to some other thing, which is unexpected",
+        )
+        assert admission_failure_time(pod) is None
+
+    def test_ignores_topology_affinity_error(self):
+        """TopologyAffinityError is a distinct typed reason, not this fault."""
+        pod = make_pod("TopologyAffinityError", "Resources cannot be allocated with Topology locality")
+        assert admission_failure_time(pod) is None
+
+    def test_tolerates_missing_message(self):
+        assert admission_failure_time(make_pod("UnexpectedAdmissionError", None)) is None
+
+    def test_tolerates_missing_status(self):
+        pod = MagicMock()
+        pod.status = None
+        assert admission_failure_time(pod) is None
+
+
+# ============================================================================
+# count_recent_failures
+# ============================================================================
+
+
+class TestCountRecentFailures:
+    def test_counts_within_window(self):
+        ns = make_gpu_node("n1", failures=5, age_seconds=10)
+        assert count_recent_failures(ns, make_config(), NOW) == 5
+
+    def test_excludes_stale_failures(self):
+        """Rejected pod objects linger in Failed phase and are not always reaped.
+
+        An unbounded count would keep a node quarantined off corpses long
+        after the fault, so anything outside the window must not count.
+        """
+        ns = make_gpu_node("n1", failures=9, age_seconds=3600)
+        assert count_recent_failures(ns, make_config(), NOW) == 0
+
+    def test_boundary_is_inclusive(self):
+        ns = make_gpu_node("n1", failures=1, age_seconds=300)
+        assert count_recent_failures(ns, make_config(gpu_quarantine_window_seconds=300), NOW) == 1
+
+
+# ============================================================================
+# select_quarantine_nodes
+# ============================================================================
+
+
+class TestSelectQuarantineNodes:
+    def test_quarantines_node_over_threshold(self):
+        states = {"bad": make_gpu_node("bad", failures=3)}
+        selected, counts = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == {"bad"}
+        assert counts == {"bad": 3}
+
+    def test_leaves_node_under_threshold(self):
+        states = {"n1": make_gpu_node("n1", failures=2)}
+        selected, counts = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == set()
+        # Still reported, so the metric shows pressure before the taint lands.
+        assert counts == {"n1": 2}
+
+    def test_ignores_non_gpu_nodes(self):
+        """A CPU node cannot hit this fault; its failures mean something else."""
+        cpu_node = make_gpu_node("cpu-1", failures=10, gpus=0, fleet="c7a")
+        selected, counts = select_quarantine_nodes({"cpu-1": cpu_node}, make_config(), fleet_key, NOW)
+        assert selected == set()
+        assert counts == {}
+
+    def test_skips_already_quarantined(self):
+        states = {"bad": make_gpu_node("bad", failures=9, quarantined=True)}
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == set()
+
+    def test_disabled_returns_nothing(self):
+        states = {"bad": make_gpu_node("bad", failures=99)}
+        selected, counts = select_quarantine_nodes(states, make_config(gpu_quarantine_enabled=False), fleet_key, NOW)
+        assert selected == set()
+        assert counts == {}
+
+    def test_only_the_failing_node_in_a_healthy_fleet(self):
+        states = {f"ok-{i}": make_gpu_node(f"ok-{i}") for i in range(9)}
+        states["bad"] = make_gpu_node("bad", failures=4)
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == {"bad"}
+
+    def test_fleet_cap_limits_mass_quarantine(self):
+        """A fleet-wide fault must not cordon the whole fleet.
+
+        10 nodes at ratio 0.2 caps total quarantine at 2, even though all 10
+        are failing — turning a degraded fleet into no fleet is worse.
+        """
+        states = {f"n{i}": make_gpu_node(f"n{i}", failures=5) for i in range(10)}
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert len(selected) == 2
+
+    def test_fleet_cap_counts_existing_quarantines(self):
+        states = {f"n{i}": make_gpu_node(f"n{i}", failures=5) for i in range(10)}
+        states["n0"] = make_gpu_node("n0", failures=5, quarantined=True)
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        # Cap of 2 with one already quarantined leaves room for exactly one.
+        assert len(selected) == 1
+
+    def test_cap_allows_at_least_one(self):
+        """Small fleets would otherwise round the cap down to zero."""
+        states = {"only": make_gpu_node("only", failures=5)}
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == {"only"}
+
+    def test_cap_is_per_fleet(self):
+        states = {f"g5-{i}": make_gpu_node(f"g5-{i}", failures=5, fleet="g5") for i in range(5)}
+        states.update({f"g6-{i}": make_gpu_node(f"g6-{i}", failures=5, fleet="g6") for i in range(5)})
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert len([n for n in selected if n.startswith("g5-")]) == 1
+        assert len([n for n in selected if n.startswith("g6-")]) == 1
+
+    def test_worst_offender_wins_when_capped(self):
+        states = {f"n{i}": make_gpu_node(f"n{i}", failures=3) for i in range(10)}
+        states["worst"] = make_gpu_node("worst", failures=50)
+        selected, _ = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert "worst" in selected
+
+    def test_stale_failures_do_not_trigger(self):
+        states = {"n1": make_gpu_node("n1", failures=99, age_seconds=7200)}
+        selected, counts = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+        assert selected == set()
+        assert counts == {}
+
+
+# ============================================================================
+# Regression: the 2026-09-03 episode
+# ============================================================================
+
+
+class TestSep3Episode:
+    """The real incident: one lost A10G on a 4-GPU g5.24xlarge.
+
+    The node stayed Ready and kept advertising 4 allocatable GPUs while its
+    kubelet rejected 554 pods over 1h46m. Detection has to come from the pod
+    corpses, because nothing on the node itself was ever wrong.
+    """
+
+    def test_black_hole_is_quarantined_within_the_first_handful_of_pods(self):
+        node = make_gpu_node("ip-10-4-164-212.us-east-2.compute.internal", failures=0, gpus=4)
+        # Observed rate was roughly one rejection every 6-13 seconds.
+        node.admission_failures = [NOW - timedelta(seconds=s) for s in (26, 13, 0)]
+        healthy = {f"ok-{i}": make_gpu_node(f"ok-{i}") for i in range(19)}
+        states = {node.name: node, **healthy}
+
+        selected, counts = select_quarantine_nodes(states, make_config(), fleet_key, NOW)
+
+        assert selected == {node.name}
+        assert counts[node.name] == 3
+        # The other 19 g5 nodes were healthy and must be untouched.
+        assert all(n.startswith("ok-") is False for n in selected)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1061
* #1060
* #1059
* __->__ #1058

One dead GPU silently takes an entire GPU node out of service.
nvidia-device-plugin's alignedAlloc builds the NVLink topology across ALL
GPUs on the node before filtering to the ones the pod requested, so a
single lost GPU fails GetPreferredAllocation for every GPU pod --
including pods that would have landed on a healthy GPU. The node keeps
reporting Ready and keeps advertising full allocatable GPUs, so it
accepts work at full rate and destroys all of it.

On meta-prod-aws-ue2 today, ip-10-4-164-212 rejected 554 pods over 1h46m,
every one aborting on the same GPU pair (0, 1). It never evaluated GPUs 2
or 3, and never looked at which GPU the pod asked for. The node was
removed at 16:42:23Z by emptiness consolidation, not by health.

Detect this from the rejected pods themselves -- the only place the fault
is observable, since nothing on the node ever reports it -- and taint the
node NoSchedule. The compactor already lists every pod each cycle and
already holds nodes:patch, so this needs no new component and no RBAC
change.

The taint uses its own key: every untaint path is keyed on cfg.taint_key,
so the quarantine cannot be cleared by burst demand, cooldown or
min_nodes. The node drains as its healthy in-flight pods finish and
Karpenter's WhenEmpty policy reaps it, so no running job is killed.
Selection is capped at 20% of a fleet -- a bad AMI or driver rollout must
not cordon every GPU node at once, the same guard Karpenter's own
node-repair path applies.

Refs: https://github.com/meta-pytorch/pytorch-gha-infra/issues/1470