### PR TITLE
[gpu-dev] Point B200 at the new capacity block cr-0ff6b4e00366a231d

### DIFF
--- a/gpu-dev/terraform-gpu-devservers/main.tf
+++ b/gpu-dev/terraform-gpu-devservers/main.tf
@@ -488,9 +488,9 @@ locals {
         { key = "cr2", id = null, instance_count = 2 },                   # B200 on-demand (2 instances)
         # cr-0ff6b4e00366a231d replaces cr-0f5f6bb30a8fe3c68 (expired 2026-09-01).
         # The new block holds ONE instance where the old held two, so cr3 + cr4
-        # must sum to <= 1. Both start at 0 so this is safe to land before the
-        # block opens (2026-09-10 11:30 UTC); set exactly one to 1 afterwards.
-        { key = "cr3", id = "cr-0ff6b4e00366a231d", instance_count = 0 }, # B200 reservation us-east-2b (full 8-GPU node)
+        # must sum to <= 1. The instance goes to cr3 (whole node); cr4 stays at 0
+        # until there is a second instance to partition.
+        { key = "cr3", id = "cr-0ff6b4e00366a231d", instance_count = 1 }, # B200 reservation us-east-2b (full 8-GPU node)
         { key = "cr4", id = "cr-0ff6b4e00366a231d", instance_count = 0, mig_profile = "b200-6full-2mig-balanced" }, # B200 reservation us-east-2b (MIG node, auto-labeled)
       ]
       # T4 and L4 don't have capacity reservations - managed via supported_gpu_types fallback

--- a/gpu-dev/terraform-gpu-devservers/main.tf
+++ b/gpu-dev/terraform-gpu-devservers/main.tf
@@ -484,10 +484,14 @@ locals {
       ]
       b200 = [
         { key = "cr0", id = "cr-0c366fb8339a10f69", instance_count = 0 }, # B200 reservation us-east-2a (disabled - CR freed)
-        { key = "cr1", id = "cr-08e7fee0b8dc3de5e", instance_count = 3 }, # B200 reservation (3 instances)
+        { key = "cr1", id = "cr-08e7fee0b8dc3de5e", instance_count = 0 }, # B200 reservation us-east-2b (disabled - CR deleted 2026-09)
         { key = "cr2", id = null, instance_count = 2 },                   # B200 on-demand (2 instances)
-        { key = "cr3", id = "cr-0f5f6bb30a8fe3c68", instance_count = 1 }, # B200 reservation us-east-2b (1 regular instance)
-        { key = "cr4", id = "cr-0f5f6bb30a8fe3c68", instance_count = 1, mig_profile = "b200-6full-2mig-balanced" }, # B200 reservation us-east-2b (1 MIG instance, auto-labeled)
+        # cr-0ff6b4e00366a231d replaces cr-0f5f6bb30a8fe3c68 (expired 2026-09-01).
+        # The new block holds ONE instance where the old held two, so cr3 + cr4
+        # must sum to <= 1. Both start at 0 so this is safe to land before the
+        # block opens (2026-09-10 11:30 UTC); set exactly one to 1 afterwards.
+        { key = "cr3", id = "cr-0ff6b4e00366a231d", instance_count = 0 }, # B200 reservation us-east-2b (full 8-GPU node)
+        { key = "cr4", id = "cr-0ff6b4e00366a231d", instance_count = 0, mig_profile = "b200-6full-2mig-balanced" }, # B200 reservation us-east-2b (MIG node, auto-labeled)
       ]
       # T4 and L4 don't have capacity reservations - managed via supported_gpu_types fallback
     }
