### PR TITLE
Add a GPU release runner for the CUDA wheel rows

### DIFF
--- a/osdc/modules/arc-runners/defs/rel-l-x86aavx2-29-113-l4.yaml
+++ b/osdc/modules/arc-runners/defs/rel-l-x86aavx2-29-113-l4.yaml
@@ -1,0 +1,25 @@
+# ARC runner definition: rel-l-x86aavx2-29-113-l4
+# Release wheel-build runner (x86, GPU) — dedicated runner group + node isolation.
+# Instance type: g6.8xlarge — 1-GPU L4, 32c/128Gi node (pool: g6-8xlarge-release).
+# Sized like the CI l-x86aavx2-29-113-l4 runner on the same instance: actual K8s
+# capacity ~118.4Gi, max job memory after overhead 113Gi. One GPU per node means
+# one runner per node without needing bare-metal sizing.
+#
+# Exists for the CUDA x86_64 wheel rows, whose smoke test exports a model through
+# the CUDA partitioner and runs it, so unlike the CPU release runners this one
+# needs a device. L4 is sm_89, which the x86_64 rows already compile for
+# (.ci/scripts/wheel/cuda_arch_list.sh: 8.0 8.6 8.9 9.0 10.0 12.0).
+runner:
+  name: rel-l-x86aavx2-29-113-l4
+  instance_type: g6.8xlarge
+  disk_size: 600
+  vcpu: 29
+  memory: 113Gi
+  gpu: 1
+  runner_class: release
+  # No runner_group here: release-class runners always land in the per-region
+  # group {cluster_group}-release-runners, derived by generate_runners.py from
+  # the cluster config (a def-level runner_group would be ignored for them).
+  proactive_capacity: 0
+  hud_failure_base_capacity: 0    # release builds aren't in the HUD queue; scale on demand
+  max_burst_capacity: 10

--- a/osdc/modules/nodepools/defs/g6.yaml
+++ b/osdc/modules/nodepools/defs/g6.yaml
@@ -13,6 +13,17 @@ fleet:
   # survivors are reordered by cost per delivered runner-hour rather than
   # left in largest-first order. See docs/current_runner_load_distribution.md
   # for the runner mix (94% 1-GPU / 6% 4-GPU) that the LF order is tuned for.
+  # Release wheel-build GPU runner (rel-l-x86aavx2-29-113-l4). Generates the
+  # g6-8xlarge-release NodePool with osdc.io/runner-class: release, so the CUDA
+  # x86_64 wheel rows get a device without sharing nodes with CI GPU jobs.
+  # g6.8xlarge rather than g5.8xlarge: same 32c/128Gi 1-GPU shape, cheaper per
+  # runner-hour, and L4 (sm_89) is in the arch list those wheels compile for.
+  release:
+    - type: g6.8xlarge
+      weight: 100
+      node_disk_size: 600
+      has_nvme: true
+
   instances:
     - type: g6.48xlarge
       weight:


### PR DESCRIPTION
Adds `rel-l-x86aavx2-29-113-l4` on `g6.8xlarge`, plus the `g6-8xlarge-release` NodePool it schedules onto.

Both existing release runners are CPU-only, so the CUDA x86_64 wheel rows have nowhere isolated to build: their smoke test exports a model through the CUDA partitioner and runs it, so pointing them at the r7a release pool would turn that check into a silent skip.

g6 over g5: same 32c/128Gi 1-GPU shape, and this fleet's own measured numbers put `g6.8xlarge` at the 1-GPU cost optimum ($2.01/runner-hr) vs ~$2.45 for `g5.8xlarge`. L4 is sm_89, which the wheel rows already compile device code for (`8.0 8.6 8.9 9.0 10.0 12.0`), so the smoke test still exercises an architecture the artifact claims.

Tests: `generate_nodepools` and `generate_runners` suites pass. Rendered against `meta-prod-aws-ue1` — `g6-8xlarge-release` carries `osdc.io/runner-class: release` and the NVIDIA AMI; the runner lands in `meta-prod-aws-ue1-release-runners` with `nvidia.com/gpu: 1`.

Consumer: pytorch/executorch#22753.