### PR TITLE
nodepools: park a Packer build for an NVIDIA 615 GPU AMI (CUDA 13.4)

### DIFF
--- a/osdc/CLAUDE.md
+++ b/osdc/CLAUDE.md
@@ -83,3 +83,4 @@ Reference documentation in `docs/`:
 | `docs/pypi-package-cache.md` | PyPI wheel cache architecture, slug naming, S3 layout, runner integration |
 | `docs/h100-fabric-handles-imex-channels.md` | Enabling CUDA fabric handles (`CU_MEM_HANDLE_TYPE_FABRIC`) on H100 runners — IMEX channel creation, the gated fabric runner, and verification |
 | `docs/dcgm-exporter-memory-tuning.md` | Why dcgm-exporter OOMs on high-vCPU GPU nodes (Go 1.24 GOMAXPROCS defaults to host vCPU count) and the GOMAXPROCS=2 fix |
+| `docs/nvidia-driver-615-ami.md` | CUDA 13.4 / NVIDIA R615 — why the stock EKS GPU AMI cannot reach it, and the parked (unadopted) Packer driver-swap in `modules/nodepools/packer/` |

--- a/osdc/docs/nvidia-driver-615-ami.md
+++ b/osdc/docs/nvidia-driver-615-ami.md
@@ -1,0 +1,170 @@
+# NVIDIA driver R615 for the compute GPU fleets (CUDA 13.4)
+
+Investigation and a parked implementation. **Nothing is adopted** — every GPU
+pool still runs the stock EKS GPU AMI at driver 580. This records what CUDA 13.4
+actually requires, why the obvious upgrade paths do not work, and what the build
+in `modules/nodepools/packer/` does if we decide we need it.
+
+Verified September 2026 against CUDA 13.4.1 GA and EKS AMI `v20260903`.
+
+> **Companion doc:** `docs/nvidia-driver-ahead-of-aws.md` (PR #1064) is the
+> broader survey — observed driver versions across recent AMI releases, the
+> `cuda-compat-13-4` and GPU Operator options, and the separate GPU-AMI-glob
+> Kubernetes skew bug it turned up. This doc is narrower: it is the build for
+> that survey's leading candidate, plus the two things that only surface once
+> you try it (the GRID runfile ceiling, and the boot-time kmod selection
+> failure). Read that one first for the decision, this one for the mechanics.
+> Note 13.4 has since gone GA, which that doc predates.
+
+## What CUDA 13.4 actually requires
+
+CUDA 13.4.1 went GA in September 2026 (13.4.0 was a July developer preview). Its
+corresponding driver branch is **R615** — `615.71.09` on Linux.
+
+The distinction that decides whether any of this is worth doing:
+
+| Need | Minimum driver |
+|------|----------------|
+| Run existing CUDA 13.x applications (minor version compatibility) | **>= 580** |
+| CUDA 13.4's *new* features and newly enabled platforms | **R615** |
+
+The fleet is already at 580. **CUDA 13.4 binaries run on it today.** R615 buys
+13.4-specific features — Vera Rubin support (developer preview), PTX ISA 9.4,
+GCC 16 / Clang 22 / libc++ 22 with nvcc, Windows-on-Arm — none of which is on
+the critical path for PyTorch CI as of this writing. `pypi-cache` currently
+builds `cu126`, `cu128` and `cu130` (`clusters.yaml`), so nothing in the fleet
+targets 13.4 yet either.
+
+If the only goal is "run CUDA 13.4 workloads", the correct amount of
+infrastructure work is **zero**, plus a `cu134` slug in pypi-cache.
+
+## Where the driver comes from today
+
+Nothing in `osdc/` pins a driver version. GPU nodepools take whatever the newest
+EKS GPU AMI ships:
+
+```python
+# modules/nodepools/scripts/python/generate_nodepools.py
+if is_gpu:
+    ami_family_block = "  amiFamily: AL2023"
+    ami_selector_block = """  amiSelectorTerms:
+    - name: "amazon-eks-node-al2023-x86_64-nvidia-*\""""
+```
+
+That glob covers g5/g6/g4dn, p4d, p5 (`nodepools-h100`) and p6-b200
+(`nodepools-b200`). `base_node_ami_version: "v20260903"` in `clusters.yaml` pins
+only the CPU `-standard-` image for base nodes. The H100 and B200 userData
+scripts do persistence mode and IMEX channel setup but explicitly rely on the
+AMI for the driver and Fabric Manager.
+
+Current resolution, us-east-2 / k8s 1.35: `ami-03d982742c1ceed36`, release
+`1.35.7-20260903`, **driver 580**.
+
+(For contrast, `gpu-dev/` does pin — it `dnf install`s the driver directly in
+`terraform-gpu-devservers/templates/al2023-user-data.sh`, currently landing on
+595. That fleet could move to 615 with a one-line change and no AMI build, which
+makes it the cheaper place to get a first real signal on R615.)
+
+## Why there is no easy path to 615
+
+Three doors, all closed:
+
+**1. Wait for the stock AMI.** The EKS AMI build defaults to
+`nvidia_driver_major_version = "580"`. Upstream added *build* support for 595
+recently, but 595 is not the published default, and there is no 610 or 615 work
+in `awslabs/amazon-eks-ami` at all.
+
+**2. Build the EKS AMI from source with `=615`.** Two hard blockers:
+
+- The build resolves the full version as `min(kmod-nvidia-open-dkms, AWS GRID
+  runfile)`. AWS's public `s3://ec2-linux-nvidia-drivers` bucket tops out at
+  `595.91.07` — no 610, no 615. `archive-grid-kmod` hard-errors when no runfile
+  matches, and the `min()` would pin back to 595 regardless.
+- `archive-proprietary-kmod` installs `kmod-nvidia-latest-dkms-<version>`.
+  **R615 ships no proprietary kernel module.** The NVIDIA AL2023 repo's
+  `kmod-nvidia-latest-dkms` stops at 610; from 615 the RPMs obsolete
+  `cuda-drivers` in favour of `nvidia-open`.
+
+  This is also why AWS cannot trivially ship 615 themselves: their boot-time
+  flavor selector hardcodes `g4dn`/`g5`/`g5g` to the proprietary module for a
+  GSP workaround.
+
+**3. NVIDIA GPU Operator managing the driver.** Not supported on Amazon Linux —
+AWS's own guidance is to run the operator with `driver.enabled=false` on the
+accelerated AMIs, and NVIDIA publishes no AL2023 precompiled driver container.
+It would mean moving the GPU fleets to self-managed Ubuntu nodes.
+
+**What is available:** the NVIDIA `cuda-amzn2023` repo has the complete 615.71.09
+set — `kmod-nvidia-open-dkms`, `nvidia-driver*`, `nvidia-fabricmanager`,
+`nvidia-imex`, `nvidia-persistenced`, and `cuda-compat-13-4`. So the packages
+exist; only AWS's packaging of them does not.
+
+## The fourth door, which is what got built
+
+Take the finished EKS GPU AMI and swap the driver in place with Packer. Keeps us
+on AWS's image, confines the delta to one reviewable script, and reuses the
+`ami_selector_tags` escape hatch and Packer pattern the repo already has from
+`nodepools-agent-sandbox`.
+
+`modules/nodepools/packer/` — see its README for the mechanics (DKMS archives,
+the supported-devices list, and the two patches to
+`/etc/eks/nvidia-kmod-load.sh` that are required because upstream's flavor
+selection assumes a proprietary kmod exists).
+
+```bash
+just build-gpu-driver-ami meta-prod-aws-ue2
+```
+
+Building changes no running fleet. Adoption is a per-def opt-in:
+
+```yaml
+  ami_selector_tags:
+    osdc.io/ami: gpu-nvidia-615
+```
+
+## Risk notes
+
+Two R615 items that sound alarming and are not, here:
+
+- **CDMM.** R615 defaults to driver-managed GPU memory instead of onlining it as
+  a NUMA node, on hardware-coherent platforms. That is GB200-class hardware;
+  every OSDC GPU node is an x86 host with PCIe/NVLink GPUs. It does not apply —
+  and `nvidia-kmod-load.sh` already writes
+  `NVreg_CoherentGPUMemoryMode=driver` unconditionally today.
+- **The 610→615 in-place upgrade hang.** Karpenter nodes are born at the target
+  version; there is no in-place upgrade.
+
+Two that are real:
+
+- **g4dn/g5/g6 are out of scope.** They are exactly the pools that depend on the
+  proprietary kmod and the GSP workaround. The AMI carries a fallback so such a
+  node boots on the open kmod rather than breaking, but it is untested. Keep
+  those pools on the stock glob.
+- **The AMI stops tracking CVE fixes.** Stock GPU pools pick up AL2023 and
+  driver fixes automatically on node rotation. A fleet pinned to a baked AMI
+  only moves when the AMI is rebuilt, and nothing enforces a rebuild on an EKS
+  version bump. This is the strongest argument for not adopting until there is a
+  concrete need.
+
+## If we adopt
+
+Suggested order, smallest blast radius first:
+
+1. `p6-b200` — one node, single capacity block `cr-0b15c0b3163f09d26` in
+   `meta-prod-aws-ue2`. Newest silicon, most to gain.
+2. `p5` — but note `h100-node-setup.sh` builds IMEX channels, which is the most
+   driver-sensitive thing in the fleet. Validate fabric handles per
+   `docs/h100-fabric-handles-imex-channels.md` before trusting it.
+3. `p4d` — on-demand, no capacity block, so the easiest to revert.
+
+Per-node validation after the first boot: `nvidia-smi` reports 615.71.09;
+`nvidia-fabricmanager` and `nvidia-persistenced` are active; `dcgm-exporter` is
+scraping; `lsmod | grep nvidia` shows the open module; `gdrdrv` loaded and
+`/dev/gdrdrv` present; and a real GPU job passes end to end.
+
+## Sources
+
+- [CUDA Toolkit 13.4 release notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)
+- [NVIDIA Data Center Driver 615.71.09 release notes](https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-615-71-09/index.html)
+- [EKS-optimized accelerated AMIs](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html)
+- [awslabs/amazon-eks-ami#2768](https://github.com/awslabs/amazon-eks-ami/issues/2768) — the g7 open-vs-proprietary selection bug this AMI's patch also fixes

--- a/osdc/justfile
+++ b/osdc/justfile
@@ -2249,6 +2249,37 @@ build-agent-sandbox-ami cluster *args:
     echo "existing nodes keep their current AMI until they are recycled:"
     echo "    just recycle-nodes $CLUSTER"
 
+# Build the compute-GPU AMI with NVIDIA 615 (modules/nodepools/packer) in a cluster's region
+#
+# Nothing selects this AMI yet — the GPU pools still track the stock
+# amazon-eks-node-al2023-x86_64-nvidia-* glob (driver 580). Building it is safe
+# and changes no running fleet; adopting it is a separate one-line def change.
+# See modules/nodepools/packer/README.md and docs/nvidia-driver-615-ami.md.
+build-gpu-driver-ami cluster *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "{{UPSTREAM}}/scripts/mise-activate.sh"
+    export CLUSTERS_YAML="{{CLUSTERS_YAML}}"
+    CLUSTER="{{cluster}}"
+    REGION=$(uv run {{CFG}} "$CLUSTER" region)
+    CNAME=$(uv run {{CFG}} "$CLUSTER" cluster_name)
+    K8S_VERSION=$(uv run {{CFG}} "$CLUSTER" eks_version)
+    PACKER_DIR="{{UPSTREAM}}/modules/nodepools/packer"
+
+    echo "Building GPU driver AMI for $CLUSTER ($REGION, k8s $K8S_VERSION)..."
+    cd "$PACKER_DIR"
+    packer init .
+    packer build \
+        -var "aws_region=${REGION}" \
+        -var "cluster_name=${CNAME}" \
+        -var "k8s_version=${K8S_VERSION}" \
+        {{args}} .
+
+    echo ""
+    echo "Built, and unused until a nodepool def opts in with:"
+    echo "    ami_selector_tags:"
+    echo "      osdc.io/ami: gpu-nvidia-615"
+
 # Run full integration test against a cluster
 integration-test cluster *args:
     #!/usr/bin/env bash

--- a/osdc/modules/nodepools/packer/README.md
+++ b/osdc/modules/nodepools/packer/README.md
@@ -1,0 +1,133 @@
+# nodepools/packer — compute-GPU AMI with NVIDIA 615
+
+Builds an EKS AL2023 GPU AMI with the NVIDIA driver swapped from the stock **580**
+to **615.71.09** (R615), the branch CUDA 13.4 asks for.
+
+**Nothing selects this AMI.** Every GPU pool still tracks the stock
+`amazon-eks-node-al2023-x86_64-nvidia-*` glob. This is built and parked so the
+option exists; adopting it is a separate, one-line change per def. The *why* —
+including why 580 is very likely good enough — is in
+[`docs/nvidia-driver-615-ami.md`](../../../docs/nvidia-driver-615-ami.md).
+
+Lives under `modules/nodepools/` rather than a shim because `nodepools-h100` and
+`nodepools-b200` both delegate here, so one AMI serves p4d, p5 and p6-b200.
+
+## Build
+
+```bash
+just build-gpu-driver-ami <cluster>                              # e.g. meta-prod-aws-ue2
+just build-gpu-driver-ami <cluster> -var nvidia_driver_version=615.71.09
+```
+
+AMIs are regional — build once per cluster region. The build instance is a
+`c7a.4xlarge`, not a p-family box: DKMS compiles the module without a GPU, so a
+build costs cents rather than dollars.
+
+## Why a swap and not a build flag
+
+The upstream EKS AMI build takes `nvidia_driver_major_version`, so `=615` looks
+like it should just work. It does not, for two independent reasons:
+
+- `install-nvidia-driver.sh` resolves the full version as
+  `min(kmod-nvidia-open-dkms, AWS GRID runfile)`, and AWS's
+  `s3://ec2-linux-nvidia-drivers` bucket stops at **595.91.07**. There is no 615
+  runfile, so the build either errors or silently pins back to 595.
+- `archive-proprietary-kmod` installs `kmod-nvidia-latest-dkms-<version>`.
+  **R615 ships no proprietary kernel module** — the NVIDIA AL2023 repo's
+  proprietary packages stop at 610 — so that step cannot succeed.
+
+Both are fixable, but only by forking the upstream template. Swapping the driver
+on the finished AMI keeps us on AWS's image and confines the delta to one script.
+
+## What the swap touches
+
+Following the same sequence as upstream's `install-nvidia-driver.sh`:
+
+1. **DKMS archives** under `/var/lib/dkms-archive/` — this is what
+   `nvidia-kmod-load.service` unpacks at boot, so it is the thing that actually
+   determines a node's driver. `nvidia-open` and `gdrdrv` are rebuilt at 615;
+   `nvidia` (proprietary) and `nvidia-open-grid` are deleted and not replaced,
+   because neither exists for this branch.
+2. **Userspace RPMs** — driver, CUDA libs, Fabric Manager, IMEX, persistenced,
+   all pinned to the same full version. A closing assertion fails the build if
+   dnf left any `nvidia-*` package behind at 580.
+3. **`/etc/eks/nvidia-open-supported-devices-615.txt`** — generated from the
+   `supported-gpus.json` the `nvidia-driver` RPM ships, using upstream's own jq
+   filter. Upstream only publishes lists up to 595. The build asserts that A100
+   (`0x20B2`), H100 (`0x2330`) and B200 (`0x2901`) are in it.
+4. **`/etc/eks/nvidia-kmod-load.sh`** — two patches, described below.
+
+## The two patches to nvidia-kmod-load.sh
+
+Both are anchored on exact upstream text, and **the build fails if an anchor is
+missing**. A base-AMI refresh that rewrites this script should be reviewed, not
+silently shipped.
+
+**The version probe.** Upstream reads the major version from the proprietary
+kmod:
+
+```bash
+KMOD_MAJOR_VERSION=$(rpmquery kmod-nvidia-latest-dkms --queryformat '%{VERSION}' | cut -d. -f1)
+```
+
+That package does not exist here, so the probe fails, `devices-support-open`
+returns 1, and selection falls through to a proprietary flavor that also does not
+exist — a node with no driver loaded at all. It is replaced with a read of
+`/etc/eks/osdc-nvidia-driver-major`, written at bake time. (This is the same
+shape as the g7 bug in [awslabs/amazon-eks-ami#2768](https://github.com/awslabs/amazon-eks-ami/issues/2768).)
+
+**The flavor fallback.** `g4dn`/`g5`/`g5g` are hardcoded to the proprietary
+module for a GSP workaround, and GRID subdevices select `nvidia-open-grid`. A
+guard before `kmod-util load` redirects any selection whose archive is absent to
+`nvidia-open`, and removes `nvidia-disable-gsp.conf` on the way (the open kmod
+*requires* GSP firmware, so `NVreg_EnableGpuFirmware=0` must not outlive the
+proprietary flavor that set it).
+
+The guard means a g5 node would boot rather than break, but **that path is
+untested** — see scope below.
+
+## Scope: compute GPUs only
+
+Intended for `p4d` (A100), `p5` (H100), `p6-b200` (B200). Not validated on
+`g4dn`/`g5`/`g6`, which are the pools that actually depend on the proprietary
+kmod and the GSP workaround upstream added for them.
+
+Two things that are *not* a concern here, both worth knowing:
+
+- **CDMM.** R615 changes the default to driver-managed GPU memory on
+  hardware-coherent platforms. Every OSDC GPU node is an x86 host with PCIe /
+  NVLink-attached GPUs, so it does not apply — and the EKS AMI already writes
+  `NVreg_CoherentGPUMemoryMode=driver` unconditionally regardless.
+- **The 610→615 upgrade hang.** NVIDIA advises a reboot after upgrading in
+  place. Karpenter nodes are born at the target version, so there is no in-place
+  upgrade to survive.
+
+## Adopting it
+
+One block per def, e.g. `modules/nodepools-b200/defs/p6.yaml`:
+
+```yaml
+  ami_selector_tags:
+    osdc.io/ami: gpu-nvidia-615
+```
+
+The generator (`generate_nodepools.py`) turns that into an EC2NodeClass
+`amiSelectorTerms.tags` and drops the name glob. Roll back by deleting the block
+and redeploying — existing nodes keep their AMI until recycled
+(`just recycle-nodes <cluster>`).
+
+Start with `p6-b200`: one node behind a single capacity block in
+`meta-prod-aws-ue2`, the smallest blast radius of the three, and the Blackwell
+part with the most to gain from a newer driver.
+
+## Rebuild cadence
+
+Stock GPU pools track the AMI glob and pick up AL2023 and driver CVE fixes
+automatically on node rotation. **A fleet on this AMI does not** — it pins
+whatever EKS GPU image was current at build time, and only moves when rebuilt.
+Each rebuild re-resolves the base from the EKS SSM parameter, so rebuilding is
+the whole refresh procedure. An EKS version bump needs one too, and nothing
+enforces it at launch: the def selects on `osdc.io/ami` alone, so `K8sVersion` in
+the tags is recorded but ignored.
+
+That ongoing cost is the main argument for waiting for AWS to ship 615 instead.

--- a/osdc/modules/nodepools/packer/gpu-nvidia-driver.pkr.hcl
+++ b/osdc/modules/nodepools/packer/gpu-nvidia-driver.pkr.hcl
@@ -1,0 +1,167 @@
+# EKS AL2023 GPU AMI with a newer NVIDIA driver branch baked in, for the compute
+# GPU fleets (p4d / p5 / p6-b200).
+#
+#   just build-gpu-driver-ami <cluster>
+#
+# The stock EKS GPU AMI ships driver 580 and cannot be built past 595 (AWS's
+# GRID runfile bucket gates the version). CUDA 13.4's own feature set wants
+# R615. This takes the finished EKS AMI and swaps the driver in place — see
+# docs/nvidia-driver-615-ami.md for why that is the only route, and README.md
+# here for what the swap touches.
+#
+# Same shape as modules/nodepools-agent-sandbox/packer: base AMI and driver are
+# both pinned, so CVE fixes need a rebuild.
+
+packer {
+  required_version = ">= 1.10"
+
+  required_plugins {
+    amazon = {
+      version = ">= 1.3"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "aws_region" {
+  description = "Region to build the AMI in (must be the cluster's region — AMIs are regional)"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Cluster this AMI is built for; recorded in tags"
+  type        = string
+}
+
+variable "k8s_version" {
+  description = "Kubernetes minor version of the EKS-optimized base AMI (must match the cluster)"
+  type        = string
+}
+
+variable "nvidia_driver_version" {
+  description = "Full NVIDIA driver version to install, from the cuda-amzn2023 repo"
+  type        = string
+  # R615 is the branch CUDA 13.4 asks for. Pinned to a full version rather than
+  # a major: the repo serves several, and two nodes built a week apart should
+  # not differ.
+  default = "615.71.09"
+
+  validation {
+    # Below 615 the stock AMI or an upstream build is the right answer, and this
+    # module's open-kmod-only assumptions do not hold.
+    condition     = parseint(split(".", var.nvidia_driver_version)[0], 10) >= 615
+    error_message = "This module only handles 615+; the proprietary-kmod path it removes still exists below that."
+  }
+}
+
+variable "nvidia_gdrcopy_version" {
+  description = "gdrcopy kmod version to rebuild against the new driver"
+  type        = string
+  # Matches nvidia_gdrcopy_driver_version in the upstream EKS AMI build, so the
+  # node keeps the gdrdrv it would have had.
+  default = "2.5.2"
+}
+
+variable "subnet_filter_name" {
+  description = "Name tag pattern for the build subnet; must have outbound internet (fetches driver RPMs)"
+  type        = string
+  default     = "*-vpc-public-*"
+}
+
+variable "build_instance_type" {
+  description = "Instance type used only for the build — DKMS compiles fine without a GPU, so this is deliberately not a p-family box"
+  type        = string
+  default     = "c7a.4xlarge"
+}
+
+locals {
+  ami_name = "osdc-gpu-nvidia${var.nvidia_driver_version}-k8s${var.k8s_version}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+# Latest EKS-optimized AL2023 *NVIDIA* AMI for this Kubernetes version. This is
+# the same image the stock GPU pools resolve through their
+# `amazon-eks-node-al2023-x86_64-nvidia-*` selector, so the only delta between a
+# stock GPU node and one of these is the driver.
+data "amazon-parameterstore" "eks_al2023_nvidia" {
+  name   = "/aws/service/eks/optimized-ami/${var.k8s_version}/amazon-linux-2023/x86_64/nvidia/recommended/image_id"
+  region = var.aws_region
+}
+
+source "amazon-ebs" "gpu_nvidia" {
+  region          = var.aws_region
+  source_ami      = data.amazon-parameterstore.eks_al2023_nvidia.value
+  instance_type   = var.build_instance_type
+  ssh_username    = "ec2-user"
+  ami_name        = local.ami_name
+  ami_description = "EKS AL2023 GPU + NVIDIA ${var.nvidia_driver_version} for the OSDC compute GPU fleets"
+
+  # The GPU AMI's root volume is larger than the default, and DKMS builds three
+  # module trees before archiving them.
+  launch_block_device_mappings {
+    device_name           = "/dev/xvda"
+    volume_size           = 100
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  # metadata_options: an org SCP denies RunInstances without http_tokens=required.
+  imds_support = "v2.0"
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  # Public subnet: no usable default VPC, and the build pulls driver RPMs from
+  # developer.download.nvidia.com.
+  subnet_filter {
+    filters = {
+      "tag:Name" = "${var.cluster_name}${var.subnet_filter_name}"
+    }
+    most_free = true
+    random    = false
+  }
+  associate_public_ip_address = true
+
+  # Otherwise Packer opens :22 to 0.0.0.0/0 for the build. See the note in
+  # modules/nodepools-agent-sandbox/packer if SSH hangs behind a NAT pool or VPN.
+  temporary_security_group_source_public_ip = true
+
+  # Karpenter selects by tag, so the name is free to change. NvidiaDriver is the
+  # tag to read when auditing which driver a fleet is actually on.
+  tags = {
+    Name             = local.ami_name
+    "osdc.io/ami"    = "gpu-nvidia-615"
+    "osdc.io/module" = "nodepools"
+    Cluster          = var.cluster_name
+    NvidiaDriver     = var.nvidia_driver_version
+    GdrcopyVersion   = var.nvidia_gdrcopy_version
+    K8sVersion       = var.k8s_version
+    SourceAMI        = data.amazon-parameterstore.eks_al2023_nvidia.value
+    Project          = "ciforge"
+  }
+  snapshot_tags = {
+    Name          = local.ami_name
+    "osdc.io/ami" = "gpu-nvidia-615"
+  }
+}
+
+build {
+  name    = "gpu-nvidia-driver"
+  sources = ["source.amazon-ebs.gpu_nvidia"]
+
+  provisioner "shell" {
+    script = "${path.root}/scripts/install-nvidia-driver.sh"
+    environment_vars = [
+      "NVIDIA_DRIVER_VERSION=${var.nvidia_driver_version}",
+      "NVIDIA_GDRCOPY_VERSION=${var.nvidia_gdrcopy_version}",
+    ]
+    # {{ .Vars }} is required — overriding execute_command drops environment_vars.
+    execute_command = "{{ .Vars }} sudo -E bash -eux '{{ .Path }}'"
+  }
+
+  post-processor "manifest" {
+    output     = "${path.root}/manifest.json"
+    strip_path = true
+  }
+}

--- a/osdc/modules/nodepools/packer/scripts/install-nvidia-driver.sh
+++ b/osdc/modules/nodepools/packer/scripts/install-nvidia-driver.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Replace the stock NVIDIA driver on the EKS-optimized AL2023 GPU AMI with a
+# newer branch. Build time only, never node boot.
+#
+# The EKS AMI ships driver 580 and there is no knob to change that: upstream's
+# own build resolves the version as min(kmod-nvidia-open-dkms, AWS GRID runfile)
+# and AWS's GRID bucket stops at 595, so even building the AMI from source can
+# not reach 615. See docs/nvidia-driver-615-ami.md for the full analysis.
+#
+# What this does instead is take the finished GPU AMI and swap the driver in
+# place, following the same sequence upstream's install-nvidia-driver.sh uses:
+# rebuild the DKMS module, re-archive it under /var/lib/dkms-archive (which is
+# what nvidia-kmod-load.service unpacks at boot), then move userspace to match.
+#
+# Scope: compute GPUs (p4d/p5/p6) only. R615 dropped the proprietary kernel
+# module entirely — see the guard installed by patch-kmod-load below.
+set -euxo pipefail
+
+: "${NVIDIA_DRIVER_VERSION:?NVIDIA_DRIVER_VERSION must be set (full version, e.g. 615.71.09)}"
+: "${NVIDIA_GDRCOPY_VERSION:?NVIDIA_GDRCOPY_VERSION must be set (e.g. 2.5.2)}"
+
+NVIDIA_DRIVER_MAJOR="${NVIDIA_DRIVER_VERSION%%.*}"
+DKMS_ARCHIVE_DIR=/var/lib/dkms-archive
+KMOD_LOAD=/etc/eks/nvidia-kmod-load.sh
+MAJOR_STAMP=/etc/eks/osdc-nvidia-driver-major
+
+################################################################################
+### Preflight ##################################################################
+################################################################################
+# Fail early and loudly if the base image is not what we think it is. Every step
+# below edits files the EKS AMI owns, so a base that has moved on is a rebuild
+# signal, not something to paper over.
+for required in /usr/bin/kmod-util "${KMOD_LOAD}" "${DKMS_ARCHIVE_DIR}"; do
+  if [[ ! -e "${required}" ]]; then
+    echo >&2 "ERROR: ${required} missing — base AMI is not an EKS AL2023 NVIDIA image"
+    exit 1
+  fi
+done
+
+STOCK_VERSION=$(rpmquery --queryformat '%{VERSION}' nvidia-driver-cuda 2>/dev/null || echo "unknown")
+echo "Stock driver: ${STOCK_VERSION} -> target: ${NVIDIA_DRIVER_VERSION}"
+
+if [[ "${STOCK_VERSION}" == "${NVIDIA_DRIVER_VERSION}" ]]; then
+  echo >&2 "ERROR: base AMI already ships ${NVIDIA_DRIVER_VERSION} — drop this module and use the stock AMI"
+  exit 1
+fi
+
+sudo dnf -y install jq
+
+################################################################################
+### Point dnf at the target branch #############################################
+################################################################################
+# The CUDA repo serves kmod-nvidia* through module streams and only the newest
+# stream is visible by default; module_hotfixes disables that filtering so an
+# exact version can be pinned. Same trick upstream uses.
+sudo dnf -y module reset nvidia-driver || true
+sudo dnf -y module enable "nvidia-driver:${NVIDIA_DRIVER_MAJOR}-open"
+
+if ! dnf -q repoquery --setopt='*.module_hotfixes=true' \
+  "kmod-nvidia-open-dkms-${NVIDIA_DRIVER_VERSION}" | grep -q .; then
+  echo >&2 "ERROR: kmod-nvidia-open-dkms-${NVIDIA_DRIVER_VERSION} not found in the configured repos"
+  exit 1
+fi
+
+# The kernel is versionlocked by the EKS build, so DKMS compiles against exactly
+# the kernel this AMI boots. Headers are already present; assert rather than
+# install, so a base image that stopped shipping them fails here.
+if ! rpmquery "kernel-devel-$(uname -r)" >/dev/null 2>&1; then
+  echo >&2 "ERROR: kernel-devel-$(uname -r) missing — cannot build DKMS modules"
+  exit 1
+fi
+
+################################################################################
+### Drop the stock kmod archives ###############################################
+################################################################################
+# nvidia-kmod-load.service picks a flavor at boot and unpacks it from here. A
+# stale 580 tarball left next to 615 userspace is the one failure mode that
+# would survive to a running node, so all four go.
+#
+# nvidia (proprietary) and nvidia-open-grid are removed and never rebuilt:
+# R615 ships no proprietary kmod, and AWS publishes no 615 GRID runfile. The
+# boot-time guard installed below redirects both selections to nvidia-open.
+for flavor in nvidia nvidia-open nvidia-open-grid gdrdrv; do
+  sudo rm -rf "${DKMS_ARCHIVE_DIR:?}/${flavor}"
+done
+sudo rm -rf /usr/src/nvidia-*
+
+################################################################################
+### Build and archive the open kmod ############################################
+################################################################################
+# The RPM and the upstream dkms.conf disagree on the package name (the module
+# was renamed nvidia-open -> nvidia in 570.148.08), so the DKMS entry has to be
+# re-registered under the name kmod-util and nvidia-kmod-load.sh expect.
+# Verbatim from upstream's archive-open-kmods.
+sudo dnf -y --setopt='*.module_hotfixes=true' install \
+  "kmod-nvidia-open-dkms-${NVIDIA_DRIVER_VERSION}"
+
+sudo dkms remove "nvidia/${NVIDIA_DRIVER_VERSION}" --all
+sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/' \
+  "/usr/src/nvidia-${NVIDIA_DRIVER_VERSION}/dkms.conf"
+sudo mv "/usr/src/nvidia-${NVIDIA_DRIVER_VERSION}" "/usr/src/nvidia-open-${NVIDIA_DRIVER_VERSION}"
+sudo dkms add -m nvidia-open -v "${NVIDIA_DRIVER_VERSION}"
+sudo dkms build -m nvidia-open -v "${NVIDIA_DRIVER_VERSION}"
+sudo dkms install -m nvidia-open -v "${NVIDIA_DRIVER_VERSION}"
+sudo kmod-util archive nvidia-open
+
+# gdrdrv links against the nvidia module's symbols, so it has to be built while
+# nvidia-open is still DKMS-installed — same ordering as upstream.
+sudo dnf -y install "gdrcopy-kmod-${NVIDIA_GDRCOPY_VERSION}"
+sudo kmod-util archive gdrdrv
+sudo kmod-util remove gdrdrv
+sudo dnf -y remove --all "gdrcopy-kmod-${NVIDIA_GDRCOPY_VERSION}"
+
+sudo kmod-util remove nvidia-open
+sudo dnf -y remove --all "kmod-nvidia-open*"
+sudo rm -rf /usr/src/nvidia-open-*
+
+################################################################################
+### Move userspace to match ####################################################
+################################################################################
+# Versions are pinned explicitly on the top-level packages; their nvidia-* deps
+# are strictly versioned, so dnf pulls the matching set. The assertion at the
+# bottom catches anything left behind at the old version.
+sudo dnf -y install \
+  "libnvidia-fbc-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-driver-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-driver-cuda-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-fabricmanager-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-imex-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-libXNVCtrl-devel-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-modprobe-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-persistenced-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-settings-${NVIDIA_DRIVER_VERSION}" \
+  "nvidia-xconfig-${NVIDIA_DRIVER_VERSION}" \
+  "xorg-x11-nvidia-${NVIDIA_DRIVER_VERSION}"
+
+# Enabled in the base image already, but nvidia-fabricmanager is reinstalled
+# above and RPM does not carry the enablement across.
+sudo systemctl enable nvidia-fabricmanager
+sudo systemctl enable nvidia-persistenced
+sudo systemctl enable nvidia-kmod-load.service
+
+################################################################################
+### Supported-device list for the new branch ###################################
+################################################################################
+# nvidia-kmod-load.sh greps this to decide whether the attached GPUs can use the
+# open kmod. Upstream generates it from the .run file at AMI-build time and only
+# ships lists up to 595; the nvidia-driver RPM carries the same JSON, so the 615
+# list is generated here from the package rather than a 500MB download.
+SUPPORTED_GPUS_JSON=/usr/share/doc/nvidia-driver/supported-gpus.json
+DEVICE_FILE="/etc/eks/nvidia-open-supported-devices-${NVIDIA_DRIVER_MAJOR}.txt"
+
+if [[ ! -f "${SUPPORTED_GPUS_JSON}" ]]; then
+  echo >&2 "ERROR: ${SUPPORTED_GPUS_JSON} not shipped by nvidia-driver-${NVIDIA_DRIVER_VERSION}"
+  exit 1
+fi
+
+# Same jq filter as upstream hack/generate-nvidia-open-supported-devices.sh.
+{
+  echo "# Generated at AMI build time from ${SUPPORTED_GPUS_JSON}"
+  echo "# (nvidia-driver-${NVIDIA_DRIVER_VERSION}), by osdc modules/nodepools/packer."
+  jq -r '.chips[] | select(.features[]? | contains("kernelopen")) | "\(.devid) \(.name)"' \
+    "${SUPPORTED_GPUS_JSON}" | sort -u
+} | sudo tee "${DEVICE_FILE}" >/dev/null
+
+# Sanity-check the GPUs this AMI actually targets: A100 (0x20B2), H100 (0x2330),
+# B200 (0x2901). If the open kmod ever stops covering one of them, the node
+# would silently fall through to a flavor that no longer exists.
+for devid in 0x20B2 0x2330 0x2901; do
+  if ! grep -qi "^${devid} " "${DEVICE_FILE}"; then
+    echo >&2 "ERROR: ${devid} not open-kmod supported in ${NVIDIA_DRIVER_VERSION}"
+    exit 1
+  fi
+done
+
+################################################################################
+### Patch the boot-time kmod selector ##########################################
+################################################################################
+# Two upstream assumptions break on 615, both of which would leave a node with
+# no driver loaded at all:
+#
+#   1. The major version is probed with `rpmquery kmod-nvidia-latest-dkms`.
+#      That package is the proprietary kmod and does not exist at 615, so the
+#      probe fails, devices-support-open returns 1, and selection falls through
+#      to the proprietary flavor.
+#   2. g4dn/g5/g5g are hardcoded to the proprietary flavor for a GSP workaround,
+#      and the GRID path selects nvidia-open-grid. Neither archive exists here.
+#
+# Both patches are anchored on exact upstream text and the build fails if an
+# anchor is missing — a base-AMI refresh that rewrites this script must be
+# reviewed, not silently shipped.
+echo "${NVIDIA_DRIVER_MAJOR}" | sudo tee "${MAJOR_STAMP}" >/dev/null
+
+VERSION_PROBE="  KMOD_MAJOR_VERSION=\$(rpmquery kmod-nvidia-latest-dkms --queryformat '%{VERSION}' | cut -d. -f1)"
+if ! grep -qF "${VERSION_PROBE}" "${KMOD_LOAD}"; then
+  echo >&2 "ERROR: version-probe anchor not found in ${KMOD_LOAD}; upstream changed, re-review this patch"
+  exit 1
+fi
+sudo python3 - "${KMOD_LOAD}" "${VERSION_PROBE}" "${MAJOR_STAMP}" <<'PY'
+import sys
+
+path, anchor, stamp = sys.argv[1], sys.argv[2], sys.argv[3]
+replacement = (
+    "  # Patched by osdc modules/nodepools/packer: the stock probe reads the\n"
+    "  # proprietary kmod's version, which this AMI does not ship.\n"
+    f"  KMOD_MAJOR_VERSION=$(cat {stamp})"
+)
+with open(path) as f:
+    content = f.read()
+with open(path, "w") as f:
+    f.write(content.replace(anchor, replacement, 1))
+PY
+
+# shellcheck disable=SC2016  # literal upstream text to match, not an expansion
+LOAD_ANCHOR='kmod-util load "${MODULE_NAME}"'
+if ! grep -qF "${LOAD_ANCHOR}" "${KMOD_LOAD}"; then
+  echo >&2 "ERROR: kmod-load anchor not found in ${KMOD_LOAD}; upstream changed, re-review this patch"
+  exit 1
+fi
+sudo python3 - "${KMOD_LOAD}" "${LOAD_ANCHOR}" <<'PY'
+import sys
+
+path, anchor = sys.argv[1], sys.argv[2]
+guard = """# Patched by osdc modules/nodepools/packer. This AMI archives only the open
+# kmod: 615 ships no proprietary module and AWS publishes no 615 GRID runfile.
+# Redirect rather than fail, so a GPU outside this AMI's intended scope still
+# boots with a driver instead of none.
+if [ ! -d "/var/lib/dkms-archive/${MODULE_NAME}" ]; then
+  echo "No ${MODULE_NAME} archive on this AMI; falling back to nvidia-open"
+  MODULE_NAME="nvidia-open"
+  # NVreg_EnableGpuFirmware=0 is a proprietary-only workaround and the open
+  # kmod requires GSP firmware, so it has to go with the flavor that set it.
+  rm -f /etc/modprobe.d/nvidia-disable-gsp.conf
+fi
+
+"""
+with open(path) as f:
+    content = f.read()
+with open(path, "w") as f:
+    f.write(content.replace(anchor, guard + anchor, 1))
+PY
+
+sudo bash -n "${KMOD_LOAD}"
+
+################################################################################
+### Verify ####################################################################
+################################################################################
+# No GPU on the build instance, so nvidia-smi proves nothing. Check the things
+# that are actually decided at build time.
+shopt -s nullglob
+
+test ! -e "${DKMS_ARCHIVE_DIR}/nvidia"
+test ! -e "${DKMS_ARCHIVE_DIR}/nvidia-open-grid"
+
+gdrdrv_archives=("${DKMS_ARCHIVE_DIR}/gdrdrv/"*.tar.gz)
+if [[ ${#gdrdrv_archives[@]} -eq 0 ]]; then
+  echo >&2 "ERROR: no gdrdrv archive was produced"
+  exit 1
+fi
+
+# The archive tarball name carries the version DKMS built; this is the check
+# that the node will actually load the target driver and not something stale.
+open_archives=("${DKMS_ARCHIVE_DIR}/nvidia-open/"*"${NVIDIA_DRIVER_VERSION}"*.tar.gz)
+if [[ ${#open_archives[@]} -eq 0 ]]; then
+  echo >&2 "ERROR: no archived nvidia-open kmod at ${NVIDIA_DRIVER_VERSION}. Present:"
+  ls >&2 -la "${DKMS_ARCHIVE_DIR}/nvidia-open/"
+  exit 1
+fi
+
+# Anything nvidia-ish left at the old version means dnf resolved a dependency
+# we did not pin. nvidia-container-* is excluded: it versions independently of
+# the driver and is intentionally left alone.
+STALE=$(rpmquery --queryformat '%{NAME} %{VERSION}\n' 'nvidia-*' 'libnvidia-*' 'xorg-x11-nvidia*' \
+  | grep -v '^nvidia-container' \
+  | grep -v " ${NVIDIA_DRIVER_VERSION}$" || true)
+if [[ -n "${STALE}" ]]; then
+  echo >&2 "ERROR: packages left at a non-target version:"
+  echo >&2 "${STALE}"
+  exit 1
+fi
+
+sudo dnf clean all
+
+echo "NVIDIA ${NVIDIA_DRIVER_VERSION} baked (was ${STOCK_VERSION}); open kmod only."


### PR DESCRIPTION
Draft — parked, not proposed for adoption yet.

Builds an EKS AL2023 GPU AMI with the NVIDIA driver swapped from the stock **580** to **615.71.09** (R615), the branch CUDA 13.4 asks for. **Nothing selects it.** Every GPU pool still tracks the `amazon-eks-node-al2023-x86_64-nvidia-*` glob. This is the implementation sitting ready if we decide we need R615; adopting it is a separate per-def change.

### Overlaps #1064 — needs a call before this leaves draft

#1064 (`docs/nvidia-driver-ahead-of-aws.md`) is the broader survey of this same question, and lists "custom packer AMI" as the leading candidate. This is that candidate, built. The two docs overlap and both append a row to the same `CLAUDE.md` table, so they will conflict on merge.

Options, roughly in order of how much I like them:

1. Land #1064 first, then rebase this and fold my doc's net-new findings into `nvidia-driver-ahead-of-aws.md`, keeping only the packer README here.
2. Keep both docs — mine now cross-references #1064 as the decision doc and scopes itself to mechanics.
3. Close this if we're happy to wait for AWS, and keep the branch for later.

One correction for #1064 while it's open: it says CUDA 13.4 is a Developer Preview. **13.4.1 went GA in September 2026**; the July developer preview was 13.4.0.

### Why 580 is probably still fine

Worth stating plainly, because it argues against merging this:

| Need | Minimum driver |
|------|----------------|
| Run existing CUDA 13.x applications (minor version compatibility) | **>= 580** |
| CUDA 13.4's *new* features and newly enabled platforms | **R615** |

We're at 580. CUDA 13.4 binaries run today. R615 buys 13.4-specific features — Vera Rubin (dev preview), PTX ISA 9.4, GCC 16 / Clang 22 with nvcc — none of which is on the critical path. `pypi-cache` tops out at `cu130`, so nothing in the fleet targets 13.4 either. If the real goal is "run CUDA 13.4 workloads", the correct amount of infra work here is zero plus a `cu134` slug.

### Why a driver swap and not a build flag

The upstream EKS AMI build takes `nvidia_driver_major_version`, so `=615` looks like it should just work. Two independent blockers:

- It resolves the full version as `min(kmod-nvidia-open-dkms, AWS GRID runfile)`, and `s3://ec2-linux-nvidia-drivers` stops at **595.91.07**. No 610, no 615. `archive-grid-kmod` hard-errors with no matching runfile, and the `min()` would pin back to 595 anyway.
- `archive-proprietary-kmod` installs `kmod-nvidia-latest-dkms-<version>`. **R615 ships no proprietary kernel module** — the NVIDIA AL2023 repo's proprietary packages stop at 610.

Both are fixable only by forking the upstream template. Swapping the driver on the finished AMI keeps us on AWS's image and confines the delta to one script. (The GPU Operator third option doesn't apply: it doesn't manage drivers on Amazon Linux.)

### The part that would have bitten us

`/etc/eks/nvidia-kmod-load.sh` has to be patched or **nodes boot with no driver at all**. Upstream probes the major version with:

```bash
KMOD_MAJOR_VERSION=$(rpmquery kmod-nvidia-latest-dkms --queryformat '%{VERSION}' | cut -d. -f1)
```

That's the proprietary kmod, which doesn't exist at 615. The probe fails, `devices-support-open` returns 1, and selection falls through to a proprietary flavor that isn't there. Same shape as the g7 bug in awslabs/amazon-eks-ami#2768. A second guard redirects any flavor whose archive is absent (the g4dn/g5 GSP override, GRID subdevices) to `nvidia-open`, and drops `nvidia-disable-gsp.conf` with it since the open kmod requires GSP firmware.

Both patches are anchored on exact upstream text and **fail the build if an anchor moves**, so a base-AMI refresh can't ship a silently broken image.

### What the swap does

Follows upstream's own sequence: rebuild the DKMS module and re-archive it under `/var/lib/dkms-archive` (what `nvidia-kmod-load.service` unpacks at boot), rebuild `gdrdrv` against it, move userspace RPMs to the matching version, and generate `/etc/eks/nvidia-open-supported-devices-615.txt` from the `supported-gpus.json` the `nvidia-driver` RPM ships — upstream only publishes lists up to 595. `nvidia` (proprietary) and `nvidia-open-grid` archives are deleted and not replaced. Closing assertions fail the build if any `nvidia-*` package is left at 580 or the archived kmod isn't the target version.

### Scope

Compute GPUs — p4d (A100), p5 (H100), p6-b200 (B200). **Not** g4dn/g5/g6, which are exactly the pools depending on the proprietary kmod and the GSP workaround; the fallback guard means such a node boots rather than breaks, but that path is untested.

Two R615 items that sound alarming and don't apply: **CDMM** is GB200-class hardware only (all our GPU hosts are x86, and the EKS AMI already writes `NVreg_CoherentGPUMemoryMode=driver` unconditionally), and the **610→615 in-place upgrade hang** needs an in-place upgrade, which Karpenter nodes never do.

The real cost is that a fleet on this AMI stops picking up AL2023 and driver CVE fixes on node rotation, and nothing enforces a rebuild on an EKS version bump. That's the strongest argument for waiting — #1064 makes the same point about the base nodes being the only ones left unpatched for CVE-2026-64561.

### Test plan

- `just test` — pass, 98.84% coverage.
- `just lint` — 13/14. The failure is hadolint `DL3066` on `base/docker/runner-base/Dockerfile:36`, pre-existing on `main` and untouched here.
- `packer validate` clean; the `>= 615` variable guard correctly rejects 595.
- Both `nvidia-kmod-load.sh` patches replayed against the real upstream file: anchors match, patched result passes `bash -n`, and the fallback guard lands after the g4dn/g5 `esac` and before `kmod-util load`.

**Not done: the build has never been run against a real AMI.** It needs AWS (a `c7a.4xlarge` — DKMS compiles without a GPU, so it's cents). Treat the script as reviewed but unrun. Adopting it also needs a real GPU job end-to-end, and on p5 a fabric-handles check per `docs/h100-fabric-handles-imex-channels.md`, since IMEX is the most driver-sensitive thing in the fleet.

### If we want a cheap signal on R615 first

`gpu-dev/` already `dnf install`s the driver directly in `terraform-gpu-devservers/templates/al2023-user-data.sh` (landing on 595 today). Moving that to 615 is roughly a one-line change with no AMI build, and would tell us whether R615 is well-behaved on this hardware before OSDC commits.
