### PR TITLE
[node-compactor] Add per-node quarantine metric and same-cycle taint view

### DIFF
--- a/osdc/base/node-compactor/scripts/python/compactor.py
+++ b/osdc/base/node-compactor/scripts/python/compactor.py
@@ -28,6 +28,7 @@ import metrics as m
 from discovery import build_node_states, discover_managed_nodes
 from gpu_health import select_quarantine_nodes
 from lightkube import ApiError, Client
+from lightkube.models.core_v1 import Taint
 from models import LABEL_NODE_FLEET, TAINT_KEY_GPU_UNHEALTHY, Config, NodeState
 from packing import _count_spare_nodes, compute_taints, select_reserved_nodes
 from phantom import apply_pending_phantom_load
@@ -58,7 +59,11 @@ def quarantine_gpu_black_holes(client: Client, cfg: Config, node_states: dict[st
 
     Returns the set of node names newly quarantined this cycle.
     """
-    quarantine, _failure_counts = select_quarantine_nodes(node_states, cfg, _fleet_group_key)
+    quarantine, failure_counts = select_quarantine_nodes(node_states, cfg, _fleet_group_key)
+    m.refresh_gauge(
+        m.gpu_admission_failures,
+        {(node,): float(count) for node, count in failure_counts.items()},
+    )
 
     quarantined: set[str] = set()
     for node_name in sorted(quarantine):
@@ -66,6 +71,13 @@ def quarantine_gpu_black_holes(client: Client, cfg: Config, node_states: dict[st
             apply_taint(client, node_name, TAINT_KEY_GPU_UNHEALTHY, cfg.dry_run)
             m.taint_operations_total.labels(action="gpu_quarantine", status="success").inc()
             quarantined.add(node_name)
+            if not cfg.dry_run:
+                # Reflect the taint in the in-memory view so this cycle's
+                # scheduling-compatibility checks already treat the node as
+                # unusable rather than waiting for the next reconcile.
+                ns = node_states[node_name]
+                ns.is_gpu_quarantined = True
+                ns.node_taints.append(Taint(key=TAINT_KEY_GPU_UNHEALTHY, value="true", effect="NoSchedule"))
         except ApiError as e:
             if e.status.code == 404:
                 log.info("Node %s disappeared before quarantine, skipping", node_name)

--- a/osdc/base/node-compactor/scripts/python/metrics.py
+++ b/osdc/base/node-compactor/scripts/python/metrics.py
@@ -80,6 +80,12 @@ gpu_quarantined_nodes = Gauge(
     ["fleet"],
 )
 
+gpu_admission_failures = Gauge(
+    "compactor_gpu_admission_failures",
+    "Device plugin allocation failures per GPU node within the detection window",
+    ["node"],
+)
+
 # --- Counters ---
 
 reconcile_cycles_total = Counter(

--- a/osdc/base/node-compactor/scripts/python/test_compactor.py
+++ b/osdc/base/node-compactor/scripts/python/test_compactor.py
@@ -3191,6 +3191,28 @@ class TestQuarantineGPUBlackHoles:
         assert mock_apply.call_args[0][2] == "node-compactor.osdc.io/gpu-unhealthy"
 
     @patch("compactor.apply_taint")
+    def test_updates_in_memory_state_same_cycle(self, _mock_apply):
+        """Downstream scheduling checks in this same cycle must see the taint."""
+        cfg = make_config()
+        node = self._failing_node()
+        states = {"bad": node}
+
+        quarantine_gpu_black_holes(MagicMock(), cfg, states)
+
+        assert node.is_gpu_quarantined is True
+        assert any(t.key == "node-compactor.osdc.io/gpu-unhealthy" for t in node.node_taints)
+
+    @patch("compactor.apply_taint")
+    def test_dry_run_does_not_mutate_state(self, _mock_apply):
+        cfg = make_config(dry_run=True)
+        node = self._failing_node()
+
+        quarantine_gpu_black_holes(MagicMock(), cfg, {"bad": node})
+
+        assert node.is_gpu_quarantined is False
+        assert node.node_taints == []
+
+    @patch("compactor.apply_taint")
     def test_healthy_node_untouched(self, mock_apply):
         cfg = make_config()
         states = {"ok": self._failing_node("ok", failures=0)}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1061
* __->__ #1060
* #1059
* #1058

Two refinements on top of the quarantine, neither required for it to
work.

Export compactor_gpu_admission_failures per node so the metric shows
pressure building before the threshold trips, rather than only after the
taint lands. This is the series to alert on.

Reflect a freshly applied quarantine taint in the in-memory NodeState so
this cycle's scheduling-compatibility checks already treat the node as
unusable. Without it the node is correctly excluded on the next reconcile
anyway, roughly 7s later.

Refs: https://github.com/meta-pytorch/pytorch-gha-infra/issues/1470