@@ -564,7 +568,8 @@ locals {
       "cr-0c366fb8339a10f69" = "primary"   # us-east-2a
       "cr-0122dff5e01d566dc" = "secondary" # us-east-2b
       "cr-08e7fee0b8dc3de5e" = "secondary" # us-east-2b
-      "cr-0f5f6bb30a8fe3c68" = "secondary" # us-east-2b
+      "cr-0f5f6bb30a8fe3c68" = "secondary" # us-east-2b (expired 2026-09-01 - kept to prevent ASG destroy)
+      "cr-0ff6b4e00366a231d" = "secondary" # us-east-2b (capacity block 2026-09-10 -> 2026-11-05, 1 instance)
       # H200 capacity reservations
       "cr-0f6d0766f5d3339e6" = "tertiary" # us-east-2c (may be expired - kept to prevent ASG destroy)
       "cr-06c9c978dea756a26" = "tertiary"  # us-east-2c


### PR DESCRIPTION
B200 has been at **zero nodes** — all four reserved slots pointed at capacity reservations AWS has since deleted, so every launch failed and the ASGs just retried:

| ASG | desired | running | failure |
|---|---|---|---|
| `b200-cr1` | 3 | 0 | `cr-08e7fee0b8dc3de5e` not valid (deleted) |
| `b200-cr2` | 2 | 0 | no `p6-b200.48xlarge` on-demand capacity in us-east-2b |
| `b200-cr3` | 1 | 0 | `cr-0f5f6bb30a8fe3c68` not valid (expired 2026-09-01) |
| `b200-cr4` | 1 | 0 | same |

The replacement capacity block `cr-0ff6b4e00366a231d` (`p6-b200.48xlarge`, us-east-2b, 2026-09-10 → 2026-11-05) is now **active** with `TotalInstanceCount = 1`.

## Changes

- **`cr3` → `cr-0ff6b4e00366a231d`, `instance_count = 1`** — the one instance, as a full 8-GPU node.
- **`cr4` → same CR, `instance_count = 0`.** The old CR held *two* instances (cr3 = whole node, cr4 = MIG `b200-6full-2mig-balanced`); the new block holds one, so cr3 + cr4 must sum to ≤ 1. Whole-node wins; MIG comes back if we get a second instance.
- **`cr1`: 3 → 0.** Its CR is deleted too, so the ASG could never satisfy 3 desired. Stops the churn.
- **AZ map**: added the new CR as `secondary` (us-east-2b). Kept the expired entry — removing it destroys the ASG.

**Not changed:** `cr2` is on-demand (`id = null`) and its failure is AWS-side capacity in us-east-2b, not a config bug. Worth a separate look if it stays dry.

## Test plan

Config-only change to a `locals` map; no CI coverage applies.

- Verified against AWS: new CR `active`, 1 instance available; `cr-08e7fee0b8dc3de5e`, `cr-0f5f6bb30a8fe3c68` and `cr-0c366fb8339a10f69` all return `InvalidCapacityReservationId.NotFound`.
- `tofu plan` (workspace `prod`), attributable to this PR: `b200-cr1` ASG 3→0, `b200-cr4` ASG 1→0, `b200-cr3` ASG holds at 1, and the cr3/cr4 launch templates retarget `capacity_reservation_id` to the new CR.
- The same plan shows extra noise **unrelated to this PR**, all of it pre-existing:
  - 20 launch templates show `image_id -> (known after apply)`. This is cosmetic: `data.aws_ami_ids.gpu_baked_resolved` is deferred because `null_resource.ami_baker` has a pending destroy, and it resolves to `ami-0b77ff34fd6bd7665` — the AMI those templates already reference. No AMI change, no node roll.
  - `null_resource.ami_baker[0]` destroyed: its `count` drops to 0 now that the baked AMI exists. Create-time `local-exec` only, no destroy provisioner, so state-only.
  - `availability_updater_build` / `reservation_expiry_build` replaced: real unapplied `lambda/shared/` changes (on-disk hash `3cefaac5…` vs state `ee4a88b4…`). `reservation_processor_build` hashes the same folder and is already current, so this is leftover from an earlier partial apply.
- `tofu fmt` left alone — it wants to reformat unrelated pre-existing lines, and there's no terraform-fmt pre-commit hook.

## Follow-up (separate PR)

11 of the 12 CR ids in `main.tf` are now deleted. The lone survivor is `cr-044bc72b0a6b56062` (p5/H100, 4 instances, **expires 2026-12-03**), so h100/h200/a100 carry the same latent problem and H100 will go the way B200 just did. Worth doing: sweep the dead ids, and alert on `EndDate` approaching. This is the second silent full-fleet loss in two weeks, and both surfaced only when a user couldn't reserve.
