### PR TITLE
[logging] Stop dropping every kernel journal line

### DIFF
--- a/osdc/modules/logging/pipelines/base.alloy
+++ b/osdc/modules/logging/pipelines/base.alloy
@@ -20,19 +20,35 @@ loki.source.journal "system" {
     relabel_rules = loki.relabel.journal_relabel.rules
 }
 
-// Filter journal to only the units we care about
+// Filter journal to only the units we care about.
+//
+// Order matters. `unit` is derived FIRST and the keep is applied to the
+// derived label, because kernel messages carry no `_SYSTEMD_UNIT` at all —
+// they are identified by `_TRANSPORT=kernel`. Keeping directly on
+// `__journal__systemd_unit` (as this did previously) therefore dropped every
+// kernel line silently while still listing "kernel" in the regex, which cost
+// us the NVIDIA Xid records during the 2026-09-03 GPU black-hole incident.
 loki.relabel "journal_relabel" {
     forward_to = []
 
     rule {
         source_labels = ["__journal__systemd_unit"]
-        regex         = "kubelet.service|containerd.service|kernel|nvidia-fabricmanager.service|nvidia-persistenced.service"
-        action        = "keep"
+        target_label  = "unit"
+    }
+
+    // Kernel messages have no systemd unit; label them from the transport so
+    // the keep below retains them. NVRM/Xid lines arrive on this path.
+    rule {
+        source_labels = ["__journal__transport"]
+        regex         = "kernel"
+        target_label  = "unit"
+        replacement   = "kernel"
     }
 
     rule {
-        source_labels = ["__journal__systemd_unit"]
-        target_label  = "unit"
+        source_labels = ["unit"]
+        regex         = "kubelet.service|containerd.service|kernel|nvidia-fabricmanager.service|nvidia-persistenced.service"
+        action        = "keep"
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1061
* #1060
* #1059
* #1058

The journal keep rule matched __journal__systemd_unit against a regex
that includes "kernel", but kernel messages carry no _SYSTEMD_UNIT --
they are identified by _TRANSPORT=kernel. So the rule silently dropped
every kernel line while reading as though it collected them, and
docs/loki_query.md lists "kernel" as an available unit value that has
never actually existed. Only four unit values are present in Loki:
kubelet.service, containerd.service, nvidia-fabricmanager.service and
nvidia-persistenced.service.

This cost us the NVRM/Xid records for the 2026-09-03 GPU black-hole
incident, and it is the same stream the EKS node monitoring agent parses,
so it also blocks evaluating whether AcceleratedHardwareReady would fire
for that fault.

Derive `unit` first, label kernel messages from the transport, then apply
the keep to the derived label.

Not yet verified against a live cluster: confirming it is one query for
{unit="kernel"} once the logging module rolls out.

Refs: https://github.com/meta-pytorch/pytorch-gha-infra/issues/1470